### PR TITLE
feat(backend): add mentee candidate viewing endpoint for mentors (#103)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MatchingController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MatchingController.java
@@ -1,9 +1,11 @@
 package com.group7.backend.controller;
 
+import com.group7.backend.dto.response.MenteeCandidateResponse;
 import com.group7.backend.dto.response.MentorMatchResponse;
 import com.group7.backend.service.MatchingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -21,7 +23,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/matching")
-@Tag(name = "Matching", description = "Mentor matching endpoint for mentees")
+@Tag(name = "Matching", description = "Matching endpoints for mentors and mentees")
 public class MatchingController {
 
     private final MatchingService matchingService;
@@ -40,7 +42,7 @@ public class MatchingController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Ranked mentor list",
-                    content = @Content(schema = @Schema(implementation = MentorMatchResponse.class))),
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = MentorMatchResponse.class)))),
             @ApiResponse(responseCode = "403", description = "Not a mentee, or mentee already has an active mentor", content = @Content),
             @ApiResponse(responseCode = "404", description = "Mentee profile not found", content = @Content)
     })
@@ -49,6 +51,29 @@ public class MatchingController {
             Authentication authentication) {
         Long menteeId = (Long) authentication.getCredentials();
         List<MentorMatchResponse> results = matchingService.getTopMentors(menteeId, keyword);
+        return ResponseEntity.ok(results);
+    }
+
+    @GetMapping("/mentees")
+    @PreAuthorize("hasRole('MENTOR')")
+    @Operation(
+            summary = "Get candidate mentees",
+            description = "Returns mentee candidates whose interests, skills, or major align with the mentor's preferences. "
+                    + "Excludes mentees who already have an active mentor. "
+                    + "Requires the caller to be a mentor with available capacity. "
+                    + "Optionally filter by keyword matched against goals, major, career interest, background, interests, and skills."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Candidate mentee list",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = MenteeCandidateResponse.class)))),
+            @ApiResponse(responseCode = "403", description = "Not a mentor, or mentor has reached maximum mentee capacity", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentor profile not found", content = @Content)
+    })
+    public ResponseEntity<List<MenteeCandidateResponse>> getCandidateMentees(
+            @Parameter(description = "Optional keyword to filter mentees") @RequestParam(required = false) String keyword,
+            Authentication authentication) {
+        Long mentorId = (Long) authentication.getCredentials();
+        List<MenteeCandidateResponse> results = matchingService.getCandidateMentees(mentorId, keyword);
         return ResponseEntity.ok(results);
     }
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/MenteeCandidateResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MenteeCandidateResponse.java
@@ -1,0 +1,57 @@
+package com.group7.backend.dto.response;
+
+import com.group7.backend.entity.Mentee;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Privacy-safe mentee candidate visible to mentors during matching")
+public class MenteeCandidateResponse {
+
+    @Schema(description = "Mentee user ID", example = "7")
+    private Long id;
+
+    @Schema(description = "First name only (last name hidden for privacy)", example = "Elif")
+    private String firstName;
+
+    @Schema(description = "Learning goals", example = "Improve backend development skills")
+    private String goals;
+
+    @Schema(description = "Major / field of study", example = "Computer Science")
+    private String major;
+
+    @Schema(description = "List of interests", example = "[\"AI\", \"Databases\"]")
+    private List<String> interests;
+
+    @Schema(description = "Career interest", example = "Backend Engineering")
+    private String careerInterest;
+
+    @Schema(description = "List of skills", example = "[\"Java\", \"Python\"]")
+    private List<String> skills;
+
+    @Schema(description = "Background information", example = "3rd year CS student at Bogazici")
+    private String backgroundInfo;
+
+    @Schema(description = "Preferred meeting frequency", example = "Weekly")
+    private String meetingFreqPref;
+
+    public static MenteeCandidateResponse from(Mentee mentee) {
+        MenteeCandidateResponse r = new MenteeCandidateResponse();
+        r.setId(mentee.getId());
+        r.setFirstName(mentee.getFirstName());
+        r.setGoals(mentee.getGoals());
+        r.setMajor(mentee.getMajor());
+        r.setInterests(mentee.getInterests());
+        r.setCareerInterest(mentee.getCareerInterest());
+        r.setSkills(mentee.getSkills());
+        r.setBackgroundInfo(mentee.getBackgroundInfo());
+        r.setMeetingFreqPref(mentee.getMeetingFreqPref());
+        return r;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -22,6 +22,11 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.FORBIDDEN, "Forbidden", ex.getMessage());
     }
 
+    @ExceptionHandler(MatchingNotAllowedException.class)
+    public ResponseEntity<Map<String, String>> handleMatchingNotAllowed(MatchingNotAllowedException ex) {
+        return buildErrorResponse(HttpStatus.FORBIDDEN, "Forbidden", ex.getMessage());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, Object>> handleValidationErrors(MethodArgumentNotValidException ex) {
         Map<String, String> fieldErrors = new HashMap<>();

--- a/backend/src/main/java/com/group7/backend/exception/MatchingNotAllowedException.java
+++ b/backend/src/main/java/com/group7/backend/exception/MatchingNotAllowedException.java
@@ -1,0 +1,7 @@
+package com.group7.backend.exception;
+
+public class MatchingNotAllowedException extends RuntimeException {
+    public MatchingNotAllowedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MatchingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchingService.java
@@ -1,11 +1,11 @@
 package com.group7.backend.service;
 
+import com.group7.backend.dto.response.MenteeCandidateResponse;
 import com.group7.backend.dto.response.MentorMatchResponse;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.MatchingNotAllowedException;
 import com.group7.backend.exception.ResourceNotFoundException;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
 import com.group7.backend.repository.MenteeRepository;
 import com.group7.backend.repository.MentorRepository;
 import org.springframework.stereotype.Service;
@@ -32,7 +32,7 @@ public class MatchingService {
                 .orElseThrow(() -> new ResourceNotFoundException("Mentee not found"));
 
         if (mentee.getActiveMentorId() != null) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You already have an active mentor");
+            throw new MatchingNotAllowedException("You already have an active mentor");
         }
 
         List<Mentor> mentors = mentorRepository.findAll();
@@ -44,6 +44,67 @@ public class MatchingService {
                 .sorted(Comparator.comparingInt(MentorMatchResponse::getMatchScore).reversed())
                 .limit(5)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MenteeCandidateResponse> getCandidateMentees(Long mentorId, String keyword) {
+        Mentor mentor = mentorRepository.findById(mentorId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mentor not found"));
+
+        if (mentor.getCurrentMenteeCount() >= mentor.getMaxMenteeCapacity()) {
+            throw new MatchingNotAllowedException("You have reached your maximum mentee capacity");
+        }
+
+        List<Mentee> mentees = menteeRepository.findAll();
+
+        return mentees.stream()
+                .filter(m -> m.getActiveMentorId() == null)
+                .filter(m -> matchesMentorPreferences(mentor, m))
+                .filter(m -> matchesMenteeKeyword(m, keyword))
+                .map(MenteeCandidateResponse::from)
+                .toList();
+    }
+
+    boolean matchesMentorPreferences(Mentor mentor, Mentee mentee) {
+        List<String> mentorInterests = nullSafe(mentor.getInterests());
+        List<String> menteeInterests = nullSafe(mentee.getInterests());
+        for (String interest : menteeInterests) {
+            if (containsIgnoreCase(mentorInterests, interest)) {
+                return true;
+            }
+        }
+
+        List<String> preferredSkills = nullSafe(mentor.getPreferredMenteeSkills());
+        for (String skill : nullSafe(mentee.getSkills())) {
+            if (containsIgnoreCase(preferredSkills, skill)) {
+                return true;
+            }
+        }
+
+        if (mentee.getMajor() != null && mentor.getPreferredMenteeMajor() != null
+                && mentee.getMajor().equalsIgnoreCase(mentor.getPreferredMenteeMajor())) {
+            return true;
+        }
+
+        if (mentee.getMajor() != null && mentor.getField() != null
+                && mentee.getMajor().equalsIgnoreCase(mentor.getField())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean matchesMenteeKeyword(Mentee mentee, String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return true;
+        }
+        String kw = keyword.toLowerCase();
+        return containsSubstring(mentee.getGoals(), kw)
+                || containsSubstring(mentee.getMajor(), kw)
+                || containsSubstring(mentee.getCareerInterest(), kw)
+                || containsSubstring(mentee.getBackgroundInfo(), kw)
+                || listContainsSubstring(mentee.getInterests(), kw)
+                || listContainsSubstring(mentee.getSkills(), kw);
     }
 
     int calculateScore(Mentor mentor, Mentee mentee) {

--- a/backend/src/test/java/com/group7/backend/controller/MatchingControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MatchingControllerTest.java
@@ -2,6 +2,7 @@ package com.group7.backend.controller;
 
 import com.group7.backend.config.JwtAuthenticationFilter;
 import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.MenteeCandidateResponse;
 import com.group7.backend.dto.response.MentorMatchResponse;
 import com.group7.backend.service.JwtService;
 import com.group7.backend.service.MatchingService;
@@ -96,11 +97,144 @@ class MatchingControllerTest {
     void getTopMentorsReturns403WhenAlreadyHasMentor() throws Exception {
         mockValidMenteeJwt("mentee-token", 1L);
         when(matchingService.getTopMentors(eq(1L), any()))
-                .thenThrow(new org.springframework.web.server.ResponseStatusException(
-                        org.springframework.http.HttpStatus.FORBIDDEN, "You already have an active mentor"));
+                .thenThrow(new com.group7.backend.exception.MatchingNotAllowedException(
+                        "You already have an active mentor"));
 
         mockMvc.perform(get("/api/matching/mentors")
                         .header("Authorization", "Bearer mentee-token"))
                 .andExpect(status().isForbidden());
+    }
+
+    // ── Candidate mentees endpoint ──────────────────────────────────────────
+
+    @Test
+    void getCandidateMenteesReturns200ForMentor() throws Exception {
+        mockValidMentorJwt("mentor-token", 2L);
+        MenteeCandidateResponse candidate = new MenteeCandidateResponse();
+        candidate.setFirstName("Elif");
+        candidate.setMajor("Computer Science");
+        when(matchingService.getCandidateMentees(eq(2L), any())).thenReturn(List.of(candidate));
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].firstName").value("Elif"))
+                .andExpect(jsonPath("$[0].major").value("Computer Science"));
+    }
+
+    @Test
+    void getCandidateMenteesWithKeywordReturns200() throws Exception {
+        mockValidMentorJwt("mentor-token", 2L);
+        when(matchingService.getCandidateMentees(eq(2L), eq("java"))).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/matching/mentees?keyword=java")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void getCandidateMenteesReturns403ForMenteeRole() throws Exception {
+        mockValidMenteeJwt("mentee-token", 1L);
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getCandidateMenteesReturns403WithoutToken() throws Exception {
+        mockMvc.perform(get("/api/matching/mentees"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getCandidateMenteesReturns403WhenAtCapacity() throws Exception {
+        mockValidMentorJwt("mentor-token", 2L);
+        when(matchingService.getCandidateMentees(eq(2L), any()))
+                .thenThrow(new com.group7.backend.exception.MatchingNotAllowedException(
+                        "You have reached your maximum mentee capacity"));
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getCandidateMenteesReturns404WhenMentorNotFound() throws Exception {
+        mockValidMentorJwt("mentor-token", 2L);
+        when(matchingService.getCandidateMentees(eq(2L), any()))
+                .thenThrow(new com.group7.backend.exception.ResourceNotFoundException("Mentor not found"));
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getCandidateMenteesReturnsEmptyArrayWhenNoCandidates() throws Exception {
+        mockValidMentorJwt("mentor-token", 2L);
+        when(matchingService.getCandidateMentees(eq(2L), any())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void getCandidateMenteesResponseExcludesPrivateFields() throws Exception {
+        mockValidMentorJwt("mentor-token", 2L);
+        MenteeCandidateResponse candidate = new MenteeCandidateResponse();
+        candidate.setFirstName("Elif");
+        candidate.setGoals("Learn AI");
+        candidate.setMajor("CS");
+        candidate.setInterests(List.of("AI"));
+        candidate.setSkills(List.of("Java"));
+        when(matchingService.getCandidateMentees(eq(2L), any())).thenReturn(List.of(candidate));
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].firstName").value("Elif"))
+                .andExpect(jsonPath("$[0].goals").value("Learn AI"))
+                .andExpect(jsonPath("$[0].interests[0]").value("AI"))
+                .andExpect(jsonPath("$[0].skills[0]").value("Java"))
+                .andExpect(jsonPath("$[0].lastName").doesNotExist())
+                .andExpect(jsonPath("$[0].profilePhoto").doesNotExist())
+                .andExpect(jsonPath("$[0].email").doesNotExist())
+                .andExpect(jsonPath("$[0].passwordHash").doesNotExist());
+    }
+
+    @Test
+    void getCandidateMenteesReturnsMultipleCandidates() throws Exception {
+        mockValidMentorJwt("mentor-token", 2L);
+        MenteeCandidateResponse c1 = new MenteeCandidateResponse();
+        c1.setFirstName("Elif");
+        MenteeCandidateResponse c2 = new MenteeCandidateResponse();
+        c2.setFirstName("Ayse");
+        when(matchingService.getCandidateMentees(eq(2L), any())).thenReturn(List.of(c1, c2));
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].firstName").value("Elif"))
+                .andExpect(jsonPath("$[1].firstName").value("Ayse"));
+    }
+
+    @Test
+    void getCandidateMenteesCapacityErrorResponseFormat() throws Exception {
+        mockValidMentorJwt("mentor-token", 2L);
+        when(matchingService.getCandidateMentees(eq(2L), any()))
+                .thenThrow(new com.group7.backend.exception.MatchingNotAllowedException(
+                        "You have reached your maximum mentee capacity"));
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value("You have reached your maximum mentee capacity"));
     }
 }

--- a/backend/src/test/java/com/group7/backend/integration/MatchingIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MatchingIntegrationTest.java
@@ -242,4 +242,257 @@ class MatchingIntegrationTest {
         var matches = objectMapper.readTree(result.getResponse().getContentAsString());
         assertThat(matches.size()).isLessThanOrEqualTo(5);
     }
+
+    // ── Candidate mentees (mentor-side) ─────────────────────────────────────
+
+    @Test
+    void mentorGetsCandidateMenteeList() throws Exception {
+        String mentorToken = registerAndLogin("cm_mentor1@example.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentor1@example.com"))
+                .findFirst().orElseThrow();
+        mentor.setField("Computer Science");
+        mentor.setPreferredMenteeMajor("Computer Science");
+        mentor.setPreferredMenteeSkills(List.of("Java"));
+        mentor.setInterests(List.of("AI"));
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        registerAndLogin("cm_mentee1@example.com", false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentee1@example.com"))
+                .findFirst().orElseThrow();
+        mentee.setMajor("Computer Science");
+        mentee.setSkills(List.of("Java"));
+        mentee.setInterests(List.of("AI"));
+        menteeRepository.save(mentee);
+
+        MvcResult result = mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andReturn();
+
+        var candidates = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(candidates.size()).isGreaterThan(0);
+        assertThat(candidates.get(0).has("lastName")).isFalse();
+        assertThat(candidates.get(0).has("profilePhoto")).isFalse();
+        assertThat(candidates.get(0).get("firstName").asText()).isNotBlank();
+    }
+
+    @Test
+    void candidateMenteesExcludesActiveMentored() throws Exception {
+        String mentorToken = registerAndLogin("cm_mentor2@example.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentor2@example.com"))
+                .findFirst().orElseThrow();
+        mentor.setInterests(List.of("AI"));
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        registerAndLogin("cm_mentee2@example.com", false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentee2@example.com"))
+                .findFirst().orElseThrow();
+        mentee.setInterests(List.of("AI"));
+        mentee.setActiveMentorId(mentor.getId());
+        menteeRepository.save(mentee);
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void candidateMenteesKeywordFilter() throws Exception {
+        String mentorToken = registerAndLogin("cm_mentor3@example.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentor3@example.com"))
+                .findFirst().orElseThrow();
+        mentor.setInterests(List.of("AI"));
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        registerAndLogin("cm_mentee3@example.com", false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentee3@example.com"))
+                .findFirst().orElseThrow();
+        mentee.setInterests(List.of("AI"));
+        mentee.setGoals("machine learning research");
+        menteeRepository.save(mentee);
+
+        // keyword "machine" should match
+        mockMvc.perform(get("/api/matching/mentees?keyword=machine")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").exists());
+
+        // keyword "rust" should not match
+        mockMvc.perform(get("/api/matching/mentees?keyword=rust")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void menteeRoleBlockedFromCandidateMenteesEndpoint() throws Exception {
+        String menteeToken = registerAndLogin("cm_mentee4@example.com", false);
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void fullCapacityMentorBlockedFromCandidateMentees() throws Exception {
+        String mentorToken = registerAndLogin("cm_mentor5@example.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentor5@example.com"))
+                .findFirst().orElseThrow();
+        mentor.setMaxMenteeCapacity(1);
+        mentor.setCurrentMenteeCount(1);
+        mentorRepository.save(mentor);
+
+        mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void candidateMenteesExcludesNonMatchingMentees() throws Exception {
+        String mentorToken = registerAndLogin("cm_mentor6@example.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentor6@example.com"))
+                .findFirst().orElseThrow();
+        mentor.setField("Computer Science");
+        mentor.setInterests(List.of("AI"));
+        mentor.setPreferredMenteeSkills(List.of("Java"));
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        // Matching mentee
+        registerAndLogin("cm_mentee6a@example.com", false);
+        Mentee matching = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentee6a@example.com"))
+                .findFirst().orElseThrow();
+        matching.setInterests(List.of("AI"));
+        matching.setSkills(List.of("Java"));
+        menteeRepository.save(matching);
+
+        // Non-matching mentee
+        registerAndLogin("cm_mentee6b@example.com", false);
+        Mentee nonMatching = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentee6b@example.com"))
+                .findFirst().orElseThrow();
+        nonMatching.setMajor("Music");
+        nonMatching.setInterests(List.of("Jazz"));
+        nonMatching.setSkills(List.of("Piano"));
+        menteeRepository.save(nonMatching);
+
+        MvcResult result = mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        var candidates = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(candidates.size()).isEqualTo(1);
+        assertThat(candidates.get(0).get("firstName").asText()).isEqualTo("Test");
+    }
+
+    @Test
+    void candidateMenteesResponseContainsExpectedFields() throws Exception {
+        String mentorToken = registerAndLogin("cm_mentor7@example.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentor7@example.com"))
+                .findFirst().orElseThrow();
+        mentor.setInterests(List.of("AI"));
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        registerAndLogin("cm_mentee7@example.com", false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentee7@example.com"))
+                .findFirst().orElseThrow();
+        mentee.setInterests(List.of("AI"));
+        mentee.setGoals("Learn machine learning");
+        mentee.setMajor("Computer Science");
+        mentee.setSkills(List.of("Java", "Python"));
+        mentee.setCareerInterest("Backend Engineering");
+        mentee.setBackgroundInfo("3rd year CS student");
+        menteeRepository.save(mentee);
+
+        MvcResult result = mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        var candidates = objectMapper.readTree(result.getResponse().getContentAsString());
+        var candidate = candidates.get(0);
+        assertThat(candidate.get("id").asLong()).isPositive();
+        assertThat(candidate.get("firstName").asText()).isEqualTo("Test");
+        assertThat(candidate.get("goals").asText()).isEqualTo("Learn machine learning");
+        assertThat(candidate.get("major").asText()).isEqualTo("Computer Science");
+        assertThat(candidate.get("careerInterest").asText()).isEqualTo("Backend Engineering");
+        assertThat(candidate.get("backgroundInfo").asText()).isEqualTo("3rd year CS student");
+        assertThat(candidate.get("interests").size()).isEqualTo(1);
+        assertThat(candidate.get("skills").size()).isEqualTo(2);
+        // Privacy fields must not be present
+        assertThat(candidate.has("lastName")).isFalse();
+        assertThat(candidate.has("profilePhoto")).isFalse();
+        assertThat(candidate.has("email")).isFalse();
+        assertThat(candidate.has("passwordHash")).isFalse();
+        assertThat(candidate.has("activeMentorId")).isFalse();
+    }
+
+    @Test
+    void candidateMenteesCapacityErrorResponseFormat() throws Exception {
+        String mentorToken = registerAndLogin("cm_mentor8@example.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentor8@example.com"))
+                .findFirst().orElseThrow();
+        mentor.setMaxMenteeCapacity(1);
+        mentor.setCurrentMenteeCount(1);
+        mentorRepository.save(mentor);
+
+        MvcResult result = mockMvc.perform(get("/api/matching/mentees")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        var body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("error").asText()).isEqualTo("Forbidden");
+        assertThat(body.get("message").asText()).contains("capacity");
+    }
+
+    @Test
+    void candidateMenteesKeywordFilterCaseInsensitive() throws Exception {
+        String mentorToken = registerAndLogin("cm_mentor9@example.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentor9@example.com"))
+                .findFirst().orElseThrow();
+        mentor.setInterests(List.of("AI"));
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        registerAndLogin("cm_mentee9@example.com", false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("cm_mentee9@example.com"))
+                .findFirst().orElseThrow();
+        mentee.setInterests(List.of("AI"));
+        mentee.setGoals("Machine Learning Research");
+        menteeRepository.save(mentee);
+
+        // lowercase keyword should match uppercase goals
+        mockMvc.perform(get("/api/matching/mentees?keyword=machine")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").exists());
+
+        // uppercase keyword should also match
+        mockMvc.perform(get("/api/matching/mentees?keyword=MACHINE")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").exists());
+    }
 }

--- a/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
@@ -1,5 +1,6 @@
 package com.group7.backend.service;
 
+import com.group7.backend.dto.response.MenteeCandidateResponse;
 import com.group7.backend.dto.response.MentorMatchResponse;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
@@ -159,7 +160,7 @@ class MatchingServiceTest {
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
 
         assertThatThrownBy(() -> matchingService.getTopMentors(1L, null))
-                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+                .isInstanceOf(com.group7.backend.exception.MatchingNotAllowedException.class)
                 .hasMessageContaining("active mentor");
     }
 
@@ -239,5 +240,354 @@ class MatchingServiceTest {
         List<MentorMatchResponse> result = matchingService.getTopMentors(1L, null);
 
         assertThat(result.get(0).getMatchScore()).isGreaterThanOrEqualTo(result.get(1).getMatchScore());
+    }
+
+    // ── Candidate mentees: preference matching ──────────────────────────────
+
+    @Test
+    void candidateMenteesMatchesByInterest() {
+        assertThat(matchingService.matchesMentorPreferences(mentor, mentee)).isTrue();
+    }
+
+    @Test
+    void candidateMenteesMatchesBySkill() {
+        Mentor m = new Mentor();
+        m.setPreferredMenteeSkills(List.of("Python"));
+
+        Mentee me = new Mentee();
+        me.setSkills(List.of("Python"));
+
+        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    @Test
+    void candidateMenteesMatchesByPreferredMajor() {
+        Mentor m = new Mentor();
+        m.setPreferredMenteeMajor("Computer Science");
+
+        Mentee me = new Mentee();
+        me.setMajor("Computer Science");
+
+        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    @Test
+    void candidateMenteesMatchesByField() {
+        Mentor m = new Mentor();
+        m.setField("Computer Science");
+
+        Mentee me = new Mentee();
+        me.setMajor("Computer Science");
+
+        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    @Test
+    void candidateMenteesNoOverlapReturnsfalse() {
+        Mentor m = new Mentor();
+        m.setField("Music");
+        m.setPreferredMenteeMajor("Music");
+        m.setPreferredMenteeSkills(List.of("Piano"));
+        m.setInterests(List.of("Jazz"));
+
+        Mentee me = new Mentee();
+        me.setMajor("Computer Science");
+        me.setSkills(List.of("Java"));
+        me.setInterests(List.of("AI"));
+
+        assertThat(matchingService.matchesMentorPreferences(m, me)).isFalse();
+    }
+
+    @Test
+    void candidateMenteesNullFieldsDoNotCrash() {
+        Mentor m = new Mentor();
+        Mentee me = new Mentee();
+
+        assertThat(matchingService.matchesMentorPreferences(m, me)).isFalse();
+    }
+
+    // ── Candidate mentees: active mentor exclusion ──────────────────────────
+
+    @Test
+    void candidateMenteesExcludesActivelyMentoredMentees() {
+        Mentee activeMentee = new Mentee();
+        activeMentee.setActiveMentorId(99L);
+        activeMentee.setInterests(List.of("AI"));
+
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee, activeMentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null);
+
+        assertThat(result).hasSize(1);
+    }
+
+    // ── Candidate mentees: capacity check ───────────────────────────────────
+
+    @Test
+    void candidateMenteesFullCapacityBlocksRequest() {
+        mentor.setCurrentMenteeCount(3); // full
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+
+        assertThatThrownBy(() -> matchingService.getCandidateMentees(1L, null))
+                .isInstanceOf(com.group7.backend.exception.MatchingNotAllowedException.class)
+                .hasMessageContaining("capacity");
+    }
+
+    // ── Candidate mentees: mentor not found ─────────────────────────────────
+
+    @Test
+    void candidateMenteesMentorNotFoundThrows() {
+        when(mentorRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> matchingService.getCandidateMentees(99L, null))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── Candidate mentees: keyword filter ───────────────────────────────────
+
+    @Test
+    void candidateMenteesKeywordFilterMatchesGoals() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "machine");
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void candidateMenteesKeywordFilterNoMatchReturnsEmpty() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "rust");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void candidateMenteesNullKeywordReturnsAll() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null);
+
+        assertThat(result).hasSize(1);
+    }
+
+    // ── Candidate mentees: case insensitivity ───────────────────────────────
+
+    @Test
+    void candidateMenteesMatchesByInterestCaseInsensitive() {
+        Mentor m = new Mentor();
+        m.setInterests(List.of("ai"));
+
+        Mentee me = new Mentee();
+        me.setInterests(List.of("AI"));
+
+        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    @Test
+    void candidateMenteesMatchesBySkillCaseInsensitive() {
+        Mentor m = new Mentor();
+        m.setPreferredMenteeSkills(List.of("JAVA"));
+
+        Mentee me = new Mentee();
+        me.setSkills(List.of("java"));
+
+        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    @Test
+    void candidateMenteesMatchesByMajorCaseInsensitive() {
+        Mentor m = new Mentor();
+        m.setPreferredMenteeMajor("computer science");
+
+        Mentee me = new Mentee();
+        me.setMajor("Computer Science");
+
+        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    // ── Candidate mentees: keyword on different fields ──────────────────────
+
+    @Test
+    void candidateMenteesKeywordFilterMatchesMajor() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "Computer");
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void candidateMenteesKeywordFilterMatchesSkill() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "Java");
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void candidateMenteesKeywordFilterMatchesInterest() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "AI");
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void candidateMenteesKeywordFilterMatchesCareerInterest() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "backend");
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void candidateMenteesKeywordFilterIsCaseInsensitive() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "MACHINE");
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void candidateMenteesEmptyKeywordReturnsAll() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "");
+
+        assertThat(result).hasSize(1);
+    }
+
+    // ── Candidate mentees: multiple mentees filtering ───────────────────────
+
+    @Test
+    void candidateMenteesFiltersOutNonMatchingMentees() {
+        Mentee nonMatching = new Mentee();
+        nonMatching.setMajor("Music");
+        nonMatching.setSkills(List.of("Piano"));
+        nonMatching.setInterests(List.of("Jazz"));
+
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee, nonMatching));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getMajor()).isEqualTo("Computer Science");
+    }
+
+    @Test
+    void candidateMenteesReturnsMultipleMatchingMentees() {
+        Mentee secondMatch = new Mentee();
+        secondMatch.setInterests(List.of("AI"));
+        secondMatch.setSkills(List.of("Kotlin"));
+
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee, secondMatch));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null);
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void candidateMenteesExcludesAllActivelyMentoredMentees() {
+        Mentee active1 = new Mentee();
+        active1.setActiveMentorId(10L);
+        active1.setInterests(List.of("AI"));
+
+        Mentee active2 = new Mentee();
+        active2.setActiveMentorId(20L);
+        active2.setInterests(List.of("Systems"));
+
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee, active1, active2));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null);
+
+        assertThat(result).hasSize(1);
+    }
+
+    // ── Candidate mentees: capacity edge cases ──────────────────────────────
+
+    @Test
+    void candidateMenteesExactCapacityBlocksRequest() {
+        mentor.setMaxMenteeCapacity(2);
+        mentor.setCurrentMenteeCount(2);
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+
+        assertThatThrownBy(() -> matchingService.getCandidateMentees(1L, null))
+                .isInstanceOf(com.group7.backend.exception.MatchingNotAllowedException.class);
+    }
+
+    @Test
+    void candidateMenteesOneSlotLeftAllowed() {
+        mentor.setMaxMenteeCapacity(3);
+        mentor.setCurrentMenteeCount(2);
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null);
+
+        assertThat(result).hasSize(1);
+    }
+
+    // ── Candidate mentees: DTO mapping ──────────────────────────────────────
+
+    @Test
+    void candidateMenteesResponseContainsCorrectFields() {
+        mentee.setFirstName("Elif");
+        mentee.setBackgroundInfo("3rd year CS student");
+        mentee.setMeetingFreqPref("Weekly");
+
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null);
+
+        assertThat(result).hasSize(1);
+        MenteeCandidateResponse dto = result.get(0);
+        assertThat(dto.getFirstName()).isEqualTo("Elif");
+        assertThat(dto.getGoals()).isEqualTo("career machine learning");
+        assertThat(dto.getMajor()).isEqualTo("Computer Science");
+        assertThat(dto.getInterests()).containsExactly("AI", "Databases");
+        assertThat(dto.getSkills()).containsExactly("Java", "Python");
+        assertThat(dto.getCareerInterest()).isEqualTo("backend engineering");
+        assertThat(dto.getBackgroundInfo()).isEqualTo("3rd year CS student");
+        assertThat(dto.getMeetingFreqPref()).isEqualTo("Weekly");
+    }
+
+    @Test
+    void candidateMenteesKeywordAndPreferenceFilterCombined() {
+        Mentee matchingWithKeyword = new Mentee();
+        matchingWithKeyword.setInterests(List.of("AI"));
+        matchingWithKeyword.setGoals("machine learning research");
+
+        Mentee matchingWithoutKeyword = new Mentee();
+        matchingWithoutKeyword.setInterests(List.of("AI"));
+        matchingWithoutKeyword.setGoals("web development");
+
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(menteeRepository.findAll()).thenReturn(List.of(matchingWithKeyword, matchingWithoutKeyword));
+
+        List<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "machine");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getGoals()).isEqualTo("machine learning research");
     }
 }


### PR DESCRIPTION
## Summary
- Add `GET /api/matching/mentees` endpoint restricted to mentors, returning mentee candidates whose profiles align with the mentor's defined preferences
- Filter candidates by overlapping interests, skills, major, and field between mentor criteria and mentee profile
- Enforce privacy during matching: only first name is visible; surname and profile photo are excluded from the response
- Exclude mentees who already have an active mentor from the candidate list
- Return 403 when the authenticated mentor has reached maximum mentee capacity
- Support optional `?keyword=` query parameter for filtering candidates by goals, major, career interest, background, interests, and skills
- Introduce `MenteeCandidateResponse` DTO for privacy-safe serialization and `MatchingNotAllowedException` for matching business rule violations
- Replace `ResponseStatusException` usage with `MatchingNotAllowedException` handled by `GlobalExceptionHandler` for consistent error response formatting across the API
- Fix Swagger `@ArraySchema` annotation on both `/api/matching/mentors` and `/api/matching/mentees` endpoints

## Test plan
- [x] Unit tests — `MatchingServiceTest`: preference matching, keyword filtering, capacity checks, case insensitivity, DTO mapping, combined filters (42 tests)
- [x] Controller tests — `MatchingControllerTest`: role enforcement, error responses, privacy field exclusion, response format validation (15 tests)
- [x] Integration tests — `MatchingIntegrationTest`: end-to-end flows with real database including candidate retrieval, active mentor exclusion, keyword filtering, and capacity blocking (15 tests)