### PR TITLE
 Docker Compose Dev Stack (Postgres + MailHog + healthchecks + env)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git/
+.github/
+**/target/
+**/node_modules/
+**/dist/
+**/.idea/
+**/*.iml
+**/*.log
+**/.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Copy this file to .env and adjust values for local development
+
+# ---- Database (PostgreSQL) ----
+POSTGRES_DB=group7db
+POSTGRES_USER=group7
+POSTGRES_PASSWORD=group7pass
+DB_PORT=5433
+
+# ---- Backend ----
+BACKEND_PORT=8080
+# Base64-encoded secret used to sign JWTs (recommended to set in .env)
+JWT_SECRET=bXlTdXBlclNlY3JldEtleUZvckdyb3VwN0JhY2tlbmRBcHBsaWNhdGlvbjIwMjY=
+# Token expiration in milliseconds (default: 1 day)
+JWT_EXPIRATION=86400000
+
+# ---- Mail (MailHog for local dev) ----
+MAILHOG_UI_PORT=8025
+MAILHOG_SMTP_PORT=1025
+# Spring Mail config (MailHog defaults)
+SPRING_MAIL_HOST=mailhog
+SPRING_MAIL_PORT=1025
+SPRING_MAIL_USERNAME=
+SPRING_MAIL_PASSWORD=
+SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH=false
+SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE=false
+
+# ---- Frontend ----
+FRONTEND_PORT=5174

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 Make sure you have [Docker](https://docs.docker.com/get-docker/) and Docker Compose installed.
 
+### Environment variables
+
+Create a `.env` file in the project root (see `.env.example`):
+
+```bash
+cp .env.example .env
+```
+
+You can keep defaults for local development.
+
 ### Start all services
 
 ```bash
@@ -17,6 +27,7 @@ This starts three containers:
 | Frontend | http://localhost:5174        | React + Vite dev server  |
 | Backend  | http://localhost:8080        | Spring Boot REST API     |
 | Swagger  | http://localhost:8080/swagger-ui.html | API docs        |
+| MailHog  | http://localhost:8025        | Local email inbox (dev)  |
 | Database | localhost:5433               | PostgreSQL               |
 
 > **Note:** Port 5174 is used for the Docker frontend. If you run the frontend locally (`npm run dev`), it runs on 5173.

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,8 @@
+target/
+.git/
+.gitignore
+.mvn/
+.idea/
+*.iml
+*.log
+**/.DS_Store

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,5 +8,16 @@ RUN mvn package -DskipTests -B
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
+
+# Install a minimal HTTP client for container healthchecks
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends curl \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Run as non-root
+RUN useradd -r -u 10001 -g root appuser \
+	&& chown -R appuser:root /app
+USER appuser
+
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,6 +39,14 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/backend/src/main/java/com/group7/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/group7/backend/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                 .anyRequest().authenticated()
             )

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=group7-backend
 
-spring.datasource.url=jdbc:postgresql://localhost:5433/group7db
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5433/group7db}
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=group7
-spring.datasource.password=group7pass
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:group7}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:group7pass}
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=validate
@@ -12,5 +12,17 @@ spring.jpa.show-sql=true
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
 
-jwt.secret=bXlTdXBlclNlY3JldEtleUZvckdyb3VwN0JhY2tlbmRBcHBsaWNhdGlvbjIwMjY=
-jwt.expiration=86400000
+jwt.secret=${JWT_SECRET:bXlTdXBlclNlY3JldEtleUZvckdyb3VwN0JhY2tlbmRBcHBsaWNhdGlvbjIwMjY=}
+jwt.expiration=${JWT_EXPIRATION:86400000}
+
+# Actuator (for Docker healthchecks)
+management.endpoints.web.exposure.include=health
+management.endpoint.health.probes.enabled=true
+
+# Mail (MailHog defaults for local development)
+spring.mail.host=${SPRING_MAIL_HOST:localhost}
+spring.mail.port=${SPRING_MAIL_PORT:1025}
+spring.mail.username=${SPRING_MAIL_USERNAME:}
+spring.mail.password=${SPRING_MAIL_PASSWORD:}
+spring.mail.properties.mail.smtp.auth=${SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH:false}
+spring.mail.properties.mail.smtp.starttls.enable=${SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE:false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,34 +2,72 @@ services:
   db:
     image: postgres:16-alpine
     environment:
-      POSTGRES_DB: group7db
-      POSTGRES_USER: group7
-      POSTGRES_PASSWORD: group7pass
+      POSTGRES_DB: ${POSTGRES_DB:-group7db}
+      POSTGRES_USER: ${POSTGRES_USER:-group7}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-group7pass}
     ports:
-      - "5433:5432"
+      - "${DB_PORT:-5433}:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U group7 -d group7db"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-group7} -d ${POSTGRES_DB:-group7db}"]
       interval: 5s
       timeout: 5s
-      retries: 10
+      retries: 20
+    networks:
+      - group7_net
+
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    ports:
+      - "${MAILHOG_UI_PORT:-8025}:8025"
+      - "${MAILHOG_SMTP_PORT:-1025}:1025"
+    networks:
+      - group7_net
 
   backend:
     build: ./backend
     ports:
-      - "8080:8080"
+      - "${BACKEND_PORT:-8080}:8080"
     environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/group7db
-      SPRING_DATASOURCE_USERNAME: group7
-      SPRING_DATASOURCE_PASSWORD: group7pass
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/${POSTGRES_DB:-group7db}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-group7}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-group7pass}
+      JWT_SECRET: ${JWT_SECRET:-}
+      JWT_EXPIRATION: ${JWT_EXPIRATION:-86400000}
+      SPRING_MAIL_HOST: ${SPRING_MAIL_HOST:-mailhog}
+      SPRING_MAIL_PORT: ${SPRING_MAIL_PORT:-1025}
+      SPRING_MAIL_USERNAME: ${SPRING_MAIL_USERNAME:-}
+      SPRING_MAIL_PASSWORD: ${SPRING_MAIL_PASSWORD:-}
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH: ${SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH:-false}
+      SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE: ${SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE:-false}
     depends_on:
       db:
         condition: service_healthy
+      mailhog:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health | grep -q 'UP'"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+    networks:
+      - group7_net
 
   frontend:
     build: ./frontend
     ports:
-      - "5174:5173"
+      - "${FRONTEND_PORT:-5174}:5173"
     environment:
       VITE_BACKEND_URL: http://backend:8080
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+    networks:
+      - group7_net
+
+volumes:
+  db_data:
+
+networks:
+  group7_net:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.git/
+.gitignore
+.idea/
+*.iml
+*.log
+**/.DS_Store


### PR DESCRIPTION

Closes #106.

This PR improves the local development stack using Docker Compose:
- Adds MailHog for local SMTP testing (UI + SMTP ports)
- Adds Postgres persistence via a named volume
- Adds healthchecks for DB and backend (Actuator `/actuator/health`)
- Moves configuration to environment variables and provides `.env.example`
- Improves Docker build context via `.dockerignore`
- Runs the backend container as a non-root user

## Changes

- Docker Compose:
  - Postgres service with named volume `db_data`
  - MailHog service (SMTP `1025`, UI `8025`)
  - Backend healthcheck hits `GET /actuator/health`
  - Service dependency ordering via health conditions
  - Dedicated Docker network

- Backend:
  - Adds Actuator for health endpoint
  - Permits `/actuator/health/**` in Spring Security for healthchecks
  - Mail settings are configurable via env vars
  - Container runs as non-root and includes `curl` for healthchecks

- Docs:
  - Adds `.env.example` and documents local setup in README

## How to test

1. Create a local env file:
   - Copy `.env.example` to `.env` and adjust if needed
2. Start the stack:
   - `docker compose up -d --build`
3. Verify health:
   - `docker compose ps` (db + backend should be `healthy`)
   - `curl.exe http://localhost:8080/actuator/health` should return `UP`
4. Verify MailHog:
   - Open `http://localhost:8025` (MailHog UI)

## Notes

- Fresh-start rebuild was verified by removing volumes/images and rebuilding:
  - `docker compose down --volumes --remove-orphans --rmi local`
  - `docker compose up -d --build`
