### PR TITLE
feat(backend): JSON-LD / Schema.org content negotiation (#251)

### DIFF
--- a/backend/src/main/java/com/group7/backend/BackendApplication.java
+++ b/backend/src/main/java/com/group7/backend/BackendApplication.java
@@ -2,12 +2,14 @@ package com.group7.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
 @EnableAsync
+@ConfigurationPropertiesScan
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/group7/backend/config/AppProperties.java
+++ b/backend/src/main/java/com/group7/backend/config/AppProperties.java
@@ -1,0 +1,23 @@
+package com.group7.backend.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.URL;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "app")
+@Validated
+public class AppProperties {
+
+    @NotBlank
+    @URL
+    private String baseUrl;
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdContext.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdContext.java
@@ -1,0 +1,9 @@
+package com.group7.backend.config.jsonld;
+
+public final class JsonLdContext {
+
+    public static final String SCHEMA_ORG = "https://schema.org";
+
+    private JsonLdContext() {
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMapping.java
@@ -1,0 +1,10 @@
+package com.group7.backend.config.jsonld;
+
+import java.util.Map;
+
+public interface JsonLdMapping {
+
+    boolean supports(Class<?> bodyType);
+
+    Map<String, Object> apply(Object body);
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMediaType.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMediaType.java
@@ -1,0 +1,12 @@
+package com.group7.backend.config.jsonld;
+
+import org.springframework.http.MediaType;
+
+public final class JsonLdMediaType {
+
+    public static final String APPLICATION_LD_JSON_VALUE = "application/ld+json";
+    public static final MediaType APPLICATION_LD_JSON = MediaType.parseMediaType(APPLICATION_LD_JSON_VALUE);
+
+    private JsonLdMediaType() {
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMediaTypeConfig.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMediaTypeConfig.java
@@ -1,0 +1,31 @@
+package com.group7.backend.config.jsonld;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class JsonLdMediaTypeConfig implements WebMvcConfigurer {
+
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        for (HttpMessageConverter<?> converter : converters) {
+            if (!(converter instanceof MappingJackson2HttpMessageConverter jackson)) {
+                continue;
+            }
+            List<MediaType> supported = jackson.getSupportedMediaTypes();
+            boolean handlesPlainJson = supported.stream().anyMatch(MediaType.APPLICATION_JSON::equals);
+            if (!handlesPlainJson || supported.contains(JsonLdMediaType.APPLICATION_LD_JSON)) {
+                continue;
+            }
+            List<MediaType> updated = new ArrayList<>(supported);
+            updated.add(JsonLdMediaType.APPLICATION_LD_JSON);
+            jackson.setSupportedMediaTypes(updated);
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdResponseBodyAdvice.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdResponseBodyAdvice.java
@@ -1,0 +1,139 @@
+package com.group7.backend.config.jsonld;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Wraps controller responses as JSON-LD when the client requests
+ * {@code Accept: application/ld+json}.
+ *
+ * Contract: if the response Content-Type is {@code application/ld+json},
+ * the body IS valid JSON-LD. When we cannot produce a JSON-LD shape (no
+ * registered mapping, heterogeneous collection, {@link Page} wrapper, etc.),
+ * the Content-Type is downgraded to {@code application/json} and the body
+ * passes through unchanged.
+ */
+@ControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class JsonLdResponseBodyAdvice implements ResponseBodyAdvice<Object> {
+
+    private static final Logger log = LoggerFactory.getLogger(JsonLdResponseBodyAdvice.class);
+
+    private final List<JsonLdMapping> mappings;
+
+    public JsonLdResponseBodyAdvice(List<JsonLdMapping> mappings) {
+        this.mappings = List.copyOf(mappings);
+    }
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return !mappings.isEmpty();
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+        if (body == null) {
+            return null;
+        }
+        if (!JsonLdMediaType.APPLICATION_LD_JSON.isCompatibleWith(selectedContentType)) {
+            return body;
+        }
+
+        // Page<T> wrapping in JSON-LD requires modeling pagination as a typed
+        // resource (e.g., schema.org ItemList). Deferred to a Wave 2 slice.
+        if (body instanceof Page<?>) {
+            return downgrade(body, response, "Page<T> body is not JSON-LD-shaped");
+        }
+
+        if (body instanceof Collection<?> collection) {
+            return transformCollection(collection, response);
+        }
+
+        return findMappingFor(body.getClass())
+                .<Object>map(m -> m.apply(body))
+                .orElseGet(() -> downgrade(body, response,
+                        "no JSON-LD mapping for " + body.getClass().getSimpleName()));
+    }
+
+    private Optional<JsonLdMapping> findMappingFor(Class<?> bodyType) {
+        return mappings.stream().filter(m -> m.supports(bodyType)).findFirst();
+    }
+
+    private Object transformCollection(Collection<?> collection, ServerHttpResponse response) {
+        if (collection.isEmpty()) {
+            return wrapAsGraph(List.of());
+        }
+
+        Object firstNonNull = null;
+        for (Object element : collection) {
+            if (element != null) {
+                firstNonNull = element;
+                break;
+            }
+        }
+        if (firstNonNull == null) {
+            return downgrade(collection, response, "collection contains only null elements");
+        }
+
+        Optional<JsonLdMapping> maybeMapping = findMappingFor(firstNonNull.getClass());
+        if (maybeMapping.isEmpty()) {
+            return downgrade(collection, response,
+                    "no JSON-LD mapping for collection elements of " + firstNonNull.getClass().getSimpleName());
+        }
+        JsonLdMapping mapping = maybeMapping.get();
+
+        for (Object element : collection) {
+            if (element != null && !mapping.supports(element.getClass())) {
+                return downgrade(collection, response,
+                        "heterogeneous collection (first=" + firstNonNull.getClass().getSimpleName()
+                                + ", found=" + element.getClass().getSimpleName() + ")");
+            }
+        }
+
+        List<Map<String, Object>> items = new ArrayList<>(collection.size());
+        for (Object element : collection) {
+            if (element == null) {
+                continue;
+            }
+            Map<String, Object> mapped = new LinkedHashMap<>(mapping.apply(element));
+            mapped.remove("@context");
+            items.add(mapped);
+        }
+        return wrapAsGraph(items);
+    }
+
+    private static Object downgrade(Object body, ServerHttpResponse response, String reason) {
+        log.debug("ld+json downgrade to application/json: {}", reason);
+        response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+        return body;
+    }
+
+    private static Map<String, Object> wrapAsGraph(List<?> items) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("@context", JsonLdContext.SCHEMA_ORG);
+        result.put("@graph", items);
+        return result;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/PersonMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/PersonMapping.java
@@ -1,0 +1,108 @@
+package com.group7.backend.config.jsonld;
+
+import com.group7.backend.config.AppProperties;
+import com.group7.backend.dto.response.MenteeResponse;
+import com.group7.backend.dto.response.MentorResponse;
+import com.group7.backend.dto.response.UserResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class PersonMapping implements JsonLdMapping {
+
+    private final String baseUrl;
+
+    public PersonMapping(AppProperties appProperties) {
+        String configured = appProperties.getBaseUrl();
+        this.baseUrl = configured.endsWith("/")
+                ? configured.substring(0, configured.length() - 1)
+                : configured;
+    }
+
+    @Override
+    public boolean supports(Class<?> bodyType) {
+        return UserResponse.class.isAssignableFrom(bodyType);
+    }
+
+    @Override
+    public Map<String, Object> apply(Object body) {
+        UserResponse user = (UserResponse) body;
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("@context", JsonLdContext.SCHEMA_ORG);
+        result.put("@type", "Person");
+        if (user.getId() != null) {
+            result.put("@id", baseUrl + "/api/users/" + user.getId());
+        }
+        putIfPresent(result, "givenName", user.getFirstName());
+        putIfPresent(result, "familyName", user.getLastName());
+        putIfPresent(result, "email", user.getEmail());
+        putIfPresent(result, "image", user.getProfilePhoto());
+
+        // schema.org/description is intentionally freeform prose for both roles
+        // (bio for mentors, backgroundInfo for mentees). schema.org treats
+        // description as a generic self-description property regardless of
+        // role; consumers disambiguate Mentor vs Mentee via @type plus
+        // role-specific fields (jobTitle, affiliation for mentors). Wrapping
+        // in Role / OrganizationRole is a future enhancement that depends on
+        // organization modeling and is out of scope for Wave 1.
+        if (user instanceof MentorResponse mentor) {
+            putIfPresent(result, "description", mentor.getBio());
+            putIfPresent(result, "jobTitle", mentor.getField());
+            putIfPresent(result, "affiliation", mentor.getAffiliation());
+
+            LinkedHashSet<String> knowsAbout = new LinkedHashSet<>();
+            addNonBlank(knowsAbout, mentor.getExpertise());
+            addNonBlank(knowsAbout, mentor.getInterests());
+            if (!knowsAbout.isEmpty()) {
+                result.put("knowsAbout", new ArrayList<>(knowsAbout));
+            }
+        } else if (user instanceof MenteeResponse mentee) {
+            putIfPresent(result, "description", mentee.getBackgroundInfo());
+
+            LinkedHashSet<String> knowsAbout = new LinkedHashSet<>();
+            addNonBlank(knowsAbout, mentee.getInterests());
+            addNonBlank(knowsAbout, mentee.getSkills());
+            if (!knowsAbout.isEmpty()) {
+                result.put("knowsAbout", new ArrayList<>(knowsAbout));
+            }
+            // mentee.major and mentee.careerInterest do not yet have a clean
+            // schema.org mapping in our domain (memberOf would imply membership
+            // in an organisation; knowsAbout would imply mastery rather than
+            // interest). Both are deferred until the ESCO/ISCED-F migration in
+            // Wave 3a (#137) introduces typed identifiers for fields of study.
+        }
+
+        return result;
+    }
+
+    private static void putIfPresent(Map<String, Object> map, String key, Object value) {
+        if (value == null) {
+            return;
+        }
+        if (value instanceof String s && s.isBlank()) {
+            return;
+        }
+        map.put(key, value);
+    }
+
+    private static void addNonBlank(LinkedHashSet<String> target, String value) {
+        if (value != null && !value.isBlank()) {
+            target.add(value);
+        }
+    }
+
+    private static void addNonBlank(LinkedHashSet<String> target, List<String> values) {
+        if (values == null) {
+            return;
+        }
+        for (String value : values) {
+            addNonBlank(target, value);
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/ScheduleMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/ScheduleMapping.java
@@ -1,0 +1,45 @@
+package com.group7.backend.config.jsonld;
+
+import com.group7.backend.dto.response.AvailabilitySlotResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Component
+public class ScheduleMapping implements JsonLdMapping {
+
+    @Override
+    public boolean supports(Class<?> bodyType) {
+        return AvailabilitySlotResponse.class.isAssignableFrom(bodyType);
+    }
+
+    @Override
+    public Map<String, Object> apply(Object body) {
+        AvailabilitySlotResponse slot = (AvailabilitySlotResponse) body;
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("@context", JsonLdContext.SCHEMA_ORG);
+        result.put("@type", "Schedule");
+        // No @id: availability slots are sub-resources of a mentor and have no
+        // dedicated GET-by-id endpoint. JSON-LD allows blank nodes here.
+        if (slot.getDayOfWeek() != null) {
+            result.put("byDay", "https://schema.org/" + capitalize(slot.getDayOfWeek()));
+        }
+        if (slot.getStartTime() != null) {
+            result.put("startTime", slot.getStartTime().toString());
+        }
+        if (slot.getEndTime() != null) {
+            result.put("endTime", slot.getEndTime().toString());
+        }
+        if (slot.isRecurring()) {
+            result.put("repeatFrequency", "P1W");
+        }
+        return result;
+    }
+
+    private static String capitalize(String dayOfWeek) {
+        String lower = dayOfWeek.toLowerCase();
+        return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/config/AppPropertiesTest.java
+++ b/backend/src/test/java/com/group7/backend/config/AppPropertiesTest.java
@@ -1,0 +1,80 @@
+package com.group7.backend.config;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppPropertiesTest {
+
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        factory.close();
+    }
+
+    @Test
+    void validHttpUrl_passesValidation() {
+        AppProperties props = new AppProperties();
+        props.setBaseUrl("http://localhost:8080");
+        assertThat(validator.validate(props)).isEmpty();
+    }
+
+    @Test
+    void validHttpsUrl_passesValidation() {
+        AppProperties props = new AppProperties();
+        props.setBaseUrl("https://api.example.com");
+        assertThat(validator.validate(props)).isEmpty();
+    }
+
+    @Test
+    void blankBaseUrl_failsValidation() {
+        AppProperties props = new AppProperties();
+        props.setBaseUrl("");
+
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(props);
+
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("baseUrl");
+    }
+
+    @Test
+    void nullBaseUrl_failsValidation() {
+        AppProperties props = new AppProperties();
+        // baseUrl left null
+
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(props);
+
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("baseUrl");
+    }
+
+    @Test
+    void garbageString_failsValidation() {
+        AppProperties props = new AppProperties();
+        props.setBaseUrl("not a url with spaces");
+
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(props);
+
+        assertThat(violations)
+                .as("malformed URL must trigger @URL constraint")
+                .isNotEmpty();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/JsonLdContentNegotiationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/JsonLdContentNegotiationTest.java
@@ -1,0 +1,346 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.repository.AvailabilitySlotRepository;
+import com.group7.backend.repository.MentorshipRequestRepository;
+import com.group7.backend.repository.PasswordResetTokenRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class JsonLdContentNegotiationTest {
+
+    private static final String LD_JSON = "application/ld+json";
+    private static final String LD_JSON_WITH_CHARSET = "application/ld+json;charset=UTF-8";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired private MentorshipRequestRepository mentorshipRequestRepository;
+    @Autowired private AvailabilitySlotRepository availabilitySlotRepository;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        availabilitySlotRepository.deleteAll();
+        mentorshipRequestRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    @Test
+    void plainJsonRequest_returnsPlainJsonResponseUnchanged() throws Exception {
+        String token = registerAndLogin("Esra", "Yilmaz", "ld_mentor1@test.com", true);
+
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@context")).isNull();
+        assertThat(body.get("@type")).isNull();
+        assertThat(body.get("firstName").asText()).isEqualTo("Esra");
+        assertThat(body.get("role").asText()).isEqualTo("MENTOR");
+    }
+
+    @Test
+    void ldJsonRequest_returnsPersonJsonLdForMentor() throws Exception {
+        String token = registerAndLogin("Esra", "Yilmaz", "ld_mentor2@test.com", true);
+
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .accept(LD_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(LD_JSON))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@context").asText()).isEqualTo("https://schema.org");
+        assertThat(body.get("@type").asText()).isEqualTo("Person");
+        String id = body.get("@id").asText();
+        assertThat(id).as("@id must be an absolute IRI").startsWith("http");
+        assertThat(id).contains("/api/users/");
+        assertThat(body.get("givenName").asText()).isEqualTo("Esra");
+        assertThat(body.get("familyName").asText()).isEqualTo("Yilmaz");
+        assertThat(body.get("email").asText()).isEqualTo("ld_mentor2@test.com");
+        // mentor without filled-in profile has no bio/expertise/etc — those fields should be omitted
+        assertThat(body.get("description")).isNull();
+        // legacy fields should not appear
+        assertThat(body.get("firstName")).isNull();
+        assertThat(body.get("role")).isNull();
+    }
+
+    @Test
+    void ldJsonRequest_fullyPopulatedMentor_emitsAllFields() throws Exception {
+        String token = registerAndLogin("Sami", "Cakmak", "ld_mentor_full@test.com", true);
+
+        Map<String, Object> patch = Map.of(
+                "bio", "10+ years backend engineer.",
+                "field", "Computer Science",
+                "expertise", "Distributed Systems",
+                "affiliation", "Bogazici University",
+                "interests", List.of("Distributed Systems", "Databases", "Performance Engineering")
+        );
+        mockMvc.perform(patch("/api/users/me/mentor")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(patch)))
+                .andExpect(status().isOk());
+
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .accept(LD_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("description").asText()).isEqualTo("10+ years backend engineer.");
+        assertThat(body.get("jobTitle").asText()).isEqualTo("Computer Science");
+        assertThat(body.get("affiliation").asText()).isEqualTo("Bogazici University");
+
+        JsonNode knowsAbout = body.get("knowsAbout");
+        assertThat(knowsAbout).isNotNull();
+        assertThat(knowsAbout.isArray()).isTrue();
+        // expertise leads, then interests; "Distributed Systems" appears once due to dedup
+        List<String> values = new ArrayList<>();
+        knowsAbout.forEach(n -> values.add(n.asText()));
+        assertThat(values).containsExactly("Distributed Systems", "Databases", "Performance Engineering");
+    }
+
+    @Test
+    void ldJsonRequest_returnsPersonJsonLdForMentee() throws Exception {
+        String token = registerAndLogin("Ali", "Demir", "ld_mentee1@test.com", false);
+
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .accept(LD_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@type").asText()).isEqualTo("Person");
+        assertThat(body.get("givenName").asText()).isEqualTo("Ali");
+        assertThat(body.get("familyName").asText()).isEqualTo("Demir");
+        // memberOf was incorrect for mentee.major; verify it does NOT appear
+        assertThat(body.get("memberOf")).isNull();
+    }
+
+    @Test
+    void ldJsonRequest_wrapsAvailabilityListAsGraph() throws Exception {
+        String mentorToken = registerAndLogin("Cem", "Kaya", "ld_mentor3@test.com", true);
+        Long mentorId = userRepository.findByEmail("ld_mentor3@test.com").orElseThrow().getId();
+
+        // add two availability slots so we can verify graph wrapping
+        mockMvc.perform(post("/api/availability")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("dayOfWeek", "MONDAY", "startTime", "09:00",
+                                        "endTime", "12:00", "recurring", true))))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/api/availability")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("dayOfWeek", "TUESDAY", "startTime", "13:00",
+                                        "endTime", "17:00", "recurring", true))))
+                .andExpect(status().isCreated());
+
+        MvcResult result = mockMvc.perform(get("/api/availability/" + mentorId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken)
+                        .accept(LD_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(LD_JSON))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@context").asText()).isEqualTo("https://schema.org");
+        JsonNode graph = body.get("@graph");
+        assertThat(graph).isNotNull();
+        assertThat(graph.isArray()).isTrue();
+        assertThat(graph).hasSize(2);
+
+        JsonNode firstSlot = graph.get(0);
+        assertThat(firstSlot.get("@type").asText()).isEqualTo("Schedule");
+        assertThat(firstSlot.get("@context")).as("inner items must not duplicate @context").isNull();
+        assertThat(firstSlot.get("byDay").asText()).startsWith("https://schema.org/");
+        assertThat(firstSlot.get("startTime").asText()).startsWith("09:00");
+        assertThat(firstSlot.get("repeatFrequency").asText()).isEqualTo("P1W");
+    }
+
+    @Test
+    void ldJsonRequest_emptyAvailabilityList_returnsEmptyGraph() throws Exception {
+        String mentorToken = registerAndLogin("Empty", "Slots", "ld_mentor_empty@test.com", true);
+        Long mentorId = userRepository.findByEmail("ld_mentor_empty@test.com").orElseThrow().getId();
+
+        MvcResult result = mockMvc.perform(get("/api/availability/" + mentorId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken)
+                        .accept(LD_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(LD_JSON))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@context").asText()).isEqualTo("https://schema.org");
+        JsonNode graph = body.get("@graph");
+        assertThat(graph).isNotNull();
+        assertThat(graph.isArray()).isTrue();
+        assertThat(graph).isEmpty();
+    }
+
+    @Test
+    void ldJsonRequest_pageResponse_downgradesContentType() throws Exception {
+        // seed a couple of mentors so the page has content
+        registerAndLogin("Page", "Mentor1", "ld_page1@test.com", true);
+        registerAndLogin("Page", "Mentor2", "ld_page2@test.com", true);
+
+        String menteeToken = registerAndLogin("Pager", "Reader", "ld_pager@test.com", false);
+
+        MvcResult result = mockMvc.perform(get("/api/users/mentors")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken)
+                        .param("page", "0")
+                        .param("size", "10")
+                        .accept(LD_JSON))
+                .andExpect(status().isOk())
+                // Page<T> can't be JSON-LD-shaped without modeling pagination as
+                // a typed resource, so the advice downgrades Content-Type to
+                // plain JSON. The body remains the standard Page envelope.
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@context")).isNull();
+        assertThat(body.get("@graph")).isNull();
+        assertThat(body.get("content")).isNotNull();
+        assertThat(body.get("content").isArray()).isTrue();
+        assertThat(body.get("totalElements")).isNotNull();
+    }
+
+    @Test
+    void ldJsonRequest_unmappedSingleBody_downgradesContentType() throws Exception {
+        // /api/auth/login returns AuthResponse, which has no JSON-LD mapping.
+        // The advice should downgrade Content-Type to plain JSON rather than
+        // emit a body labeled as ld+json without a @context.
+        registerAndLogin("Down", "Grade", "ld_downgrade@test.com", true);
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail("ld_downgrade@test.com");
+        login.setPassword("Password1");
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(LD_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@context")).isNull();
+        assertThat(body.get("sessionToken")).isNotNull();
+        assertThat(body.get("role").asText()).isEqualTo("MENTOR");
+    }
+
+    @Test
+    void ldJsonRequestWithCharset_returnsJsonLd() throws Exception {
+        String token = registerAndLogin("Char", "Set", "ld_charset@test.com", true);
+
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .accept(LD_JSON_WITH_CHARSET))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(LD_JSON))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@context").asText()).isEqualTo("https://schema.org");
+        assertThat(body.get("@type").asText()).isEqualTo("Person");
+    }
+
+    @Test
+    void wildcardAcceptHeader_returnsPlainJson() throws Exception {
+        String token = registerAndLogin("Wild", "Card", "ld_wildcard@test.com", true);
+
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .accept(MediaType.ALL))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@context")).isNull();
+        assertThat(body.get("firstName").asText()).isEqualTo("Wild");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────
+
+    private String registerAndLogin(String firstName, String lastName, String email, boolean isMentor) throws Exception {
+        RegisterRequest reg = new RegisterRequest();
+        reg.setFirstName(firstName);
+        reg.setLastName(lastName);
+        reg.setEmail(email);
+        reg.setPassword("Password1");
+        reg.setIsMentor(isMentor);
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reg)))
+                .andExpect(status().isCreated());
+
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+}


### PR DESCRIPTION
## Summary
- New `JsonLdResponseBodyAdvice` (`@ControllerAdvice`) wraps responses as JSON-LD when the client sends `Accept: application/ld+json`. Extension point is the `JsonLdMapping` interface — Wave 2 slices add their own `@Component` implementations without changing the advice.
- Two initial mappings ship: Schema.org `Person` for `MentorResponse`/`MenteeResponse` (with absolute `@id` IRIs) and Schema.org `Schedule` for `AvailabilitySlotResponse`.
- Strict contract: **if `Content-Type` is `application/ld+json`, the body IS valid JSON-LD**. Anything we cannot produce a JSON-LD shape for (`Page<T>`, unmapped body, heterogeneous collection, all-null collection) downgrades the response Content-Type to `application/json` and passes the body through unchanged.
- New `AppProperties` (`@ConfigurationProperties` + `@Validated` + Hibernate Validator's `@URL`) makes `app.base-url` fail-fast at startup if misconfigured. `BackendApplication` gains `@ConfigurationPropertiesScan` so future config-properties classes auto-register.

## What this implements from the wiki standards page
- **JSON-LD 1.1** (W3C) — content negotiation infrastructure.
- **Schema.org vocabulary** — `Person` and `Schedule` types mapped from existing DTOs.
- Lays the foundation for Wave 2 / Wave 3 slices to add `Note`, `Event`, `Rating`, `Article` mappings without further infrastructure changes.

## Behavior matrix
| Request | Body | Response |
|---|---|---|
| `Accept: application/json` | anything | unchanged plain JSON |
| `Accept: application/ld+json` | `MentorResponse` / `MenteeResponse` | `application/ld+json`, `@type: Person` |
| `Accept: application/ld+json` | `List<AvailabilitySlotResponse>` (non-empty) | `application/ld+json`, `{@context, @graph: [Schedule, ...]}` |
| `Accept: application/ld+json` | empty supported collection | `application/ld+json`, `{@context, @graph: []}` |
| `Accept: application/ld+json` | `Page<T>` | downgrade to `application/json`, body unchanged |
| `Accept: application/ld+json` | unmapped DTO (e.g. `AuthResponse`) | downgrade to `application/json`, body unchanged |
| `Accept: application/ld+json; charset=UTF-8` | mapped body | works (`isCompatibleWith` accepts charset) |

## Files changed
- **Main** (9): `BackendApplication.java` (added `@ConfigurationPropertiesScan`); new `config/AppProperties.java`; new package `config/jsonld/` with `JsonLdContext`, `JsonLdMediaType`, `JsonLdMapping`, `JsonLdMediaTypeConfig`, `JsonLdResponseBodyAdvice`, `PersonMapping`, `ScheduleMapping`.
- **Tests** (2): `config/AppPropertiesTest.java` (5 unit tests for `@URL`/`@NotBlank` constraints); `integration/JsonLdContentNegotiationTest.java` (10 integration tests covering all behavior matrix rows above).

## Test plan
- [x] `mvn test -Dtest=JsonLdContentNegotiationTest` — 10 / 10 pass
- [x] `mvn test -Dtest=AppPropertiesTest` — 5 / 5 pass
- [x] `mvn test` (full suite) — 406 / 406 pass (no regressions)
- [x] Manual `curl` against the running Docker backend confirms:
  - `GET /api/users/me` with default `Accept` returns plain JSON unchanged
  - `GET /api/users/me` with `Accept: application/ld+json` returns Schema.org Person
  - `GET /api/availability/{id}` with `Accept: application/ld+json` returns `@graph` of Schedules
  - `/swagger-ui.html` and `/v3/api-docs` are unaffected (springdoc still works)

## Out of scope (will be addressed in later waves)
- `Page<T>` JSON-LD wrapping (needs Schema.org `ItemList` modeling — Wave 2).
- Activity Streams 2.0 emissions for notifications/blog/messaging — lands per Wave 2/3 slice.
- ESCO / Wikidata / ISCED-F vocabulary integration — Wave 3a (issue #137).
- `Role` / `OrganizationRole` wrapping for explicit mentor/mentee role typing — depends on organization modeling, Wave 2+.
- Mentee `major` / `careerInterest` mapped only after ESCO/ISCED-F lands (commented in `PersonMapping`).