### PR TITLE
feat(web): add /notifications page and link from navbar dropdown

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ import MentorshipDetailPage from './pages/MentorshipDetailPage'
 import MessagesPage from './pages/MessagesPage'
 import TasksPage from './pages/TasksPage'
 import SchedulePage from './pages/SchedulePage'
+import NotificationsPage from './pages/NotificationsPage'
 
 export default function App() {
   return (
@@ -37,6 +38,7 @@ export default function App() {
           <Route path="/messages" element={<MessagesPage />} />
           <Route path="/tasks" element={<TasksPage />} />
           <Route path="/schedule" element={<SchedulePage />} />
+          <Route path="/notifications" element={<NotificationsPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { getNotifications, markNotificationAsRead, markAllNotificationsAsRead } from '../services/api'
 import { timeAgo } from '../utils/timeAgo'
 
@@ -34,6 +35,7 @@ function typeColorClass(type) {
 }
 
 export default function NotificationBell() {
+  const navigate = useNavigate()
   const [open, setOpen] = useState(false)
   const [notifications, setNotifications] = useState([])
   const [filter, setFilter] = useState('all')
@@ -184,6 +186,13 @@ export default function NotificationBell() {
             ))
           )}
         </div>
+
+        <button
+          className="notif-see-all"
+          onClick={() => { setOpen(false); navigate('/notifications') }}
+        >
+          See all notifications →
+        </button>
       </div>
     </div>
   )

--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -1,13 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { getNotifications, markNotificationAsRead, markAllNotificationsAsRead } from '../services/api'
-
-function timeAgo(iso) {
-  const diff = Math.floor((Date.now() - new Date(iso)) / 1000)
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
-}
+import { timeAgo } from '../utils/timeAgo'
 
 function TypeIcon({ type }) {
   if (type === 'REQUEST_ACCEPTED') {

--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState } from 'react'
+import MainLayout from '../components/MainLayout'
+import {
+  getNotifications,
+  markNotificationAsRead,
+  markAllNotificationsAsRead,
+} from '../services/api'
+import { timeAgo } from '../utils/timeAgo'
+import '../styles/main.css'
+
+const PAGE_SIZE = 20
+
+const TYPE_ICON = {
+  REQUEST_ACCEPTED: '✅',
+  REQUEST_REJECTED: '❌',
+  REQUEST_RECEIVED: '🔔',
+  MATCH_FOUND: '🤝',
+  NEW_MESSAGE: '💬',
+  MEETING_REMINDER: '📅',
+}
+
+function iconFor(type) {
+  return TYPE_ICON[type] || '🔔'
+}
+
+export default function NotificationsPage() {
+  const [notifications, setNotifications] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
+  const [markingAll, setMarkingAll] = useState(false)
+
+  const fetchNotifications = useCallback(() => {
+    setLoading(true)
+    setError(null)
+    getNotifications()
+      .then(data => {
+        setNotifications(Array.isArray(data) ? data : [])
+        setVisibleCount(PAGE_SIZE)
+      })
+      .catch(err => setError(err.message || 'Failed to load notifications'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    fetchNotifications()
+  }, [fetchNotifications])
+
+  const unreadCount = notifications.filter(n => !n.read).length
+  const visible = notifications.slice(0, visibleCount)
+  const hasMore = visibleCount < notifications.length
+
+  function handleMarkRead(id) {
+    setNotifications(prev => prev.map(n => n.id === id ? { ...n, read: true } : n))
+    markNotificationAsRead(id).catch(() => {
+      setNotifications(prev => prev.map(n => n.id === id ? { ...n, read: false } : n))
+    })
+  }
+
+  function handleMarkAllRead() {
+    if (unreadCount === 0 || markingAll) return
+    setMarkingAll(true)
+    setNotifications(prev => prev.map(n => ({ ...n, read: true })))
+    markAllNotificationsAsRead()
+      .catch(() => fetchNotifications())
+      .finally(() => setMarkingAll(false))
+  }
+
+  return (
+    <MainLayout>
+      <section className="notif-page">
+        <header className="notif-page-header">
+          <div>
+            <h1 className="notif-page-title">Notifications</h1>
+            <p className="notif-page-subtitle">
+              {unreadCount > 0
+                ? `${unreadCount} unread`
+                : notifications.length > 0
+                  ? "You're all caught up"
+                  : ' '}
+            </p>
+          </div>
+          {unreadCount > 0 && (
+            <button
+              className="notif-page-mark-all"
+              onClick={handleMarkAllRead}
+              disabled={markingAll}
+            >
+              Mark all as read
+            </button>
+          )}
+        </header>
+
+        {loading && notifications.length === 0 ? (
+          <div className="notif-page-state">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              strokeWidth="1.5" style={{ opacity: 0.3, animation: 'spin 0.8s linear infinite' }}>
+              <polyline points="23 4 23 10 17 10" />
+              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+            </svg>
+            <p>Loading…</p>
+          </div>
+        ) : error ? (
+          <div className="notif-page-state">
+            <p>{error}</p>
+            <button className="notif-load-more" onClick={fetchNotifications}>Try again</button>
+          </div>
+        ) : notifications.length === 0 ? (
+          <div className="notif-page-state">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              strokeWidth="1.5" style={{ opacity: 0.25 }}>
+              <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+              <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+            </svg>
+            <p>No notifications yet</p>
+          </div>
+        ) : (
+          <>
+            <ul className="notif-page-list">
+              {visible.map(n => (
+                <li
+                  key={n.id}
+                  className={`notif-page-item${!n.read ? ' notif-page-item--unread' : ''}`}
+                  onClick={() => !n.read && handleMarkRead(n.id)}
+                  role={!n.read ? 'button' : undefined}
+                  tabIndex={!n.read ? 0 : undefined}
+                  onKeyDown={e => {
+                    if (!n.read && (e.key === 'Enter' || e.key === ' ')) {
+                      e.preventDefault()
+                      handleMarkRead(n.id)
+                    }
+                  }}
+                >
+                  <span className="notif-page-emoji" aria-hidden="true">{iconFor(n.type)}</span>
+                  <div className="notif-page-body">
+                    <div className="notif-page-item-head">
+                      <p className="notif-page-item-title">{n.title}</p>
+                      {!n.read && <span className="notif-unread-dot" aria-label="Unread" />}
+                    </div>
+                    <p className="notif-page-item-text">{n.body}</p>
+                    <span className="notif-page-item-time">{timeAgo(n.createdAt)}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+
+            {hasMore && (
+              <button
+                className="notif-load-more"
+                onClick={() => setVisibleCount(c => c + PAGE_SIZE)}
+              >
+                Load more
+              </button>
+            )}
+          </>
+        )}
+      </section>
+    </MainLayout>
+  )
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -2081,3 +2081,132 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* ── NOTIFICATIONS PAGE ───────────────────────────────────────── */
+.notif-page {
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 28px 20px 48px;
+}
+.notif-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.notif-page-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text-dark);
+  margin: 0;
+  line-height: 1.2;
+}
+.notif-page-subtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 4px 0 0;
+  min-height: 18px;
+}
+.notif-page-mark-all {
+  background: var(--green-pale);
+  color: var(--green-dark);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s, opacity 0.12s;
+}
+.notif-page-mark-all:hover { background: #ddeee5; }
+.notif-page-mark-all:disabled { opacity: 0.5; cursor: default; }
+
+.notif-page-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.notif-page-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 14px 16px;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  transition: background 0.12s, border-color 0.12s, box-shadow 0.12s;
+}
+.notif-page-item[role="button"] { cursor: pointer; }
+.notif-page-item[role="button"]:hover {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+}
+.notif-page-item--unread {
+  background: var(--green-pale);
+  border-color: #c8dec9;
+}
+.notif-page-item--unread:hover { background: #ddeee5; }
+
+.notif-page-emoji {
+  font-size: 22px;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 2px;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.notif-page-body { flex: 1; min-width: 0; }
+.notif-page-item-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.notif-page-item-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin: 0;
+}
+.notif-page-item-text {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin: 4px 0 0;
+  line-height: 1.5;
+}
+.notif-page-item-time {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 6px;
+  display: block;
+}
+
+.notif-page-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 60px 20px;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.notif-load-more {
+  display: block;
+  margin: 20px auto 0;
+  background: #fff;
+  color: var(--green-dark);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.notif-load-more:hover { background: var(--green-pale); }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1369,6 +1369,21 @@
   background: var(--green-mid); flex-shrink: 0; margin-top: 6px;
 }
 
+.notif-see-all {
+  width: 100%;
+  padding: 11px 16px;
+  background: #fff;
+  border: none;
+  border-top: 0.5px solid rgba(0,0,0,0.08);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--green-dark);
+  cursor: pointer;
+  transition: background 0.12s;
+  text-align: center;
+}
+.notif-see-all:hover { background: var(--green-pale); }
+
 /* ── MENTOR DASHBOARD STATS ── */
 .mentor-stats-row {
   display: grid;

--- a/frontend/src/utils/timeAgo.js
+++ b/frontend/src/utils/timeAgo.js
@@ -1,0 +1,7 @@
+export function timeAgo(iso) {
+  const diff = Math.floor((Date.now() - new Date(iso)) / 1000)
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}


### PR DESCRIPTION
Refs: #129 
### Summary         
---
  - Adds a dedicated /notifications page listing all notifications for the authenticated user, with per-item mark-as-read, mark-all-as-read, and client-side "Load more" pagination (20 
  per page).
  - Wires the navbar NotificationBell "See all notifications →" button to navigate to the new page.                                                                                     
  - Extracts the shared timeAgo helper into utils/timeAgo.js so both NotificationBell and NotificationsPage use the same formatting.                                                    
                                                                                                                                                                                        
###  Changes                                                                                                                                                                               
---                                                                                                                                                                                    
  - frontend/src/utils/timeAgo.js — new shared helper (just now / Xm / Xh / Xd).                                                                                                        
  - frontend/src/pages/NotificationsPage.jsx — new page inside MainLayout; fetches via getNotifications, handles loading/error/empty states, optimistic mark-read with revert on
  failure, and keyboard-accessible list items.                                                                                                                                          
  - frontend/src/components/NotificationBell.jsx — drops the inline timeAgo in favor of the shared util; "See all" now routes to /notifications and closes the dropdown.
  - frontend/src/App.jsx — registers /notifications under ProtectedRoute.                                                                                                               
  - frontend/src/styles/main.css — styles for the new page (notif-page-*, notif-load-more, states).                                                                                     
        
###  Backend wiring (verified)                                                                                                                                                             
---                                                                                                                                                                            
  No backend changes; existing endpoints in NotificationController are consumed unchanged:                                                                                              
  - GET /api/notifications?unreadOnly=false → getNotifications()
  - PATCH /api/notifications/{id}/read → markNotificationAsRead(id)                                                                                                                     
  - PATCH /api/notifications/read-all → markAllNotificationsAsRead()
---                                                                                                                                                                                        
###  Contract checks:                                                                                                                                                                      
  - Bearer token is attached on all three calls.
  - Response DTO fields (id, type, title, body, read, createdAt) line up with the UI — NotificationResponse.isRead is serialized by Jackson as "read", which is what the page reads.    
  - All six NotificationType values (MATCH_FOUND, REQUEST_RECEIVED, REQUEST_ACCEPTED, REQUEST_REJECTED, NEW_MESSAGE, MEETING_REMINDER) have icons in the page's TYPE_ICON map, with a
  generic 🔔 fallback.                                                                                                                                                                  
  - /notifications sits inside ProtectedRoute, matching the authenticated endpoints.                                                                                                    
                                                                        
###  Test plan                                                                                                                                                                             
---                                                                                                                                                                                        
  - Log in, open the bell, click "See all notifications →" — lands on /notifications and the dropdown closes.                                                                           
  - Unread notifications render with the dot and bold styling; clicking (or Enter/Space) marks them read and the badge/count decrements.                                                
  - "Mark all as read" clears the unread count; on simulated failure the list reverts.                                                                                                  
  - With >20 notifications, "Load more" reveals the next batch.                                                                                                                         
  - Empty, loading, and error states each render.                                                                                                                                       
  - Unauthenticated visit to /notifications redirects to login.       