### PR TITLE
fix(backend): reject JWTs with missing userId/role claims (#271)

### DIFF
--- a/backend/src/main/java/com/group7/backend/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/group7/backend/config/JwtAuthenticationFilter.java
@@ -5,6 +5,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -18,6 +20,8 @@ import java.util.UUID;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
     private static final String REQUEST_ID_HEADER = "X-Request-ID";
     private static final String REQUEST_ID_MDC_KEY = "requestId";
@@ -56,14 +60,27 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 String role = jwtService.extractRole(token);
                 Long userId = jwtService.extractUserId(token);
 
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                email,
-                                userId,
-                                List.of(new SimpleGrantedAuthority("ROLE_" + role))
-                        );
+                if (email == null || email.isBlank()
+                        || role == null || role.isBlank()
+                        || userId == null) {
+                    // Defensive: isTokenValid already rejects this, but guard
+                    // against future callers reordering the checks. Log only
+                    // claim presence (booleans), never values, to keep PII out
+                    // of logs.
+                    log.warn("Rejecting JWT with missing claims: email={}, role={}, userId={}",
+                            email != null && !email.isBlank(),
+                            role != null && !role.isBlank(),
+                            userId != null);
+                } else {
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    email,
+                                    userId,
+                                    List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                            );
 
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
 
             filterChain.doFilter(request, response);

--- a/backend/src/main/java/com/group7/backend/service/JwtService.java
+++ b/backend/src/main/java/com/group7/backend/service/JwtService.java
@@ -48,7 +48,18 @@ public class JwtService {
     public boolean isTokenValid(String token) {
         try {
             Claims claims = extractAllClaims(token);
-            return !claims.getExpiration().before(new Date());
+            if (claims.getExpiration().before(new Date())) {
+                return false;
+            }
+            String subject = claims.getSubject();
+            if (subject == null || subject.isBlank()) {
+                return false;
+            }
+            if (claims.get("userId", Long.class) == null) {
+                return false;
+            }
+            String role = claims.get("role", String.class);
+            return role != null && !role.isBlank();
         } catch (Exception e) {
             return false;
         }

--- a/backend/src/test/java/com/group7/backend/config/JwtAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/group7/backend/config/JwtAuthenticationFilterTest.java
@@ -1,0 +1,123 @@
+package com.group7.backend.config;
+
+import com.group7.backend.service.JwtService;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class JwtAuthenticationFilterTest {
+
+    private static final String SECRET =
+            "bXlTdXBlclNlY3JldEtleUZvckdyb3VwN0JhY2tlbmRBcHBsaWNhdGlvbjIwMjY=";
+
+    private JwtService jwtService;
+    private JwtAuthenticationFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService();
+        ReflectionTestUtils.setField(jwtService, "secret", SECRET);
+        ReflectionTestUtils.setField(jwtService, "expiration", 86400000L);
+        filter = new JwtAuthenticationFilter(jwtService);
+    }
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void validToken_populatesSecurityContext() throws Exception {
+        String token = jwtService.generateToken(42L, "user@example.com", "MENTOR");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users/me");
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        Authentication authn = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authn).isNotNull();
+        assertThat(authn.getPrincipal()).isEqualTo("user@example.com");
+        assertThat(authn.getCredentials()).isEqualTo(42L);
+        assertThat(authn.getAuthorities()).extracting(Object::toString).containsExactly("ROLE_MENTOR");
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    void tokenMissingUserId_doesNotPopulateContext_andCallsChain() throws Exception {
+        String token = malformedToken(Map.<String, Object>of("role", "MENTOR"), "user@example.com");
+        runFilter(token);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void tokenMissingRole_doesNotPopulateContext_andCallsChain() throws Exception {
+        String token = malformedToken(Map.<String, Object>of("userId", 1L), "user@example.com");
+        runFilter(token);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void tokenWithBlankRole_doesNotPopulateContext() throws Exception {
+        String token = malformedToken(Map.<String, Object>of("userId", 1L, "role", ""), "user@example.com");
+        runFilter(token);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void noBearerHeader_doesNotPopulateContext() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users/me");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    private void runFilter(String token) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/users/me");
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        filter.doFilter(request, response, chain);
+        verify(chain, times(1)).doFilter(request, response);
+    }
+
+    private static String malformedToken(Map<String, Object> claims, String subject) {
+        Key key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(SECRET));
+        io.jsonwebtoken.JwtBuilder builder = Jwts.builder()
+                .addClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 86400000L))
+                .signWith(key, SignatureAlgorithm.HS256);
+        if (subject != null) {
+            builder.setSubject(subject);
+        }
+        return builder.compact();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/JwtServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/JwtServiceTest.java
@@ -1,8 +1,16 @@
 package com.group7.backend.service;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -59,5 +67,43 @@ class JwtServiceTest {
     void menteeRole() {
         String token = jwtService.generateToken(1L, "mentee@example.com", "MENTEE");
         assertEquals("MENTEE", jwtService.extractRole(token));
+    }
+
+    @Test
+    void tokenWithoutUserIdClaim_isInvalid() {
+        String token = buildToken(Map.<String, Object>of("role", "MENTOR"), "test@example.com");
+        assertFalse(jwtService.isTokenValid(token));
+    }
+
+    @Test
+    void tokenWithoutRoleClaim_isInvalid() {
+        String token = buildToken(Map.<String, Object>of("userId", 1L), "test@example.com");
+        assertFalse(jwtService.isTokenValid(token));
+    }
+
+    @Test
+    void tokenWithoutSubject_isInvalid() {
+        String token = buildToken(Map.<String, Object>of("userId", 1L, "role", "MENTOR"), null);
+        assertFalse(jwtService.isTokenValid(token));
+    }
+
+    @Test
+    void tokenWithBlankRole_isInvalid() {
+        String token = buildToken(Map.<String, Object>of("userId", 1L, "role", ""), "test@example.com");
+        assertFalse(jwtService.isTokenValid(token));
+    }
+
+    private String buildToken(Map<String, Object> claims, String subject) {
+        String secret = (String) ReflectionTestUtils.getField(jwtService, "secret");
+        Key key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
+        io.jsonwebtoken.JwtBuilder builder = Jwts.builder()
+                .addClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + 86400000L))
+                .signWith(key, SignatureAlgorithm.HS256);
+        if (subject != null) {
+            builder.setSubject(subject);
+        }
+        return builder.compact();
     }
 }


### PR DESCRIPTION
## Summary
- `JwtService.isTokenValid` now verifies `subject`, `userId`, and a non-blank `role` claim alongside expiration — eliminating silent `null` returns from `claims.get(...)`.
- `JwtAuthenticationFilter` re-checks extracted claims defensively, logs a WARN with claim **presence** (no PII), and skips populating `SecurityContext` on a miss → request falls through to Spring's default 401 handling.
- Closes #271.

## Why
A signed, non-expired token missing `userId` or `role` previously produced a half-formed principal: `credentials=null` caused NPEs in controllers, and `"ROLE_" + null` created a literal `"ROLE_null"` authority that passed `.authenticated()` but failed opaquely at `@PreAuthorize`. Exploit surface is small (requires key compromise or schema drift) but the failure mode is hard to diagnose.

## Changes
- `backend/src/main/java/com/group7/backend/service/JwtService.java` — extend `isTokenValid` with claim presence checks.
- `backend/src/main/java/com/group7/backend/config/JwtAuthenticationFilter.java` — add SLF4J logger; defensive null/blank guard around claim use; WARN on rejection.
- `backend/src/test/java/com/group7/backend/service/JwtServiceTest.java` — +4 negative tests (no userId / no role / no subject / blank role).
- `backend/src/test/java/com/group7/backend/config/JwtAuthenticationFilterTest.java` — new unit-test class covering valid token, each missing claim, blank role, and no-bearer-header.

No changes to `SecurityConfig`, `GlobalExceptionHandler`, or any controller. Existing 401 path is sufficient because the filter simply does not authenticate on a malformed token.

## Test plan
- [x] `mvn test -Dtest=JwtServiceTest,JwtAuthenticationFilterTest` — 16/16 pass
- [x] `mvn test` — full suite 472/472 pass, no regressions
- [x] Verified WARN log contains only booleans, no email/role values

## Out of scope
- 401 vs 403 default for anonymous requests — separate `AuthenticationEntryPoint` task, not required by #271.
- Token rotation / blacklist on missing-claim detection — issue notes low exploit surface.
