### PR TITLE
fix(backend): return correct HTTP status codes from auth endpoints

### DIFF
--- a/backend/src/main/java/com/group7/backend/exception/AuthenticationFailedException.java
+++ b/backend/src/main/java/com/group7/backend/exception/AuthenticationFailedException.java
@@ -1,0 +1,7 @@
+package com.group7.backend.exception;
+
+public class AuthenticationFailedException extends RuntimeException {
+    public AuthenticationFailedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/exception/DuplicateEmailException.java
+++ b/backend/src/main/java/com/group7/backend/exception/DuplicateEmailException.java
@@ -1,0 +1,7 @@
+package com.group7.backend.exception;
+
+public class DuplicateEmailException extends RuntimeException {
+    public DuplicateEmailException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -27,6 +27,26 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.CONFLICT, "Conflict", ex.getMessage());
     }
 
+    @ExceptionHandler(AuthenticationFailedException.class)
+    public ResponseEntity<Map<String, String>> handleAuthenticationFailed(AuthenticationFailedException ex) {
+        return buildErrorResponse(HttpStatus.UNAUTHORIZED, "Unauthorized", ex.getMessage());
+    }
+
+    @ExceptionHandler(DuplicateEmailException.class)
+    public ResponseEntity<Map<String, String>> handleDuplicateEmail(DuplicateEmailException ex) {
+        return buildErrorResponse(HttpStatus.CONFLICT, "Conflict", ex.getMessage());
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidToken(InvalidTokenException ex) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage());
+    }
+
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<Map<String, String>> handleRateLimit(RateLimitExceededException ex) {
+        return buildErrorResponse(HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests", ex.getMessage());
+    }
+
     @ExceptionHandler(MatchingNotAllowedException.class)
     public ResponseEntity<Map<String, String>> handleMatchingNotAllowed(MatchingNotAllowedException ex) {
         return buildErrorResponse(HttpStatus.FORBIDDEN, "Forbidden", ex.getMessage());

--- a/backend/src/main/java/com/group7/backend/exception/InvalidTokenException.java
+++ b/backend/src/main/java/com/group7/backend/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.group7.backend.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/exception/RateLimitExceededException.java
+++ b/backend/src/main/java/com/group7/backend/exception/RateLimitExceededException.java
@@ -1,0 +1,7 @@
+package com.group7.backend.exception;
+
+public class RateLimitExceededException extends RuntimeException {
+    public RateLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/AuthService.java
+++ b/backend/src/main/java/com/group7/backend/service/AuthService.java
@@ -15,6 +15,10 @@ import com.group7.backend.repository.VerificationTokenRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import com.group7.backend.exception.AuthenticationFailedException;
+import com.group7.backend.exception.DuplicateEmailException;
+import com.group7.backend.exception.InvalidTokenException;
+import com.group7.backend.exception.RateLimitExceededException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,7 +67,7 @@ public class AuthService {
     @Transactional
     public UserResponse register(RegisterRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
-            throw new RuntimeException("Email already in use");
+            throw new DuplicateEmailException("Email already in use");
         }
 
         User user;
@@ -109,14 +113,14 @@ public class AuthService {
 
     public AuthResponse authenticate(LoginRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new RuntimeException("Invalid email or password"));
+                .orElseThrow(() -> new AuthenticationFailedException("Invalid email or password"));
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPasswordHash())) {
-            throw new RuntimeException("Invalid email or password");
+            throw new AuthenticationFailedException("Invalid email or password");
         }
 
         if (!Boolean.TRUE.equals(user.getIsEmailVerified())) {
-            throw new RuntimeException("Email not verified. Please check your inbox.");
+            throw new AuthenticationFailedException("Email not verified. Please check your inbox.");
         }
 
         String role = (user instanceof Mentor) ? "MENTOR" : "MENTEE";
@@ -128,14 +132,14 @@ public class AuthService {
     @Transactional
     public void verifyEmail(String token) {
         VerificationToken verificationToken = verificationTokenRepository.findByToken(token)
-                .orElseThrow(() -> new RuntimeException("Invalid verification token"));
+                .orElseThrow(() -> new InvalidTokenException("Invalid verification token"));
 
         if (Boolean.TRUE.equals(verificationToken.getUsed())) {
-            throw new RuntimeException("Verification token already used");
+            throw new InvalidTokenException("Verification token already used");
         }
 
         if (verificationToken.getExpiresAt().isBefore(LocalDateTime.now())) {
-            throw new RuntimeException("Verification token has expired. Please request a new one.");
+            throw new InvalidTokenException("Verification token has expired. Please request a new one.");
         }
 
         User user = verificationToken.getUser();
@@ -149,17 +153,17 @@ public class AuthService {
     @Transactional
     public void resendVerification(String email) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("No account found with that email"));
+                .orElseThrow(() -> new InvalidTokenException("No account found with that email"));
 
         if (Boolean.TRUE.equals(user.getIsEmailVerified())) {
-            throw new RuntimeException("Email is already verified");
+            throw new InvalidTokenException("Email is already verified");
         }
 
         long recentCount = verificationTokenRepository.countByUserIdAndCreatedAtAfter(
                 user.getId(), LocalDateTime.now().minusHours(1));
 
         if (recentCount >= resendMaxPerHour) {
-            throw new RuntimeException("Too many resend requests. Please try again later.");
+            throw new RateLimitExceededException("Too many resend requests. Please try again later.");
         }
 
         String token = createVerificationToken(user);
@@ -173,7 +177,7 @@ public class AuthService {
                     user.getId(), LocalDateTime.now().minusHours(1));
 
             if (recentCount >= resetMaxRequestsPerHour) {
-                throw new RuntimeException("Too many password reset requests. Please try again later.");
+                throw new RateLimitExceededException("Too many password reset requests. Please try again later.");
             }
 
             passwordResetTokenRepository.deleteByUserIdAndUsedFalse(user.getId());
@@ -194,14 +198,14 @@ public class AuthService {
     @Transactional
     public void resetPassword(String token, String newPassword) {
         PasswordResetToken resetToken = passwordResetTokenRepository.findByToken(token)
-                .orElseThrow(() -> new RuntimeException("Invalid reset token"));
+                .orElseThrow(() -> new InvalidTokenException("Invalid reset token"));
 
         if (Boolean.TRUE.equals(resetToken.getUsed())) {
-            throw new RuntimeException("Reset token already used");
+            throw new InvalidTokenException("Reset token already used");
         }
 
         if (resetToken.getExpiresAt().isBefore(LocalDateTime.now())) {
-            throw new RuntimeException("Reset token has expired. Please request a new one.");
+            throw new InvalidTokenException("Reset token has expired. Please request a new one.");
         }
 
         User user = resetToken.getUser();
@@ -214,14 +218,14 @@ public class AuthService {
 
     public void validateResetToken(String token) {
         PasswordResetToken resetToken = passwordResetTokenRepository.findByToken(token)
-                .orElseThrow(() -> new RuntimeException("Invalid reset token"));
+                .orElseThrow(() -> new InvalidTokenException("Invalid reset token"));
 
         if (Boolean.TRUE.equals(resetToken.getUsed())) {
-            throw new RuntimeException("Reset token already used");
+            throw new InvalidTokenException("Reset token already used");
         }
 
         if (resetToken.getExpiresAt().isBefore(LocalDateTime.now())) {
-            throw new RuntimeException("Reset token has expired. Please request a new one.");
+            throw new InvalidTokenException("Reset token has expired. Please request a new one.");
         }
     }
 

--- a/backend/src/test/java/com/group7/backend/integration/AuthIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/AuthIntegrationTest.java
@@ -120,10 +120,10 @@ class AuthIntegrationTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated());
 
-        assertThrows(Exception.class, () ->
-                mockMvc.perform(post("/api/auth/register")
+        mockMvc.perform(post("/api/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))));
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
     }
 
     // --- Password Validation (1.2.3.3) ---
@@ -155,10 +155,10 @@ class AuthIntegrationTest {
         loginRequest.setEmail("ali@example.com");
         loginRequest.setPassword("Password1");
 
-        assertThrows(Exception.class, () ->
-                mockMvc.perform(post("/api/auth/login")
+        mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest))));
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -186,8 +186,8 @@ class AuthIntegrationTest {
 
     @Test
     void verifyEmailWithInvalidTokenFails() throws Exception {
-        assertThrows(Exception.class, () ->
-                mockMvc.perform(get("/api/auth/verify-email").param("token", "invalid-token")));
+        mockMvc.perform(get("/api/auth/verify-email").param("token", "invalid-token"))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -253,10 +253,10 @@ class AuthIntegrationTest {
         loginRequest.setEmail("ali@example.com");
         loginRequest.setPassword("WrongPass1");
 
-        assertThrows(Exception.class, () ->
-                mockMvc.perform(post("/api/auth/login")
+        mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest))));
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -265,10 +265,10 @@ class AuthIntegrationTest {
         loginRequest.setEmail("noone@example.com");
         loginRequest.setPassword("Password1");
 
-        assertThrows(Exception.class, () ->
-                mockMvc.perform(post("/api/auth/login")
+        mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginRequest))));
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isUnauthorized());
     }
 
     // --- Password Stored as Hash (2.2.1) ---
@@ -387,10 +387,10 @@ class AuthIntegrationTest {
         loginWithOldPass.setEmail("ali@example.com");
         loginWithOldPass.setPassword("Password1");
 
-        assertThrows(Exception.class, () ->
-                mockMvc.perform(post("/api/auth/login")
+        mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(loginWithOldPass))));
+                        .content(objectMapper.writeValueAsString(loginWithOldPass)))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -413,10 +413,10 @@ class AuthIntegrationTest {
                         .content(objectMapper.writeValueAsString(resetRequest)))
                 .andExpect(status().isOk());
 
-        assertThrows(Exception.class, () ->
-                mockMvc.perform(post("/api/auth/reset-password")
+        mockMvc.perform(post("/api/auth/reset-password")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(resetRequest))));
+                        .content(objectMapper.writeValueAsString(resetRequest)))
+                .andExpect(status().isBadRequest());
     }
 
     // --- Helpers ---

--- a/backend/src/test/java/com/group7/backend/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/AuthServiceTest.java
@@ -4,6 +4,10 @@ import com.group7.backend.dto.request.LoginRequest;
 import com.group7.backend.dto.request.RegisterRequest;
 import com.group7.backend.dto.response.AuthResponse;
 import com.group7.backend.dto.response.UserResponse;
+import com.group7.backend.exception.AuthenticationFailedException;
+import com.group7.backend.exception.DuplicateEmailException;
+import com.group7.backend.exception.InvalidTokenException;
+import com.group7.backend.exception.RateLimitExceededException;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.entity.User;
@@ -144,7 +148,7 @@ class AuthServiceTest {
     void registerWithDuplicateEmailThrows() {
         when(userRepository.existsByEmail("john@example.com")).thenReturn(true);
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        DuplicateEmailException ex = assertThrows(DuplicateEmailException.class,
                 () -> authService.register(registerRequest));
         assertEquals("Email already in use", ex.getMessage());
         verify(userRepository, never()).save(any());
@@ -220,7 +224,7 @@ class AuthServiceTest {
         when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.of(mentee));
         when(passwordEncoder.matches("Password1", "hashedPassword")).thenReturn(true);
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        AuthenticationFailedException ex = assertThrows(AuthenticationFailedException.class,
                 () -> authService.authenticate(loginRequest));
         assertEquals("Email not verified. Please check your inbox.", ex.getMessage());
     }
@@ -236,7 +240,7 @@ class AuthServiceTest {
         when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.of(mentee));
         when(passwordEncoder.matches("Password1", "hashedPassword")).thenReturn(false);
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        AuthenticationFailedException ex = assertThrows(AuthenticationFailedException.class,
                 () -> authService.authenticate(loginRequest));
         assertEquals("Invalid email or password", ex.getMessage());
     }
@@ -245,7 +249,7 @@ class AuthServiceTest {
     void loginWithNonexistentEmailThrows() {
         when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.empty());
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        AuthenticationFailedException ex = assertThrows(AuthenticationFailedException.class,
                 () -> authService.authenticate(loginRequest));
         assertEquals("Invalid email or password", ex.getMessage());
     }
@@ -287,7 +291,7 @@ class AuthServiceTest {
 
         when(verificationTokenRepository.findByToken("expired-token")).thenReturn(Optional.of(token));
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        InvalidTokenException ex = assertThrows(InvalidTokenException.class,
                 () -> authService.verifyEmail("expired-token"));
         assertTrue(ex.getMessage().contains("expired"));
     }
@@ -304,7 +308,7 @@ class AuthServiceTest {
 
         when(verificationTokenRepository.findByToken("used-token")).thenReturn(Optional.of(token));
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        InvalidTokenException ex = assertThrows(InvalidTokenException.class,
                 () -> authService.verifyEmail("used-token"));
         assertTrue(ex.getMessage().contains("already used"));
     }
@@ -313,7 +317,7 @@ class AuthServiceTest {
     void verifyEmailWithInvalidTokenThrows() {
         when(verificationTokenRepository.findByToken("nonexistent")).thenReturn(Optional.empty());
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        InvalidTokenException ex = assertThrows(InvalidTokenException.class,
                 () -> authService.verifyEmail("nonexistent"));
         assertEquals("Invalid verification token", ex.getMessage());
     }
@@ -348,7 +352,7 @@ class AuthServiceTest {
         when(verificationTokenRepository.countByUserIdAndCreatedAtAfter(eq(1L), any(LocalDateTime.class)))
                 .thenReturn(3L);
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        RateLimitExceededException ex = assertThrows(RateLimitExceededException.class,
                 () -> authService.resendVerification("john@example.com"));
         assertTrue(ex.getMessage().contains("Too many"));
     }
@@ -362,7 +366,7 @@ class AuthServiceTest {
 
         when(userRepository.findByEmail("john@example.com")).thenReturn(Optional.of(user));
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        InvalidTokenException ex = assertThrows(InvalidTokenException.class,
                 () -> authService.resendVerification("john@example.com"));
         assertTrue(ex.getMessage().contains("already verified"));
     }
@@ -404,7 +408,7 @@ class AuthServiceTest {
         when(passwordResetTokenRepository.countByUserIdAndCreatedAtAfter(eq(1L), any(LocalDateTime.class)))
                 .thenReturn(5L);
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        RateLimitExceededException ex = assertThrows(RateLimitExceededException.class,
                 () -> authService.requestPasswordReset("john@example.com"));
         assertTrue(ex.getMessage().contains("Too many"));
     }
@@ -446,7 +450,7 @@ class AuthServiceTest {
 
         when(passwordResetTokenRepository.findByToken("expired-token")).thenReturn(Optional.of(token));
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        InvalidTokenException ex = assertThrows(InvalidTokenException.class,
                 () -> authService.resetPassword("expired-token", "NewPass1"));
         assertTrue(ex.getMessage().contains("expired"));
     }
@@ -463,7 +467,7 @@ class AuthServiceTest {
 
         when(passwordResetTokenRepository.findByToken("used-token")).thenReturn(Optional.of(token));
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        InvalidTokenException ex = assertThrows(InvalidTokenException.class,
                 () -> authService.resetPassword("used-token", "NewPass1"));
         assertTrue(ex.getMessage().contains("already used"));
     }
@@ -472,7 +476,7 @@ class AuthServiceTest {
     void resetPasswordWithInvalidTokenThrows() {
         when(passwordResetTokenRepository.findByToken("bad-token")).thenReturn(Optional.empty());
 
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        InvalidTokenException ex = assertThrows(InvalidTokenException.class,
                 () -> authService.resetPassword("bad-token", "NewPass1"));
         assertEquals("Invalid reset token", ex.getMessage());
     }


### PR DESCRIPTION
Related to #182. Addresses the same issue with an alternative approach that aligns with the project's existing exception handling pattern.

## Problem

Auth endpoints returned 403 for all errors because RuntimeException had no handler in GlobalExceptionHandler, causing Spring Security's ExceptionTranslationFilter to intercept them.

## Approach

Replaces RuntimeException in AuthService with custom exceptions handled by GlobalExceptionHandler, consistent with how the rest of the codebase handles errors. The controller remains unchanged.

AuthenticationFailedException returns 401 for invalid credentials and unverified email. DuplicateEmailException returns 409 for duplicate registration. InvalidTokenException returns 400 for invalid, expired, or used tokens. RateLimitExceededException returns 429 for rate-limited requests.

This could be an alternative to the approach in #182. Happy to discuss which direction the team prefers.

## Test plan
Unit tests updated to expect custom exception types (24 tests). Integration tests now assert proper HTTP status codes instead of assertThrows (20 tests). Full suite passes (264 tests).