### PR TITLE
test(backend): cover STOMP SUBSCRIBE branches and assert ERROR-frame …

### DIFF
--- a/backend/src/test/java/com/group7/backend/config/websocket/JwtChannelInterceptorSubscribeTest.java
+++ b/backend/src/test/java/com/group7/backend/config/websocket/JwtChannelInterceptorSubscribeTest.java
@@ -1,0 +1,165 @@
+package com.group7.backend.config.websocket;
+
+import com.group7.backend.repository.ConversationParticipantRepository;
+import com.group7.backend.service.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Branch-level coverage for {@link JwtChannelInterceptor#preSend} on
+ * {@link StompCommand#SUBSCRIBE} frames. Issue #324 acceptance criteria
+ * require ≥ 90% coverage on the SUBSCRIBE authorisation path; the
+ * end-to-end {@code MessagingWebSocketIntegrationTest} only exercises the
+ * authorised and unauthorised-participant branches, so the remaining three
+ * (missing principal, malformed destination, out-of-prefix passthrough)
+ * are covered here against mocked collaborators.
+ */
+class JwtChannelInterceptorSubscribeTest {
+
+    private static final String TOPIC_PREFIX = "/topic/conversation/";
+
+    private JwtService jwtService;
+    private ConversationParticipantRepository participantRepository;
+    private MessageChannel channel;
+    private JwtChannelInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = mock(JwtService.class);
+        participantRepository = mock(ConversationParticipantRepository.class);
+        channel = mock(MessageChannel.class);
+        interceptor = new JwtChannelInterceptor(jwtService, participantRepository);
+    }
+
+    @Test
+    void subscribePassesWhenPrincipalIsParticipant() {
+        Long userId = 7L;
+        Long conversationId = 42L;
+        when(participantRepository.existsByConversationIdAndUserId(conversationId, userId))
+                .thenReturn(true);
+
+        Message<?> message = subscribeMessage(TOPIC_PREFIX + conversationId, authToken(userId));
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isSameAs(message);
+        verify(participantRepository).existsByConversationIdAndUserId(conversationId, userId);
+    }
+
+    @Test
+    void subscribeRejectedWhenPrincipalIsNotParticipant() {
+        Long userId = 7L;
+        Long conversationId = 42L;
+        when(participantRepository.existsByConversationIdAndUserId(conversationId, userId))
+                .thenReturn(false);
+
+        Message<?> message = subscribeMessage(TOPIC_PREFIX + conversationId, authToken(userId));
+
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(MessagingException.class)
+                .hasMessageContaining("not a participant");
+    }
+
+    @Test
+    void subscribeRejectedWhenPrincipalIsMissing() {
+        Message<?> message = subscribeMessage(TOPIC_PREFIX + "1", null);
+
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(MessagingException.class)
+                .hasMessageContaining("authenticated session");
+        verify(participantRepository, never()).existsByConversationIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    void subscribeRejectedWhenDestinationIdIsMalformed() {
+        Message<?> message = subscribeMessage(TOPIC_PREFIX + "abc", authToken(7L));
+
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(MessagingException.class)
+                .hasMessageContaining("Malformed");
+        verify(participantRepository, never()).existsByConversationIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    void subscribePassesThroughWhenDestinationIsOutsideManagedPrefix() {
+        Message<?> message = subscribeMessage("/topic/some-other-topic/1", authToken(7L));
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isSameAs(message);
+        verify(participantRepository, never()).existsByConversationIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    void subscribePassesThroughWhenDestinationIsNull() {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setUser(authToken(7L));
+        accessor.setSessionId("session-id");
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isSameAs(message);
+        verify(participantRepository, never()).existsByConversationIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    void connectRejectedWhenTokenInvalid() {
+        when(jwtService.isTokenValid(any())).thenReturn(false);
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.setSessionId("session-id");
+        accessor.setNativeHeader("Authorization", "Bearer not-a-real-token");
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(MessagingException.class)
+                .hasMessageContaining("Authentication required");
+        verify(participantRepository, never()).existsByConversationIdAndUserId(anyLong(), anyLong());
+    }
+
+    @Test
+    void nonStompMessagePassesThrough() {
+        Message<byte[]> message = MessageBuilder.withPayload(new byte[0]).build();
+
+        Message<?> result = interceptor.preSend(message, channel);
+
+        assertThat(result).isSameAs(message);
+        verify(participantRepository, never()).existsByConversationIdAndUserId(anyLong(), anyLong());
+    }
+
+    private static Message<?> subscribeMessage(String destination, UsernamePasswordAuthenticationToken user) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination(destination);
+        accessor.setSessionId("session-id");
+        if (user != null) {
+            accessor.setUser(user);
+        }
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private static UsernamePasswordAuthenticationToken authToken(Long userId) {
+        return new UsernamePasswordAuthenticationToken(
+                "user@example.com",
+                userId,
+                List.of(new SimpleGrantedAuthority("ROLE_MENTOR")));
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/MessagingWebSocketIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MessagingWebSocketIntegrationTest.java
@@ -37,6 +37,7 @@ import org.springframework.web.socket.messaging.WebSocketStompClient;
 
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
@@ -162,10 +163,17 @@ class MessagingWebSocketIntegrationTest {
         String outsiderToken = registerAndLogin("ws_outsider@test.com", true);
 
         // CONNECT succeeds (the outsider has a valid JWT) but the SUBSCRIBE
-        // frame is rejected by the interceptor; the server then closes the
-        // session. From the client's perspective the subscription handler is
-        // simply never invoked, even after a real broadcast happens.
-        StompSession session = connect(outsiderToken);
+        // frame is rejected by the interceptor; the server sends a STOMP
+        // ERROR frame (surfaced via handleException) and/or closes the
+        // transport (surfaced via handleTransportError). Either signal is a
+        // server-side rejection; the test asserts that at least one fires
+        // and that no broadcast frame is ever delivered to the outsider.
+        RecordingSessionHandler handler = new RecordingSessionHandler();
+        StompHeaders stompHeaders = new StompHeaders();
+        stompHeaders.add("Authorization", "Bearer " + outsiderToken);
+        StompSession session = stompClient
+                .connectAsync(wsUrl(), new WebSocketHttpHeaders(), stompHeaders, handler)
+                .get(5, TimeUnit.SECONDS);
 
         LinkedBlockingDeque<MessageResponse> received = new LinkedBlockingDeque<>();
         try {
@@ -178,11 +186,14 @@ class MessagingWebSocketIntegrationTest {
                 }
             });
         } catch (Exception ignored) {
-            // Some Spring versions surface the rejection as an exception here;
-            // others close the session asynchronously. Either way, no frame
-            // should be delivered.
+            // Some Spring versions surface the rejection synchronously here;
+            // either way handleException / handleTransportError will fire.
         }
-        Thread.sleep(500);
+
+        // Server-side rejection MUST surface within a bounded window.
+        assertThat(handler.rejection.await(2, TimeUnit.SECONDS))
+                .as("server should send STOMP ERROR or close the session for non-participant SUBSCRIBE")
+                .isTrue();
 
         // Have the mentor send a real message via REST and confirm the outsider
         // never receives it.
@@ -301,6 +312,29 @@ class MessagingWebSocketIntegrationTest {
                                     StompHeaders headers, byte[] payload, Throwable exception) {
             // Allow the test to observe failures via session state instead of
             // letting them spam stderr.
+        }
+    }
+
+    /**
+     * Session handler that opens a {@link CountDownLatch} the moment the
+     * server signals a rejection — either via a STOMP ERROR frame
+     * ({@code handleException}) or by closing the underlying transport
+     * ({@code handleTransportError}). The test for non-participant SUBSCRIBE
+     * awaits this latch to assert the rejection actually arrived rather than
+     * inferring it from the absence of a broadcast.
+     */
+    private static class RecordingSessionHandler extends StompSessionHandlerAdapter {
+        final CountDownLatch rejection = new CountDownLatch(1);
+
+        @Override
+        public void handleException(StompSession session, StompCommand command,
+                                    StompHeaders headers, byte[] payload, Throwable exception) {
+            rejection.countDown();
+        }
+
+        @Override
+        public void handleTransportError(StompSession session, Throwable exception) {
+            rejection.countDown();
         }
     }
 }


### PR DESCRIPTION
(#324)## Summary
- Closes #324. The actual SUBSCRIBE authorization logic already shipped in #245 (`JwtChannelInterceptor.authorizeSubscribe`); this PR closes the two remaining acceptance-criteria gaps.
- Adds `JwtChannelInterceptorSubscribeTest` (plain JUnit + Mockito) covering all six SUBSCRIBE branches plus CONNECT invalid-token and non-STOMP passthrough.
- Tightens `nonParticipantSubscriptionDoesNotReceiveBroadcast` with a `RecordingSessionHandler` that asserts the server actually emits a STOMP ERROR frame (or closes the transport) within 2s, instead of inferring rejection from the absence of a broadcast.

## Acceptance criteria (#324)
- [x] Participant successfully receives broadcasts after SUBSCRIBE — covered by existing `participantSubscribesAndReceivesBroadcastFromRestSend`.
- [x] Non-participant receives a STOMP ERROR and is not subscribed — now explicit via `RecordingSessionHandler.rejection` latch + retained "no broadcast received" check.
- [x] Existing messaging WebSocket tests continue to pass.
- [x] Coverage on the interceptor ≥ 90 % — JaCoCo: `JwtChannelInterceptor` at 100% line / 92% branch overall; `authorizeSubscribe` at 100% / 100%.

## Test plan
- [x] `mvn test -Dtest=JwtChannelInterceptorSubscribeTest` → 8/8 pass
- [x] `mvn test -Dtest=MessagingWebSocketIntegrationTest` → 3/3 pass (requires `docker compose up -d db`)
- [x] `mvn verify` → 715/715 pass
- [x] Verified `target/site/jacoco/com.group7.backend.config.websocket/JwtChannelInterceptor.html` shows ≥ 90 % branch coverage

## Notes
No production code changes — `JwtChannelInterceptor` was already correct. PR scope is purely tests + a recording session handler in the existing integration test class.
