### PR TITLE
feat(backend): list-my-mentor-pair-conversations endpoint (#323)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MatchingController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MatchingController.java
@@ -1,5 +1,6 @@
 package com.group7.backend.controller;
 
+import com.group7.backend.controller.support.PageableSupport;
 import com.group7.backend.dto.response.MenteeCandidateResponse;
 import com.group7.backend.dto.response.MentorMatchResponse;
 import com.group7.backend.service.MatchingService;
@@ -10,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -52,7 +52,7 @@ public class MatchingController {
             @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
             Authentication authentication) {
         Long menteeId = (Long) authentication.getCredentials();
-        Pageable pageable = clampPageable(page, size);
+        Pageable pageable = PageableSupport.clampPageable(page, size);
         return ResponseEntity.ok(matchingService.getTopMentors(menteeId, keyword, pageable));
     }
 
@@ -92,12 +92,7 @@ public class MatchingController {
             @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
             Authentication authentication) {
         Long mentorId = (Long) authentication.getCredentials();
-        Pageable pageable = clampPageable(page, size);
+        Pageable pageable = PageableSupport.clampPageable(page, size);
         return ResponseEntity.ok(matchingService.getCandidateMentees(mentorId, keyword, pageable));
-    }
-
-    private Pageable clampPageable(int page, int size) {
-        int clampedSize = Math.min(Math.max(size, 1), 100);
-        return PageRequest.of(Math.max(page, 0), clampedSize);
     }
 }

--- a/backend/src/main/java/com/group7/backend/controller/MentorPairInboxController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorPairInboxController.java
@@ -1,0 +1,65 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.controller.support.PageableSupport;
+import com.group7.backend.dto.response.MentorPairInboxItem;
+import com.group7.backend.service.MentorPairInboxService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Mentor-pair inbox listing for the authenticated mentor: their peer-mentor
+ * conversations with last-message preview and unread count, paginated
+ * newest-first.
+ *
+ * <p>Companion to {@code MentorPairMessageController} (per-conversation
+ * messaging surface). Class-level {@code @PreAuthorize} mirrors that
+ * controller's role gate.
+ */
+@RestController
+@RequestMapping("/api/conversations/mentor-pair")
+@PreAuthorize("hasRole('MENTOR')")
+@Tag(name = "Mentor Pair Inbox",
+        description = "Listing of the caller's mentor-pair conversations")
+public class MentorPairInboxController {
+
+    private final MentorPairInboxService inboxService;
+
+    public MentorPairInboxController(MentorPairInboxService inboxService) {
+        this.inboxService = inboxService;
+    }
+
+    @GetMapping
+    @Operation(summary = "List my mentor-pair conversations",
+            description = "Returns the caller's mentor-pair conversations, paginated and "
+                    + "ordered by most recent activity. Each item carries peer identity, "
+                    + "the last message's content and timestamp (nullable when the "
+                    + "conversation has no messages yet), and the caller's unread count.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated inbox"),
+            @ApiResponse(responseCode = "403", description = "Caller is not a mentor",
+                    content = @Content)
+    })
+    public ResponseEntity<Page<MentorPairInboxItem>> listInbox(
+            @Parameter(description = "Page number (0-based)")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size; clamped to [1, 100]")
+            @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        Pageable pageable = PageableSupport.clampPageable(page, size);
+        return ResponseEntity.ok(inboxService.listInbox(requesterId, pageable));
+    }
+}

--- a/backend/src/main/java/com/group7/backend/controller/UserController.java
+++ b/backend/src/main/java/com/group7/backend/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.group7.backend.controller;
 
+import com.group7.backend.controller.support.PageableSupport;
 import com.group7.backend.dto.request.MenteeProfileRequest;
 import com.group7.backend.dto.request.MentorProfileRequest;
 import com.group7.backend.dto.response.MenteeResponse;
@@ -16,7 +17,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -139,7 +139,7 @@ public class UserController {
             @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
             Authentication authentication) {
         Long requesterId = (Long) authentication.getCredentials();
-        Pageable pageable = clampPageable(page, size);
+        Pageable pageable = PageableSupport.clampPageable(page, size);
         return ResponseEntity.ok(userService.getAllUsersFiltered(requesterId, pageable));
     }
 
@@ -166,7 +166,7 @@ public class UserController {
     public ResponseEntity<Page<MentorResponse>> getAllMentors(
             @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
-        Pageable pageable = clampPageable(page, size);
+        Pageable pageable = PageableSupport.clampPageable(page, size);
         return ResponseEntity.ok(userService.getAllMentors(pageable));
     }
 
@@ -186,7 +186,7 @@ public class UserController {
     public ResponseEntity<Page<MenteeResponse>> getAllMentees(
             @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
-        Pageable pageable = clampPageable(page, size);
+        Pageable pageable = PageableSupport.clampPageable(page, size);
         return ResponseEntity.ok(userService.getAllMentees(pageable));
     }
 
@@ -207,10 +207,5 @@ public class UserController {
         }
         userService.deleteUser(id);
         return ResponseEntity.noContent().build();
-    }
-
-    private Pageable clampPageable(int page, int size) {
-        int clampedSize = Math.min(Math.max(size, 1), 100);
-        return PageRequest.of(Math.max(page, 0), clampedSize);
     }
 }

--- a/backend/src/main/java/com/group7/backend/controller/support/PageableSupport.java
+++ b/backend/src/main/java/com/group7/backend/controller/support/PageableSupport.java
@@ -1,0 +1,34 @@
+package com.group7.backend.controller.support;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Page/size clamping shared by paginated list endpoints. Extracted from the
+ * private copies that previously lived in {@code UserController},
+ * {@code MatchingController}, and would otherwise have appeared in
+ * {@code MentorPairInboxController} — three is the rule-of-three threshold for
+ * extraction, so this consolidates the policy in one place.
+ *
+ * <p>Clamp behaviour, intentionally permissive (silent rather than 400):
+ * <ul>
+ *   <li>{@code size < 1 → 1} — the {@code defaultValue = "20"} on
+ *       {@code @RequestParam} fires only when the param is absent; an explicit
+ *       too-small value falls through to the lower bound.</li>
+ *   <li>{@code size > 100 → 100}</li>
+ *   <li>{@code page < 0 → 0}</li>
+ * </ul>
+ *
+ * <p>If a future endpoint needs different bounds, prefer adding a parameterised
+ * variant rather than re-introducing per-controller copies.
+ */
+public final class PageableSupport {
+
+    private PageableSupport() {
+    }
+
+    public static Pageable clampPageable(int page, int size) {
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return PageRequest.of(Math.max(page, 0), clampedSize);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorPairInboxItem.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorPairInboxItem.java
@@ -1,0 +1,43 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Wire shape for one row of a mentor's mentor-pair inbox: peer identity,
+ * last-message preview, and unread count. Built by
+ * {@code MentorPairInboxService} from the page query plus three batch
+ * lookups; never serialised when the assembling service detects a missing
+ * peer (see the race-defensive null-peer filter in that service).
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "A mentor's view of one mentor-pair conversation in their inbox")
+public class MentorPairInboxItem {
+
+    @Schema(description = "Conversation ID", example = "1024")
+    private Long conversationId;
+
+    @Schema(description = "Peer mentor's user ID", example = "42")
+    private Long peerId;
+
+    @Schema(description = "Peer mentor's first name", example = "Mira")
+    private String peerFirstName;
+
+    @Schema(description = "Content of the most recent message; null if the conversation has no messages yet",
+            example = "see you Tuesday")
+    private String lastMessageContent;
+
+    @Schema(description = "Timestamp of the most recent message; null if the conversation has no messages yet",
+            example = "2026-05-04T10:00:00Z")
+    private OffsetDateTime lastMessageSentAt;
+
+    @Schema(description = "Number of messages in this conversation that the caller has not read",
+            example = "3")
+    private long unreadCount;
+}

--- a/backend/src/main/java/com/group7/backend/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/ConversationRepository.java
@@ -2,7 +2,11 @@ package com.group7.backend.repository;
 
 import com.group7.backend.entity.Conversation;
 import com.group7.backend.entity.ConversationKind;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -24,4 +28,33 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
      */
     Optional<Conversation> findByPairAIdAndPairBIdAndKind(
             Long lowerId, Long higherId, ConversationKind kind);
+
+    /**
+     * Page of MENTOR_PAIR conversations the given user participates in,
+     * ordered by most-recent activity (NULLS LAST) with a deterministic
+     * tiebreaker on {@code c.id} so two conversations whose latest message
+     * landed in the same millisecond don't shift between requests.
+     *
+     * <p>Lookup goes through the participant junction (uses
+     * {@code idx_conversation_participants_user}) rather than
+     * {@code (pair_a_id = X OR pair_b_id = X)} which would require a per-
+     * column index on {@code pair_b_id} that doesn't exist today.
+     *
+     * <p>Spring Data's count-query auto-derivation around an order-by
+     * subquery is brittle, so the count is specified explicitly via
+     * {@code countQuery}.
+     */
+    @Query(
+            value = "SELECT c FROM Conversation c "
+                    + "JOIN ConversationParticipant cp ON cp.conversation = c "
+                    + "WHERE cp.user.id = :userId "
+                    + "AND c.kind = com.group7.backend.entity.ConversationKind.MENTOR_PAIR "
+                    + "ORDER BY (SELECT MAX(m.sentAt) FROM Message m WHERE m.conversation = c) DESC NULLS LAST, "
+                    + "c.id DESC",
+            countQuery = "SELECT COUNT(c) FROM Conversation c "
+                    + "WHERE c.kind = com.group7.backend.entity.ConversationKind.MENTOR_PAIR "
+                    + "AND EXISTS (SELECT 1 FROM ConversationParticipant cp "
+                    + "WHERE cp.conversation = c AND cp.user.id = :userId)")
+    Page<Conversation> findMentorPairConversationsForUserOrderedByLastMessage(
+            @Param("userId") Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/com/group7/backend/repository/MessageRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MessageRepository.java
@@ -1,6 +1,8 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.Message;
+import com.group7.backend.repository.projection.ConversationLastMessageView;
+import com.group7.backend.repository.projection.ConversationUnreadCount;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
@@ -49,4 +53,44 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
                                @Param("readerId") Long readerId,
                                @Param("readAt") OffsetDateTime readAt);
 
+    /**
+     * For each conversation in {@code conversationIds}, returns the latest
+     * message's content + sentAt. Postgres-specific {@code DISTINCT ON} hits
+     * the {@code idx_messages_conversation_sent_at} index for an index-only
+     * pick of one row per conversation; H2 doesn't support this, so this
+     * method is integration-tested against real Postgres rather than via
+     * {@code @DataJpaTest}.
+     *
+     * <p>Callers MUST pass a non-empty collection; Postgres rejects {@code IN ()}
+     * as a syntax error (Hibernate's empty-collection rewrite to {@code 1=0}
+     * applies only to JPQL, not to native queries). The inbox service
+     * short-circuits the empty-page case before invoking this method.
+     */
+    @Query(value = "SELECT DISTINCT ON (conversation_id) "
+            + "conversation_id AS conversationId, "
+            + "content AS content, "
+            + "sent_at AS sentAt "
+            + "FROM messages "
+            + "WHERE conversation_id IN :conversationIds "
+            + "ORDER BY conversation_id, sent_at DESC, id DESC",
+            nativeQuery = true)
+    List<ConversationLastMessageView> findLatestPerConversation(
+            @Param("conversationIds") Collection<Long> conversationIds);
+
+    /**
+     * For each conversation in {@code conversationIds}, returns the count of
+     * messages that are unread by {@code readerId} — i.e. {@code read_at IS NULL}
+     * and not sent by the reader themself. Returns one row per conversation
+     * that has at least one unread message; conversations with zero unread
+     * are absent from the result and the caller treats absence as zero.
+     */
+    @Query("SELECT m.conversation.id AS conversationId, COUNT(m) AS unreadCount "
+            + "FROM Message m "
+            + "WHERE m.conversation.id IN :conversationIds "
+            + "AND m.sender.id <> :readerId "
+            + "AND m.readAt IS NULL "
+            + "GROUP BY m.conversation.id")
+    List<ConversationUnreadCount> countUnreadPerConversationForReader(
+            @Param("conversationIds") Collection<Long> conversationIds,
+            @Param("readerId") Long readerId);
 }

--- a/backend/src/main/java/com/group7/backend/repository/projection/ConversationLastMessageView.java
+++ b/backend/src/main/java/com/group7/backend/repository/projection/ConversationLastMessageView.java
@@ -1,0 +1,28 @@
+package com.group7.backend.repository.projection;
+
+import java.time.Instant;
+
+/**
+ * Spring Data interface projection for the latest message of a conversation.
+ * Returned by {@code MessageRepository.findLatestPerConversation} so the inbox
+ * can build its preview without round-tripping a managed {@code Message}
+ * entity (which would lazy-load {@code Message.getConversation()} during DTO
+ * assembly).
+ *
+ * <p>Lives in {@code repository/projection/} rather than {@code dto/response/}
+ * because this is an internal data carrier — never serialised to clients.
+ *
+ * <p>{@code getSentAt()} returns {@link Instant} rather than
+ * {@code OffsetDateTime} because Hibernate maps Postgres
+ * {@code timestamp with time zone} columns to {@code Instant} for native
+ * queries (no Converter is registered for Instant → OffsetDateTime). The
+ * service converts to {@link java.time.OffsetDateTime} at the DTO boundary.
+ */
+public interface ConversationLastMessageView {
+
+    Long getConversationId();
+
+    String getContent();
+
+    Instant getSentAt();
+}

--- a/backend/src/main/java/com/group7/backend/repository/projection/ConversationUnreadCount.java
+++ b/backend/src/main/java/com/group7/backend/repository/projection/ConversationUnreadCount.java
@@ -1,0 +1,16 @@
+package com.group7.backend.repository.projection;
+
+/**
+ * Spring Data interface projection for the unread-message count per
+ * conversation, scoped to a specific reader. Returned by
+ * {@code MessageRepository.countUnreadPerConversationForReader}.
+ *
+ * <p>Lives in {@code repository/projection/} rather than {@code dto/response/}
+ * because this is an internal data carrier — never serialised to clients.
+ */
+public interface ConversationUnreadCount {
+
+    Long getConversationId();
+
+    Long getUnreadCount();
+}

--- a/backend/src/main/java/com/group7/backend/service/MentorPairInboxService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorPairInboxService.java
@@ -1,0 +1,145 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.MentorPairInboxItem;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.ConversationRepository;
+import com.group7.backend.repository.MessageRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.projection.ConversationLastMessageView;
+import com.group7.backend.repository.projection.ConversationUnreadCount;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Read-side service that assembles a mentor's mentor-pair inbox: their
+ * peer-mentor conversations with last-message preview and unread count,
+ * paginated newest-first.
+ *
+ * <p>The assembly avoids N+1 by resolving the page once and then issuing
+ * three bulk lookups (latest-message-per-conversation, unread-counts,
+ * peers-by-id) keyed by the page's conversation ids. Total: five queries
+ * (page + count + three bulk lookups) regardless of page size.
+ *
+ * <p><b>Invariant trusted by this service.</b> Every {@code MENTOR_PAIR}
+ * row in {@code conversation_participants} has the matching user in
+ * {@code pair_a_id} or {@code pair_b_id}. {@code ConversationCreator}
+ * is the only writer of these rows and inserts both atomically; the
+ * peer-id computation here ({@link #peerIdFor}) silently picks the wrong
+ * user if a future writer breaks that assumption.
+ */
+@Service
+public class MentorPairInboxService {
+
+    private final ConversationRepository conversationRepository;
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+
+    public MentorPairInboxService(ConversationRepository conversationRepository,
+                                  MessageRepository messageRepository,
+                                  UserRepository userRepository) {
+        this.conversationRepository = conversationRepository;
+        this.messageRepository = messageRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<MentorPairInboxItem> listInbox(Long requesterId, Pageable pageable) {
+        Page<Conversation> page = conversationRepository
+                .findMentorPairConversationsForUserOrderedByLastMessage(requesterId, pageable);
+        if (page.isEmpty()) {
+            // Either the user has no pair conversations at all (totalElements
+            // == 0) or the caller asked for a page beyond the last
+            // (totalElements > 0, page content empty). In both cases skip the
+            // helper batch loads — passing an empty collection to
+            // `WHERE conversation_id IN :ids` on the native DISTINCT ON query
+            // would make Postgres throw on `IN ()`. Preserve the page query's
+            // own totalElements so the client can tell the two cases apart
+            // (and learn they overshot when requesting a past-end page).
+            return new PageImpl<>(List.of(), pageable, page.getTotalElements());
+        }
+
+        List<Long> conversationIds = page.getContent().stream()
+                .map(Conversation::getId)
+                .toList();
+
+        Map<Long, ConversationLastMessageView> latestByConversation = messageRepository
+                .findLatestPerConversation(conversationIds).stream()
+                .collect(Collectors.toMap(
+                        ConversationLastMessageView::getConversationId,
+                        Function.identity()));
+
+        Map<Long, Long> unreadByConversation = messageRepository
+                .countUnreadPerConversationForReader(conversationIds, requesterId).stream()
+                .collect(Collectors.toMap(
+                        ConversationUnreadCount::getConversationId,
+                        ConversationUnreadCount::getUnreadCount));
+
+        List<Long> peerIds = page.getContent().stream()
+                .map(c -> peerIdFor(c, requesterId))
+                .toList();
+
+        Map<Long, User> peersById = userRepository.findAllById(peerIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<MentorPairInboxItem> items = page.getContent().stream()
+                .map(c -> toItem(c, requesterId, latestByConversation, unreadByConversation, peersById))
+                .filter(Objects::nonNull)
+                .toList();
+
+        // Pass page.getTotalElements() through; Spring's PageImpl auto-corrects
+        // the total to (offset + content.size()) when the requested window
+        // overshoots the supplied total (i.e., on the last page) — so during a
+        // peer-deletion race totalElements naturally drops to match the visible
+        // content rather than being inflated by the dropped row. The next
+        // request, after ON DELETE CASCADE on pair_a_id/pair_b_id has
+        // propagated, sees a fully consistent state.
+        return new PageImpl<>(items, pageable, page.getTotalElements());
+    }
+
+    private static MentorPairInboxItem toItem(Conversation conversation,
+                                              Long requesterId,
+                                              Map<Long, ConversationLastMessageView> latestByConversation,
+                                              Map<Long, Long> unreadByConversation,
+                                              Map<Long, User> peersById) {
+        Long peerId = peerIdFor(conversation, requesterId);
+        User peer = peersById.get(peerId);
+        if (peer == null) {
+            // Race-defensive: peer's account was deleted between the page
+            // query and the peer load. Drop this row rather than NPE on
+            // peer.getFirstName(); ON DELETE CASCADE will remove the
+            // conversation row by the time the client refetches.
+            return null;
+        }
+
+        ConversationLastMessageView latest = latestByConversation.get(conversation.getId());
+
+        MentorPairInboxItem item = new MentorPairInboxItem();
+        item.setConversationId(conversation.getId());
+        item.setPeerId(peerId);
+        item.setPeerFirstName(peer.getFirstName());
+        item.setLastMessageContent(latest != null ? latest.getContent() : null);
+        item.setLastMessageSentAt(latest != null
+                ? OffsetDateTime.ofInstant(latest.getSentAt(), ZoneOffset.UTC)
+                : null);
+        item.setUnreadCount(unreadByConversation.getOrDefault(conversation.getId(), 0L));
+        return item;
+    }
+
+    private static Long peerIdFor(Conversation conversation, Long requesterId) {
+        return conversation.getPairAId().equals(requesterId)
+                ? conversation.getPairBId()
+                : conversation.getPairAId();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/MentorPairInboxControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorPairInboxControllerTest.java
@@ -1,0 +1,157 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.MentorPairInboxItem;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.MentorPairInboxService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MentorPairInboxController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class MentorPairInboxControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private MentorPairInboxService inboxService;
+    @MockitoBean private JwtService jwtService;
+
+    private void mockMentorJwt(String token, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn("mentor@example.com");
+        when(jwtService.extractRole(token)).thenReturn("MENTOR");
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private void mockMenteeJwt(String token, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn("mentee@example.com");
+        when(jwtService.extractRole(token)).thenReturn("MENTEE");
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private MentorPairInboxItem sampleItem() {
+        MentorPairInboxItem item = new MentorPairInboxItem();
+        item.setConversationId(901L);
+        item.setPeerId(42L);
+        item.setPeerFirstName("Mira");
+        item.setLastMessageContent("see you Tuesday");
+        item.setLastMessageSentAt(OffsetDateTime.parse("2026-05-04T10:00:00Z"));
+        item.setUnreadCount(3L);
+        return item;
+    }
+
+    // ── 9. Happy path: 200 + paged body shape ──────────────────────────────
+
+    @Test
+    void listInbox_asMentor_returns200WithPagedBody() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        Page<MentorPairInboxItem> page = new PageImpl<>(List.of(sampleItem()));
+        when(inboxService.listInbox(eq(1L), any())).thenReturn(page);
+
+        mockMvc.perform(get("/api/conversations/mentor-pair")
+                        .header("Authorization", "Bearer mentor-a-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].conversationId").value(901))
+                .andExpect(jsonPath("$.content[0].peerId").value(42))
+                .andExpect(jsonPath("$.content[0].peerFirstName").value("Mira"))
+                .andExpect(jsonPath("$.content[0].lastMessageContent").value("see you Tuesday"))
+                .andExpect(jsonPath("$.content[0].unreadCount").value(3));
+    }
+
+    // ── 10. Mentee role denied ─────────────────────────────────────────────
+
+    @Test
+    void listInbox_asMentee_returns403() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+
+        mockMvc.perform(get("/api/conversations/mentor-pair")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── 11. Unauthenticated denied (this codebase: 403, not 401) ───────────
+
+    @Test
+    void listInbox_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/conversations/mentor-pair"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── 12. Pagination params honoured (page+size both within bounds) ──────
+
+    @Test
+    void listInbox_paginationParamsHonored() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        when(inboxService.listInbox(eq(1L), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/conversations/mentor-pair?page=2&size=5")
+                        .header("Authorization", "Bearer mentor-a-token"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(inboxService).listInbox(eq(1L), captor.capture());
+        assertThat(captor.getValue().getPageNumber()).isEqualTo(2);
+        assertThat(captor.getValue().getPageSize()).isEqualTo(5);
+    }
+
+    // ── 13. Oversized size clamps to 100 ───────────────────────────────────
+
+    @Test
+    void listInbox_clampsOversizedPageSize() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        when(inboxService.listInbox(eq(1L), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/conversations/mentor-pair?size=10000")
+                        .header("Authorization", "Bearer mentor-a-token"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(inboxService).listInbox(eq(1L), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isEqualTo(100);
+        assertThat(captor.getValue().getPageNumber()).isZero();
+    }
+
+    // ── 14. Negative inputs clamped silently (page→0, size→1) ──────────────
+
+    @Test
+    void listInbox_clampsNegativeInputs() throws Exception {
+        mockMentorJwt("mentor-a-token", 1L);
+        when(inboxService.listInbox(eq(1L), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/conversations/mentor-pair?page=-1&size=-5")
+                        .header("Authorization", "Bearer mentor-a-token"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(inboxService).listInbox(eq(1L), captor.capture());
+        // Math.max(page, 0) -> 0; Math.max(size, 1) wins over Math.min(_, 100) -> 1.
+        // The 20 default would only fire if `size` were absent (defaultValue),
+        // but here it was supplied as -5, so the clamp lower bound applies.
+        assertThat(captor.getValue().getPageNumber()).isZero();
+        assertThat(captor.getValue().getPageSize()).isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/MentorPairInboxIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorPairInboxIntegrationTest.java
@@ -1,0 +1,281 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.dto.request.SendMessageRequest;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.ConversationParticipantRepository;
+import com.group7.backend.repository.ConversationRepository;
+import com.group7.backend.repository.MessageRepository;
+import com.group7.backend.repository.NotificationRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the mentor-pair inbox listing (#323) against real
+ * Postgres. Mirrors the helpers and shape of
+ * {@link MentorPairMessagingIntegrationTest} (registerAndLogin,
+ * registerTwoMentors, sendPair) so the messaging package keeps a consistent
+ * test pattern.
+ *
+ * <p>Each scenario is self-contained: {@code @BeforeEach cleanDb()} wipes
+ * the relevant repositories, then the scenario seeds users and conversations
+ * fresh. The codebase uses explicit {@code deleteAll()} cleanup rather than
+ * {@code @Transactional} rollback because the messaging stack publishes
+ * events via {@code @TransactionalEventListener(AFTER_COMMIT)}, which never
+ * fires inside a rolled-back transaction.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MentorPairInboxIntegrationTest {
+
+    private static final String INBOX_URL = "/api/conversations/mentor-pair";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private NotificationRepository notificationRepository;
+    @Autowired private MessageRepository messageRepository;
+    @Autowired private ConversationParticipantRepository conversationParticipantRepository;
+    @Autowired private ConversationRepository conversationRepository;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        messageRepository.deleteAll();
+        conversationParticipantRepository.deleteAll();
+        conversationRepository.deleteAll();
+        notificationRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    // ── 15. Empty inbox: no pair conversations → empty page ────────────────
+
+    @Test
+    void mentorWithNoPairConversations_seesEmptyInbox() throws Exception {
+        String token = registerAndLogin("inbox_empty@test.com", true);
+
+        mockMvc.perform(get(INBOX_URL)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(0))
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    // ── 16. A sends to B, A views own inbox: unread=0 (self-sent filter) ───
+
+    @Test
+    void senderViewsOwnInbox_unreadIsZero() throws Exception {
+        Mentors m = registerTwoMentors("inbox_send_a@test.com", "inbox_send_b@test.com");
+        sendPair(m.tokenA, m.idB, "see you Tuesday");
+
+        mockMvc.perform(get(INBOX_URL)
+                        .header("Authorization", "Bearer " + m.tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].peerId").value(m.idB))
+                .andExpect(jsonPath("$.content[0].peerFirstName").value("Mira"))
+                .andExpect(jsonPath("$.content[0].lastMessageContent").value("see you Tuesday"))
+                .andExpect(jsonPath("$.content[0].lastMessageSentAt").exists())
+                .andExpect(jsonPath("$.content[0].unreadCount").value(0));
+    }
+
+    // ── 17. Receiver sees non-zero unread (the always-zero-bug guard) ──────
+
+    @Test
+    void receiverViewsInboxBeforeReading_unreadMatchesMessageCount() throws Exception {
+        Mentors m = registerTwoMentors("inbox_unread_a@test.com", "inbox_unread_b@test.com");
+        sendPair(m.tokenA, m.idB, "one");
+        sendPair(m.tokenA, m.idB, "two");
+        sendPair(m.tokenA, m.idB, "three");
+
+        mockMvc.perform(get(INBOX_URL)
+                        .header("Authorization", "Bearer " + m.tokenB))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].peerId").value(m.idA))
+                .andExpect(jsonPath("$.content[0].unreadCount").value(3));
+    }
+
+    // ── 18. Mark-read drops unread to 0 ────────────────────────────────────
+
+    @Test
+    void markReadByReceiver_unreadDropsToZero() throws Exception {
+        Mentors m = registerTwoMentors("inbox_read_a@test.com", "inbox_read_b@test.com");
+        sendPair(m.tokenA, m.idB, "one");
+        sendPair(m.tokenA, m.idB, "two");
+
+        // Existing #284 endpoint: PATCH /api/conversations/mentor-pair/{otherMentorId}/messages/read.
+        mockMvc.perform(patch("/api/conversations/mentor-pair/" + m.idA + "/messages/read")
+                        .header("Authorization", "Bearer " + m.tokenB))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get(INBOX_URL)
+                        .header("Authorization", "Bearer " + m.tokenB))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].unreadCount").value(0));
+    }
+
+    // ── 19. Recency ordering across multiple peers ─────────────────────────
+
+    @Test
+    void multiplePeers_orderedByMostRecentActivity() throws Exception {
+        // Three mentors A, B, C. A↔B exchange first, then A↔C exchange — A's
+        // inbox should list [C-pair, B-pair]. The c.id DESC tiebreaker in the
+        // ORDER BY makes this deterministic even if both messages land in the
+        // same millisecond, so no Thread.sleep needed.
+        String tokenA = registerAndLogin("inbox_order_a@test.com", true);
+        registerAndLogin("inbox_order_b@test.com", true);
+        registerAndLogin("inbox_order_c@test.com", true);
+        Long idB = userRepository.findByEmail("inbox_order_b@test.com").orElseThrow().getId();
+        Long idC = userRepository.findByEmail("inbox_order_c@test.com").orElseThrow().getId();
+
+        sendPair(tokenA, idB, "earlier message to B");
+        sendPair(tokenA, idC, "later message to C");
+
+        mockMvc.perform(get(INBOX_URL)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].peerId").value(idC))
+                .andExpect(jsonPath("$.content[0].lastMessageContent").value("later message to C"))
+                .andExpect(jsonPath("$.content[1].peerId").value(idB))
+                .andExpect(jsonPath("$.content[1].lastMessageContent").value("earlier message to B"));
+    }
+
+    // ── 20. Pagination across 5 pair conversations ─────────────────────────
+
+    @Test
+    void fivePairConversations_paginateCleanly() throws Exception {
+        String tokenA = registerAndLogin("inbox_page_a@test.com", true);
+        for (int i = 1; i <= 5; i++) {
+            String peerEmail = "inbox_page_p" + i + "@test.com";
+            registerAndLogin(peerEmail, true);
+            Long peerId = userRepository.findByEmail(peerEmail).orElseThrow().getId();
+            sendPair(tokenA, peerId, "msg-" + i);
+        }
+
+        long totalSeen = 0;
+        totalSeen += assertPage(tokenA, 0, 2, 2);
+        totalSeen += assertPage(tokenA, 1, 2, 2);
+        totalSeen += assertPage(tokenA, 2, 2, 1);
+        assertThat(totalSeen).isEqualTo(5L);
+
+        // Past-end page: client asks for page 5 (well beyond totalPages=3).
+        // Empty content but the response must still report the actual total
+        // so the client can detect they overshot, rather than mistaking it
+        // for an empty inbox. Caught by manual testing — the early
+        // implementation collapsed to totalElements=0 here.
+        mockMvc.perform(get(INBOX_URL).param("page", "5").param("size", "2")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(0))
+                .andExpect(jsonPath("$.totalElements").value(5));
+    }
+
+    // ── 21. Mentee role denied ─────────────────────────────────────────────
+
+    @Test
+    void menteeCallingInbox_returns403() throws Exception {
+        String menteeToken = registerAndLogin("inbox_mentee@test.com", false);
+
+        mockMvc.perform(get(INBOX_URL)
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Helpers (copied verbatim from MentorPairMessagingIntegrationTest) ──
+
+    private record Mentors(String tokenA, String tokenB, Long idA, Long idB) {
+    }
+
+    private Mentors registerTwoMentors(String emailA, String emailB) throws Exception {
+        String tokenA = registerAndLogin(emailA, true);
+        String tokenB = registerAndLogin(emailB, true);
+        Long idA = userRepository.findByEmail(emailA).orElseThrow().getId();
+        Long idB = userRepository.findByEmail(emailB).orElseThrow().getId();
+        return new Mentors(tokenA, tokenB, idA, idB);
+    }
+
+    private void sendPair(String token, Long otherId, String content) throws Exception {
+        SendMessageRequest body = new SendMessageRequest();
+        body.setContent(content);
+        mockMvc.perform(post("/api/conversations/mentor-pair/" + otherId + "/messages")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.content").value(content));
+    }
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName(isMentor ? "Mira" : "Eli");
+        req.setLastName(isMentor ? "Mentor" : "Mentee");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private long assertPage(String token, int page, int size, int expectedContentSize) throws Exception {
+        MvcResult result = mockMvc.perform(get(INBOX_URL)
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size))
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(expectedContentSize))
+                .andExpect(jsonPath("$.totalElements").value(5))
+                .andExpect(jsonPath("$.totalPages").value(3))
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        return body.get("content").size();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorPairInboxServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorPairInboxServiceTest.java
@@ -1,0 +1,333 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.MentorPairInboxItem;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.ConversationRepository;
+import com.group7.backend.repository.MessageRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.projection.ConversationLastMessageView;
+import com.group7.backend.repository.projection.ConversationUnreadCount;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-level coverage of {@link MentorPairInboxService}'s assembly logic.
+ * The repositories are mocked; this suite pins the service's mapping rules
+ * (peer-id ternary, latest-message lookup, unread default-zero, race-defensive
+ * null-peer filter, totalElements preservation) so a future refactor catches
+ * regressions without needing the integration suite to spot them.
+ *
+ * <p>The native {@code findLatestPerConversation} query itself is exercised
+ * end-to-end against real Postgres in {@code MentorPairInboxIntegrationTest};
+ * H2's lack of {@code DISTINCT ON} support keeps it out of {@code @DataJpaTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+class MentorPairInboxServiceTest {
+
+    private static final Long REQUESTER_ID = 100L;
+
+    @Mock private ConversationRepository conversationRepository;
+    @Mock private MessageRepository messageRepository;
+    @Mock private UserRepository userRepository;
+
+    private MentorPairInboxService inboxService;
+
+    @BeforeEach
+    void setUp() {
+        inboxService = new MentorPairInboxService(
+                conversationRepository, messageRepository, userRepository);
+    }
+
+    // ── 1. Empty page short-circuits the helper queries ────────────────────
+
+    @Test
+    void emptyInbox_returnsEmptyPageWithoutBatchLoads() {
+        Pageable pageable = PageRequest.of(0, 20);
+        when(conversationRepository.findMentorPairConversationsForUserOrderedByLastMessage(
+                eq(REQUESTER_ID), eq(pageable)))
+                .thenReturn(Page.empty(pageable));
+
+        Page<MentorPairInboxItem> result = inboxService.listInbox(REQUESTER_ID, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        verify(messageRepository, never()).findLatestPerConversation(anyCollection());
+        verify(messageRepository, never()).countUnreadPerConversationForReader(anyCollection(), any());
+        verify(userRepository, never()).findAllById(anyCollection());
+    }
+
+    // ── 1b. Past-end page preserves totalElements (manual-test catch) ──────
+
+    @Test
+    void pageBeyondLast_preservesTotalElements() {
+        // User has 4 conversations; client asks for page 2 of size 2.
+        // The repo's page object has empty content but totalElements = 4. The
+        // service must NOT short-circuit to `Page.empty(pageable)` because
+        // that would drop the count to 0 and hide from the client that they
+        // overshot. The empty-collection guard still has to fire (avoid
+        // `IN ()` on the native query), but with the original total preserved.
+        Pageable pageable = PageRequest.of(2, 2);
+        when(conversationRepository.findMentorPairConversationsForUserOrderedByLastMessage(
+                eq(REQUESTER_ID), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(), pageable, 4L));
+
+        Page<MentorPairInboxItem> result = inboxService.listInbox(REQUESTER_ID, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(4L);
+        // Helper queries still skipped — empty IN list would throw on the native query.
+        verify(messageRepository, never()).findLatestPerConversation(anyCollection());
+        verify(messageRepository, never()).countUnreadPerConversationForReader(anyCollection(), any());
+        verify(userRepository, never()).findAllById(anyCollection());
+    }
+
+    // ── 2. Single-conversation happy path: every field is populated ────────
+
+    @Test
+    void singleConversation_mapsAllFieldsCorrectly() {
+        Long conversationId = 901L;
+        Long peerId = 200L;
+        OffsetDateTime sentAt = OffsetDateTime.parse("2026-05-04T10:00:00Z");
+
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation c = pairConversation(conversationId, REQUESTER_ID, peerId);
+        Mentor peer = mentor(peerId, "Mira");
+
+        stubPage(pageable, List.of(c));
+        when(messageRepository.findLatestPerConversation(List.of(conversationId)))
+                .thenReturn(List.of(latest(conversationId, "see you Tuesday", sentAt)));
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(conversationId), REQUESTER_ID))
+                .thenReturn(List.of(unread(conversationId, 2L)));
+        when(userRepository.findAllById(List.of(peerId))).thenReturn(List.<User>of(peer));
+
+        Page<MentorPairInboxItem> result = inboxService.listInbox(REQUESTER_ID, pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        MentorPairInboxItem item = result.getContent().get(0);
+        assertThat(item.getConversationId()).isEqualTo(conversationId);
+        assertThat(item.getPeerId()).isEqualTo(peerId);
+        assertThat(item.getPeerFirstName()).isEqualTo("Mira");
+        assertThat(item.getLastMessageContent()).isEqualTo("see you Tuesday");
+        assertThat(item.getLastMessageSentAt()).isEqualTo(sentAt);
+        assertThat(item.getUnreadCount()).isEqualTo(2L);
+    }
+
+    // ── 3. Service preserves repository ORDER BY (does not re-sort) ────────
+
+    @Test
+    void multipleConversations_preservesPageOrder() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation cFirst = pairConversation(901L, REQUESTER_ID, 200L);
+        Conversation cSecond = pairConversation(902L, REQUESTER_ID, 201L);
+        // Repository returns [cFirst, cSecond] — service must keep this order.
+        stubPage(pageable, List.of(cFirst, cSecond));
+        when(messageRepository.findLatestPerConversation(List.of(901L, 902L)))
+                .thenReturn(List.of());
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(901L, 902L), REQUESTER_ID))
+                .thenReturn(List.of());
+        when(userRepository.findAllById(List.of(200L, 201L)))
+                .thenReturn(List.<User>of(mentor(200L, "Mira"), mentor(201L, "Mira")));
+
+        Page<MentorPairInboxItem> result = inboxService.listInbox(REQUESTER_ID, pageable);
+
+        assertThat(result.getContent())
+                .extracting(MentorPairInboxItem::getConversationId)
+                .containsExactly(901L, 902L);
+    }
+
+    // ── 4. Unread-count batch value is used verbatim ───────────────────────
+
+    @Test
+    void unreadCount_takesValueFromBatchMap() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation c = pairConversation(901L, REQUESTER_ID, 200L);
+        stubPage(pageable, List.of(c));
+        when(messageRepository.findLatestPerConversation(List.of(901L)))
+                .thenReturn(List.of());
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(901L), REQUESTER_ID))
+                .thenReturn(List.of(unread(901L, 5L)));
+        when(userRepository.findAllById(List.of(200L)))
+                .thenReturn(List.<User>of(mentor(200L, "Mira")));
+
+        Page<MentorPairInboxItem> result = inboxService.listInbox(REQUESTER_ID, pageable);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getUnreadCount()).isEqualTo(5L);
+    }
+
+    // ── 5. Missing unread row defaults to zero (Map.getOrDefault branch) ───
+
+    @Test
+    void unreadCount_zeroWhenAllRead() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation c = pairConversation(901L, REQUESTER_ID, 200L);
+        stubPage(pageable, List.of(c));
+        when(messageRepository.findLatestPerConversation(List.of(901L)))
+                .thenReturn(List.of());
+        // No row in the unread aggregate -> default 0.
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(901L), REQUESTER_ID))
+                .thenReturn(List.of());
+        when(userRepository.findAllById(List.of(200L)))
+                .thenReturn(List.<User>of(mentor(200L, "Mira")));
+
+        Page<MentorPairInboxItem> result = inboxService.listInbox(REQUESTER_ID, pageable);
+
+        assertThat(result.getContent().get(0).getUnreadCount()).isZero();
+    }
+
+    // ── 6. Latest-message batch maps each conversation to its own latest ───
+
+    @Test
+    void latestMessage_isPickedFromBatchedResult() {
+        Pageable pageable = PageRequest.of(0, 20);
+        OffsetDateTime t1 = OffsetDateTime.parse("2026-05-01T08:00:00Z");
+        OffsetDateTime t2 = OffsetDateTime.parse("2026-05-04T08:00:00Z");
+        Conversation c1 = pairConversation(901L, REQUESTER_ID, 200L);
+        Conversation c2 = pairConversation(902L, REQUESTER_ID, 201L);
+        stubPage(pageable, List.of(c1, c2));
+        when(messageRepository.findLatestPerConversation(List.of(901L, 902L)))
+                .thenReturn(List.of(
+                        latest(901L, "old", t1),
+                        latest(902L, "fresh", t2)));
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(901L, 902L), REQUESTER_ID))
+                .thenReturn(List.of());
+        when(userRepository.findAllById(List.of(200L, 201L)))
+                .thenReturn(List.<User>of(mentor(200L, "Mira"), mentor(201L, "Mira")));
+
+        List<MentorPairInboxItem> items = inboxService.listInbox(REQUESTER_ID, pageable).getContent();
+
+        assertThat(items).hasSize(2);
+        assertThat(items.get(0).getLastMessageContent()).isEqualTo("old");
+        assertThat(items.get(0).getLastMessageSentAt()).isEqualTo(t1);
+        assertThat(items.get(1).getLastMessageContent()).isEqualTo("fresh");
+        assertThat(items.get(1).getLastMessageSentAt()).isEqualTo(t2);
+    }
+
+    // ── 7. Conversation with no messages renders nulls + zero unread ───────
+
+    @Test
+    void conversationWithNoMessages_rendersNullsAndZeroUnread() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation c = pairConversation(901L, REQUESTER_ID, 200L);
+        stubPage(pageable, List.of(c));
+        // Both batch lookups return empty for this conversation.
+        when(messageRepository.findLatestPerConversation(List.of(901L))).thenReturn(List.of());
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(901L), REQUESTER_ID)).thenReturn(List.of());
+        when(userRepository.findAllById(List.of(200L)))
+                .thenReturn(List.<User>of(mentor(200L, "Mira")));
+
+        MentorPairInboxItem item = inboxService.listInbox(REQUESTER_ID, pageable).getContent().get(0);
+
+        assertThat(item.getLastMessageContent()).isNull();
+        assertThat(item.getLastMessageSentAt()).isNull();
+        assertThat(item.getUnreadCount()).isZero();
+    }
+
+    // ── 8. Race-defensive null-peer filter; totalElements preserved ────────
+
+    @Test
+    void racedPeerDeletion_dropsConversationFromResult() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation c1 = pairConversation(901L, REQUESTER_ID, 200L); // peer 200 still exists
+        Conversation c2 = pairConversation(902L, REQUESTER_ID, 201L); // peer 201 was deleted
+        // Repository reports two conversations, totalElements = 2.
+        when(conversationRepository.findMentorPairConversationsForUserOrderedByLastMessage(
+                eq(REQUESTER_ID), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(c1, c2), pageable, 2L));
+        when(messageRepository.findLatestPerConversation(List.of(901L, 902L)))
+                .thenReturn(List.of());
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(901L, 902L), REQUESTER_ID))
+                .thenReturn(List.of());
+        // findAllById returns only the peer that still exists — simulating the
+        // narrow window where peer 201's account commit-deleted between the
+        // page query and the peer load.
+        when(userRepository.findAllById(List.of(200L, 201L)))
+                .thenReturn(List.<User>of(mentor(200L, "Mira")));
+
+        Page<MentorPairInboxItem> result = inboxService.listInbox(REQUESTER_ID, pageable);
+
+        assertThat(result.getContent())
+                .extracting(MentorPairInboxItem::getConversationId)
+                .containsExactly(901L);
+        // PageImpl's invariant: when (offset + pageSize > total), the total
+        // is auto-corrected to (offset + content.size()) so the page stays
+        // self-consistent. Here offset=0, pageSize=20, supplied total=2, so
+        // the post-filter content.size()=1 drives the visible total to 1.
+        // This matches what the next request will return after the
+        // ON DELETE CASCADE propagates — exactly the right behaviour for the
+        // race window.
+        assertThat(result.getTotalElements()).isEqualTo(1L);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private void stubPage(Pageable pageable, List<Conversation> content) {
+        when(conversationRepository.findMentorPairConversationsForUserOrderedByLastMessage(
+                eq(REQUESTER_ID), eq(pageable)))
+                .thenReturn(new PageImpl<>(content, pageable, content.size()));
+    }
+
+    private static Conversation pairConversation(Long id, Long requesterId, Long peerId) {
+        Conversation c = new Conversation();
+        c.setId(id);
+        c.setKind(ConversationKind.MENTOR_PAIR);
+        // The DB CHECK constraint conversations_pair_ordering enforces
+        // pair_a_id < pair_b_id; honour it here so the test fixtures stay
+        // aligned with production data.
+        c.setPairAId(Math.min(requesterId, peerId));
+        c.setPairBId(Math.max(requesterId, peerId));
+        return c;
+    }
+
+    private static Mentor mentor(Long id, String firstName) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName(firstName);
+        return m;
+    }
+
+    private static ConversationLastMessageView latest(Long conversationId, String content, OffsetDateTime sentAt) {
+        Instant asInstant = sentAt.toInstant();
+        return new ConversationLastMessageView() {
+            @Override public Long getConversationId() { return conversationId; }
+            @Override public String getContent() { return content; }
+            @Override public Instant getSentAt() { return asInstant; }
+        };
+    }
+
+    private static ConversationUnreadCount unread(Long conversationId, Long count) {
+        return new ConversationUnreadCount() {
+            @Override public Long getConversationId() { return conversationId; }
+            @Override public Long getUnreadCount() { return count; }
+        };
+    }
+}


### PR DESCRIPTION
Closes #323. Adds `GET /api/conversations/mentor-pair`, the listing surface mentors need to build a peer-chat inbox. Companion to #284's per-conversation messaging endpoint at `/api/conversations/mentor-pair/{otherMentorId}/messages`.

Returns the caller's `MENTOR_PAIR` conversations paginated newest-first, each with peer identity, last-message preview/timestamp, and unread count.

## Design notes

- Lookup goes through `conversation_participants` (uses `idx_conversation_participants_user`), not the `pair_a_id`/`pair_b_id` columns which would need a per-column index that doesn't exist.
- 5 queries regardless of page size: page + count + latest-per-conversation (Postgres `DISTINCT ON`) + unread counts + peers-by-id. Spring Data drops the count when results fit one page.
- `PageableSupport.clampPageable` extracted as a prep refactor — `UserController` and `MatchingController` had identical private copies; this would have been the third. Both existing controllers switch to the shared helper.
- Projections live in `repository/projection/` (new sub-package), not `dto/response/` — they're internal carriers, never serialised.

## Test plan

- [x] `mvn clean test` — 729/729 green (+21 new tests)
- [x] JaCoCo: 100% branch coverage on `MentorPairInboxService` (10/10), full instruction coverage on `MentorPairInboxController` and `PageableSupport`
- [x] Manual end-to-end against live Postgres: ordering, unread counts, mark-read, mentee 403, pagination across 4 conversations, size/page clamps, query count via `spring.jpa.show-sql=true`

## Commits

1. `refactor(backend): extract PageableSupport from controller copies (#323 prep)`
2. `feat(backend): repository queries and projections for mentor-pair inbox (#323)`
3. `feat(backend): MentorPairInboxService and DTO (#323)`
4. `feat(backend): mentor-pair inbox endpoint (#323)`
5. `test(backend): integration coverage for mentor-pair inbox (#323)`