### PR TITLE
feat(backend): add notification triggering infrastructure and APIs (#…

### DIFF
--- a/backend/src/main/java/com/group7/backend/BackendApplication.java
+++ b/backend/src/main/java/com/group7/backend/BackendApplication.java
@@ -2,10 +2,12 @@ package com.group7.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/group7/backend/controller/NotificationController.java
+++ b/backend/src/main/java/com/group7/backend/controller/NotificationController.java
@@ -1,0 +1,65 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.dto.response.NotificationResponse;
+import com.group7.backend.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/notifications")
+@Tag(name = "Notifications", description = "In-app notification endpoints")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @GetMapping
+    @Operation(summary = "List notifications", description = "Returns notifications for the authenticated user.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Notification list",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = NotificationResponse.class))))
+    })
+    public ResponseEntity<List<NotificationResponse>> getNotifications(
+            @Parameter(description = "When true, returns only unread notifications")
+            @RequestParam(defaultValue = "false") boolean unreadOnly,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(notificationService.getNotifications(userId, unreadOnly));
+    }
+
+    @PatchMapping("/{id}/read")
+    @Operation(summary = "Mark as read", description = "Marks one notification as read for the authenticated user.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Notification marked read",
+                    content = @Content(schema = @Schema(implementation = NotificationResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Notification not found", content = @Content)
+    })
+    public ResponseEntity<NotificationResponse> markAsRead(@PathVariable Long id, Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(notificationService.markAsRead(userId, id));
+    }
+
+    @PatchMapping("/read-all")
+    @Operation(summary = "Mark all as read", description = "Marks all unread notifications as read for the authenticated user.")
+    @ApiResponse(responseCode = "200", description = "Notifications updated")
+    public ResponseEntity<Map<String, Integer>> markAllAsRead(Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        int updatedCount = notificationService.markAllAsRead(userId);
+        return ResponseEntity.ok(Map.of("updatedCount", updatedCount));
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/NotificationResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/NotificationResponse.java
@@ -1,0 +1,53 @@
+package com.group7.backend.dto.response;
+
+import com.group7.backend.entity.Notification;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "In-app notification payload")
+public class NotificationResponse {
+
+    @Schema(description = "Notification ID", example = "12")
+    private Long id;
+
+    @Schema(description = "Recipient user ID", example = "7")
+    private Long recipientId;
+
+    @Schema(description = "Notification type", example = "REQUEST_ACCEPTED")
+    private String type;
+
+    @Schema(description = "Short notification title", example = "Mentorship Request Accepted")
+    private String title;
+
+    @Schema(description = "Detailed notification body")
+    private String body;
+
+    @Schema(description = "Read status", example = "false")
+    private boolean isRead;
+
+    @Schema(description = "When notification was read")
+    private LocalDateTime readAt;
+
+    @Schema(description = "When notification was created")
+    private LocalDateTime createdAt;
+
+    public static NotificationResponse from(Notification notification) {
+        NotificationResponse response = new NotificationResponse();
+        response.setId(notification.getId());
+        response.setRecipientId(notification.getRecipient().getId());
+        response.setType(notification.getType().name());
+        response.setTitle(notification.getTitle());
+        response.setBody(notification.getBody());
+        response.setRead(notification.isRead());
+        response.setReadAt(notification.getReadAt());
+        response.setCreatedAt(notification.getCreatedAt());
+        return response;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/entity/Notification.java
+++ b/backend/src/main/java/com/group7/backend/entity/Notification.java
@@ -1,0 +1,48 @@
+package com.group7.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipient_id", nullable = false)
+    private User recipient;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private NotificationType type;
+
+    @Column(nullable = false, length = 160)
+    private String title;
+
+    @Column(nullable = false, length = 1000)
+    private String body;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/group7/backend/entity/NotificationType.java
+++ b/backend/src/main/java/com/group7/backend/entity/NotificationType.java
@@ -1,0 +1,9 @@
+package com.group7.backend.entity;
+
+public enum NotificationType {
+    MATCH_FOUND,
+    REQUEST_ACCEPTED,
+    REQUEST_REJECTED,
+    NEW_MESSAGE,
+    MEETING_REMINDER
+}

--- a/backend/src/main/java/com/group7/backend/event/NotificationCreatedEvent.java
+++ b/backend/src/main/java/com/group7/backend/event/NotificationCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.group7.backend.event;
+
+import com.group7.backend.entity.NotificationType;
+
+public record NotificationCreatedEvent(
+        Long recipientId,
+        NotificationType type,
+        String title,
+        String body
+) {
+}

--- a/backend/src/main/java/com/group7/backend/event/NotificationEventListener.java
+++ b/backend/src/main/java/com/group7/backend/event/NotificationEventListener.java
@@ -1,0 +1,56 @@
+package com.group7.backend.event;
+
+import com.group7.backend.entity.Notification;
+import com.group7.backend.entity.NotificationType;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.NotificationRepository;
+import com.group7.backend.repository.UserRepository;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDateTime;
+
+@Component
+public class NotificationEventListener {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    public NotificationEventListener(NotificationRepository notificationRepository, UserRepository userRepository) {
+        this.notificationRepository = notificationRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onNotificationCreated(NotificationCreatedEvent event) {
+        User recipient = userRepository.findById(event.recipientId()).orElse(null);
+        if (recipient == null) {
+            return;
+        }
+
+        if (event.type() == NotificationType.MATCH_FOUND) {
+            boolean existsRecent = notificationRepository.existsByRecipient_IdAndTypeAndBodyAndCreatedAtAfter(
+                    event.recipientId(),
+                    NotificationType.MATCH_FOUND,
+                    event.body(),
+                    LocalDateTime.now().minusHours(12)
+            );
+            if (existsRecent) {
+                return;
+            }
+        }
+
+        Notification notification = new Notification();
+        notification.setRecipient(recipient);
+        notification.setType(event.type());
+        notification.setTitle(event.title());
+        notification.setBody(event.body());
+        notificationRepository.save(notification);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/NotificationRepository.java
@@ -1,0 +1,34 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query("SELECT n FROM Notification n WHERE n.recipient.id = :userId "
+            + "AND (:unreadOnly = false OR n.isRead = false) ORDER BY n.createdAt DESC")
+    List<Notification> findForUser(@Param("userId") Long userId, @Param("unreadOnly") boolean unreadOnly);
+
+    @Query("SELECT n FROM Notification n JOIN FETCH n.recipient WHERE n.id = :notificationId "
+            + "AND n.recipient.id = :userId")
+    Optional<Notification> findByIdAndRecipientId(@Param("notificationId") Long notificationId, @Param("userId") Long userId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true, n.readAt = :readAt "
+            + "WHERE n.recipient.id = :userId AND n.isRead = false")
+    int markAllAsRead(@Param("userId") Long userId, @Param("readAt") LocalDateTime readAt);
+
+    boolean existsByRecipient_IdAndTypeAndBodyAndCreatedAtAfter(
+            Long recipientId,
+            com.group7.backend.entity.NotificationType type,
+            String body,
+            LocalDateTime createdAt
+    );
+}

--- a/backend/src/main/java/com/group7/backend/service/MatchingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchingService.java
@@ -20,10 +20,14 @@ public class MatchingService {
 
     private final MenteeRepository menteeRepository;
     private final MentorRepository mentorRepository;
+    private final NotificationEventPublisher notificationEventPublisher;
 
-    public MatchingService(MenteeRepository menteeRepository, MentorRepository mentorRepository) {
+    public MatchingService(MenteeRepository menteeRepository,
+                           MentorRepository mentorRepository,
+                           NotificationEventPublisher notificationEventPublisher) {
         this.menteeRepository = menteeRepository;
         this.mentorRepository = mentorRepository;
+        this.notificationEventPublisher = notificationEventPublisher;
     }
 
     @Transactional(readOnly = true)
@@ -37,13 +41,19 @@ public class MatchingService {
 
         List<Mentor> mentors = mentorRepository.findAll();
 
-        return mentors.stream()
+        List<MentorMatchResponse> matches = mentors.stream()
                 .filter(m -> m.getCurrentMenteeCount() < m.getMaxMenteeCapacity())
                 .filter(m -> matchesKeyword(m, keyword))
                 .map(m -> MentorMatchResponse.from(m, calculateScore(m, mentee)))
                 .sorted(Comparator.comparingInt(MentorMatchResponse::getMatchScore).reversed())
                 .limit(5)
                 .toList();
+
+        if (!matches.isEmpty()) {
+            notificationEventPublisher.publishMatchFound(menteeId, matches.get(0).getFirstName());
+        }
+
+        return matches;
     }
 
     @Transactional(readOnly = true)
@@ -57,12 +67,18 @@ public class MatchingService {
 
         List<Mentee> mentees = menteeRepository.findAll();
 
-        return mentees.stream()
+        List<MenteeCandidateResponse> candidates = mentees.stream()
                 .filter(m -> m.getActiveMentorId() == null)
                 .filter(m -> matchesMentorPreferences(mentor, m))
                 .filter(m -> matchesMenteeKeyword(m, keyword))
                 .map(MenteeCandidateResponse::from)
                 .toList();
+
+        if (!candidates.isEmpty()) {
+            notificationEventPublisher.publishMatchFound(mentorId, candidates.get(0).getFirstName());
+        }
+
+        return candidates;
     }
 
     boolean matchesMentorPreferences(Mentor mentor, Mentee mentee) {

--- a/backend/src/main/java/com/group7/backend/service/MentorshipService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipService.java
@@ -22,11 +22,14 @@ public class MentorshipService {
 
     private final MentorshipRepository mentorshipRepository;
     private final MentorshipRequestRepository mentorshipRequestRepository;
+    private final NotificationEventPublisher notificationEventPublisher;
 
     public MentorshipService(MentorshipRepository mentorshipRepository,
-                             MentorshipRequestRepository mentorshipRequestRepository) {
+                             MentorshipRequestRepository mentorshipRequestRepository,
+                             NotificationEventPublisher notificationEventPublisher) {
         this.mentorshipRepository = mentorshipRepository;
         this.mentorshipRequestRepository = mentorshipRequestRepository;
+        this.notificationEventPublisher = notificationEventPublisher;
     }
 
     @Transactional
@@ -71,6 +74,7 @@ public class MentorshipService {
         mentorshipRequestRepository.cancelOtherPendingRequests(mentee.getId(), requestId);
 
         Mentorship saved = mentorshipRepository.save(mentorship);
+        notificationEventPublisher.publishRequestAccepted(mentee.getId(), mentor.getFirstName());
         return MentorshipResponse.from(saved);
     }
 
@@ -85,6 +89,7 @@ public class MentorshipService {
         }
 
         request.setStatus(MentorshipRequestStatus.REJECTED);
+        notificationEventPublisher.publishRequestRejected(request.getMentee().getId(), request.getMentor().getFirstName());
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/group7/backend/service/NotificationEventPublisher.java
+++ b/backend/src/main/java/com/group7/backend/service/NotificationEventPublisher.java
@@ -1,0 +1,65 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.NotificationType;
+import com.group7.backend.event.NotificationCreatedEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public NotificationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    public void publishRequestAccepted(Long recipientId, String mentorFirstName) {
+        publish(
+                recipientId,
+                NotificationType.REQUEST_ACCEPTED,
+                "Mentorship request accepted",
+                mentorFirstName + " accepted your mentorship request."
+        );
+    }
+
+    public void publishRequestRejected(Long recipientId, String mentorFirstName) {
+        publish(
+                recipientId,
+                NotificationType.REQUEST_REJECTED,
+                "Mentorship request rejected",
+                mentorFirstName + " rejected your mentorship request."
+        );
+    }
+
+    public void publishMatchFound(Long recipientId, String counterpartName) {
+        publish(
+                recipientId,
+                NotificationType.MATCH_FOUND,
+                "New match found",
+                "We found a potential match for you: " + counterpartName
+        );
+    }
+
+    public void publishNewMessage(Long recipientId, String senderName) {
+        publish(
+                recipientId,
+                NotificationType.NEW_MESSAGE,
+                "New message",
+                "You received a new message from " + senderName
+        );
+    }
+
+    public void publishMeetingReminder(Long recipientId, String reminderText) {
+        publish(
+                recipientId,
+                NotificationType.MEETING_REMINDER,
+                "Meeting reminder",
+                reminderText
+        );
+    }
+
+    public void publish(Long recipientId, NotificationType type, String title, String body) {
+        applicationEventPublisher.publishEvent(new NotificationCreatedEvent(recipientId, type, title, body));
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/NotificationService.java
+++ b/backend/src/main/java/com/group7/backend/service/NotificationService.java
@@ -1,0 +1,47 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.NotificationResponse;
+import com.group7.backend.entity.Notification;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public NotificationService(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getNotifications(Long userId, boolean unreadOnly) {
+        return notificationRepository.findForUser(userId, unreadOnly)
+                .stream()
+                .map(NotificationResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public NotificationResponse markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndRecipientId(notificationId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
+
+        if (!notification.isRead()) {
+            notification.setRead(true);
+            notification.setReadAt(LocalDateTime.now());
+        }
+
+        return NotificationResponse.from(notificationRepository.save(notification));
+    }
+
+    @Transactional
+    public int markAllAsRead(Long userId) {
+        return notificationRepository.markAllAsRead(userId, LocalDateTime.now());
+    }
+}

--- a/backend/src/main/resources/db/migration/V8__create_notifications.sql
+++ b/backend/src/main/resources/db/migration/V8__create_notifications.sql
@@ -1,0 +1,16 @@
+CREATE TABLE notifications (
+    id           BIGSERIAL PRIMARY KEY,
+    recipient_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    type         VARCHAR(32) NOT NULL,
+    title        VARCHAR(160) NOT NULL,
+    body         VARCHAR(1000) NOT NULL,
+    is_read      BOOLEAN NOT NULL DEFAULT FALSE,
+    read_at      TIMESTAMP,
+    created_at   TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_notifications_recipient_created_at
+    ON notifications (recipient_id, created_at DESC);
+
+CREATE INDEX idx_notifications_recipient_is_read
+    ON notifications (recipient_id, is_read);

--- a/backend/src/test/java/com/group7/backend/integration/NotificationIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/NotificationIntegrationTest.java
@@ -1,0 +1,230 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Notification;
+import com.group7.backend.entity.NotificationType;
+import com.group7.backend.repository.*;
+import com.group7.backend.service.EmailService;
+import com.group7.backend.service.NotificationEventPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NotificationIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired private MentorshipRequestRepository mentorshipRequestRepository;
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private NotificationRepository notificationRepository;
+    @Autowired(required = false) private MentorshipRepository mentorshipRepository;
+    @MockitoBean private EmailService emailService;
+        @Autowired private NotificationEventPublisher notificationEventPublisher;
+
+    @BeforeEach
+    void cleanDb() {
+        if (mentorshipRepository != null) mentorshipRepository.deleteAll();
+        notificationRepository.deleteAll();
+        mentorshipRequestRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+        doNothing().when(emailService).sendPasswordResetEmail(any(), anyString());
+    }
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName(isMentor ? "Mentor" : "Mentee");
+        req.setLastName("User");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("sessionToken").asText();
+    }
+
+    private Long createMentorshipRequest(String menteeToken, Long mentorId) throws Exception {
+        String body = objectMapper.writeValueAsString(Map.of("mentorId", mentorId));
+        MvcResult result = mockMvc.perform(post("/api/mentorship-requests")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asLong();
+    }
+
+    private Notification waitForNotification(Long recipientId, NotificationType type) {
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(5));
+        while (Instant.now().isBefore(deadline)) {
+            List<Notification> notifications = notificationRepository.findForUser(recipientId, false);
+            for (Notification notification : notifications) {
+                if (notification.getType() == type) {
+                    return notification;
+                }
+            }
+
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        return null;
+    }
+
+    @Test
+    void acceptRequestCreatesNotificationAndReadEndpointsWork() throws Exception {
+        String mentorToken = registerAndLogin("notif_mentor1@test.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("notif_mentor1@test.com"))
+                .findFirst().orElseThrow();
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        String menteeToken = registerAndLogin("notif_mentee1@test.com", false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("notif_mentee1@test.com"))
+                .findFirst().orElseThrow();
+
+        Long requestId = createMentorshipRequest(menteeToken, mentor.getId());
+
+        mockMvc.perform(put("/api/mentorship-requests/" + requestId + "/accept")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("duration", 3))))
+                .andExpect(status().isOk());
+
+        Notification created = waitForNotification(mentee.getId(), NotificationType.REQUEST_ACCEPTED);
+        assertThat(created).isNotNull();
+
+        MvcResult listResult = mockMvc.perform(get("/api/notifications")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .param("unreadOnly", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].type").value("REQUEST_ACCEPTED"))
+                .andExpect(jsonPath("$[0].read").value(false))
+                .andReturn();
+
+        JsonNode listJson = objectMapper.readTree(listResult.getResponse().getContentAsString());
+        Long notificationId = listJson.get(0).get("id").asLong();
+
+        mockMvc.perform(patch("/api/notifications/" + notificationId + "/read")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.read").value(true));
+
+        mockMvc.perform(get("/api/notifications")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .param("unreadOnly", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void matchingEndpointCreatesMatchFoundNotification() throws Exception {
+        registerAndLogin("notif_mentor2@test.com", true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("notif_mentor2@test.com"))
+                .findFirst().orElseThrow();
+        mentor.setFirstName("Ayse");
+        mentor.setMaxMenteeCapacity(3);
+        mentor.setCurrentMenteeCount(0);
+        mentor.setField("Computer Science");
+        mentor.setExpertise("java backend systems");
+        mentorRepository.save(mentor);
+
+        String menteeToken = registerAndLogin("notif_mentee2@test.com", false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("notif_mentee2@test.com"))
+                .findFirst().orElseThrow();
+        mentee.setMajor("Computer Science");
+        mentee.setGoals("learn backend development");
+        menteeRepository.save(mentee);
+
+        mockMvc.perform(get("/api/matching/mentors")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].firstName").value("Ayse"));
+
+        Notification created = waitForNotification(mentee.getId(), NotificationType.MATCH_FOUND);
+        assertThat(created).isNotNull();
+    }
+
+        @Test
+        void publisherCreatesNewMessageAndMeetingReminderNotifications() throws Exception {
+                String userToken = registerAndLogin("notif_user3@test.com", false);
+                Long userId = userRepository.findByEmail("notif_user3@test.com").orElseThrow().getId();
+
+                notificationEventPublisher.publishNewMessage(userId, "Ayse");
+                notificationEventPublisher.publishMeetingReminder(userId, "Your meeting starts in 30 minutes.");
+
+                Notification messageNotification = waitForNotification(userId, NotificationType.NEW_MESSAGE);
+                Notification meetingNotification = waitForNotification(userId, NotificationType.MEETING_REMINDER);
+
+                assertThat(messageNotification).isNotNull();
+                assertThat(meetingNotification).isNotNull();
+
+                mockMvc.perform(get("/api/notifications")
+                                                .header("Authorization", "Bearer " + userToken)
+                                                .param("unreadOnly", "false"))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[?(@.type=='NEW_MESSAGE')]").isNotEmpty())
+                                .andExpect(jsonPath("$[?(@.type=='MEETING_REMINDER')]").isNotEmpty());
+        }
+}

--- a/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,6 +30,9 @@ class MatchingServiceTest {
 
     @Mock
     private MentorRepository mentorRepository;
+
+    @Mock
+    private NotificationEventPublisher notificationEventPublisher;
 
     @InjectMocks
     private MatchingService matchingService;
@@ -203,6 +207,7 @@ class MatchingServiceTest {
         List<MentorMatchResponse> result = matchingService.getTopMentors(1L, "Java");
 
         assertThat(result).hasSize(1);
+        verify(notificationEventPublisher).publishMatchFound(1L, result.get(0).getFirstName());
     }
 
     @Test

--- a/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
@@ -34,6 +34,9 @@ class MentorshipServiceTest {
     @Mock
     private MentorshipRequestRepository mentorshipRequestRepository;
 
+    @Mock
+    private NotificationEventPublisher notificationEventPublisher;
+
     @InjectMocks
     private MentorshipService mentorshipService;
 
@@ -83,6 +86,7 @@ class MentorshipServiceTest {
         assertThat(response.getMenteeId()).isEqualTo(2L);
         assertThat(response.getDuration()).isEqualTo(3);
         assertThat(response.getStatus()).isEqualTo("ACTIVE");
+        verify(notificationEventPublisher).publishRequestAccepted(2L, "Ahmet");
     }
 
     @Test
@@ -206,6 +210,7 @@ class MentorshipServiceTest {
         mentorshipService.rejectRequest(1L, 10L);
 
         assertThat(request.getStatus()).isEqualTo(MentorshipRequestStatus.REJECTED);
+        verify(notificationEventPublisher).publishRequestRejected(2L, "Ahmet");
     }
 
     @Test

--- a/backend/src/test/java/com/group7/backend/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/NotificationServiceTest.java
@@ -1,0 +1,92 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.NotificationResponse;
+import com.group7.backend.entity.Notification;
+import com.group7.backend.entity.NotificationType;
+import com.group7.backend.entity.User;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    private Notification notification;
+
+    @BeforeEach
+    void setUp() {
+        User recipient = new com.group7.backend.entity.Mentee();
+        recipient.setId(7L);
+
+        notification = new Notification();
+        notification.setId(1L);
+        notification.setRecipient(recipient);
+        notification.setType(NotificationType.REQUEST_ACCEPTED);
+        notification.setTitle("Mentorship request accepted");
+        notification.setBody("Ahmet accepted your mentorship request.");
+        notification.setRead(false);
+        notification.setCreatedAt(LocalDateTime.now());
+    }
+
+    @Test
+    void getNotificationsReturnsMappedResults() {
+        when(notificationRepository.findForUser(7L, false)).thenReturn(List.of(notification));
+
+        List<NotificationResponse> result = notificationService.getNotifications(7L, false);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRecipientId()).isEqualTo(7L);
+        assertThat(result.get(0).getType()).isEqualTo("REQUEST_ACCEPTED");
+    }
+
+    @Test
+    void markAsReadUpdatesUnreadNotification() {
+        when(notificationRepository.findByIdAndRecipientId(1L, 7L)).thenReturn(Optional.of(notification));
+        when(notificationRepository.save(notification)).thenReturn(notification);
+
+        NotificationResponse response = notificationService.markAsRead(7L, 1L);
+
+        assertThat(response.isRead()).isTrue();
+        assertThat(response.getReadAt()).isNotNull();
+    }
+
+    @Test
+    void markAsReadThrowsWhenNotificationNotFound() {
+        when(notificationRepository.findByIdAndRecipientId(99L, 7L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> notificationService.markAsRead(7L, 99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Notification not found");
+    }
+
+    @Test
+    void markAllAsReadReturnsUpdatedCount() {
+        when(notificationRepository.markAllAsRead(org.mockito.ArgumentMatchers.eq(7L), org.mockito.ArgumentMatchers.any()))
+                .thenReturn(3);
+
+        int updated = notificationService.markAllAsRead(7L);
+
+        assertThat(updated).isEqualTo(3);
+        verify(notificationRepository).markAllAsRead(org.mockito.ArgumentMatchers.eq(7L), org.mockito.ArgumentMatchers.any());
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements Issue #108 by introducing a backend notification subsystem with event-driven triggering, persistence, and user-facing REST endpoints for in-app notifications.

## Implemented Scope
- Added notification domain model and persistence layer:
  - `Notification` entity
  - `NotificationType` enum
  - Flyway migration for `notifications` table with indexes
- Added notification APIs:
  - `GET /api/notifications` (with optional `unreadOnly` filter)
  - `PATCH /api/notifications/{id}/read`
  - `PATCH /api/notifications/read-all`
- Added async event infrastructure:
  - notification event model
  - publisher service
  - async listener (after transaction commit)
- Integrated event triggers for key flows:
  - `MATCH_FOUND`
  - `REQUEST_ACCEPTED`
  - `REQUEST_REJECTED`
- Added support paths for:
  - `NEW_MESSAGE`
  - `MEETING_REMINDER`
- Enforced ownership-safe notification access/update behavior.

## Validation
- Automated: full backend test suite passed.
- Manual: Swagger-based validation completed for notification creation, retrieval, unread filtering, mark-one-read, and mark-all-read flows.

## Notes
- This PR focuses on in-app notification storage and retrieval for MVP.
- Push delivery channels (e.g., WebSocket/Firebase) remain out of scope for this issue.