### PR TITLE
fix(backend): document availability GET access policy (#274)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/AvailabilityController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AvailabilityController.java
@@ -21,6 +21,19 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * Authorization model for this controller (decided per issue #274):
+ * <ul>
+ *   <li>{@code GET /{mentorId}} — open to any authenticated user. Mentor weekly
+ *       availability is part of the discoverable mentor profile; mentees need it
+ *       before deciding whether to send a mentorship request. Global
+ *       {@code .anyRequest().authenticated()} in {@code SecurityConfig} is the
+ *       only gate. Deliberate, not an oversight.</li>
+ *   <li>{@code PUT}, {@code POST}, {@code DELETE} — restricted to {@code MENTOR}
+ *       role via {@code @PreAuthorize}; the affected mentor id is read from the
+ *       authenticated principal, so a mentor can only mutate their own slots.</li>
+ * </ul>
+ */
 @RestController
 @RequestMapping("/api/availability")
 @Tag(name = "Availability", description = "Mentor weekly availability management")
@@ -32,10 +45,15 @@ public class AvailabilityController {
         this.availabilityService = availabilityService;
     }
 
+    /**
+     * Returns the mentor's weekly availability. Visible to any authenticated
+     * user — see class-level javadoc and issue #274 for the policy decision.
+     */
     @GetMapping("/{mentorId}")
     @Operation(
             summary = "Get mentor availability",
-            description = "Returns all availability slots for the specified mentor, sorted by day and time."
+            description = "Returns all availability slots for the specified mentor, sorted by day and time. "
+                    + "Visible to any authenticated user — mentor availability is part of the discoverable profile."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Availability slots",

--- a/backend/src/test/java/com/group7/backend/controller/AvailabilityControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/AvailabilityControllerTest.java
@@ -10,6 +10,7 @@ import com.group7.backend.exception.OverlappingSlotException;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.service.AvailabilityService;
 import com.group7.backend.service.JwtService;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -73,6 +74,7 @@ class AvailabilityControllerTest {
     // ── GET /{mentorId} ─────────────────────────────────────────────────────
 
     @Test
+    @DisplayName("Any authenticated user — including unrelated mentees — can read any mentor's availability (issue #274)")
     void getSlotsReturns200ForMentee() throws Exception {
         mockMenteeJwt("mentee-token", 1L);
         when(availabilityService.getSlots(2L)).thenReturn(List.of(sampleSlot()));
@@ -91,6 +93,29 @@ class AvailabilityControllerTest {
         mockMvc.perform(get("/api/availability/2")
                         .header("Authorization", "Bearer mentor-token"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("A mentor can read another mentor's availability (issue #274 — open policy)")
+    void getSlotsReturns200ForUnrelatedMentor() throws Exception {
+        mockMentorJwt("other-mentor-token", 3L);
+        when(availabilityService.getSlots(2L)).thenReturn(List.of(sampleSlot()));
+
+        mockMvc.perform(get("/api/availability/2")
+                        .header("Authorization", "Bearer other-mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].dayOfWeek").value("MONDAY"));
+    }
+
+    @Test
+    @DisplayName("Unauthenticated requests are rejected (issue #274 — denied case)")
+    void getSlotsRejectsUnauthenticatedRequests() throws Exception {
+        // Spring Security's default entry point returns 403 (not 401) when no
+        // authentication is present and no custom AuthenticationEntryPoint is
+        // configured. The assertion locks in "rejected without a Bearer token",
+        // which is the policy contract; the exact code is a Spring detail.
+        mockMvc.perform(get("/api/availability/2"))
+                .andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
Closes #274.

## Context

`AvailabilityController.getSlots` had no per-resource authorization check, and
the policy was undocumented. The issue asked for a PM-confirmed policy + tests.

## Decision

PM chose **policy (a) — open to all authenticated users**. Mentor weekly
availability is part of the discoverable mentor profile; mentees need it before
deciding to send a mentorship request. The matching service already reads
availability via the repository, so this endpoint exists for UI display, not
for automated discovery.

## Changes

- `AvailabilityController`: class-level javadoc summarising the auth model
  (write = MENTOR + own data via token; read = any authenticated user,
  deliberate). `getSlots` method javadoc + Swagger `@Operation.description`
  updated.
- `AvailabilityControllerTest`: 3 new tests
  - mentor reads another mentor's slots → 200
  - unauthenticated request → 403 (Spring Security default entry point)
  - existing mentee-reads-mentor test now carries an explicit `@DisplayName`
    locking in the cross-user intent

No production code change beyond comments/annotations.

## Test plan

- [x] `AvailabilityControllerTest` — 15/15 passing
- [x] All `*ControllerTest` — 122/122 passing
- [x] Manual smoke: `curl -H "Authorization: Bearer <mentee-token>" /api/availability/<mentor-id>` → 200
- [x] Manual smoke: `curl /api/availability/<mentor-id>` (no auth) → 403
- [x] Swagger UI shows updated description under the Availability tag
