### PR TITLE
Swagger/OpenAPI docs + JWT auth in Swagger UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## API Documentation (Swagger / OpenAPI)
+
+This project uses `springdoc-openapi` to generate interactive API documentation at `http://localhost:8080/swagger-ui.html`.
+
+When adding or changing backend endpoints:
+
+- Add Swagger annotations to controllers so endpoints stay documented and grouped in Swagger UI.
+  - Use `@Tag` at the controller level (e.g., `Auth`, `Profiles`, `Matching`).
+  - Use `@Operation` and (when helpful) `@ApiResponses` at the handler level.
+- Add Swagger annotations to request/response models.
+  - Use `@Schema` on DTO classes/fields for clear descriptions/examples.
+
+Keeping these annotations up to date is required for new backend work.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # BounSWE 2026 - Group 7
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
 ## Running with Docker
 
 Make sure you have [Docker](https://docs.docker.com/get-docker/) and Docker Compose installed.

--- a/backend/src/main/java/com/group7/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/group7/backend/config/OpenApiConfig.java
@@ -2,6 +2,7 @@ package com.group7.backend.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
@@ -11,16 +12,21 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
+    public static final String SECURITY_SCHEME_NAME = "bearerAuth";
+
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
                         .title("Group7 Backend API")
                         .version("0.0.1")
-                        .description("BounSwe2026 Group7 Backend API"))
-                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+                        .description("BounSwe2026 Group7 Backend API")
+                        .contact(new Contact()
+                                .name("BounSWE 2026 Group 7")
+                                .url("https://github.com/bounswe/bounswe2026group7")))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
                 .components(new Components()
-                        .addSecuritySchemes("Bearer Authentication",
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
                                 new SecurityScheme()
                                         .type(SecurityScheme.Type.HTTP)
                                         .scheme("bearer")

--- a/backend/src/main/java/com/group7/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AuthController.java
@@ -5,6 +5,12 @@ import com.group7.backend.dto.request.RegisterRequest;
 import com.group7.backend.dto.response.AuthResponse;
 import com.group7.backend.dto.response.UserResponse;
 import com.group7.backend.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import jakarta.validation.Valid;
@@ -12,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
+@Tag(name = "Auth", description = "Authentication endpoints")
 public class AuthController {
 
     private final AuthService authService;
@@ -21,12 +28,24 @@ public class AuthController {
     }
 
     @PostMapping("/register")
+    @Operation(summary = "Register user", description = "Creates a new user and returns basic user details.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "User created",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Validation error", content = @Content)
+    })
     public ResponseEntity<UserResponse> register(@Valid @RequestBody RegisterRequest request) {
         UserResponse response = authService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/login")
+    @Operation(summary = "Login", description = "Authenticates credentials and returns a JWT session token.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Authenticated",
+                    content = @Content(schema = @Schema(implementation = AuthResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Invalid credentials", content = @Content)
+    })
     public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request) {
         AuthResponse response = authService.authenticate(request);
         return ResponseEntity.ok(response);

--- a/backend/src/main/java/com/group7/backend/controller/UserController.java
+++ b/backend/src/main/java/com/group7/backend/controller/UserController.java
@@ -4,6 +4,13 @@ import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.entity.User;
 import com.group7.backend.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,6 +18,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
+@Tag(name = "Profiles", description = "User, mentor, and mentee profile endpoints")
 public class UserController {
 
     private final UserService userService;
@@ -20,39 +28,65 @@ public class UserController {
     }
 
     @GetMapping
+    @Operation(summary = "List users")
+    @ApiResponse(responseCode = "200", description = "List of users",
+            content = @Content(schema = @Schema(implementation = User.class)))
     public List<User> getAllUsers() {
         return userService.getAllUsers();
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<User> getUserById(@PathVariable Long id) {
+    @Operation(summary = "Get user by id")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "User found",
+                    content = @Content(schema = @Schema(implementation = User.class))),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content)
+    })
+    public ResponseEntity<User> getUserById(@Parameter(description = "User id") @PathVariable Long id) {
         return userService.getUserById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @PostMapping("/mentors")
+    @Operation(summary = "Create mentor profile")
+    @ApiResponse(responseCode = "200", description = "Mentor created",
+            content = @Content(schema = @Schema(implementation = Mentor.class)))
     public Mentor createMentor(@RequestBody Mentor mentor) {
         return userService.createMentor(mentor);
     }
 
     @PostMapping("/mentees")
+    @Operation(summary = "Create mentee profile")
+    @ApiResponse(responseCode = "200", description = "Mentee created",
+            content = @Content(schema = @Schema(implementation = Mentee.class)))
     public Mentee createMentee(@RequestBody Mentee mentee) {
         return userService.createMentee(mentee);
     }
 
     @GetMapping("/mentors")
+    @Operation(summary = "List mentors")
+    @ApiResponse(responseCode = "200", description = "List of mentors",
+            content = @Content(schema = @Schema(implementation = Mentor.class)))
     public List<Mentor> getAllMentors() {
         return userService.getAllMentors();
     }
 
     @GetMapping("/mentees")
+    @Operation(summary = "List mentees")
+    @ApiResponse(responseCode = "200", description = "List of mentees",
+            content = @Content(schema = @Schema(implementation = Mentee.class)))
     public List<Mentee> getAllMentees() {
         return userService.getAllMentees();
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+    @Operation(summary = "Delete user")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "User deleted"),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content)
+    })
+    public ResponseEntity<Void> deleteUser(@Parameter(description = "User id") @PathVariable Long id) {
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/group7/backend/dto/request/EditProfileRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/EditProfileRequest.java
@@ -1,13 +1,18 @@
 package com.group7.backend.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Profile edit payload")
 public class EditProfileRequest {
+    @Schema(description = "First name")
     private String firstName;
+    @Schema(description = "Last name")
     private String lastName;
+    @Schema(description = "Profile photo URL")
     private String profilePhoto;
 }

--- a/backend/src/main/java/com/group7/backend/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/LoginRequest.java
@@ -1,12 +1,17 @@
 package com.group7.backend.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Login payload")
 public class LoginRequest {
+    @Schema(description = "Email address", example = "user@example.com")
     private String email;
+
+    @Schema(description = "Password")
     private String password;
 }

--- a/backend/src/main/java/com/group7/backend/dto/request/MenteeProfileRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/MenteeProfileRequest.java
@@ -1,5 +1,6 @@
 package com.group7.backend.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.util.List;
@@ -8,13 +9,29 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Mentee profile payload")
 public class MenteeProfileRequest {
+    @Schema(description = "Whether the profile is visible to others")
     private Boolean profileVisibility;
+
+    @Schema(description = "Goals")
     private String goals;
+
+    @Schema(description = "Major")
     private String major;
+
+    @Schema(description = "Interests")
     private List<String> interests;
+
+    @Schema(description = "Career interest")
     private String careerInterest;
+
+    @Schema(description = "Skills")
     private List<String> skills;
+
+    @Schema(description = "Meeting frequency preference")
     private String meetingFreqPref;
+
+    @Schema(description = "Background information")
     private String backgroundInfo;
 }

--- a/backend/src/main/java/com/group7/backend/dto/request/MentorProfileRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/MentorProfileRequest.java
@@ -1,5 +1,6 @@
 package com.group7.backend.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.util.List;
@@ -8,15 +9,35 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Mentor profile payload")
 public class MentorProfileRequest {
+    @Schema(description = "Short bio")
     private String bio;
+
+    @Schema(description = "Mentoring field")
     private String field;
+
+    @Schema(description = "Expertise summary")
     private String expertise;
+
+    @Schema(description = "Affiliation (university/company)")
     private String affiliation;
+
+    @Schema(description = "Interests")
     private List<String> interests;
+
+    @Schema(description = "Maximum number of mentees")
     private Integer maxMenteeCapacity;
+
+    @Schema(description = "Preferred mentee skills")
     private List<String> preferredMenteeSkills;
+
+    @Schema(description = "Preferred mentee major")
     private String preferredMenteeMajor;
+
+    @Schema(description = "Mentoring goals")
     private String mentoringGoals;
+
+    @Schema(description = "Mentorship duration (e.g., weeks/months)")
     private Integer mentorshipDuration;
 }

--- a/backend/src/main/java/com/group7/backend/dto/request/RegisterRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/RegisterRequest.java
@@ -1,6 +1,7 @@
 package com.group7.backend.dto.request;
 
 import com.group7.backend.validation.ValidPassword;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
@@ -9,20 +10,26 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Registration payload")
 public class RegisterRequest {
     @NotBlank(message = "First name is required")
+    @Schema(description = "First name")
     private String firstName;
 
     @NotBlank(message = "Last name is required")
+    @Schema(description = "Last name")
     private String lastName;
 
     @NotBlank(message = "Email is required")
     @Email(message = "Invalid email format")
+    @Schema(description = "Email address", example = "user@example.com")
     private String email;
 
     @NotBlank(message = "Password is required")
     @ValidPassword
+    @Schema(description = "Password (validated by backend rules)")
     private String password;
 
+    @Schema(description = "Whether the user registers as a mentor")
     private Boolean isMentor;
 }

--- a/backend/src/main/java/com/group7/backend/dto/request/ResetPasswordRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/ResetPasswordRequest.java
@@ -1,13 +1,18 @@
 package com.group7.backend.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Reset password payload")
 public class ResetPasswordRequest {
+    @Schema(description = "Email address", example = "user@example.com")
     private String email;
+    @Schema(description = "Password reset token")
     private String token;
+    @Schema(description = "New password")
     private String newPassword;
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/AuthResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/AuthResponse.java
@@ -1,13 +1,20 @@
 package com.group7.backend.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Authentication result")
 public class AuthResponse {
+    @Schema(description = "JWT token used for authenticated requests", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String sessionToken;
+
+    @Schema(description = "User role", example = "MENTOR")
     private String role;
+
+    @Schema(description = "Authenticated user id", example = "1")
     private Long userId;
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/MenteeResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MenteeResponse.java
@@ -1,5 +1,6 @@
 package com.group7.backend.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -9,7 +10,9 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Mentee profile response")
 public class MenteeResponse {
+    @Schema(description = "Mentee id", example = "1")
     private Long id;
     private String firstName;
     private String lastName;

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorResponse.java
@@ -1,5 +1,6 @@
 package com.group7.backend.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -9,7 +10,9 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Mentor profile response")
 public class MentorResponse {
+    @Schema(description = "Mentor id", example = "1")
     private Long id;
     private String firstName;
     private String lastName;

--- a/backend/src/main/java/com/group7/backend/dto/response/UserResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/UserResponse.java
@@ -1,5 +1,6 @@
 package com.group7.backend.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -8,13 +9,22 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "Basic user response")
 public class UserResponse {
+    @Schema(description = "User id", example = "1")
     private Long id;
+    @Schema(description = "First name")
     private String firstName;
+    @Schema(description = "Last name")
     private String lastName;
+    @Schema(description = "Email address")
     private String email;
+    @Schema(description = "Profile photo URL")
     private String profilePhoto;
+    @Schema(description = "Whether email is verified")
     private Boolean isEmailVerified;
+    @Schema(description = "Creation timestamp")
     private LocalDateTime createdAt;
+    @Schema(description = "Role", example = "MENTEE")
     private String role;
 }


### PR DESCRIPTION
Closes #111

## Summary
- Configured OpenAPI metadata and standardized JWT Bearer security scheme for Swagger UI authorization.
- Added Swagger annotations to existing controllers to provide endpoint grouping and clear operation docs.
- Added `@Schema` annotations to request/response DTOs so models show descriptions/examples in Swagger UI.
- Added a contributing note requiring Swagger annotations for new/updated backend endpoints.

## How to test
1. Run: `docker compose up --build`
2. Open: http://localhost:8080/swagger-ui.html
3. Verify endpoints are grouped (e.g., Auth, Profiles) and show descriptions/models.
4. Call `POST /api/auth/login` to get a token, then click **Authorize** in Swagger UI and paste the JWT to test protected endpoints.

## Acceptance Criteria
-  Swagger UI is accessible at `/swagger-ui.html` without authentication
-  All existing endpoints are listed with descriptions, parameters, and response types
-  JWT auth can be configured in Swagger UI to test protected endpoints
-  API docs reflect the actual state of the codebase

## Notes
- Backend build validated via `docker compose build backend` (local Maven not required).