### PR TITLE
Add mentor-to-mentor messaging via MENTOR_PAIR conversation kind (#284)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MentorPairMessageController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorPairMessageController.java
@@ -1,0 +1,132 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.dto.request.SendMessageRequest;
+import com.group7.backend.dto.response.MessageResponse;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.service.ConversationService;
+import com.group7.backend.service.MessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Issue-spec REST surface for mentor-to-mentor (peer) chat. Each handler
+ * resolves the mentor-pair {@link Conversation} via {@link ConversationService}
+ * and then delegates to {@link MessageService} — the data model is
+ * conversation-centric but the API surface stays user-id-centric per #284.
+ *
+ * <p>Class-level {@code @PreAuthorize("hasRole('MENTOR')")} is the role gate
+ * for the caller; {@link ConversationService#findOrCreateForMentorPair} is the
+ * gate for the target user (must also be a mentor) and for self-pair
+ * rejection.
+ */
+@RestController
+@RequestMapping("/api/conversations/mentor-pair/{otherMentorId}/messages")
+@PreAuthorize("hasRole('MENTOR')")
+@Tag(name = "Mentor Pair Messages",
+        description = "Peer messaging between mentors (no mentorship required)")
+public class MentorPairMessageController {
+
+    private final MessageService messageService;
+    private final ConversationService conversationService;
+
+    public MentorPairMessageController(MessageService messageService,
+                                       ConversationService conversationService) {
+        this.messageService = messageService;
+        this.conversationService = conversationService;
+    }
+
+    @PostMapping
+    @Operation(summary = "Send a message to a peer mentor",
+            description = "Sends a chat message to another mentor. The conversation is "
+                    + "created on first call (idempotent: both mentors POSTing first "
+                    + "resolve to the same conversation row).")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Message sent",
+                    content = @Content(schema = @Schema(implementation = MessageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Self-pair or non-mentor target",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Caller is not a mentor",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Other user not found",
+                    content = @Content)
+    })
+    public ResponseEntity<MessageResponse> send(
+            @PathVariable Long otherMentorId,
+            @Valid @RequestBody SendMessageRequest request,
+            Authentication authentication) {
+        Long senderId = (Long) authentication.getCredentials();
+        Conversation conversation = conversationService.findOrCreateForMentorPair(
+                senderId, otherMentorId);
+        MessageResponse created = messageService.send(senderId, conversation.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @GetMapping
+    @Operation(summary = "List peer-mentor messages",
+            description = "Returns paginated message history with the specified peer mentor, "
+                    + "newest first.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated messages"),
+            @ApiResponse(responseCode = "400", description = "Self-pair or non-mentor target",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Caller is not a mentor",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Other user not found",
+                    content = @Content)
+    })
+    public ResponseEntity<Page<MessageResponse>> list(
+            @PathVariable Long otherMentorId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        Conversation conversation = conversationService.findOrCreateForMentorPair(
+                requesterId, otherMentorId);
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(messageService.list(requesterId, conversation.getId(), pageable));
+    }
+
+    @PatchMapping("/read")
+    @Operation(summary = "Mark all peer-mentor messages as read",
+            description = "Marks every unread message in this peer-mentor thread that was NOT "
+                    + "sent by the authenticated user as read. Returns 204.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Read receipts updated",
+                    content = @Content),
+            @ApiResponse(responseCode = "400", description = "Self-pair or non-mentor target",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Caller is not a mentor",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Other user not found",
+                    content = @Content)
+    })
+    public ResponseEntity<Void> markAllRead(
+            @PathVariable Long otherMentorId,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        Conversation conversation = conversationService.findOrCreateForMentorPair(
+                requesterId, otherMentorId);
+        messageService.markAllRead(requesterId, conversation.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/group7/backend/entity/Conversation.java
+++ b/backend/src/main/java/com/group7/backend/entity/Conversation.java
@@ -38,6 +38,22 @@ public class Conversation {
     @JoinColumn(name = "mentorship_id")
     private Mentorship mentorship;
 
+    /**
+     * Lower of the two user ids when {@link #kind} is
+     * {@link ConversationKind#MENTOR_PAIR}; null otherwise. The DB constraint
+     * {@code conversations_pair_ordering} enforces {@code pair_a_id < pair_b_id}
+     * when populated, so this column always carries the numerically-smaller id.
+     */
+    @Column(name = "pair_a_id")
+    private Long pairAId;
+
+    /**
+     * Higher of the two user ids when {@link #kind} is
+     * {@link ConversationKind#MENTOR_PAIR}; null otherwise.
+     */
+    @Column(name = "pair_b_id")
+    private Long pairBId;
+
     @OneToMany(mappedBy = "conversation", fetch = FetchType.LAZY,
             cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<ConversationParticipant> participants = new LinkedHashSet<>();

--- a/backend/src/main/java/com/group7/backend/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/ConversationRepository.java
@@ -1,6 +1,7 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -12,4 +13,15 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
      * partial unique index {@code uq_conversations_mentorship}.
      */
     Optional<Conversation> findByMentorshipId(Long mentorshipId);
+
+    /**
+     * Looks up a conversation by its canonical pair of user ids and kind.
+     * Callers MUST pre-order the ids so that {@code lowerId < higherId};
+     * this method does not normalise. The only intended caller is
+     * {@code ConversationService.findOrCreateForMentorPair}, which
+     * encapsulates the ordering. Backed by the partial unique index
+     * {@code uq_conversations_pair_kind}.
+     */
+    Optional<Conversation> findByPairAIdAndPairBIdAndKind(
+            Long lowerId, Long higherId, ConversationKind kind);
 }

--- a/backend/src/main/java/com/group7/backend/service/ConversationCreator.java
+++ b/backend/src/main/java/com/group7/backend/service/ConversationCreator.java
@@ -1,0 +1,81 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
+import com.group7.backend.entity.ConversationParticipant;
+import com.group7.backend.entity.ConversationParticipantId;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.ConversationParticipantRepository;
+import com.group7.backend.repository.ConversationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Atomic conversation creation in a fresh transaction. This bean exists
+ * solely so {@link ConversationService} can call into a
+ * {@link Propagation#REQUIRES_NEW} transactional method through a normally
+ * injected dependency, without using {@code ApplicationContext.getBean(...)}
+ * or {@code @Lazy} self-injection — both work but couple the service to
+ * Spring internals and complicate unit testing.
+ *
+ * <p>The two methods are intentionally narrow: each does exactly one
+ * conversation insert plus its participant rows, in a brand-new transaction.
+ * If a unique-constraint violation surfaces (concurrent first-write race),
+ * Hibernate raises {@link org.springframework.dao.DataIntegrityViolationException}
+ * and only this transaction rolls back; the caller in {@code ConversationService}
+ * recovers via a re-read.
+ */
+@Component
+public class ConversationCreator {
+
+    private static final Logger log = LoggerFactory.getLogger(ConversationCreator.class);
+
+    private final ConversationRepository conversationRepository;
+    private final ConversationParticipantRepository participantRepository;
+
+    public ConversationCreator(ConversationRepository conversationRepository,
+                               ConversationParticipantRepository participantRepository) {
+        this.conversationRepository = conversationRepository;
+        this.participantRepository = participantRepository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Conversation createForMentorshipInNewTx(Mentorship mentorship) {
+        Conversation conversation = new Conversation();
+        conversation.setKind(ConversationKind.MENTORSHIP);
+        conversation.setMentorship(mentorship);
+        Conversation saved = conversationRepository.save(conversation);
+        participantRepository.save(participant(saved, mentorship.getMentor()));
+        participantRepository.save(participant(saved, mentorship.getMentee()));
+        log.info("Conversation created: id={}, kind=MENTORSHIP, mentorshipId={}",
+                saved.getId(), mentorship.getId());
+        return saved;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Conversation createForMentorPairInNewTx(User requester, User other,
+                                                   long lower, long higher) {
+        Conversation conversation = new Conversation();
+        conversation.setKind(ConversationKind.MENTOR_PAIR);
+        conversation.setPairAId(lower);
+        conversation.setPairBId(higher);
+        Conversation saved = conversationRepository.save(conversation);
+        participantRepository.save(participant(saved, requester));
+        participantRepository.save(participant(saved, other));
+        log.info("Conversation created: id={}, kind=MENTOR_PAIR, pair=({}, {})",
+                saved.getId(), lower, higher);
+        return saved;
+    }
+
+    private static ConversationParticipant participant(Conversation conversation, User user) {
+        ConversationParticipant cp = new ConversationParticipant();
+        cp.setConversation(conversation);
+        cp.setUser(user);
+        cp.setId(new ConversationParticipantId(conversation.getId(), user.getId()));
+        return cp;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/ConversationService.java
+++ b/backend/src/main/java/com/group7/backend/service/ConversationService.java
@@ -148,6 +148,23 @@ public class ConversationService {
             throw new IllegalArgumentException(
                     "Cannot start a conversation with yourself");
         }
+
+        // Resolve the canonical key first so we can short-circuit on the
+        // common idempotent path (existing conversation) without paying for
+        // two userRepository lookups. Loading the User entities is only
+        // needed when we actually have to insert participant rows.
+        long lower = Math.min(requesterId, otherMentorId);
+        long higher = Math.max(requesterId, otherMentorId);
+        Optional<Conversation> existing = conversationRepository
+                .findByPairAIdAndPairBIdAndKind(lower, higher, ConversationKind.MENTOR_PAIR);
+        if (existing.isPresent()) {
+            // History survives role changes intentionally: even if a former
+            // mentor was demoted, their existing peer conversations remain
+            // readable. The role check below only gates new-conversation
+            // creation.
+            return existing.get();
+        }
+
         User requester = userRepository.findById(requesterId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
         User other = userRepository.findById(otherMentorId)
@@ -157,13 +174,6 @@ public class ConversationService {
                     "Both participants must be mentors");
         }
 
-        long lower = Math.min(requesterId, otherMentorId);
-        long higher = Math.max(requesterId, otherMentorId);
-        Optional<Conversation> existing = conversationRepository
-                .findByPairAIdAndPairBIdAndKind(lower, higher, ConversationKind.MENTOR_PAIR);
-        if (existing.isPresent()) {
-            return existing.get();
-        }
         try {
             return conversationCreator.createForMentorPairInNewTx(requester, other, lower, higher);
         } catch (DataIntegrityViolationException e) {

--- a/backend/src/main/java/com/group7/backend/service/ConversationService.java
+++ b/backend/src/main/java/com/group7/backend/service/ConversationService.java
@@ -4,6 +4,7 @@ import com.group7.backend.entity.Conversation;
 import com.group7.backend.entity.ConversationKind;
 import com.group7.backend.entity.ConversationParticipant;
 import com.group7.backend.entity.ConversationParticipantId;
+import com.group7.backend.entity.Mentor;
 import com.group7.backend.entity.Mentorship;
 import com.group7.backend.entity.MentorshipStatus;
 import com.group7.backend.entity.User;
@@ -12,6 +13,7 @@ import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.ConversationParticipantRepository;
 import com.group7.backend.repository.ConversationRepository;
 import com.group7.backend.repository.MentorshipRepository;
+import com.group7.backend.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -20,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -37,13 +40,18 @@ import java.util.Optional;
  * The find-or-create flow uses the canonical Spring pattern: the outer method
  * is <strong>non-transactional</strong>, so the read and the recovery path see
  * separate, fully-committed states. The actual create runs in
- * {@link Propagation#REQUIRES_NEW} — when the partial unique index on
- * {@code conversations.mentorship_id} catches a concurrent insert and Hibernate
- * raises {@link DataIntegrityViolationException}, only the inner transaction
- * rolls back; the outer method then re-reads and returns the winner. Wrapping
- * everything in a single {@code @Transactional} would mark that outer
- * transaction rollback-only and produce {@code UnexpectedRollbackException} at
- * commit.
+ * {@link Propagation#REQUIRES_NEW} — when a partial unique index catches a
+ * concurrent insert and Hibernate raises {@link DataIntegrityViolationException},
+ * only the inner transaction rolls back; the outer method then re-reads and
+ * returns the winner. Wrapping everything in a single {@code @Transactional}
+ * would mark that outer transaction rollback-only and produce
+ * {@code UnexpectedRollbackException} at commit.
+ *
+ * <h2>Self-invocation</h2>
+ * The inner {@code REQUIRES_NEW} method is invoked through the bean factory
+ * ({@code applicationContext.getBean(ConversationService.class)}) so the
+ * Spring AOP advice fires. A direct {@code this.method(...)} call would
+ * bypass the proxy and silently downgrade to the outer transaction.
  */
 @Service
 public class ConversationService {
@@ -53,17 +61,22 @@ public class ConversationService {
     private final ConversationRepository conversationRepository;
     private final ConversationParticipantRepository participantRepository;
     private final MentorshipRepository mentorshipRepository;
+    private final UserRepository userRepository;
     private final ApplicationContext applicationContext;
 
     public ConversationService(ConversationRepository conversationRepository,
                                ConversationParticipantRepository participantRepository,
                                MentorshipRepository mentorshipRepository,
+                               UserRepository userRepository,
                                ApplicationContext applicationContext) {
         this.conversationRepository = conversationRepository;
         this.participantRepository = participantRepository;
         this.mentorshipRepository = mentorshipRepository;
+        this.userRepository = userRepository;
         this.applicationContext = applicationContext;
     }
+
+    // ── Mentorship-scoped conversations (issue #245) ────────────────────────
 
     /**
      * Returns the conversation for {@code mentorshipId}, creating it on first
@@ -99,16 +112,10 @@ public class ConversationService {
         if (mentorship.getStatus() != MentorshipStatus.ACTIVE) {
             throw new ResourceNotFoundException("Conversation not found");
         }
-        return createOrRecover(mentorship);
+        return createOrRecoverForMentorship(mentorship);
     }
 
-    /**
-     * Attempts to create the conversation in a fresh inner transaction; if the
-     * unique constraint catches a concurrent winner, re-reads and returns it.
-     * Self-invocation goes through the bean factory so the {@code REQUIRES_NEW}
-     * advice fires.
-     */
-    private Conversation createOrRecover(Mentorship mentorship) {
+    private Conversation createOrRecoverForMentorship(Mentorship mentorship) {
         ConversationService self = applicationContext.getBean(ConversationService.class);
         try {
             return self.createForMentorshipInNewTx(mentorship);
@@ -125,8 +132,8 @@ public class ConversationService {
     /**
      * Atomic create: conversation row + two participant rows in one transaction.
      * Public so the bean proxy intercepts the call when invoked via
-     * {@link #createOrRecover(Mentorship)}; not part of the service's external
-     * contract.
+     * {@link #createOrRecoverForMentorship(Mentorship)}; not part of the
+     * service's external contract.
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Conversation createForMentorshipInNewTx(Mentorship mentorship) {
@@ -140,6 +147,97 @@ public class ConversationService {
                 saved.getId(), mentorship.getId());
         return saved;
     }
+
+    // ── Mentor-pair conversations (issue #284) ─────────────────────────────
+
+    /**
+     * Returns the mentor-pair conversation for the unordered pair
+     * {@code (requesterId, otherMentorId)}, creating it on first call.
+     * Idempotent: concurrent first-message requests collapse via
+     * {@code uq_conversations_pair_kind}, the same insert-then-fallback shape
+     * used for mentorship conversations.
+     *
+     * <p>Both participants must be {@link Mentor} instances. The role check
+     * fires regardless of which side initiated, so the ordering of the
+     * arguments does not matter for authorization purposes — only for the
+     * canonical key, which the method computes internally. Callers never pass
+     * raw ordered ids to the repository.
+     *
+     * <p>Like {@link #findOrCreateForMentorship}, this method MUST stay
+     * non-transactional. Wrapping it in {@code @Transactional} would cause the
+     * inner-tx {@link DataIntegrityViolationException} on the race path to
+     * mark the outer transaction rollback-only, producing
+     * {@code UnexpectedRollbackException} at commit instead of a clean
+     * re-find.
+     *
+     * @throws IllegalArgumentException 400 — same id on both sides, or either
+     *         user is not a mentor (the action is invalid input, not an
+     *         authorization mismatch).
+     * @throws ResourceNotFoundException 404 — either user id is unknown.
+     */
+    public Conversation findOrCreateForMentorPair(Long requesterId, Long otherMentorId) {
+        if (Objects.equals(requesterId, otherMentorId)) {
+            throw new IllegalArgumentException(
+                    "Cannot start a conversation with yourself");
+        }
+        User requester = userRepository.findById(requesterId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        User other = userRepository.findById(otherMentorId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        if (!(requester instanceof Mentor) || !(other instanceof Mentor)) {
+            throw new IllegalArgumentException(
+                    "Both participants must be mentors");
+        }
+
+        long lower = Math.min(requesterId, otherMentorId);
+        long higher = Math.max(requesterId, otherMentorId);
+        Optional<Conversation> existing = conversationRepository
+                .findByPairAIdAndPairBIdAndKind(lower, higher, ConversationKind.MENTOR_PAIR);
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+        return createOrRecoverPair(requester, other, lower, higher);
+    }
+
+    private Conversation createOrRecoverPair(User requester, User other,
+                                             long lower, long higher) {
+        ConversationService self = applicationContext.getBean(ConversationService.class);
+        try {
+            return self.createForMentorPairInNewTx(requester, other, lower, higher);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Concurrent mentor-pair creation for ({}, {}); resolving via re-find",
+                    lower, higher);
+            return conversationRepository
+                    .findByPairAIdAndPairBIdAndKind(lower, higher, ConversationKind.MENTOR_PAIR)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Mentor-pair creation race resolved with no row visible — "
+                                    + "transaction isolation issue?", e));
+        }
+    }
+
+    /**
+     * Atomic create for a {@link ConversationKind#MENTOR_PAIR} conversation:
+     * one conversation row plus two participant rows. Public so the
+     * {@code @Lazy self} proxy intercepts the call from
+     * {@link #createOrRecoverPair(User, User, long, long)}; not part of the
+     * service's external contract.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Conversation createForMentorPairInNewTx(User requester, User other,
+                                                   long lower, long higher) {
+        Conversation conversation = new Conversation();
+        conversation.setKind(ConversationKind.MENTOR_PAIR);
+        conversation.setPairAId(lower);
+        conversation.setPairBId(higher);
+        Conversation saved = conversationRepository.save(conversation);
+        participantRepository.save(participant(saved, requester));
+        participantRepository.save(participant(saved, other));
+        log.info("Conversation created: id={}, kind=MENTOR_PAIR, pair=({}, {})",
+                saved.getId(), lower, higher);
+        return saved;
+    }
+
+    // ── Internals ───────────────────────────────────────────────────────────
 
     private static ConversationParticipant participant(Conversation conversation, User user) {
         ConversationParticipant cp = new ConversationParticipant();

--- a/backend/src/main/java/com/group7/backend/service/ConversationService.java
+++ b/backend/src/main/java/com/group7/backend/service/ConversationService.java
@@ -2,25 +2,20 @@ package com.group7.backend.service;
 
 import com.group7.backend.entity.Conversation;
 import com.group7.backend.entity.ConversationKind;
-import com.group7.backend.entity.ConversationParticipant;
-import com.group7.backend.entity.ConversationParticipantId;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.entity.Mentorship;
 import com.group7.backend.entity.MentorshipStatus;
 import com.group7.backend.entity.User;
 import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.exception.ResourceNotFoundException;
-import com.group7.backend.repository.ConversationParticipantRepository;
 import com.group7.backend.repository.ConversationRepository;
 import com.group7.backend.repository.MentorshipRepository;
 import com.group7.backend.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationContext;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -37,21 +32,16 @@ import java.util.Optional;
  * to existing branches.
  *
  * <h2>Race-safe creation</h2>
- * The find-or-create flow uses the canonical Spring pattern: the outer method
- * is <strong>non-transactional</strong>, so the read and the recovery path see
- * separate, fully-committed states. The actual create runs in
- * {@link Propagation#REQUIRES_NEW} — when a partial unique index catches a
+ * The find-or-create flow uses the canonical Spring pattern: this service
+ * stays <strong>non-transactional</strong>, so the read and the recovery path
+ * see separate, fully-committed states. The actual creation is delegated to
+ * {@link ConversationCreator}, whose methods run with
+ * {@link Propagation#REQUIRES_NEW}. When a partial unique index catches a
  * concurrent insert and Hibernate raises {@link DataIntegrityViolationException},
- * only the inner transaction rolls back; the outer method then re-reads and
- * returns the winner. Wrapping everything in a single {@code @Transactional}
- * would mark that outer transaction rollback-only and produce
- * {@code UnexpectedRollbackException} at commit.
- *
- * <h2>Self-invocation</h2>
- * The inner {@code REQUIRES_NEW} method is invoked through the bean factory
- * ({@code applicationContext.getBean(ConversationService.class)}) so the
- * Spring AOP advice fires. A direct {@code this.method(...)} call would
- * bypass the proxy and silently downgrade to the outer transaction.
+ * only the inner transaction rolls back; this service then re-reads and
+ * returns the winner. Wrapping these methods in a single {@code @Transactional}
+ * would mark the outer transaction rollback-only and produce
+ * {@code UnexpectedRollbackException} at commit instead of a clean re-find.
  */
 @Service
 public class ConversationService {
@@ -59,21 +49,18 @@ public class ConversationService {
     private static final Logger log = LoggerFactory.getLogger(ConversationService.class);
 
     private final ConversationRepository conversationRepository;
-    private final ConversationParticipantRepository participantRepository;
     private final MentorshipRepository mentorshipRepository;
     private final UserRepository userRepository;
-    private final ApplicationContext applicationContext;
+    private final ConversationCreator conversationCreator;
 
     public ConversationService(ConversationRepository conversationRepository,
-                               ConversationParticipantRepository participantRepository,
                                MentorshipRepository mentorshipRepository,
                                UserRepository userRepository,
-                               ApplicationContext applicationContext) {
+                               ConversationCreator conversationCreator) {
         this.conversationRepository = conversationRepository;
-        this.participantRepository = participantRepository;
         this.mentorshipRepository = mentorshipRepository;
         this.userRepository = userRepository;
-        this.applicationContext = applicationContext;
+        this.conversationCreator = conversationCreator;
     }
 
     // ── Mentorship-scoped conversations (issue #245) ────────────────────────
@@ -112,40 +99,21 @@ public class ConversationService {
         if (mentorship.getStatus() != MentorshipStatus.ACTIVE) {
             throw new ResourceNotFoundException("Conversation not found");
         }
-        return createOrRecoverForMentorship(mentorship);
-    }
-
-    private Conversation createOrRecoverForMentorship(Mentorship mentorship) {
-        ConversationService self = applicationContext.getBean(ConversationService.class);
         try {
-            return self.createForMentorshipInNewTx(mentorship);
+            return conversationCreator.createForMentorshipInNewTx(mentorship);
         } catch (DataIntegrityViolationException e) {
             log.warn("Concurrent conversation creation for mentorshipId={}; resolving via re-find",
-                    mentorship.getId());
-            return conversationRepository.findByMentorshipId(mentorship.getId())
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Conversation creation race resolved with no row visible — "
-                                    + "transaction isolation issue?", e));
+                    mentorshipId);
+            return conversationRepository.findByMentorshipId(mentorshipId)
+                    .orElseThrow(() -> {
+                        log.error("Mentorship conversation race resolved with no row visible "
+                                + "(mentorshipId={}); transaction isolation misconfigured?",
+                                mentorshipId, e);
+                        return new IllegalStateException(
+                                "Conversation creation race resolved with no row visible — "
+                                        + "transaction isolation issue?", e);
+                    });
         }
-    }
-
-    /**
-     * Atomic create: conversation row + two participant rows in one transaction.
-     * Public so the bean proxy intercepts the call when invoked via
-     * {@link #createOrRecoverForMentorship(Mentorship)}; not part of the
-     * service's external contract.
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public Conversation createForMentorshipInNewTx(Mentorship mentorship) {
-        Conversation conversation = new Conversation();
-        conversation.setKind(ConversationKind.MENTORSHIP);
-        conversation.setMentorship(mentorship);
-        Conversation saved = conversationRepository.save(conversation);
-        participantRepository.save(participant(saved, mentorship.getMentor()));
-        participantRepository.save(participant(saved, mentorship.getMentee()));
-        log.info("Conversation created: id={}, kind=MENTORSHIP, mentorshipId={}",
-                saved.getId(), mentorship.getId());
-        return saved;
     }
 
     // ── Mentor-pair conversations (issue #284) ─────────────────────────────
@@ -196,56 +164,25 @@ public class ConversationService {
         if (existing.isPresent()) {
             return existing.get();
         }
-        return createOrRecoverPair(requester, other, lower, higher);
-    }
-
-    private Conversation createOrRecoverPair(User requester, User other,
-                                             long lower, long higher) {
-        ConversationService self = applicationContext.getBean(ConversationService.class);
         try {
-            return self.createForMentorPairInNewTx(requester, other, lower, higher);
+            return conversationCreator.createForMentorPairInNewTx(requester, other, lower, higher);
         } catch (DataIntegrityViolationException e) {
             log.warn("Concurrent mentor-pair creation for ({}, {}); resolving via re-find",
                     lower, higher);
             return conversationRepository
                     .findByPairAIdAndPairBIdAndKind(lower, higher, ConversationKind.MENTOR_PAIR)
-                    .orElseThrow(() -> new IllegalStateException(
-                            "Mentor-pair creation race resolved with no row visible — "
-                                    + "transaction isolation issue?", e));
+                    .orElseThrow(() -> {
+                        log.error("Mentor-pair conversation race resolved with no row visible "
+                                + "(pair=({}, {})); transaction isolation misconfigured?",
+                                lower, higher, e);
+                        return new IllegalStateException(
+                                "Mentor-pair creation race resolved with no row visible — "
+                                        + "transaction isolation issue?", e);
+                    });
         }
     }
 
-    /**
-     * Atomic create for a {@link ConversationKind#MENTOR_PAIR} conversation:
-     * one conversation row plus two participant rows. Public so the
-     * {@code @Lazy self} proxy intercepts the call from
-     * {@link #createOrRecoverPair(User, User, long, long)}; not part of the
-     * service's external contract.
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public Conversation createForMentorPairInNewTx(User requester, User other,
-                                                   long lower, long higher) {
-        Conversation conversation = new Conversation();
-        conversation.setKind(ConversationKind.MENTOR_PAIR);
-        conversation.setPairAId(lower);
-        conversation.setPairBId(higher);
-        Conversation saved = conversationRepository.save(conversation);
-        participantRepository.save(participant(saved, requester));
-        participantRepository.save(participant(saved, other));
-        log.info("Conversation created: id={}, kind=MENTOR_PAIR, pair=({}, {})",
-                saved.getId(), lower, higher);
-        return saved;
-    }
-
     // ── Internals ───────────────────────────────────────────────────────────
-
-    private static ConversationParticipant participant(Conversation conversation, User user) {
-        ConversationParticipant cp = new ConversationParticipant();
-        cp.setConversation(conversation);
-        cp.setUser(user);
-        cp.setId(new ConversationParticipantId(conversation.getId(), user.getId()));
-        return cp;
-    }
 
     private static boolean isParticipant(Mentorship mentorship, Long userId) {
         return mentorship.getMentor().getId().equals(userId)

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -92,3 +92,9 @@ app.ratelimit.rules.message-send.pattern=/api/mentorships/*/messages
 app.ratelimit.rules.message-send.key-strategy=USER
 app.ratelimit.rules.message-send.capacity=60
 app.ratelimit.rules.message-send.refill=PT1M
+
+app.ratelimit.rules.mentor-pair-message-send.method=POST
+app.ratelimit.rules.mentor-pair-message-send.pattern=/api/conversations/mentor-pair/*/messages
+app.ratelimit.rules.mentor-pair-message-send.key-strategy=USER
+app.ratelimit.rules.mentor-pair-message-send.capacity=60
+app.ratelimit.rules.mentor-pair-message-send.refill=PT1M

--- a/backend/src/main/resources/db/migration/V17__add_conversation_pair_columns.sql
+++ b/backend/src/main/resources/db/migration/V17__add_conversation_pair_columns.sql
@@ -1,0 +1,47 @@
+-- Adds the pair columns + invariant constraints needed for mentor-to-mentor
+-- conversations (issue #284). The conversations table already supports a
+-- MENTOR_PAIR kind (V14), but had no columns to identify which two users a
+-- pair conversation belongs to and no DB-level guarantee that the kind
+-- discriminator agrees with the populated columns.
+--
+-- After this migration each conversation row is exactly one of:
+--   MENTORSHIP : mentorship_id non-null, pair_a_id null
+--   MENTOR_PAIR: mentorship_id null,    pair_a_id non-null < pair_b_id
+--
+-- The FK ON DELETE CASCADE on pair_*_id matches the existing semantics for
+-- mentorship_id: deleting a participant cascades the conversation away.
+
+alter table conversations
+    add column pair_a_id bigint references users(id) on delete cascade,
+    add column pair_b_id bigint references users(id) on delete cascade;
+
+-- Pair columns are either both populated or both null, and pair_a_id is the
+-- numerically-smaller user id when populated. Strict ordering is what makes
+-- (pair_a_id, pair_b_id) a canonical key for an unordered user pair.
+alter table conversations
+    add constraint conversations_pair_completeness check (
+        (pair_a_id is null and pair_b_id is null)
+        or (pair_a_id is not null and pair_b_id is not null)
+    ),
+    add constraint conversations_pair_ordering check (
+        pair_a_id is null or pair_a_id < pair_b_id
+    );
+
+-- The kind discriminator and the column populations must agree. Without this
+-- check, a buggy migration or hand-written INSERT could produce a MENTOR_PAIR
+-- row with a non-null mentorship_id, and MessageService.assertSendable would
+-- silently misbehave because it dispatches on kind, not on which column is
+-- populated.
+alter table conversations
+    add constraint conversations_kind_columns_consistent check (
+        (kind = 'MENTORSHIP'  and mentorship_id is not null and pair_a_id is null)
+        or
+        (kind = 'MENTOR_PAIR' and mentorship_id is null     and pair_a_id is not null)
+    );
+
+-- Defense-in-depth uniqueness for canonical mentor pairs. Includes `kind` in
+-- the key so a future kind that reuses the pair columns (e.g. open DM) can
+-- coexist with mentor-pair without colliding.
+create unique index uq_conversations_pair_kind
+    on conversations (pair_a_id, pair_b_id, kind)
+    where pair_a_id is not null;

--- a/backend/src/test/java/com/group7/backend/controller/MentorPairMessageControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorPairMessageControllerTest.java
@@ -1,0 +1,224 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.MessageResponse;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.service.ConversationService;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.MessageService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MentorPairMessageController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class MentorPairMessageControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private MessageService messageService;
+    @MockitoBean private ConversationService conversationService;
+    @MockitoBean private JwtService jwtService;
+
+    private void mockMentorJwt(String token, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn("mentor@example.com");
+        when(jwtService.extractRole(token)).thenReturn("MENTOR");
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private void mockMenteeJwt(String token, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn("mentee@example.com");
+        when(jwtService.extractRole(token)).thenReturn("MENTEE");
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private Conversation pairConversation(Long pairAId, Long pairBId) {
+        Conversation c = new Conversation();
+        c.setId(901L);
+        c.setKind(ConversationKind.MENTOR_PAIR);
+        c.setPairAId(Math.min(pairAId, pairBId));
+        c.setPairBId(Math.max(pairAId, pairBId));
+        return c;
+    }
+
+    private MessageResponse sampleMessage() {
+        MessageResponse r = new MessageResponse();
+        r.setId(1L);
+        r.setConversationId(901L);
+        r.setSenderId(1L);
+        r.setSenderFirstName("Mira");
+        r.setSenderLastName("Aydin");
+        r.setContent("hi");
+        r.setSentAt(OffsetDateTime.parse("2026-05-04T10:00:00Z"));
+        return r;
+    }
+
+    // ── POST: send ─────────────────────────────────────────────────────────
+
+    @Test
+    void send_asMentor_returns201() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        when(conversationService.findOrCreateForMentorPair(1L, 3L))
+                .thenReturn(pairConversation(1L, 3L));
+        when(messageService.send(eq(1L), eq(901L), any())).thenReturn(sampleMessage());
+
+        mockMvc.perform(post("/api/conversations/mentor-pair/3/messages")
+                        .header("Authorization", "Bearer mentor-a-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"hi\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.content").value("hi"))
+                .andExpect(jsonPath("$.conversationId").value(901));
+    }
+
+    @Test
+    void send_asMentee_returns403() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+
+        mockMvc.perform(post("/api/conversations/mentor-pair/3/messages")
+                        .header("Authorization", "Bearer mentee-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"hi\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void send_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(post("/api/conversations/mentor-pair/3/messages")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"hi\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void send_selfPair_returns400() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        when(conversationService.findOrCreateForMentorPair(1L, 1L))
+                .thenThrow(new IllegalArgumentException("Cannot start a conversation with yourself"));
+
+        mockMvc.perform(post("/api/conversations/mentor-pair/1/messages")
+                        .header("Authorization", "Bearer mentor-a-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"hi\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void send_menteeTarget_returns400() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        when(conversationService.findOrCreateForMentorPair(1L, 2L))
+                .thenThrow(new IllegalArgumentException("Both participants must be mentors"));
+
+        mockMvc.perform(post("/api/conversations/mentor-pair/2/messages")
+                        .header("Authorization", "Bearer mentor-a-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"hi\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void send_unknownTarget_returns404() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        when(conversationService.findOrCreateForMentorPair(1L, 999L))
+                .thenThrow(new ResourceNotFoundException("User not found"));
+
+        mockMvc.perform(post("/api/conversations/mentor-pair/999/messages")
+                        .header("Authorization", "Bearer mentor-a-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"hi\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void send_emptyContent_returns400() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+
+        mockMvc.perform(post("/api/conversations/mentor-pair/3/messages")
+                        .header("Authorization", "Bearer mentor-a-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void send_oversizedContent_returns400() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        String content = "x".repeat(4001);
+
+        mockMvc.perform(post("/api/conversations/mentor-pair/3/messages")
+                        .header("Authorization", "Bearer mentor-a-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"" + content + "\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── GET: list ──────────────────────────────────────────────────────────
+
+    @Test
+    void list_asMentor_returns200() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        when(conversationService.findOrCreateForMentorPair(1L, 3L))
+                .thenReturn(pairConversation(1L, 3L));
+        Page<MessageResponse> page = new PageImpl<>(List.of(sampleMessage()));
+        when(messageService.list(eq(1L), eq(901L), any())).thenReturn(page);
+
+        mockMvc.perform(get("/api/conversations/mentor-pair/3/messages")
+                        .header("Authorization", "Bearer mentor-a-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].content").value("hi"));
+    }
+
+    @Test
+    void list_asMentee_returns403() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+
+        mockMvc.perform(get("/api/conversations/mentor-pair/3/messages")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── PATCH /read ────────────────────────────────────────────────────────
+
+    @Test
+    void markRead_asMentor_returns204() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        when(conversationService.findOrCreateForMentorPair(1L, 3L))
+                .thenReturn(pairConversation(1L, 3L));
+        when(messageService.markAllRead(1L, 901L)).thenReturn(2);
+
+        mockMvc.perform(patch("/api/conversations/mentor-pair/3/messages/read")
+                        .header("Authorization", "Bearer mentor-a-token"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void markRead_asMentee_returns403() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+
+        mockMvc.perform(patch("/api/conversations/mentor-pair/3/messages/read")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/MentorPairMessagingIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorPairMessagingIntegrationTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,14 +32,17 @@ import org.springframework.test.web.servlet.MvcResult;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -238,6 +242,54 @@ class MentorPairMessagingIntegrationTest {
     }
 
     @Test
+    void mentorPair_attachment_isUploadableBySenderAndDownloadableByPeer() throws Exception {
+        // Mentor A uploads a PDF, then sends it as an attachment on the
+        // mentor-pair endpoint. The attachment ACL is conversation-graph
+        // based, so B (the other participant) can download it without any
+        // pair-specific code paths in the attachment subsystem.
+        Mentors m = registerTwoMentors("pair_attach_a@test.com", "pair_attach_b@test.com");
+
+        byte[] pdf = pdfBody("peer-shared");
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "peer.pdf", "application/pdf", pdf);
+        MvcResult upload = mockMvc.perform(multipart("/api/messages/attachments")
+                        .file(file)
+                        .header("Authorization", "Bearer " + m.tokenA))
+                .andExpect(status().isCreated())
+                .andReturn();
+        String attachmentId = objectMapper.readTree(upload.getResponse().getContentAsString())
+                .get("id").asText();
+        String downloadUrl = objectMapper.readTree(upload.getResponse().getContentAsString())
+                .get("downloadUrl").asText();
+
+        SendMessageRequest body = new SendMessageRequest();
+        body.setContent("here is the doc");
+        body.setAttachmentId(UUID.fromString(attachmentId));
+        mockMvc.perform(post("/api/conversations/mentor-pair/" + m.idB + "/messages")
+                        .header("Authorization", "Bearer " + m.tokenA)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.attachment.id").value(attachmentId))
+                .andExpect(jsonPath("$.attachment.downloadUrl").value(downloadUrl));
+
+        // Mentor B (peer participant) can download.
+        String downloadPath = downloadUrl.substring(downloadUrl.indexOf("/api/"));
+        mockMvc.perform(get(downloadPath)
+                        .header("Authorization", "Bearer " + m.tokenB))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"));
+
+        // Mentee (no participation in this conversation) cannot download.
+        // Existing ACL returns 404 (not 403) to avoid leaking the attachment's
+        // existence to non-participants.
+        String menteeToken = registerAndLogin("pair_attach_mentee@test.com", false);
+        mockMvc.perform(get(downloadPath)
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
     void mentorPair_doesNotCollideWithExistingMentorshipConversation() throws Exception {
         // The unique index on (pair_a_id, pair_b_id, kind) includes `kind` so
         // a future scenario where two users share both a mentorship and a
@@ -305,6 +357,15 @@ class MentorPairMessagingIntegrationTest {
                 .andReturn();
         return objectMapper.readTree(result.getResponse().getContentAsString())
                 .get("sessionToken").asText();
+    }
+
+    private static byte[] pdfBody(String trailing) {
+        byte[] header = new byte[]{0x25, 0x50, 0x44, 0x46}; // %PDF
+        byte[] tail = trailing.getBytes();
+        byte[] result = new byte[header.length + tail.length];
+        System.arraycopy(header, 0, result, 0, header.length);
+        System.arraycopy(tail, 0, result, header.length, tail.length);
+        return result;
     }
 
     private Notification waitForNotification(Long recipientId, NotificationType type) {

--- a/backend/src/test/java/com/group7/backend/integration/MentorPairMessagingIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorPairMessagingIntegrationTest.java
@@ -1,0 +1,328 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.dto.request.SendMessageRequest;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
+import com.group7.backend.entity.Notification;
+import com.group7.backend.entity.NotificationType;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.ConversationParticipantRepository;
+import com.group7.backend.repository.ConversationRepository;
+import com.group7.backend.repository.MessageRepository;
+import com.group7.backend.repository.NotificationRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for mentor-to-mentor messaging (#284). Mirrors the
+ * helpers and shape of {@link MessagingIntegrationTest} (registerAndLogin,
+ * waitForNotification) so anyone tracing the messaging package finds one
+ * consistent pattern.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MentorPairMessagingIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private NotificationRepository notificationRepository;
+    @Autowired private MessageRepository messageRepository;
+    @Autowired private ConversationParticipantRepository conversationParticipantRepository;
+    @Autowired private ConversationRepository conversationRepository;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        messageRepository.deleteAll();
+        conversationParticipantRepository.deleteAll();
+        conversationRepository.deleteAll();
+        notificationRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    @Test
+    void twoMentors_exchangeMessages_onMentorPairEndpoint() throws Exception {
+        Mentors m = registerTwoMentors("pair_a@test.com", "pair_b@test.com");
+
+        sendPair(m.tokenA, m.idB, "hello peer");
+        sendPair(m.tokenB, m.idA, "hi back");
+
+        // Both mentors see the same two messages on their respective endpoints
+        MvcResult listForA = mockMvc.perform(get("/api/conversations/mentor-pair/" + m.idB + "/messages")
+                        .header("Authorization", "Bearer " + m.tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andReturn();
+        Long convoId = objectMapper.readTree(listForA.getResponse().getContentAsString())
+                .get("content").get(0).get("conversationId").asLong();
+
+        mockMvc.perform(get("/api/conversations/mentor-pair/" + m.idA + "/messages")
+                        .header("Authorization", "Bearer " + m.tokenB))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].conversationId").value(convoId));
+
+        // The conversation row carries the canonical pair shape and no mentorship
+        Conversation persisted = conversationRepository.findById(convoId).orElseThrow();
+        assertThat(persisted.getKind()).isEqualTo(ConversationKind.MENTOR_PAIR);
+        assertThat(persisted.getMentorship()).isNull();
+        long lower = Math.min(m.idA, m.idB);
+        long higher = Math.max(m.idA, m.idB);
+        assertThat(persisted.getPairAId()).isEqualTo(lower);
+        assertThat(persisted.getPairBId()).isEqualTo(higher);
+
+        // Exactly one conversation row exists for the pair (no duplicates from
+        // both mentors initiating)
+        long pairRowCount = conversationRepository.findAll().stream()
+                .filter(c -> c.getKind() == ConversationKind.MENTOR_PAIR)
+                .count();
+        assertThat(pairRowCount).isEqualTo(1L);
+    }
+
+    @Test
+    void firstMessageFromA_producesNewMessageNotificationForB() throws Exception {
+        Mentors m = registerTwoMentors("pair_notify_a@test.com", "pair_notify_b@test.com");
+
+        sendPair(m.tokenA, m.idB, "you should see a notification");
+
+        Notification n = waitForNotification(m.idB, NotificationType.NEW_MESSAGE);
+        assertThat(n).as("recipient should receive a NEW_MESSAGE notification").isNotNull();
+    }
+
+    @Test
+    void historyReadsResolveSameConversation_inBothDirections() throws Exception {
+        Mentors m = registerTwoMentors("pair_dir_a@test.com", "pair_dir_b@test.com");
+
+        sendPair(m.tokenA, m.idB, "from A");
+        sendPair(m.tokenB, m.idA, "from B");
+
+        MvcResult fromA = mockMvc.perform(get("/api/conversations/mentor-pair/" + m.idB + "/messages")
+                        .header("Authorization", "Bearer " + m.tokenA))
+                .andReturn();
+        MvcResult fromB = mockMvc.perform(get("/api/conversations/mentor-pair/" + m.idA + "/messages")
+                        .header("Authorization", "Bearer " + m.tokenB))
+                .andReturn();
+
+        Long cidFromA = objectMapper.readTree(fromA.getResponse().getContentAsString())
+                .get("content").get(0).get("conversationId").asLong();
+        Long cidFromB = objectMapper.readTree(fromB.getResponse().getContentAsString())
+                .get("content").get(0).get("conversationId").asLong();
+
+        assertThat(cidFromA).isEqualTo(cidFromB);
+    }
+
+    @Test
+    void pairConversation_doesNotRequireActiveMentorship() throws Exception {
+        // The two mentors share no mentorship (we never created one) — the
+        // assertSendable branch for MENTORSHIP is bypassed because kind is
+        // MENTOR_PAIR. Sending must succeed.
+        Mentors m = registerTwoMentors("pair_nomship_a@test.com", "pair_nomship_b@test.com");
+
+        sendPair(m.tokenA, m.idB, "no mentorship between us");
+
+        assertThat(messageRepository.count()).isEqualTo(1L);
+    }
+
+    @Test
+    void markAllRead_byB_setsReadAtOnAsMessage() throws Exception {
+        Mentors m = registerTwoMentors("pair_read_a@test.com", "pair_read_b@test.com");
+        sendPair(m.tokenA, m.idB, "please read me");
+
+        mockMvc.perform(patch("/api/conversations/mentor-pair/" + m.idA + "/messages/read")
+                        .header("Authorization", "Bearer " + m.tokenB))
+                .andExpect(status().isNoContent());
+
+        MvcResult result = mockMvc.perform(get("/api/conversations/mentor-pair/" + m.idA + "/messages")
+                        .header("Authorization", "Bearer " + m.tokenB))
+                .andReturn();
+        JsonNode first = objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("content").get(0);
+        assertThat(first.get("readAt").isNull()).isFalse();
+    }
+
+    @Test
+    void mentee_postingToMentorPairEndpoint_returns403() throws Exception {
+        Mentors m = registerTwoMentors("pair_mentee_a@test.com", "pair_mentee_b@test.com");
+        String menteeToken = registerAndLogin("pair_mentee_caller@test.com", false);
+
+        SendMessageRequest body = new SendMessageRequest();
+        body.setContent("I shouldn't be here");
+        mockMvc.perform(post("/api/conversations/mentor-pair/" + m.idA + "/messages")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void mentor_targetingMentee_returns400() throws Exception {
+        String mentorToken = registerAndLogin("pair_target_mentor@test.com", true);
+        String menteeEmail = "pair_target_mentee@test.com";
+        registerAndLogin(menteeEmail, false);
+        Long menteeId = userRepository.findByEmail(menteeEmail).orElseThrow().getId();
+
+        SendMessageRequest body = new SendMessageRequest();
+        body.setContent("hi");
+        mockMvc.perform(post("/api/conversations/mentor-pair/" + menteeId + "/messages")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void mentor_targetingSelf_returns400() throws Exception {
+        String mentorToken = registerAndLogin("pair_self@test.com", true);
+        Long mentorId = userRepository.findByEmail("pair_self@test.com").orElseThrow().getId();
+
+        SendMessageRequest body = new SendMessageRequest();
+        body.setContent("hi me");
+        mockMvc.perform(post("/api/conversations/mentor-pair/" + mentorId + "/messages")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void threeMentors_aBandACpairs_areDistinctConversations() throws Exception {
+        // Three mentors A, B, C — A↔B and A↔C must produce two separate
+        // conversation rows.
+        String tokenA = registerAndLogin("pair_3a@test.com", true);
+        registerAndLogin("pair_3b@test.com", true);
+        registerAndLogin("pair_3c@test.com", true);
+        Long idB = userRepository.findByEmail("pair_3b@test.com").orElseThrow().getId();
+        Long idC = userRepository.findByEmail("pair_3c@test.com").orElseThrow().getId();
+
+        sendPair(tokenA, idB, "hi B");
+        sendPair(tokenA, idC, "hi C");
+
+        long pairRowCount = conversationRepository.findAll().stream()
+                .filter(c -> c.getKind() == ConversationKind.MENTOR_PAIR)
+                .count();
+        assertThat(pairRowCount).isEqualTo(2L);
+    }
+
+    @Test
+    void mentorPair_doesNotCollideWithExistingMentorshipConversation() throws Exception {
+        // The unique index on (pair_a_id, pair_b_id, kind) includes `kind` so
+        // a future scenario where two users share both a mentorship and a
+        // peer conversation will not collide. Here we just verify the
+        // mentor-pair row is created independently of the mentorship table.
+        Mentors m = registerTwoMentors("pair_coexist_a@test.com", "pair_coexist_b@test.com");
+
+        sendPair(m.tokenA, m.idB, "peer message");
+
+        // No mentorship was created, so no MENTORSHIP conversations exist.
+        long mentorshipRows = conversationRepository.findAll().stream()
+                .filter(c -> c.getKind() == ConversationKind.MENTORSHIP)
+                .count();
+        assertThat(mentorshipRows).isZero();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private record Mentors(String tokenA, String tokenB, Long idA, Long idB) {}
+
+    private Mentors registerTwoMentors(String emailA, String emailB) throws Exception {
+        String tokenA = registerAndLogin(emailA, true);
+        String tokenB = registerAndLogin(emailB, true);
+        Long idA = userRepository.findByEmail(emailA).orElseThrow().getId();
+        Long idB = userRepository.findByEmail(emailB).orElseThrow().getId();
+        return new Mentors(tokenA, tokenB, idA, idB);
+    }
+
+    private void sendPair(String token, Long otherId, String content) throws Exception {
+        SendMessageRequest body = new SendMessageRequest();
+        body.setContent(content);
+        mockMvc.perform(post("/api/conversations/mentor-pair/" + otherId + "/messages")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.content").value(content));
+    }
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName(isMentor ? "Mira" : "Eli");
+        req.setLastName(isMentor ? "Mentor" : "Mentee");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private Notification waitForNotification(Long recipientId, NotificationType type) {
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(5));
+        while (Instant.now().isBefore(deadline)) {
+            List<Notification> notifications = notificationRepository.findForUser(recipientId, false);
+            for (Notification notification : notifications) {
+                if (notification.getType() == type) {
+                    return notification;
+                }
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        return null;
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/ConversationCreatorTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ConversationCreatorTest.java
@@ -1,0 +1,116 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
+import com.group7.backend.entity.ConversationParticipant;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.repository.ConversationParticipantRepository;
+import com.group7.backend.repository.ConversationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-level contract for the atomic create methods. Integration tests cover
+ * the same invariants end-to-end against a real Postgres; these tests pin the
+ * conversation/participant shape at the unit boundary so future refactors of
+ * the per-kind creation logic surface in a focused place.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConversationCreatorTest {
+
+    @Mock private ConversationRepository conversationRepository;
+    @Mock private ConversationParticipantRepository participantRepository;
+
+    private ConversationCreator creator;
+
+    private Mentor mentor;
+    private Mentee mentee;
+    private Mentor mentorPeer;
+    private Mentorship mentorship;
+
+    @BeforeEach
+    void setUp() {
+        creator = new ConversationCreator(conversationRepository, participantRepository);
+
+        mentor = new Mentor();
+        mentor.setId(1L);
+        mentee = new Mentee();
+        mentee.setId(2L);
+        mentorPeer = new Mentor();
+        mentorPeer.setId(3L);
+
+        mentorship = new Mentorship();
+        mentorship.setId(100L);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+
+        when(conversationRepository.save(any(Conversation.class))).thenAnswer(inv -> {
+            Conversation c = inv.getArgument(0);
+            // Simulate generated id so participant rows can reference it.
+            if (c.getId() == null) {
+                c.setId(c.getKind() == ConversationKind.MENTORSHIP ? 900L : 901L);
+            }
+            return c;
+        });
+    }
+
+    @Test
+    void createForMentorshipInNewTx_savesConversationWithMentorshipAndTwoParticipants() {
+        Conversation result = creator.createForMentorshipInNewTx(mentorship);
+
+        assertThat(result.getKind()).isEqualTo(ConversationKind.MENTORSHIP);
+        assertThat(result.getMentorship()).isSameAs(mentorship);
+        assertThat(result.getPairAId()).isNull();
+        assertThat(result.getPairBId()).isNull();
+
+        ArgumentCaptor<ConversationParticipant> captor =
+                ArgumentCaptor.forClass(ConversationParticipant.class);
+        verify(participantRepository, times(2)).save(captor.capture());
+        List<Long> participantUserIds = captor.getAllValues().stream()
+                .map(p -> p.getUser().getId()).toList();
+        assertThat(participantUserIds).containsExactlyInAnyOrder(1L, 2L);
+    }
+
+    @Test
+    void createForMentorPairInNewTx_savesConversationWithCanonicalPairAndTwoParticipants() {
+        Conversation result = creator.createForMentorPairInNewTx(mentor, mentorPeer, 1L, 3L);
+
+        assertThat(result.getKind()).isEqualTo(ConversationKind.MENTOR_PAIR);
+        assertThat(result.getMentorship()).isNull();
+        assertThat(result.getPairAId()).isEqualTo(1L);
+        assertThat(result.getPairBId()).isEqualTo(3L);
+
+        ArgumentCaptor<ConversationParticipant> captor =
+                ArgumentCaptor.forClass(ConversationParticipant.class);
+        verify(participantRepository, times(2)).save(captor.capture());
+        List<Long> participantUserIds = captor.getAllValues().stream()
+                .map(p -> p.getUser().getId()).toList();
+        assertThat(participantUserIds).containsExactlyInAnyOrder(1L, 3L);
+    }
+
+    @Test
+    void createForMentorPairInNewTx_storesPairFieldsExactlyAsPassed() {
+        // The caller (ConversationService) is responsible for canonicalising
+        // (lower, higher); the creator stores them verbatim. If ConversationService
+        // passed reversed args, the DB CHECK constraint would catch it — but at
+        // the unit boundary we just verify the creator doesn't re-canonicalise.
+        Conversation result = creator.createForMentorPairInNewTx(mentor, mentorPeer, 7L, 42L);
+
+        assertThat(result.getPairAId()).isEqualTo(7L);
+        assertThat(result.getPairBId()).isEqualTo(42L);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
@@ -7,11 +7,13 @@ import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.entity.Mentorship;
 import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.entity.User;
 import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.ConversationParticipantRepository;
 import com.group7.backend.repository.ConversationRepository;
 import com.group7.backend.repository.MentorshipRepository;
+import com.group7.backend.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +38,7 @@ class ConversationServiceTest {
     @Mock private ConversationRepository conversationRepository;
     @Mock private ConversationParticipantRepository participantRepository;
     @Mock private MentorshipRepository mentorshipRepository;
+    @Mock private UserRepository userRepository;
     @Mock private ApplicationContext applicationContext;
 
     private ConversationService conversationService;
@@ -43,14 +46,17 @@ class ConversationServiceTest {
     private Mentor mentor;
     private Mentee mentee;
     private Mentorship mentorship;
+    private Mentor mentorPeer;
 
     @BeforeEach
     void setUp() {
         conversationService = new ConversationService(
-                conversationRepository, participantRepository, mentorshipRepository, applicationContext);
+                conversationRepository, participantRepository, mentorshipRepository,
+                userRepository, applicationContext);
         // Self-injection: in unit tests we route the bean lookup back to the
-        // service under test so the inner createForMentorshipInNewTx call
-        // executes the real method (no Spring proxy in pure JUnit).
+        // service under test so the inner createForMentorshipInNewTx /
+        // createForMentorPairInNewTx calls execute the real method (no Spring
+        // proxy in pure JUnit).
         org.mockito.Mockito.lenient()
                 .when(applicationContext.getBean(ConversationService.class))
                 .thenReturn(conversationService);
@@ -68,6 +74,10 @@ class ConversationServiceTest {
         mentorship.setMentor(mentor);
         mentorship.setMentee(mentee);
         mentorship.setStatus(MentorshipStatus.ACTIVE);
+
+        mentorPeer = new Mentor();
+        mentorPeer.setId(3L);
+        mentorPeer.setFirstName("Iris");
     }
 
     @Test
@@ -193,5 +203,177 @@ class ConversationServiceTest {
         Conversation result = conversationService.findOrCreateForMentorship(100L, 1L);
 
         assertThat(result).isSameAs(winnerSnapshot);
+    }
+
+    // ── findOrCreateForMentorPair (issue #284) ──────────────────────────────
+
+    @Test
+    void mentorPair_createsConversation_withCanonicalOrderAndTwoParticipants() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
+        when(conversationRepository.findByPairAIdAndPairBIdAndKind(
+                1L, 3L, ConversationKind.MENTOR_PAIR))
+                .thenReturn(Optional.empty());
+        when(conversationRepository.save(any(Conversation.class))).thenAnswer(inv -> {
+            Conversation c = inv.getArgument(0);
+            c.setId(901L);
+            return c;
+        });
+
+        Conversation result = conversationService.findOrCreateForMentorPair(1L, 3L);
+
+        assertThat(result.getId()).isEqualTo(901L);
+        assertThat(result.getKind()).isEqualTo(ConversationKind.MENTOR_PAIR);
+        assertThat(result.getPairAId()).isEqualTo(1L);
+        assertThat(result.getPairBId()).isEqualTo(3L);
+        assertThat(result.getMentorship()).isNull();
+        verify(participantRepository, times(2)).save(any(ConversationParticipant.class));
+    }
+
+    @Test
+    void mentorPair_returnsExistingConversation_whenAlreadyPresent() {
+        Conversation existing = new Conversation();
+        existing.setId(901L);
+        existing.setKind(ConversationKind.MENTOR_PAIR);
+        existing.setPairAId(1L);
+        existing.setPairBId(3L);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
+        when(conversationRepository.findByPairAIdAndPairBIdAndKind(
+                1L, 3L, ConversationKind.MENTOR_PAIR))
+                .thenReturn(Optional.of(existing));
+
+        Conversation result = conversationService.findOrCreateForMentorPair(1L, 3L);
+
+        assertThat(result).isSameAs(existing);
+        verify(conversationRepository, never()).save(any());
+        verify(participantRepository, never()).save(any());
+    }
+
+    @Test
+    void mentorPair_resolvesToSameConversation_regardlessOfArgumentOrder() {
+        // Calling (3, 1) must produce the same canonical key (1, 3) as (1, 3).
+        Conversation existing = new Conversation();
+        existing.setId(901L);
+        existing.setKind(ConversationKind.MENTOR_PAIR);
+        existing.setPairAId(1L);
+        existing.setPairBId(3L);
+
+        when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(conversationRepository.findByPairAIdAndPairBIdAndKind(
+                1L, 3L, ConversationKind.MENTOR_PAIR))
+                .thenReturn(Optional.of(existing));
+
+        Conversation result = conversationService.findOrCreateForMentorPair(3L, 1L);
+
+        assertThat(result).isSameAs(existing);
+    }
+
+    @Test
+    void mentorPair_throws400_whenSelfPair() {
+        assertThatThrownBy(() -> conversationService.findOrCreateForMentorPair(1L, 1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("yourself");
+
+        verify(userRepository, never()).findById(any());
+    }
+
+    @Test
+    void mentorPair_throws404_whenRequesterNotFound() {
+        when(userRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> conversationService.findOrCreateForMentorPair(404L, 3L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void mentorPair_throws404_whenOtherNotFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(userRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> conversationService.findOrCreateForMentorPair(1L, 404L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void mentorPair_throws400_whenRequesterIsNotAMentor() {
+        // Defense-in-depth: controller @PreAuthorize blocks mentees, but the
+        // service rejects a mentee caller too if invoked from non-controller code.
+        when(userRepository.findById(2L)).thenReturn(Optional.of(mentee));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+
+        assertThatThrownBy(() -> conversationService.findOrCreateForMentorPair(2L, 1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mentors");
+    }
+
+    @Test
+    void mentorPair_throws400_whenOtherIsNotAMentor() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(mentee));
+
+        assertThatThrownBy(() -> conversationService.findOrCreateForMentorPair(1L, 2L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mentors");
+    }
+
+    @Test
+    void mentorPair_throws400_whenOtherIsAnAdmin() {
+        // Admin extends User but is not a Mentor — instanceof check rejects.
+        com.group7.backend.entity.Admin admin = new com.group7.backend.entity.Admin();
+        admin.setId(99L);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(userRepository.findById(99L)).thenReturn(Optional.of(admin));
+
+        assertThatThrownBy(() -> conversationService.findOrCreateForMentorPair(1L, 99L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("mentors");
+    }
+
+    @Test
+    void mentorPair_recoversFromConcurrentCreate_viaUniqueConstraintRetry() {
+        Conversation winnerSnapshot = new Conversation();
+        winnerSnapshot.setId(901L);
+        winnerSnapshot.setKind(ConversationKind.MENTOR_PAIR);
+        winnerSnapshot.setPairAId(1L);
+        winnerSnapshot.setPairBId(3L);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
+        when(conversationRepository.findByPairAIdAndPairBIdAndKind(
+                1L, 3L, ConversationKind.MENTOR_PAIR))
+                // First call: no row yet → triggers create
+                // Second call (after DataIntegrityViolation): the winner is visible
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(winnerSnapshot));
+        when(conversationRepository.save(any(Conversation.class)))
+                .thenThrow(new DataIntegrityViolationException("uq_conversations_pair_kind"));
+
+        Conversation result = conversationService.findOrCreateForMentorPair(1L, 3L);
+
+        assertThat(result).isSameAs(winnerSnapshot);
+    }
+
+    @Test
+    void mentorPair_recoveryWithoutRow_throwsIllegalState() {
+        // Inner tx throws but the recovery re-find sees nothing — this should
+        // never happen in production (the unique index guarantees the winning
+        // row is committed by the time the loser re-reads). Surface as a
+        // 500-class IllegalStateException with diagnostic context so the
+        // operator knows transaction isolation is misconfigured.
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
+        when(conversationRepository.findByPairAIdAndPairBIdAndKind(
+                1L, 3L, ConversationKind.MENTOR_PAIR))
+                .thenReturn(Optional.empty());
+        when(conversationRepository.save(any(Conversation.class)))
+                .thenThrow(new DataIntegrityViolationException("uq_conversations_pair_kind"));
+
+        assertThatThrownBy(() -> conversationService.findOrCreateForMentorPair(1L, 3L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("transaction isolation");
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
@@ -209,20 +209,22 @@ class ConversationServiceTest {
 
     @Test
     void mentorPair_returnsExistingConversation_whenAlreadyPresent() {
+        // Idempotent path: the conversation lookup short-circuits before any
+        // userRepository call. The role check is intentionally NOT re-run on
+        // existing conversations so peer history survives role changes.
         Conversation existing = new Conversation();
         existing.setId(901L);
         existing.setKind(ConversationKind.MENTOR_PAIR);
         existing.setPairAId(1L);
         existing.setPairBId(3L);
 
-        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
         when(conversationRepository.findByPairAIdAndPairBIdAndKind(
                 1L, 3L, ConversationKind.MENTOR_PAIR)).thenReturn(Optional.of(existing));
 
         Conversation result = conversationService.findOrCreateForMentorPair(1L, 3L);
 
         assertThat(result).isSameAs(existing);
+        verify(userRepository, never()).findById(any());
         verify(conversationCreator, never()).createForMentorPairInNewTx(any(), any(), anyLong(), anyLong());
     }
 

--- a/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
@@ -2,15 +2,12 @@ package com.group7.backend.service;
 
 import com.group7.backend.entity.Conversation;
 import com.group7.backend.entity.ConversationKind;
-import com.group7.backend.entity.ConversationParticipant;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.entity.Mentorship;
 import com.group7.backend.entity.MentorshipStatus;
-import com.group7.backend.entity.User;
 import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.exception.ResourceNotFoundException;
-import com.group7.backend.repository.ConversationParticipantRepository;
 import com.group7.backend.repository.ConversationRepository;
 import com.group7.backend.repository.MentorshipRepository;
 import com.group7.backend.repository.UserRepository;
@@ -19,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationContext;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
@@ -27,6 +23,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,10 +34,9 @@ import static org.mockito.Mockito.when;
 class ConversationServiceTest {
 
     @Mock private ConversationRepository conversationRepository;
-    @Mock private ConversationParticipantRepository participantRepository;
     @Mock private MentorshipRepository mentorshipRepository;
     @Mock private UserRepository userRepository;
-    @Mock private ApplicationContext applicationContext;
+    @Mock private ConversationCreator conversationCreator;
 
     private ConversationService conversationService;
 
@@ -51,15 +48,7 @@ class ConversationServiceTest {
     @BeforeEach
     void setUp() {
         conversationService = new ConversationService(
-                conversationRepository, participantRepository, mentorshipRepository,
-                userRepository, applicationContext);
-        // Self-injection: in unit tests we route the bean lookup back to the
-        // service under test so the inner createForMentorshipInNewTx /
-        // createForMentorPairInNewTx calls execute the real method (no Spring
-        // proxy in pure JUnit).
-        org.mockito.Mockito.lenient()
-                .when(applicationContext.getBean(ConversationService.class))
-                .thenReturn(conversationService);
+                conversationRepository, mentorshipRepository, userRepository, conversationCreator);
 
         mentor = new Mentor();
         mentor.setId(1L);
@@ -80,6 +69,8 @@ class ConversationServiceTest {
         mentorPeer.setFirstName("Iris");
     }
 
+    // ── findOrCreateForMentorship (issue #245) ──────────────────────────────
+
     @Test
     void findOrCreate_returnsExistingConversation_whenAlreadyPresent() {
         Conversation existing = new Conversation();
@@ -93,26 +84,24 @@ class ConversationServiceTest {
         Conversation result = conversationService.findOrCreateForMentorship(100L, 1L);
 
         assertThat(result).isSameAs(existing);
-        verify(conversationRepository, never()).save(any());
-        verify(participantRepository, never()).save(any());
+        verify(conversationCreator, never()).createForMentorshipInNewTx(any());
     }
 
     @Test
-    void findOrCreate_createsConversationAndTwoParticipants_whenMissing() {
+    void findOrCreate_delegatesToCreator_whenMissing() {
+        Conversation created = new Conversation();
+        created.setId(900L);
+        created.setKind(ConversationKind.MENTORSHIP);
+        created.setMentorship(mentorship);
+
         when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
         when(conversationRepository.findByMentorshipId(100L)).thenReturn(Optional.empty());
-        when(conversationRepository.save(any(Conversation.class))).thenAnswer(inv -> {
-            Conversation c = inv.getArgument(0);
-            c.setId(900L);
-            return c;
-        });
+        when(conversationCreator.createForMentorshipInNewTx(mentorship)).thenReturn(created);
 
         Conversation result = conversationService.findOrCreateForMentorship(100L, 1L);
 
-        assertThat(result.getId()).isEqualTo(900L);
-        assertThat(result.getKind()).isEqualTo(ConversationKind.MENTORSHIP);
-        assertThat(result.getMentorship()).isSameAs(mentorship);
-        verify(participantRepository, times(2)).save(any(ConversationParticipant.class));
+        assertThat(result).isSameAs(created);
+        verify(conversationCreator, times(1)).createForMentorshipInNewTx(mentorship);
     }
 
     @Test
@@ -122,7 +111,6 @@ class ConversationServiceTest {
         when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
         when(conversationRepository.findByMentorshipId(100L)).thenReturn(Optional.of(existing));
 
-        // Mentee (id=2) is also a participant — should be authorized.
         Conversation result = conversationService.findOrCreateForMentorship(100L, 2L);
 
         assertThat(result).isSameAs(existing);
@@ -136,7 +124,7 @@ class ConversationServiceTest {
                 .isInstanceOf(ProfileNotVisibleException.class);
 
         verify(conversationRepository, never()).findByMentorshipId(any());
-        verify(conversationRepository, never()).save(any());
+        verify(conversationCreator, never()).createForMentorshipInNewTx(any());
     }
 
     @Test
@@ -149,9 +137,6 @@ class ConversationServiceTest {
 
     @Test
     void findOrCreate_returnsExisting_evenWhenMentorshipNotActive() {
-        // History remains readable after the mentorship reaches a terminal
-        // state — once the conversation row exists, status is irrelevant
-        // for resolving it on subsequent reads.
         mentorship.setStatus(MentorshipStatus.COMPLETED);
         Conversation existing = new Conversation();
         existing.setId(900L);
@@ -164,15 +149,11 @@ class ConversationServiceTest {
         Conversation result = conversationService.findOrCreateForMentorship(100L, 1L);
 
         assertThat(result).isSameAs(existing);
-        verify(conversationRepository, never()).save(any());
-        verify(participantRepository, never()).save(any());
+        verify(conversationCreator, never()).createForMentorshipInNewTx(any());
     }
 
     @Test
     void findOrCreate_throwsNotFound_whenMentorshipNotActiveAndNoConversation() {
-        // The read paths (GET /messages, PATCH /read) must not silently insert
-        // empty conversation rows for rejected/completed mentorships nor leak
-        // participation by returning 200.
         mentorship.setStatus(MentorshipStatus.TERMINATED);
         when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
         when(conversationRepository.findByMentorshipId(100L)).thenReturn(Optional.empty());
@@ -180,8 +161,7 @@ class ConversationServiceTest {
         assertThatThrownBy(() -> conversationService.findOrCreateForMentorship(100L, 1L))
                 .isInstanceOf(ResourceNotFoundException.class);
 
-        verify(conversationRepository, never()).save(any());
-        verify(participantRepository, never()).save(any());
+        verify(conversationCreator, never()).createForMentorshipInNewTx(any());
     }
 
     @Test
@@ -193,11 +173,9 @@ class ConversationServiceTest {
 
         when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
         when(conversationRepository.findByMentorshipId(100L))
-                // First call: no row yet → triggers create
-                // Second call (after DataIntegrityViolation): the winner is visible
                 .thenReturn(Optional.empty())
                 .thenReturn(Optional.of(winnerSnapshot));
-        when(conversationRepository.save(any(Conversation.class)))
+        when(conversationCreator.createForMentorshipInNewTx(mentorship))
                 .thenThrow(new DataIntegrityViolationException("uq_conversations_mentorship"));
 
         Conversation result = conversationService.findOrCreateForMentorship(100L, 1L);
@@ -208,26 +186,25 @@ class ConversationServiceTest {
     // ── findOrCreateForMentorPair (issue #284) ──────────────────────────────
 
     @Test
-    void mentorPair_createsConversation_withCanonicalOrderAndTwoParticipants() {
+    void mentorPair_delegatesToCreator_withCanonicalOrder() {
+        Conversation created = new Conversation();
+        created.setId(901L);
+        created.setKind(ConversationKind.MENTOR_PAIR);
+        created.setPairAId(1L);
+        created.setPairBId(3L);
+
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
         when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
         when(conversationRepository.findByPairAIdAndPairBIdAndKind(
-                1L, 3L, ConversationKind.MENTOR_PAIR))
-                .thenReturn(Optional.empty());
-        when(conversationRepository.save(any(Conversation.class))).thenAnswer(inv -> {
-            Conversation c = inv.getArgument(0);
-            c.setId(901L);
-            return c;
-        });
+                1L, 3L, ConversationKind.MENTOR_PAIR)).thenReturn(Optional.empty());
+        when(conversationCreator.createForMentorPairInNewTx(
+                eq(mentor), eq(mentorPeer), eq(1L), eq(3L))).thenReturn(created);
 
         Conversation result = conversationService.findOrCreateForMentorPair(1L, 3L);
 
-        assertThat(result.getId()).isEqualTo(901L);
-        assertThat(result.getKind()).isEqualTo(ConversationKind.MENTOR_PAIR);
-        assertThat(result.getPairAId()).isEqualTo(1L);
-        assertThat(result.getPairBId()).isEqualTo(3L);
-        assertThat(result.getMentorship()).isNull();
-        verify(participantRepository, times(2)).save(any(ConversationParticipant.class));
+        assertThat(result).isSameAs(created);
+        verify(conversationCreator, times(1)).createForMentorPairInNewTx(
+                mentor, mentorPeer, 1L, 3L);
     }
 
     @Test
@@ -241,34 +218,39 @@ class ConversationServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
         when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
         when(conversationRepository.findByPairAIdAndPairBIdAndKind(
-                1L, 3L, ConversationKind.MENTOR_PAIR))
-                .thenReturn(Optional.of(existing));
+                1L, 3L, ConversationKind.MENTOR_PAIR)).thenReturn(Optional.of(existing));
 
         Conversation result = conversationService.findOrCreateForMentorPair(1L, 3L);
 
         assertThat(result).isSameAs(existing);
-        verify(conversationRepository, never()).save(any());
-        verify(participantRepository, never()).save(any());
+        verify(conversationCreator, never()).createForMentorPairInNewTx(any(), any(), anyLong(), anyLong());
     }
 
     @Test
-    void mentorPair_resolvesToSameConversation_regardlessOfArgumentOrder() {
-        // Calling (3, 1) must produce the same canonical key (1, 3) as (1, 3).
-        Conversation existing = new Conversation();
-        existing.setId(901L);
-        existing.setKind(ConversationKind.MENTOR_PAIR);
-        existing.setPairAId(1L);
-        existing.setPairBId(3L);
+    void mentorPair_canonicalisesArgumentOrder_onCreatePath() {
+        // Calling (3, 1) — reverse of canonical — must still send (1, 3) to
+        // the creator. This is the test that the previous version of this
+        // suite missed (it only verified the read-side canonicalisation).
+        Conversation created = new Conversation();
+        created.setId(901L);
+        created.setKind(ConversationKind.MENTOR_PAIR);
+        created.setPairAId(1L);
+        created.setPairBId(3L);
 
         when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
         when(conversationRepository.findByPairAIdAndPairBIdAndKind(
-                1L, 3L, ConversationKind.MENTOR_PAIR))
-                .thenReturn(Optional.of(existing));
+                1L, 3L, ConversationKind.MENTOR_PAIR)).thenReturn(Optional.empty());
+        when(conversationCreator.createForMentorPairInNewTx(
+                any(), any(), eq(1L), eq(3L))).thenReturn(created);
 
         Conversation result = conversationService.findOrCreateForMentorPair(3L, 1L);
 
-        assertThat(result).isSameAs(existing);
+        assertThat(result).isSameAs(created);
+        // Whichever User went where in the create call doesn't matter — only
+        // the canonical (lower, higher) pair identifiers do.
+        verify(conversationCreator, times(1)).createForMentorPairInNewTx(
+                any(), any(), eq(1L), eq(3L));
     }
 
     @Test
@@ -299,8 +281,6 @@ class ConversationServiceTest {
 
     @Test
     void mentorPair_throws400_whenRequesterIsNotAMentor() {
-        // Defense-in-depth: controller @PreAuthorize blocks mentees, but the
-        // service rejects a mentee caller too if invoked from non-controller code.
         when(userRepository.findById(2L)).thenReturn(Optional.of(mentee));
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
 
@@ -321,7 +301,6 @@ class ConversationServiceTest {
 
     @Test
     void mentorPair_throws400_whenOtherIsAnAdmin() {
-        // Admin extends User but is not a Mentor — instanceof check rejects.
         com.group7.backend.entity.Admin admin = new com.group7.backend.entity.Admin();
         admin.setId(99L);
 
@@ -345,11 +324,10 @@ class ConversationServiceTest {
         when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
         when(conversationRepository.findByPairAIdAndPairBIdAndKind(
                 1L, 3L, ConversationKind.MENTOR_PAIR))
-                // First call: no row yet → triggers create
-                // Second call (after DataIntegrityViolation): the winner is visible
                 .thenReturn(Optional.empty())
                 .thenReturn(Optional.of(winnerSnapshot));
-        when(conversationRepository.save(any(Conversation.class)))
+        when(conversationCreator.createForMentorPairInNewTx(
+                any(), any(), eq(1L), eq(3L)))
                 .thenThrow(new DataIntegrityViolationException("uq_conversations_pair_kind"));
 
         Conversation result = conversationService.findOrCreateForMentorPair(1L, 3L);
@@ -359,17 +337,12 @@ class ConversationServiceTest {
 
     @Test
     void mentorPair_recoveryWithoutRow_throwsIllegalState() {
-        // Inner tx throws but the recovery re-find sees nothing — this should
-        // never happen in production (the unique index guarantees the winning
-        // row is committed by the time the loser re-reads). Surface as a
-        // 500-class IllegalStateException with diagnostic context so the
-        // operator knows transaction isolation is misconfigured.
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
         when(userRepository.findById(3L)).thenReturn(Optional.of(mentorPeer));
         when(conversationRepository.findByPairAIdAndPairBIdAndKind(
-                1L, 3L, ConversationKind.MENTOR_PAIR))
-                .thenReturn(Optional.empty());
-        when(conversationRepository.save(any(Conversation.class)))
+                1L, 3L, ConversationKind.MENTOR_PAIR)).thenReturn(Optional.empty());
+        when(conversationCreator.createForMentorPairInNewTx(
+                any(), any(), eq(1L), eq(3L)))
                 .thenThrow(new DataIntegrityViolationException("uq_conversations_pair_kind"));
 
         assertThatThrownBy(() -> conversationService.findOrCreateForMentorPair(1L, 3L))


### PR DESCRIPTION
Closes #284. Satisfies requirement 1.1.3.5 ("Mentors shall be able to message other mentors").

## Summary

The Conversation abstraction shipped in #245 was already kind-agnostic at the entity, message-service, broadcast, JSON-LD, and attachment-ACL layers, with `MENTOR_PAIR` reserved in `ConversationKind`. This PR fills in the missing pieces:

- A `findOrCreateForMentorPair(requesterId, otherMentorId)` policy on `ConversationService` (idempotent, race-safe via insert-then-fallback, mirrors the existing mentorship method).
- DB-level pair uniqueness on `conversations(pair_a_id, pair_b_id, kind)` plus a CHECK that the kind discriminator agrees with which columns are populated. The kind is now a real invariant, not just a label.
- New REST surface: `POST | GET | PATCH /read` on `/api/conversations/mentor-pair/{otherMentorId}/messages`, gated `@PreAuthorize("hasRole('MENTOR')")`.
- Rate-limit rule mirroring the existing mentorship send (USER-keyed, 60/min).

`MessageService`, `MessageBroadcastListener`, `NotificationEventPublisher.publishNewMessage`, the attachment ACL, and JSON-LD output are reused unchanged — pair messages broadcast on `/topic/conversation/{cid}`, produce `NEW_MESSAGE` notifications, and inherit the sender-equals-uploader gate for attachments for free.

## Acceptance criteria (#284)

- [x] Mentors can start a conversation with any other mentor.
- [x] Mentees still cannot message without an active mentorship (the mentorship endpoint is unchanged; the new endpoint is `@PreAuthorize("hasRole('MENTOR')")`).
- [x] Message history and notifications work the same as mentor-mentee messaging.
- [x] Tests pass (673 total, 33 new).

## Test plan

- [x] `mvn clean test` — 673 / 673 pass.
- [x] JaCoCo branch coverage on new code: `ConversationService` 100% branches, `MentorPairMessageController` 100% instructions.
- [x] Manual end-to-end against a running backend covering: happy path A→B→A, history reads in both directions, mark-all-read semantics, notification creation, schema invariants (kind=MENTOR_PAIR, mentorship_id IS NULL, pair_a_id < pair_b_id, exactly one row per pair).
- [x] Negative paths verified: mentee POST → 403, self-pair → 400, mentee target → 400, unknown target → 404, unauthenticated → 403, empty content → 400. The `conversations_kind_columns_consistent` CHECK was verified by hand-crafting an invariant-violating INSERT — Postgres rejects it.

## Notes

- Out of scope: idempotency-key headers, block list, "list my mentor-pair conversations" inbox endpoint, FCM push (#136), message reporting (#135 area). All deliberately deferred.
- The migration is V17 to leave V16 free for #320 (currently in PR #321). If #321 lands first, this is fine. If this lands first, #320 picks the next available number on rebase.