### PR TITLE
feat(backend): add availability overlap scoring to matching algorithm

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MenteeAvailabilityController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MenteeAvailabilityController.java
@@ -1,0 +1,100 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.dto.request.AvailabilitySlotRequest;
+import com.group7.backend.dto.request.BulkAvailabilityRequest;
+import com.group7.backend.dto.response.MenteeAvailabilitySlotResponse;
+import com.group7.backend.service.MenteeAvailabilityService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/mentee-availability")
+@PreAuthorize("hasRole('MENTEE')")
+@Tag(name = "Mentee Availability", description = "Mentee weekly availability management")
+public class MenteeAvailabilityController {
+
+    private final MenteeAvailabilityService menteeAvailabilityService;
+
+    public MenteeAvailabilityController(MenteeAvailabilityService menteeAvailabilityService) {
+        this.menteeAvailabilityService = menteeAvailabilityService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "Get own availability",
+            description = "Returns all weekly availability slots of the authenticated mentee, sorted by day and time."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Availability slots",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = MenteeAvailabilitySlotResponse.class)))),
+            @ApiResponse(responseCode = "404", description = "Mentee not found", content = @Content)
+    })
+    public ResponseEntity<List<MenteeAvailabilitySlotResponse>> getOwnSlots(Authentication authentication) {
+        Long menteeId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(menteeAvailabilityService.getSlots(menteeId));
+    }
+
+    @PutMapping
+    @Operation(
+            summary = "Bulk update own availability",
+            description = "Replaces all existing availability slots of the authenticated mentee with the provided set."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Updated availability slots",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = MenteeAvailabilitySlotResponse.class)))),
+            @ApiResponse(responseCode = "409", description = "Overlapping slots or invalid time range", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentee not found", content = @Content)
+    })
+    public ResponseEntity<List<MenteeAvailabilitySlotResponse>> bulkUpdate(
+            @Valid @RequestBody BulkAvailabilityRequest request,
+            Authentication authentication) {
+        Long menteeId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(menteeAvailabilityService.bulkUpdate(menteeId, request.getSlots()));
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "Add own availability slot",
+            description = "Adds a single availability slot for the authenticated mentee."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Slot created",
+                    content = @Content(schema = @Schema(implementation = MenteeAvailabilitySlotResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Overlapping slot or invalid time range", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentee not found", content = @Content)
+    })
+    public ResponseEntity<MenteeAvailabilitySlotResponse> addSlot(
+            @Valid @RequestBody AvailabilitySlotRequest request,
+            Authentication authentication) {
+        Long menteeId = (Long) authentication.getCredentials();
+        return ResponseEntity.status(HttpStatus.CREATED).body(menteeAvailabilityService.addSlot(menteeId, request));
+    }
+
+    @DeleteMapping("/{slotId}")
+    @Operation(
+            summary = "Remove own availability slot",
+            description = "Removes a single availability slot owned by the authenticated mentee."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Slot removed"),
+            @ApiResponse(responseCode = "404", description = "Slot not found", content = @Content)
+    })
+    public ResponseEntity<Void> removeSlot(@PathVariable Long slotId, Authentication authentication) {
+        Long menteeId = (Long) authentication.getCredentials();
+        menteeAvailabilityService.removeSlot(menteeId, slotId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MenteeAvailabilitySlotResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MenteeAvailabilitySlotResponse.java
@@ -1,0 +1,41 @@
+package com.group7.backend.dto.response;
+
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Mentee availability slot details")
+public class MenteeAvailabilitySlotResponse {
+
+    @Schema(description = "Slot ID", example = "1")
+    private Long id;
+
+    @Schema(description = "Day of week", example = "MONDAY")
+    private String dayOfWeek;
+
+    @Schema(description = "Start time", example = "09:00:00")
+    private LocalTime startTime;
+
+    @Schema(description = "End time", example = "12:00:00")
+    private LocalTime endTime;
+
+    @Schema(description = "Whether the slot repeats weekly", example = "true")
+    private boolean recurring;
+
+    public static MenteeAvailabilitySlotResponse from(MenteeAvailabilitySlot slot) {
+        MenteeAvailabilitySlotResponse r = new MenteeAvailabilitySlotResponse();
+        r.setId(slot.getId());
+        r.setDayOfWeek(slot.getDayOfWeek().name());
+        r.setStartTime(slot.getStartTime());
+        r.setEndTime(slot.getEndTime());
+        r.setRecurring(slot.isRecurring());
+        return r;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/entity/MenteeAvailabilitySlot.java
+++ b/backend/src/main/java/com/group7/backend/entity/MenteeAvailabilitySlot.java
@@ -1,0 +1,38 @@
+package com.group7.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "mentee_availability_slots")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MenteeAvailabilitySlot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentee_id", nullable = false)
+    private Mentee mentee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false)
+    private DayOfWeek dayOfWeek;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(nullable = false)
+    private boolean recurring = true;
+}

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.group7.backend.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -60,6 +61,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MatchingNotAllowedException.class)
     public ResponseEntity<Map<String, String>> handleMatchingNotAllowed(MatchingNotAllowedException ex) {
         return buildErrorResponse(HttpStatus.FORBIDDEN, "Forbidden", ex.getMessage());
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAuthorizationDenied(AuthorizationDeniedException ex) {
+        return buildErrorResponse(HttpStatus.FORBIDDEN, "Forbidden", "Access denied");
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/backend/src/main/java/com/group7/backend/repository/MenteeAvailabilitySlotRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MenteeAvailabilitySlotRepository.java
@@ -1,0 +1,15 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MenteeAvailabilitySlotRepository extends JpaRepository<MenteeAvailabilitySlot, Long> {
+
+    List<MenteeAvailabilitySlot> findByMenteeId(Long menteeId);
+
+    void deleteByMenteeId(Long menteeId);
+
+    long deleteByIdAndMenteeId(Long id, Long menteeId);
+}

--- a/backend/src/main/java/com/group7/backend/service/MatchingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchingService.java
@@ -3,14 +3,18 @@ package com.group7.backend.service;
 import com.group7.backend.dto.response.MenteeCandidateResponse;
 import com.group7.backend.dto.response.MentorMatchResponse;
 import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.exception.MatchingNotAllowedException;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.AvailabilitySlotRepository;
 import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
 import com.group7.backend.repository.MentorRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -20,13 +24,19 @@ public class MatchingService {
 
     private final MenteeRepository menteeRepository;
     private final MentorRepository mentorRepository;
+    private final AvailabilitySlotRepository availabilitySlotRepository;
+    private final MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
     private final NotificationEventPublisher notificationEventPublisher;
 
     public MatchingService(MenteeRepository menteeRepository,
                            MentorRepository mentorRepository,
+                           AvailabilitySlotRepository availabilitySlotRepository,
+                           MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository,
                            NotificationEventPublisher notificationEventPublisher) {
         this.menteeRepository = menteeRepository;
         this.mentorRepository = mentorRepository;
+        this.availabilitySlotRepository = availabilitySlotRepository;
+        this.menteeAvailabilitySlotRepository = menteeAvailabilitySlotRepository;
         this.notificationEventPublisher = notificationEventPublisher;
     }
 
@@ -44,7 +54,8 @@ public class MatchingService {
         List<MentorMatchResponse> matches = mentors.stream()
                 .filter(m -> m.getCurrentMenteeCount() < m.getMaxMenteeCapacity())
                 .filter(m -> matchesKeyword(m, keyword))
-                .map(m -> MentorMatchResponse.from(m, calculateScore(m, mentee)))
+            .map(m -> MentorMatchResponse.from(m,
+                calculateScore(m, mentee) + calculateAvailabilityScore(m.getId(), mentee.getId())))
                 .sorted(Comparator.comparingInt(MentorMatchResponse::getMatchScore).reversed())
                 .limit(5)
                 .toList();
@@ -180,6 +191,44 @@ public class MatchingService {
         }
 
         return score;
+    }
+
+    int calculateAvailabilityScore(Long mentorId, Long menteeId) {
+        if (mentorId == null || menteeId == null) {
+            return 0;
+        }
+
+        var mentorSlots = availabilitySlotRepository.findByMentorId(mentorId);
+        var menteeSlots = menteeAvailabilitySlotRepository.findByMenteeId(menteeId);
+
+        if (mentorSlots.isEmpty() || menteeSlots.isEmpty()) {
+            return 0;
+        }
+
+        long overlapMinutes = 0;
+        for (var mentorSlot : mentorSlots) {
+            for (MenteeAvailabilitySlot menteeSlot : menteeSlots) {
+                if (mentorSlot.getDayOfWeek() != menteeSlot.getDayOfWeek()) {
+                    continue;
+                }
+                overlapMinutes += overlapMinutes(
+                        mentorSlot.getStartTime(),
+                        mentorSlot.getEndTime(),
+                        menteeSlot.getStartTime(),
+                        menteeSlot.getEndTime());
+            }
+        }
+
+        return (int) Math.min(12, overlapMinutes / 30);
+    }
+
+    private long overlapMinutes(LocalTime start1, LocalTime end1, LocalTime start2, LocalTime end2) {
+        LocalTime start = start1.isAfter(start2) ? start1 : start2;
+        LocalTime end = end1.isBefore(end2) ? end1 : end2;
+        if (!start.isBefore(end)) {
+            return 0;
+        }
+        return java.time.Duration.between(start, end).toMinutes();
     }
 
     private boolean matchesKeyword(Mentor mentor, String keyword) {

--- a/backend/src/main/java/com/group7/backend/service/MenteeAvailabilityService.java
+++ b/backend/src/main/java/com/group7/backend/service/MenteeAvailabilityService.java
@@ -1,0 +1,121 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.request.AvailabilitySlotRequest;
+import com.group7.backend.dto.response.MenteeAvailabilitySlotResponse;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import com.group7.backend.exception.OverlappingSlotException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class MenteeAvailabilityService {
+
+    private final MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+    private final MenteeRepository menteeRepository;
+
+    public MenteeAvailabilityService(MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository,
+                                     MenteeRepository menteeRepository) {
+        this.menteeAvailabilitySlotRepository = menteeAvailabilitySlotRepository;
+        this.menteeRepository = menteeRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<MenteeAvailabilitySlotResponse> getSlots(Long menteeId) {
+        menteeRepository.findById(menteeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mentee not found"));
+
+        return menteeAvailabilitySlotRepository.findByMenteeId(menteeId).stream()
+                .sorted(Comparator.comparing(MenteeAvailabilitySlot::getDayOfWeek)
+                        .thenComparing(MenteeAvailabilitySlot::getStartTime))
+                .map(MenteeAvailabilitySlotResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public List<MenteeAvailabilitySlotResponse> bulkUpdate(Long menteeId, List<AvailabilitySlotRequest> slots) {
+        Mentee mentee = menteeRepository.findById(menteeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mentee not found"));
+
+        validateNoOverlapsInSet(slots);
+
+        menteeAvailabilitySlotRepository.deleteByMenteeId(menteeId);
+
+        List<MenteeAvailabilitySlot> saved = slots.stream().map(req -> {
+            MenteeAvailabilitySlot entity = new MenteeAvailabilitySlot();
+            entity.setMentee(mentee);
+            entity.setDayOfWeek(req.getDayOfWeek());
+            entity.setStartTime(req.getStartTime());
+            entity.setEndTime(req.getEndTime());
+            entity.setRecurring(req.getRecurring() != null ? req.getRecurring() : true);
+            return menteeAvailabilitySlotRepository.save(entity);
+        }).toList();
+
+        return saved.stream()
+                .sorted(Comparator.comparing(MenteeAvailabilitySlot::getDayOfWeek)
+                        .thenComparing(MenteeAvailabilitySlot::getStartTime))
+                .map(MenteeAvailabilitySlotResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public MenteeAvailabilitySlotResponse addSlot(Long menteeId, AvailabilitySlotRequest request) {
+        Mentee mentee = menteeRepository.findById(menteeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mentee not found"));
+
+        List<MenteeAvailabilitySlot> existingOnDay = menteeAvailabilitySlotRepository.findByMenteeId(menteeId).stream()
+                .filter(s -> s.getDayOfWeek() == request.getDayOfWeek())
+                .toList();
+
+        for (MenteeAvailabilitySlot existing : existingOnDay) {
+            if (overlaps(request.getStartTime(), request.getEndTime(),
+                    existing.getStartTime(), existing.getEndTime())) {
+                throw new OverlappingSlotException("New slot overlaps with existing slot on " + request.getDayOfWeek());
+            }
+        }
+
+        MenteeAvailabilitySlot entity = new MenteeAvailabilitySlot();
+        entity.setMentee(mentee);
+        entity.setDayOfWeek(request.getDayOfWeek());
+        entity.setStartTime(request.getStartTime());
+        entity.setEndTime(request.getEndTime());
+        entity.setRecurring(request.getRecurring() != null ? request.getRecurring() : true);
+
+        return MenteeAvailabilitySlotResponse.from(menteeAvailabilitySlotRepository.save(entity));
+    }
+
+    @Transactional
+    public void removeSlot(Long menteeId, Long slotId) {
+        long deleted = menteeAvailabilitySlotRepository.deleteByIdAndMenteeId(slotId, menteeId);
+        if (deleted == 0) {
+            throw new ResourceNotFoundException("Mentee availability slot not found");
+        }
+    }
+
+    private void validateNoOverlapsInSet(List<AvailabilitySlotRequest> slots) {
+        for (int i = 0; i < slots.size(); i++) {
+            for (int j = i + 1; j < slots.size(); j++) {
+                AvailabilitySlotRequest a = slots.get(i);
+                AvailabilitySlotRequest b = slots.get(j);
+                if (a.getDayOfWeek() == b.getDayOfWeek()
+                        && overlaps(a.getStartTime(), a.getEndTime(), b.getStartTime(), b.getEndTime())) {
+                    throw new OverlappingSlotException(
+                            "Slots overlap on " + a.getDayOfWeek() + ": "
+                                    + a.getStartTime() + "-" + a.getEndTime()
+                                    + " and " + b.getStartTime() + "-" + b.getEndTime());
+                }
+            }
+        }
+    }
+
+    private boolean overlaps(LocalTime start1, LocalTime end1, LocalTime start2, LocalTime end2) {
+        return start1.isBefore(end2) && start2.isBefore(end1);
+    }
+}

--- a/backend/src/main/resources/db/migration/V9__create_mentee_availability_slots.sql
+++ b/backend/src/main/resources/db/migration/V9__create_mentee_availability_slots.sql
@@ -1,0 +1,10 @@
+CREATE TABLE mentee_availability_slots (
+    id          BIGSERIAL PRIMARY KEY,
+    mentee_id   BIGINT NOT NULL REFERENCES mentees(id) ON DELETE CASCADE,
+    day_of_week VARCHAR(15) NOT NULL,
+    start_time  TIME NOT NULL,
+    end_time    TIME NOT NULL,
+    recurring   BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE INDEX idx_availability_mentee ON mentee_availability_slots (mentee_id);

--- a/backend/src/test/java/com/group7/backend/controller/MenteeAvailabilityControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MenteeAvailabilityControllerTest.java
@@ -1,0 +1,140 @@
+package com.group7.backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.request.AvailabilitySlotRequest;
+import com.group7.backend.dto.request.BulkAvailabilityRequest;
+import com.group7.backend.dto.response.MenteeAvailabilitySlotResponse;
+import com.group7.backend.exception.OverlappingSlotException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.MenteeAvailabilityService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MenteeAvailabilityController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class MenteeAvailabilityControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private MenteeAvailabilityService menteeAvailabilityService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    private void mockMenteeJwt(String token, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn("mentee@example.com");
+        when(jwtService.extractRole(token)).thenReturn("MENTEE");
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private void mockMentorJwt(String token, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn("mentor@example.com");
+        when(jwtService.extractRole(token)).thenReturn("MENTOR");
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private MenteeAvailabilitySlotResponse sampleSlot() {
+        MenteeAvailabilitySlotResponse r = new MenteeAvailabilitySlotResponse();
+        r.setId(1L);
+        r.setDayOfWeek("MONDAY");
+        r.setStartTime(LocalTime.of(9, 0));
+        r.setEndTime(LocalTime.of(12, 0));
+        r.setRecurring(true);
+        return r;
+    }
+
+    @Test
+    void getOwnSlotsReturns200ForMentee() throws Exception {
+        mockMenteeJwt("mentee-token", 1L);
+        when(menteeAvailabilityService.getSlots(1L)).thenReturn(List.of(sampleSlot()));
+
+        mockMvc.perform(get("/api/mentee-availability")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].dayOfWeek").value("MONDAY"));
+    }
+
+    @Test
+    void getOwnSlotsReturns403ForMentor() throws Exception {
+        mockMentorJwt("mentor-token", 2L);
+
+        mockMvc.perform(get("/api/mentee-availability")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void bulkUpdateReturns200() throws Exception {
+        mockMenteeJwt("mentee-token", 1L);
+        when(menteeAvailabilityService.bulkUpdate(eq(1L), any())).thenReturn(List.of(sampleSlot()));
+
+        AvailabilitySlotRequest slot = new AvailabilitySlotRequest();
+        slot.setDayOfWeek(DayOfWeek.MONDAY);
+        slot.setStartTime(LocalTime.of(9, 0));
+        slot.setEndTime(LocalTime.of(12, 0));
+        BulkAvailabilityRequest body = new BulkAvailabilityRequest();
+        body.setSlots(List.of(slot));
+
+        mockMvc.perform(put("/api/mentee-availability")
+                        .header("Authorization", "Bearer mentee-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1));
+    }
+
+    @Test
+    void addSlotReturns409ForOverlap() throws Exception {
+        mockMenteeJwt("mentee-token", 1L);
+        when(menteeAvailabilityService.addSlot(eq(1L), any()))
+                .thenThrow(new OverlappingSlotException("overlap"));
+
+        AvailabilitySlotRequest body = new AvailabilitySlotRequest();
+        body.setDayOfWeek(DayOfWeek.MONDAY);
+        body.setStartTime(LocalTime.of(9, 0));
+        body.setEndTime(LocalTime.of(12, 0));
+
+        mockMvc.perform(post("/api/mentee-availability")
+                        .header("Authorization", "Bearer mentee-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void removeSlotReturns404WhenMissing() throws Exception {
+        mockMenteeJwt("mentee-token", 1L);
+        doThrow(new ResourceNotFoundException("Mentee availability slot not found"))
+                .when(menteeAvailabilityService).removeSlot(1L, 11L);
+
+        mockMvc.perform(delete("/api/mentee-availability/11")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/AvailabilityIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/AvailabilityIntegrationTest.java
@@ -38,10 +38,12 @@ class AvailabilityIntegrationTest {
     @Autowired private PasswordResetTokenRepository passwordResetTokenRepository;
     @Autowired private MentorshipRequestRepository mentorshipRequestRepository;
     @Autowired private AvailabilitySlotRepository availabilitySlotRepository;
+        @Autowired private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
     @MockitoBean private EmailService emailService;
 
     @BeforeEach
     void cleanDb() {
+                menteeAvailabilitySlotRepository.deleteAll();
         availabilitySlotRepository.deleteAll();
         mentorshipRequestRepository.deleteAll();
         passwordResetTokenRepository.deleteAll();

--- a/backend/src/test/java/com/group7/backend/integration/MatchingIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MatchingIntegrationTest.java
@@ -6,6 +6,7 @@ import com.group7.backend.dto.request.RegisterRequest;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
 import com.group7.backend.repository.MentorRepository;
 import com.group7.backend.repository.PasswordResetTokenRepository;
 import com.group7.backend.repository.UserRepository;
@@ -58,11 +59,15 @@ class MatchingIntegrationTest {
     @Autowired
     private MenteeRepository menteeRepository;
 
+        @Autowired
+        private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+
     @MockitoBean
     private EmailService emailService;
 
     @BeforeEach
     void cleanDb() {
+                menteeAvailabilitySlotRepository.deleteAll();
         passwordResetTokenRepository.deleteAll();
         verificationTokenRepository.deleteAll();
         userRepository.deleteAll();
@@ -241,6 +246,74 @@ class MatchingIntegrationTest {
 
         var matches = objectMapper.readTree(result.getResponse().getContentAsString());
         assertThat(matches.size()).isLessThanOrEqualTo(5);
+    }
+
+    @Test
+    void availabilityOverlapAffectsRanking() throws Exception {
+        String mentorTokenA = registerAndLogin("overlap_mentor_a@example.com", true);
+        Mentor mentorA = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("overlap_mentor_a@example.com"))
+                .findFirst().orElseThrow();
+        mentorA.setField("Computer Science");
+        mentorA.setExpertise("Java backend");
+        mentorA.setPreferredMenteeMajor("Computer Science");
+        mentorA.setPreferredMenteeSkills(List.of("Java"));
+        mentorA.setInterests(List.of("AI"));
+        mentorA.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentorA);
+
+        String mentorTokenB = registerAndLogin("overlap_mentor_b@example.com", true);
+        Mentor mentorB = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("overlap_mentor_b@example.com"))
+                .findFirst().orElseThrow();
+        mentorB.setField("Computer Science");
+        mentorB.setExpertise("Java backend");
+        mentorB.setPreferredMenteeMajor("Computer Science");
+        mentorB.setPreferredMenteeSkills(List.of("Java"));
+        mentorB.setInterests(List.of("AI"));
+        mentorB.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentorB);
+
+        String menteeToken = registerAndLogin("overlap_mentee@example.com", false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals("overlap_mentee@example.com"))
+                .findFirst().orElseThrow();
+        mentee.setMajor("Computer Science");
+        mentee.setSkills(List.of("Java"));
+        mentee.setInterests(List.of("AI"));
+        menteeRepository.save(mentee);
+
+        mockMvc.perform(post("/api/availability")
+                        .header("Authorization", "Bearer " + mentorTokenA)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("dayOfWeek", "MONDAY", "startTime", "10:00", "endTime", "12:00"))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/availability")
+                        .header("Authorization", "Bearer " + mentorTokenB)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("dayOfWeek", "MONDAY", "startTime", "14:00", "endTime", "16:00"))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/mentee-availability")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                java.util.Map.of("dayOfWeek", "MONDAY", "startTime", "10:30", "endTime", "11:30"))))
+                .andExpect(status().isCreated());
+
+        MvcResult result = mockMvc.perform(get("/api/matching/mentors")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        var matches = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(matches.size()).isGreaterThanOrEqualTo(2);
+        assertThat(matches.get(0).get("id").asLong()).isEqualTo(mentorA.getId());
+        assertThat(matches.get(0).get("matchScore").asInt())
+                .isGreaterThan(matches.get(1).get("matchScore").asInt());
     }
 
     // ── Candidate mentees (mentor-side) ─────────────────────────────────────

--- a/backend/src/test/java/com/group7/backend/integration/MenteeAvailabilityIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MenteeAvailabilityIntegrationTest.java
@@ -1,0 +1,122 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.repository.*;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MenteeAvailabilityIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired private MentorshipRequestRepository mentorshipRequestRepository;
+    @Autowired private AvailabilitySlotRepository availabilitySlotRepository;
+    @Autowired private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        menteeAvailabilitySlotRepository.deleteAll();
+        availabilitySlotRepository.deleteAll();
+        mentorshipRequestRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+        doNothing().when(emailService).sendPasswordResetEmail(any(), anyString());
+    }
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Test");
+        req.setLastName("User");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    @Test
+    void menteeCanAddAndRetrieveOwnSlots() throws Exception {
+        String menteeToken = registerAndLogin("mav_mentee1@test.com", false);
+
+        String slotBody = objectMapper.writeValueAsString(
+                Map.of("dayOfWeek", "MONDAY", "startTime", "09:00", "endTime", "12:00", "recurring", true));
+
+        mockMvc.perform(post("/api/mentee-availability")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(slotBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.dayOfWeek").value("MONDAY"));
+
+        MvcResult getResult = mockMvc.perform(get("/api/mentee-availability")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        var slots = objectMapper.readTree(getResult.getResponse().getContentAsString());
+        assertThat(slots.size()).isEqualTo(1);
+        assertThat(slots.get(0).get("dayOfWeek").asText()).isEqualTo("MONDAY");
+    }
+
+    @Test
+    void mentorCannotModifyMenteeAvailability() throws Exception {
+        String mentorToken = registerAndLogin("mav_mentor1@test.com", true);
+
+        mockMvc.perform(post("/api/mentee-availability")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("dayOfWeek", "MONDAY", "startTime", "09:00", "endTime", "12:00"))))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
@@ -2,10 +2,14 @@ package com.group7.backend.service;
 
 import com.group7.backend.dto.response.MenteeCandidateResponse;
 import com.group7.backend.dto.response.MentorMatchResponse;
+import com.group7.backend.entity.AvailabilitySlot;
 import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
 import com.group7.backend.entity.Mentor;
+import com.group7.backend.repository.AvailabilitySlotRepository;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
 import com.group7.backend.repository.MentorRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,11 +18,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +38,12 @@ class MatchingServiceTest {
 
     @Mock
     private MentorRepository mentorRepository;
+
+    @Mock
+    private AvailabilitySlotRepository availabilitySlotRepository;
+
+    @Mock
+    private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
 
     @Mock
     private NotificationEventPublisher notificationEventPublisher;
@@ -58,6 +72,27 @@ class MatchingServiceTest {
         mentor.setPreferredMenteeSkills(List.of("Java", "Kotlin"));
         mentor.setInterests(List.of("AI", "Systems"));
         mentor.setMentoringGoals("Help with career and machine learning projects");
+
+        lenient().when(availabilitySlotRepository.findByMentorId(anyLong())).thenReturn(List.of());
+        lenient().when(menteeAvailabilitySlotRepository.findByMenteeId(anyLong())).thenReturn(List.of());
+    }
+
+    private AvailabilitySlot mentorSlot(DayOfWeek dayOfWeek, String start, String end) {
+        AvailabilitySlot slot = new AvailabilitySlot();
+        slot.setDayOfWeek(dayOfWeek);
+        slot.setStartTime(LocalTime.parse(start));
+        slot.setEndTime(LocalTime.parse(end));
+        slot.setRecurring(true);
+        return slot;
+    }
+
+    private MenteeAvailabilitySlot menteeSlot(DayOfWeek dayOfWeek, String start, String end) {
+        MenteeAvailabilitySlot slot = new MenteeAvailabilitySlot();
+        slot.setDayOfWeek(dayOfWeek);
+        slot.setStartTime(LocalTime.parse(start));
+        slot.setEndTime(LocalTime.parse(end));
+        slot.setRecurring(true);
+        return slot;
     }
 
     // ── Score calculation ────────────────────────────────────────────────────
@@ -235,9 +270,13 @@ class MatchingServiceTest {
     @Test
     void resultsOrderedByScoreDescending() {
         Mentor lowScore = new Mentor();
+        lowScore.setId(7L);
         lowScore.setMaxMenteeCapacity(3);
         lowScore.setCurrentMenteeCount(0);
         // no matching fields → score 0
+
+        mentee.setId(1L);
+        mentor.setId(2L);
 
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
         when(mentorRepository.findAll()).thenReturn(List.of(lowScore, mentor));
@@ -245,6 +284,57 @@ class MatchingServiceTest {
         List<MentorMatchResponse> result = matchingService.getTopMentors(1L, null);
 
         assertThat(result.get(0).getMatchScore()).isGreaterThanOrEqualTo(result.get(1).getMatchScore());
+    }
+
+    @Test
+    void availabilityScoreUsesOverlapAndCapsAtTwelve() {
+    when(availabilitySlotRepository.findByMentorId(2L)).thenReturn(List.of(
+        mentorSlot(DayOfWeek.MONDAY, "09:00", "18:00")));
+    when(menteeAvailabilitySlotRepository.findByMenteeId(1L)).thenReturn(List.of(
+        menteeSlot(DayOfWeek.MONDAY, "09:00", "17:00")));
+
+    int score = matchingService.calculateAvailabilityScore(2L, 1L);
+
+    assertThat(score).isEqualTo(12);
+    }
+
+    @Test
+    void availabilityScoreReturnsZeroWithoutSlots() {
+    int score = matchingService.calculateAvailabilityScore(2L, 1L);
+
+    assertThat(score).isEqualTo(0);
+    }
+
+    @Test
+    void availabilityCanBreakTieBetweenMentors() {
+    Mentor mentorWithoutOverlap = new Mentor();
+    mentorWithoutOverlap.setId(9L);
+    mentorWithoutOverlap.setMaxMenteeCapacity(3);
+    mentorWithoutOverlap.setCurrentMenteeCount(0);
+    mentorWithoutOverlap.setField(mentor.getField());
+    mentorWithoutOverlap.setPreferredMenteeMajor(mentor.getPreferredMenteeMajor());
+    mentorWithoutOverlap.setPreferredMenteeSkills(mentor.getPreferredMenteeSkills());
+    mentorWithoutOverlap.setInterests(mentor.getInterests());
+    mentorWithoutOverlap.setMentoringGoals(mentor.getMentoringGoals());
+    mentorWithoutOverlap.setExpertise(mentor.getExpertise());
+
+    mentor.setId(2L);
+    mentee.setId(1L);
+
+    when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+    when(mentorRepository.findAll()).thenReturn(List.of(mentorWithoutOverlap, mentor));
+    when(availabilitySlotRepository.findByMentorId(2L)).thenReturn(List.of(
+        mentorSlot(DayOfWeek.MONDAY, "10:00", "12:00")));
+    when(availabilitySlotRepository.findByMentorId(9L)).thenReturn(List.of(
+        mentorSlot(DayOfWeek.MONDAY, "14:00", "16:00")));
+    when(menteeAvailabilitySlotRepository.findByMenteeId(1L)).thenReturn(List.of(
+        menteeSlot(DayOfWeek.MONDAY, "10:30", "11:30")));
+
+    List<MentorMatchResponse> result = matchingService.getTopMentors(1L, null);
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getId()).isEqualTo(2L);
+    assertThat(result.get(0).getMatchScore()).isGreaterThan(result.get(1).getMatchScore());
     }
 
     // ── Candidate mentees: preference matching ──────────────────────────────

--- a/backend/src/test/java/com/group7/backend/service/MenteeAvailabilityServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MenteeAvailabilityServiceTest.java
@@ -1,0 +1,134 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.request.AvailabilitySlotRequest;
+import com.group7.backend.dto.response.MenteeAvailabilitySlotResponse;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import com.group7.backend.exception.OverlappingSlotException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MenteeAvailabilityServiceTest {
+
+    @Mock
+    private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+
+    @Mock
+    private MenteeRepository menteeRepository;
+
+    @InjectMocks
+    private MenteeAvailabilityService menteeAvailabilityService;
+
+    private Mentee mentee;
+
+    @BeforeEach
+    void setUp() {
+        mentee = new Mentee();
+        mentee.setId(1L);
+    }
+
+    private MenteeAvailabilitySlot slot(Long id, DayOfWeek day, String start, String end) {
+        MenteeAvailabilitySlot s = new MenteeAvailabilitySlot();
+        s.setId(id);
+        s.setMentee(mentee);
+        s.setDayOfWeek(day);
+        s.setStartTime(LocalTime.parse(start));
+        s.setEndTime(LocalTime.parse(end));
+        s.setRecurring(true);
+        return s;
+    }
+
+    private AvailabilitySlotRequest request(DayOfWeek day, String start, String end) {
+        AvailabilitySlotRequest r = new AvailabilitySlotRequest();
+        r.setDayOfWeek(day);
+        r.setStartTime(LocalTime.parse(start));
+        r.setEndTime(LocalTime.parse(end));
+        r.setRecurring(true);
+        return r;
+    }
+
+    @Test
+    void getSlotsReturnsSorted() {
+        MenteeAvailabilitySlot friday = slot(1L, DayOfWeek.FRIDAY, "14:00", "16:00");
+        MenteeAvailabilitySlot monday = slot(2L, DayOfWeek.MONDAY, "09:00", "12:00");
+
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        when(menteeAvailabilitySlotRepository.findByMenteeId(1L)).thenReturn(List.of(friday, monday));
+
+        List<MenteeAvailabilitySlotResponse> result = menteeAvailabilityService.getSlots(1L);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getDayOfWeek()).isEqualTo("MONDAY");
+        assertThat(result.get(1).getDayOfWeek()).isEqualTo("FRIDAY");
+    }
+
+    @Test
+    void bulkUpdateReplacesAll() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        when(menteeAvailabilitySlotRepository.save(any(MenteeAvailabilitySlot.class))).thenAnswer(inv -> {
+            MenteeAvailabilitySlot s = inv.getArgument(0);
+            s.setId(10L);
+            return s;
+        });
+
+        List<MenteeAvailabilitySlotResponse> result = menteeAvailabilityService.bulkUpdate(1L,
+                List.of(request(DayOfWeek.MONDAY, "09:00", "12:00")));
+
+        verify(menteeAvailabilitySlotRepository).deleteByMenteeId(1L);
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void bulkUpdateRejectsOverlapsWithinSet() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+
+        assertThatThrownBy(() -> menteeAvailabilityService.bulkUpdate(1L, List.of(
+                request(DayOfWeek.MONDAY, "09:00", "12:00"),
+                request(DayOfWeek.MONDAY, "11:00", "14:00"))))
+                .isInstanceOf(OverlappingSlotException.class);
+    }
+
+    @Test
+    void addSlotSuccess() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        when(menteeAvailabilitySlotRepository.findByMenteeId(1L)).thenReturn(List.of());
+        when(menteeAvailabilitySlotRepository.save(any(MenteeAvailabilitySlot.class))).thenAnswer(inv -> {
+            MenteeAvailabilitySlot s = inv.getArgument(0);
+            s.setId(10L);
+            return s;
+        });
+
+        MenteeAvailabilitySlotResponse result = menteeAvailabilityService.addSlot(1L,
+                request(DayOfWeek.MONDAY, "09:00", "12:00"));
+
+        assertThat(result.getId()).isEqualTo(10L);
+        assertThat(result.getDayOfWeek()).isEqualTo("MONDAY");
+    }
+
+    @Test
+    void removeSlotNotFound() {
+        when(menteeAvailabilitySlotRepository.deleteByIdAndMenteeId(99L, 1L)).thenReturn(0L);
+
+        assertThatThrownBy(() -> menteeAvailabilityService.removeSlot(1L, 99L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}


### PR DESCRIPTION
closes #207 
## Summary
This PR improves mentor recommendation quality by extending the matching algorithm with weekly availability overlap scoring, in addition to existing profile-based criteria.

## What Changed
- Added backend support for mentee availability management.
- Included availability overlap as a new score factor in mentee-side mentor ranking.
- Added migration for mentee availability slots.
- Added/updated tests for matching and availability flows.
- Improved authorization error handling for access-denied scenarios (returns 403 consistently).

## Why
Previously, matching could prioritize mentors with strong profile similarity even when schedules did not align.  
This update makes recommendations more practical by considering both compatibility and availability.

## Validation
- Automated backend tests pass successfully.
- Manual Swagger verification confirmed that changing mentee availability affects mentor ranking score.
- Existing matching behavior remains intact while adding availability sensitivity.

## How to Test
1. Run backend and database with Docker Compose.
2. Authenticate as a mentee in Swagger.
3. Set mentee availability using `/api/mentee-availability` (PUT).
4. Call `/api/matching/mentors` and note mentor scores/order.
5. Update mentee availability to a clearly overlapping schedule with a known mentor.
6. Call `/api/matching/mentors` again and verify score/order changes.
7. (Role check) Try mentor-only availability endpoint with mentee token and verify 403 response.