### PR TITLE
feat(backend): mentor availability iCalendar (.ics) export + arbitrary-period overrides (#250)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -110,6 +110,13 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>
+        <!-- RFC 5545 (iCalendar) producer for the mentor-availability ICS export
+             endpoint (#250). 4.x aligned with Java 21 and the jakarta namespace. -->
+        <dependency>
+            <groupId>org.mnode.ical4j</groupId>
+            <artifactId>ical4j</artifactId>
+            <version>4.0.6</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/backend/src/main/java/com/group7/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/group7/backend/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -72,6 +73,15 @@ public class SecurityConfig {
                 // JwtChannelInterceptor authenticates the STOMP CONNECT frame
                 // before any subscription or send is allowed.
                 .requestMatchers("/ws/chat/**").permitAll()
+                // Mentor-availability iCalendar exports (#250). Calendar apps
+                // (Google, Apple, Outlook) cannot send Authorization headers
+                // on subscription URLs, so this is anonymous by necessity.
+                // Data exposed (mentor name + availability) is already visible
+                // to any authenticated user via GET /{mentorId}; this is a
+                // transport concession, not a sensitivity change. Drive-by
+                // enumeration is rate-limited by IP via the
+                // {@code availability-ical} rule in application.properties.
+                .requestMatchers(HttpMethod.GET, "/api/availability/*/ical").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/src/main/java/com/group7/backend/controller/AvailabilityController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AvailabilityController.java
@@ -1,8 +1,11 @@
 package com.group7.backend.controller;
 
+import com.group7.backend.dto.request.AvailabilityOverrideRequest;
 import com.group7.backend.dto.request.AvailabilitySlotRequest;
 import com.group7.backend.dto.request.BulkAvailabilityRequest;
+import com.group7.backend.dto.response.AvailabilityOverrideResponse;
 import com.group7.backend.dto.response.AvailabilitySlotResponse;
+import com.group7.backend.service.AvailabilityOverrideService;
 import com.group7.backend.service.AvailabilityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,6 +16,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -40,9 +46,12 @@ import java.util.List;
 public class AvailabilityController {
 
     private final AvailabilityService availabilityService;
+    private final AvailabilityOverrideService overrideService;
 
-    public AvailabilityController(AvailabilityService availabilityService) {
+    public AvailabilityController(AvailabilityService availabilityService,
+                                  AvailabilityOverrideService overrideService) {
         this.availabilityService = availabilityService;
+        this.overrideService = overrideService;
     }
 
     /**
@@ -120,5 +129,88 @@ public class AvailabilityController {
         Long mentorId = (Long) authentication.getCredentials();
         availabilityService.removeSlot(mentorId, slotId);
         return ResponseEntity.noContent().build();
+    }
+
+    // ── One-off availability overrides (issue #250) ──────────────────────────
+
+    @GetMapping("/{mentorId}/overrides")
+    @Operation(
+            summary = "List mentor availability overrides",
+            description = "Returns the mentor's one-off availability overrides "
+                    + "(AVAILABLE additions or UNAVAILABLE blocks), paginated and "
+                    + "ordered by start time. Visible to any authenticated user — "
+                    + "mentor availability is part of the discoverable profile, "
+                    + "matching the policy of the recurring schedule above."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated overrides",
+                    content = @Content(schema = @Schema(implementation = AvailabilityOverrideResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Mentor not found", content = @Content)
+    })
+    public ResponseEntity<Page<AvailabilityOverrideResponse>> listOverrides(
+            @Parameter(description = "Mentor ID") @PathVariable Long mentorId,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = clampPageable(page, size);
+        return ResponseEntity.ok(overrideService.list(mentorId, pageable));
+    }
+
+    @PostMapping("/overrides")
+    @PreAuthorize("hasRole('MENTOR')")
+    @Operation(
+            summary = "Add availability override",
+            description = "Adds a one-off override (AVAILABLE addition or UNAVAILABLE block) "
+                    + "for the authenticated mentor. Same-kind overlapping ranges are rejected; "
+                    + "cross-kind overlap is allowed by design (an UNAVAILABLE can carve a hole "
+                    + "out of an AVAILABLE region or out of the recurring weekly schedule)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Override created",
+                    content = @Content(schema = @Schema(implementation = AvailabilityOverrideResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Validation error (missing field or endAt <= startAt)",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Caller is not a mentor", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentor not found", content = @Content),
+            @ApiResponse(responseCode = "409", description = "Overlapping same-kind override", content = @Content)
+    })
+    public ResponseEntity<AvailabilityOverrideResponse> addOverride(
+            @Valid @RequestBody AvailabilityOverrideRequest request,
+            Authentication authentication) {
+        Long mentorId = (Long) authentication.getCredentials();
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(overrideService.add(mentorId, request));
+    }
+
+    @DeleteMapping("/overrides/{overrideId}")
+    @PreAuthorize("hasRole('MENTOR')")
+    @Operation(
+            summary = "Remove availability override",
+            description = "Removes a single override owned by the authenticated mentor. "
+                    + "Returns 403 if the override belongs to a different mentor (rather than 404, "
+                    + "which would leak whether the id exists)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Override removed"),
+            @ApiResponse(responseCode = "403", description = "Override belongs to a different mentor",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Override not found", content = @Content)
+    })
+    public ResponseEntity<Void> removeOverride(
+            @Parameter(description = "Override ID") @PathVariable Long overrideId,
+            Authentication authentication) {
+        Long mentorId = (Long) authentication.getCredentials();
+        overrideService.remove(mentorId, overrideId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * Page+size clamp matching the convention used by {@code UserController}
+     * and {@code MatchingController} (size in {@code [1, 100]}, page ≥ 0).
+     * Inlined here for now; consolidate to a shared {@code PageableSupport}
+     * helper once #323's prep extraction lands on dev.
+     */
+    private static Pageable clampPageable(int page, int size) {
+        int clampedSize = Math.min(Math.max(size, 1), 100);
+        return PageRequest.of(Math.max(page, 0), clampedSize);
     }
 }

--- a/backend/src/main/java/com/group7/backend/controller/AvailabilityController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AvailabilityController.java
@@ -7,6 +7,7 @@ import com.group7.backend.dto.response.AvailabilityOverrideResponse;
 import com.group7.backend.dto.response.AvailabilitySlotResponse;
 import com.group7.backend.service.AvailabilityOverrideService;
 import com.group7.backend.service.AvailabilityService;
+import com.group7.backend.service.CalendarExportService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -19,7 +20,9 @@ import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -47,11 +50,14 @@ public class AvailabilityController {
 
     private final AvailabilityService availabilityService;
     private final AvailabilityOverrideService overrideService;
+    private final CalendarExportService calendarExportService;
 
     public AvailabilityController(AvailabilityService availabilityService,
-                                  AvailabilityOverrideService overrideService) {
+                                  AvailabilityOverrideService overrideService,
+                                  CalendarExportService calendarExportService) {
         this.availabilityService = availabilityService;
         this.overrideService = overrideService;
+        this.calendarExportService = calendarExportService;
     }
 
     /**
@@ -201,6 +207,39 @@ public class AvailabilityController {
         Long mentorId = (Long) authentication.getCredentials();
         overrideService.remove(mentorId, overrideId);
         return ResponseEntity.noContent().build();
+    }
+
+    // ── iCalendar export (issue #250) ────────────────────────────────────────
+
+    @GetMapping(value = "/{mentorId}/ical", produces = "text/calendar;charset=UTF-8")
+    @Operation(
+            summary = "Export mentor availability as iCalendar",
+            description = "Returns the mentor's recurring weekly schedule and one-off "
+                    + "AVAILABLE/UNAVAILABLE overrides as an RFC 5545 (.ics) file. "
+                    + "Anonymous endpoint — calendar applications (Google, Apple, "
+                    + "Outlook) cannot send Authorization headers on subscription URLs, "
+                    + "so this is published openly. The data exposed (mentor name + "
+                    + "availability) is already visible to any authenticated user via "
+                    + "GET /{mentorId}; making the .ics path anonymous is a transport "
+                    + "concession, not a sensitivity change. Drive-by enumeration is "
+                    + "rate-limited by IP via the {@code availability-ical} bucket."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "iCalendar file",
+                    content = @Content(mediaType = "text/calendar")),
+            @ApiResponse(responseCode = "404", description = "Mentor not found",
+                    content = @Content),
+            @ApiResponse(responseCode = "429", description = "Rate limit exceeded",
+                    content = @Content)
+    })
+    public ResponseEntity<byte[]> exportIcal(
+            @Parameter(description = "Mentor ID") @PathVariable Long mentorId) {
+        byte[] body = calendarExportService.exportMentorAvailability(mentorId);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("text/calendar;charset=UTF-8"))
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"mentor_" + mentorId + "_availability.ics\"")
+                .body(body);
     }
 
     /**

--- a/backend/src/main/java/com/group7/backend/dto/request/AvailabilityOverrideRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/AvailabilityOverrideRequest.java
@@ -1,0 +1,55 @@
+package com.group7.backend.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.group7.backend.entity.AvailabilityOverrideKind;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Request shape for adding a one-off availability override to the
+ * authenticated mentor's schedule. {@code mentorId} is intentionally absent
+ * — it comes from the JWT credentials, not the request body, so a mentor
+ * can only mutate their own data.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "One-off availability override (AVAILABLE add or UNAVAILABLE block)")
+public class AvailabilityOverrideRequest {
+
+    @NotNull(message = "kind is required")
+    @Schema(description = "Whether this period adds availability or blocks it",
+            example = "UNAVAILABLE")
+    private AvailabilityOverrideKind kind;
+
+    @NotNull(message = "startAt is required")
+    @Schema(description = "Inclusive start of the override range (timestamptz)",
+            example = "2026-06-10T09:00:00Z")
+    private OffsetDateTime startAt;
+
+    @NotNull(message = "endAt is required")
+    @Schema(description = "Exclusive end of the override range (timestamptz)",
+            example = "2026-06-20T17:00:00Z")
+    private OffsetDateTime endAt;
+
+    /**
+     * Cross-field check: range must be non-empty (end strictly after start).
+     * {@code @JsonIgnore} keeps this off the wire format. Returns {@code true}
+     * when either bound is null so the per-field {@link NotNull} messages
+     * surface first instead of being masked by a confusing range error.
+     */
+    @AssertTrue(message = "endAt must be after startAt")
+    @JsonIgnore
+    public boolean isRangeValid() {
+        if (startAt == null || endAt == null) {
+            return true;
+        }
+        return endAt.isAfter(startAt);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/AvailabilityOverrideResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/AvailabilityOverrideResponse.java
@@ -1,0 +1,46 @@
+package com.group7.backend.dto.response;
+
+import com.group7.backend.entity.AvailabilityOverride;
+import com.group7.backend.entity.AvailabilityOverrideKind;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Wire shape for a single availability override. The mentor reference is
+ * not exposed because the request and listing endpoints are already scoped
+ * by mentor (own credentials for writes, path variable for reads).
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "One-off availability override (AVAILABLE add or UNAVAILABLE block)")
+public class AvailabilityOverrideResponse {
+
+    @Schema(description = "Override ID", example = "42")
+    private Long id;
+
+    @Schema(description = "Whether this period adds availability or blocks it",
+            example = "UNAVAILABLE")
+    private AvailabilityOverrideKind kind;
+
+    @Schema(description = "Inclusive start of the override range",
+            example = "2026-06-10T09:00:00Z")
+    private OffsetDateTime startAt;
+
+    @Schema(description = "Exclusive end of the override range",
+            example = "2026-06-20T17:00:00Z")
+    private OffsetDateTime endAt;
+
+    public static AvailabilityOverrideResponse from(AvailabilityOverride entity) {
+        AvailabilityOverrideResponse r = new AvailabilityOverrideResponse();
+        r.setId(entity.getId());
+        r.setKind(entity.getKind());
+        r.setStartAt(entity.getStartAt());
+        r.setEndAt(entity.getEndAt());
+        return r;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/entity/AvailabilityOverride.java
+++ b/backend/src/main/java/com/group7/backend/entity/AvailabilityOverride.java
@@ -1,0 +1,45 @@
+package com.group7.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * One-off override on a mentor's weekly availability schedule. Each row
+ * carries either an {@link AvailabilityOverrideKind#AVAILABLE} extra slot
+ * (e.g., a one-time evening opening) or an {@link AvailabilityOverrideKind#UNAVAILABLE}
+ * block (e.g., a vacation week).
+ *
+ * <p>Effective availability is computed by the consumer (or the iCal export):
+ * recurring slots ∪ AVAILABLE overrides, minus UNAVAILABLE overrides over
+ * the same time range. The data model keeps the layers separate so each can
+ * be edited independently.
+ */
+@Entity
+@Table(name = "mentor_availability_overrides")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AvailabilityOverride {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentor_id", nullable = false)
+    private Mentor mentor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "kind", nullable = false, length = 16)
+    private AvailabilityOverrideKind kind;
+
+    @Column(name = "start_at", nullable = false)
+    private OffsetDateTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private OffsetDateTime endAt;
+}

--- a/backend/src/main/java/com/group7/backend/entity/AvailabilityOverrideKind.java
+++ b/backend/src/main/java/com/group7/backend/entity/AvailabilityOverrideKind.java
@@ -1,0 +1,20 @@
+package com.group7.backend.entity;
+
+/**
+ * Direction of a one-off {@link AvailabilityOverride} on a mentor's weekly
+ * schedule.
+ *
+ * <ul>
+ *   <li>{@link #AVAILABLE} — mentor is available during this concrete time
+ *       range, in addition to (or outside of) their weekly schedule.</li>
+ *   <li>{@link #UNAVAILABLE} — mentor is not available during this range,
+ *       overriding any weekly slot that would otherwise apply.</li>
+ * </ul>
+ *
+ * <p>Stored as a string in the {@code kind} column with a CHECK constraint;
+ * see {@code V18__add_availability_overrides.sql}.
+ */
+public enum AvailabilityOverrideKind {
+    AVAILABLE,
+    UNAVAILABLE
+}

--- a/backend/src/main/java/com/group7/backend/repository/AvailabilityOverrideRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/AvailabilityOverrideRepository.java
@@ -1,0 +1,35 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.AvailabilityOverride;
+import com.group7.backend.entity.AvailabilityOverrideKind;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AvailabilityOverrideRepository extends JpaRepository<AvailabilityOverride, Long> {
+
+    /**
+     * Paginated listing for a mentor's overrides, ordered by {@code startAt}
+     * with {@code id} as deterministic tiebreaker (two overrides created in
+     * the same millisecond would otherwise shift between requests). Backed
+     * by {@code idx_avail_ovr_mentor_start}.
+     */
+    Page<AvailabilityOverride> findByMentorIdOrderByStartAtAscIdAsc(
+            Long mentorId, Pageable pageable);
+
+    /**
+     * All overrides of a given kind for a mentor — used by the service's
+     * same-kind overlap check.
+     */
+    List<AvailabilityOverride> findByMentorIdAndKindOrderByStartAtAscIdAsc(
+            Long mentorId, AvailabilityOverrideKind kind);
+
+    /**
+     * Unfiltered list (both kinds) for a mentor — used by
+     * {@code CalendarExportService} to walk all overrides in one query when
+     * building the iCalendar export.
+     */
+    List<AvailabilityOverride> findByMentorIdOrderByStartAtAscIdAsc(Long mentorId);
+}

--- a/backend/src/main/java/com/group7/backend/service/AvailabilityOverrideService.java
+++ b/backend/src/main/java/com/group7/backend/service/AvailabilityOverrideService.java
@@ -1,0 +1,126 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.request.AvailabilityOverrideRequest;
+import com.group7.backend.dto.response.AvailabilityOverrideResponse;
+import com.group7.backend.entity.AvailabilityOverride;
+import com.group7.backend.entity.AvailabilityOverrideKind;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.OverlappingSlotException;
+import com.group7.backend.exception.ProfileNotVisibleException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.AvailabilityOverrideRepository;
+import com.group7.backend.repository.MentorRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Lifecycle service for one-off mentor {@link AvailabilityOverride} rows.
+ * Layered on top of the weekly-recurring {@code mentor_availability_slots}
+ * table — see {@code AvailabilityService} for the recurring base.
+ *
+ * <h2>Concurrency note</h2>
+ * The same-kind overlap check is read-then-insert without an explicit lock.
+ * Two near-simultaneous adds from the same mentor for the same kind could
+ * both pass the check and create overlapping rows under the default
+ * {@code READ_COMMITTED} isolation. Realistic concurrency from a single
+ * mentor's session is ~0; a stronger guarantee (SERIALIZABLE isolation or a
+ * Postgres exclusion constraint via {@code btree_gist}) is intentionally
+ * deferred until a real conflict surfaces.
+ */
+@Service
+public class AvailabilityOverrideService {
+
+    private final AvailabilityOverrideRepository overrideRepository;
+    private final MentorRepository mentorRepository;
+
+    public AvailabilityOverrideService(AvailabilityOverrideRepository overrideRepository,
+                                       MentorRepository mentorRepository) {
+        this.overrideRepository = overrideRepository;
+        this.mentorRepository = mentorRepository;
+    }
+
+    /**
+     * Adds a new override for the authenticated mentor. Caller MUST pass
+     * their own {@code mentorId} (resolved from JWT credentials in the
+     * controller); the service does not consult the request body for the
+     * mentor identity.
+     *
+     * @throws ResourceNotFoundException if the mentor row does not exist
+     * @throws OverlappingSlotException  if the new range overlaps an
+     *                                   existing same-kind override
+     */
+    @Transactional
+    public AvailabilityOverrideResponse add(Long mentorId, AvailabilityOverrideRequest request) {
+        Mentor mentor = mentorRepository.findById(mentorId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mentor not found"));
+
+        rejectIfOverlapsExistingSameKind(mentorId, request.getKind(),
+                request.getStartAt(), request.getEndAt());
+
+        AvailabilityOverride entity = new AvailabilityOverride();
+        entity.setMentor(mentor);
+        entity.setKind(request.getKind());
+        entity.setStartAt(request.getStartAt());
+        entity.setEndAt(request.getEndAt());
+        return AvailabilityOverrideResponse.from(overrideRepository.save(entity));
+    }
+
+    /**
+     * Removes a single override owned by the authenticated mentor.
+     *
+     * @throws ResourceNotFoundException if the override does not exist
+     * @throws ProfileNotVisibleException if the override exists but belongs
+     *                                    to a different mentor (404 would
+     *                                    leak existence; 403 is the right
+     *                                    signal for "not yours")
+     */
+    @Transactional
+    public void remove(Long mentorId, Long overrideId) {
+        AvailabilityOverride existing = overrideRepository.findById(overrideId)
+                .orElseThrow(() -> new ResourceNotFoundException("Override not found"));
+        if (!existing.getMentor().getId().equals(mentorId)) {
+            throw new ProfileNotVisibleException("You can only delete your own overrides");
+        }
+        overrideRepository.delete(existing);
+    }
+
+    /**
+     * Paginated listing for a mentor's overrides. Verifies the mentor
+     * exists so callers get a clean 404 rather than an empty page when the
+     * id is bogus.
+     */
+    @Transactional(readOnly = true)
+    public Page<AvailabilityOverrideResponse> list(Long mentorId, Pageable pageable) {
+        if (!mentorRepository.existsById(mentorId)) {
+            throw new ResourceNotFoundException("Mentor not found");
+        }
+        return overrideRepository
+                .findByMentorIdOrderByStartAtAscIdAsc(mentorId, pageable)
+                .map(AvailabilityOverrideResponse::from);
+    }
+
+    private void rejectIfOverlapsExistingSameKind(Long mentorId,
+                                                  AvailabilityOverrideKind kind,
+                                                  OffsetDateTime newStart,
+                                                  OffsetDateTime newEnd) {
+        List<AvailabilityOverride> sameKind = overrideRepository
+                .findByMentorIdAndKindOrderByStartAtAscIdAsc(mentorId, kind);
+        for (AvailabilityOverride existing : sameKind) {
+            if (overlaps(newStart, newEnd, existing.getStartAt(), existing.getEndAt())) {
+                throw new OverlappingSlotException(
+                        "Override overlaps an existing " + kind + " override on "
+                                + existing.getStartAt() + " — " + existing.getEndAt());
+            }
+        }
+    }
+
+    private static boolean overlaps(OffsetDateTime aStart, OffsetDateTime aEnd,
+                                    OffsetDateTime bStart, OffsetDateTime bEnd) {
+        return aStart.isBefore(bEnd) && bStart.isBefore(aEnd);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/CalendarExportService.java
+++ b/backend/src/main/java/com/group7/backend/service/CalendarExportService.java
@@ -1,0 +1,215 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.AvailabilityOverride;
+import com.group7.backend.entity.AvailabilityOverrideKind;
+import com.group7.backend.entity.AvailabilitySlot;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.AvailabilityOverrideRepository;
+import com.group7.backend.repository.AvailabilitySlotRepository;
+import com.group7.backend.repository.MentorRepository;
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.TimeZoneRegistry;
+import net.fortuna.ical4j.model.TimeZoneRegistryFactory;
+import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.component.VTimeZone;
+import net.fortuna.ical4j.model.parameter.TzId;
+import net.fortuna.ical4j.model.property.DtEnd;
+import net.fortuna.ical4j.model.property.DtStamp;
+import net.fortuna.ical4j.model.property.DtStart;
+import net.fortuna.ical4j.model.property.ProdId;
+import net.fortuna.ical4j.model.property.RRule;
+import net.fortuna.ical4j.model.property.Summary;
+import net.fortuna.ical4j.model.property.Uid;
+import net.fortuna.ical4j.model.property.immutable.ImmutableCalScale;
+import net.fortuna.ical4j.model.property.immutable.ImmutableStatus;
+import net.fortuna.ical4j.model.property.immutable.ImmutableTransp;
+import net.fortuna.ical4j.model.property.immutable.ImmutableVersion;
+import net.fortuna.ical4j.model.property.Transp;
+import net.fortuna.ical4j.validate.ValidationResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+/**
+ * Builds an RFC 5545 (iCalendar) export of a mentor's published availability.
+ *
+ * <h2>What gets exported</h2>
+ * <ul>
+ *   <li>Each weekly-recurring {@link AvailabilitySlot} → one {@code VEVENT}
+ *       with {@code RRULE:FREQ=WEEKLY} and {@code TRANSP:TRANSPARENT} (the
+ *       slot is informational, not blocking the consumer's own calendar).</li>
+ *   <li>Each {@link AvailabilityOverrideKind#AVAILABLE} override → one
+ *       {@code VEVENT} (no RRULE), {@code TRANSP:TRANSPARENT}.</li>
+ *   <li>Each {@link AvailabilityOverrideKind#UNAVAILABLE} override → one
+ *       {@code VEVENT}, {@code TRANSP:OPAQUE} (does block the consumer's
+ *       calendar — "I'm taken at this time").</li>
+ * </ul>
+ *
+ * <h2>Time-zone strategy</h2>
+ * Recurring slots carry a {@code DayOfWeek} + {@code LocalTime} (no date),
+ * so {@code DTSTART} is anchored to the first matching weekday on/after a
+ * fixed epoch ({@link #RRULE_EPOCH}). This keeps re-exports deterministic
+ * regardless of when the request runs. {@code TZID=Europe/Istanbul} is used
+ * so consumers see correct local times; the bundled VTIMEZONE block carries
+ * the offset history so calendars without an external TZ database render
+ * correctly.
+ *
+ * <p>Overrides already carry an absolute {@code OffsetDateTime}, so their
+ * {@code DTSTART}/{@code DTEND} are emitted as UTC instants.
+ *
+ * <h2>Stable UIDs</h2>
+ * UIDs are derived from the source row's id ({@code availability-slot-{id}}
+ * or {@code availability-override-{id}}) so re-exports produce identical
+ * UIDs and calendar apps deduplicate cleanly when subscribing to the
+ * publication URL.
+ */
+@Service
+public class CalendarExportService {
+
+    /** Fixed anchor week for weekly-recurring DTSTART (a Monday). */
+    private static final LocalDate RRULE_EPOCH = LocalDate.of(2024, 1, 1);
+
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Europe/Istanbul");
+
+    private static final String UID_DOMAIN = "@bounswe2026group7";
+
+    private static final String PROD_ID =
+            "-//Group7 Bounswe//Mentor Availability Export 1.0//EN";
+
+    private final MentorRepository mentorRepository;
+    private final AvailabilitySlotRepository slotRepository;
+    private final AvailabilityOverrideRepository overrideRepository;
+
+    public CalendarExportService(MentorRepository mentorRepository,
+                                 AvailabilitySlotRepository slotRepository,
+                                 AvailabilityOverrideRepository overrideRepository) {
+        this.mentorRepository = mentorRepository;
+        this.slotRepository = slotRepository;
+        this.overrideRepository = overrideRepository;
+    }
+
+    /**
+     * Builds the ICS document and returns it as UTF-8 bytes ready for the
+     * controller to set as the response body. The structure is validated
+     * against RFC 5545 via ical4j's built-in validator before bytes leave;
+     * a violation throws {@link IllegalStateException} so a misshaped
+     * publication never reaches a calendar app.
+     *
+     * @throws ResourceNotFoundException if the mentor does not exist
+     */
+    @Transactional(readOnly = true)
+    public byte[] exportMentorAvailability(Long mentorId) {
+        Mentor mentor = mentorRepository.findById(mentorId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mentor not found"));
+
+        List<AvailabilitySlot> slots = slotRepository.findByMentorId(mentorId);
+        List<AvailabilityOverride> overrides =
+                overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(mentorId);
+
+        Calendar calendar = new Calendar();
+        calendar.add(new ProdId(PROD_ID));
+        calendar.add(ImmutableVersion.VERSION_2_0);
+        calendar.add(ImmutableCalScale.GREGORIAN);
+        // METHOD:PUBLISH is intentionally omitted: ical4j's strict validator
+        // enforces RFC 5545's "PUBLISH requires ORGANIZER on every VEVENT"
+        // rule, but we have no meaningful ORGANIZER value to attach (the
+        // mentor isn't an email-routable invitee — they're the schedule's
+        // subject). Without METHOD the calendar is treated as a plain
+        // publication, which is exactly what we want.
+
+        // Bundle the VTIMEZONE so consumers without the IANA TZ database
+        // (some Outlook installs, generic ICS importers) render correctly.
+        TimeZoneRegistry registry = TimeZoneRegistryFactory.getInstance().createRegistry();
+        VTimeZone tz = registry.getTimeZone(DEFAULT_ZONE.getId()).getVTimeZone();
+        calendar.add(tz);
+
+        Instant now = Instant.now();
+        String mentorName = displayName(mentor);
+
+        for (AvailabilitySlot slot : slots) {
+            calendar.add(buildRecurringEvent(slot, mentorName, now));
+        }
+        for (AvailabilityOverride override : overrides) {
+            calendar.add(buildOverrideEvent(override, mentorName, now));
+        }
+
+        ValidationResult validation = calendar.validate();
+        if (validation.hasErrors()) {
+            throw new IllegalStateException(
+                    "Generated iCalendar failed RFC 5545 validation: " + validation);
+        }
+
+        return calendar.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static VEvent buildRecurringEvent(AvailabilitySlot slot,
+                                              String mentorName,
+                                              Instant dtstamp) {
+        // Anchor DTSTART to the first matching DayOfWeek on/after the fixed
+        // epoch; RRULE:FREQ=WEEKLY then expands forward indefinitely. We
+        // emit DTSTART/DTEND as floating LocalDateTime values + a TZID
+        // parameter so the wall-clock time is preserved across DST changes
+        // in the consumer's locale (RFC 5545 §3.3.5).
+        LocalDate firstOccurrence = RRULE_EPOCH.with(
+                TemporalAdjusters.nextOrSame(slot.getDayOfWeek()));
+        LocalDateTime start = firstOccurrence.atTime(slot.getStartTime());
+        LocalDateTime end = firstOccurrence.atTime(slot.getEndTime());
+
+        DtStart<LocalDateTime> dtStart = new DtStart<>(start);
+        dtStart.add(new TzId(DEFAULT_ZONE.getId()));
+        DtEnd<LocalDateTime> dtEnd = new DtEnd<>(end);
+        dtEnd.add(new TzId(DEFAULT_ZONE.getId()));
+
+        // false: skip ical4j's auto-population of DTSTAMP/UID. We add both
+        // explicitly with stable values so re-exports produce identical
+        // output for calendar-app deduplication.
+        VEvent event = new VEvent(false);
+        event.add(new Uid("availability-slot-" + slot.getId() + UID_DOMAIN));
+        event.add(new DtStamp(dtstamp));
+        event.add(dtStart);
+        event.add(dtEnd);
+        event.add(new Summary("Available — " + mentorName));
+        event.add(ImmutableStatus.VEVENT_CONFIRMED);
+        event.add(ImmutableTransp.TRANSPARENT);
+        event.add(new RRule<>("FREQ=WEEKLY"));
+        return event;
+    }
+
+    private static VEvent buildOverrideEvent(AvailabilityOverride override,
+                                             String mentorName,
+                                             Instant dtstamp) {
+        boolean available = override.getKind() == AvailabilityOverrideKind.AVAILABLE;
+        String summaryPrefix = available ? "Available — " : "Unavailable — ";
+        // AVAILABLE additions are informational (TRANSPARENT); UNAVAILABLE
+        // blocks should overlay on a consumer's calendar as busy (OPAQUE).
+        Transp transp = available ? ImmutableTransp.TRANSPARENT : ImmutableTransp.OPAQUE;
+
+        // false: skip ical4j's auto-population of DTSTAMP/UID. We add both
+        // explicitly with stable values so re-exports produce identical
+        // output for calendar-app deduplication.
+        VEvent event = new VEvent(false);
+        event.add(new Uid("availability-override-" + override.getId() + UID_DOMAIN));
+        event.add(new DtStamp(dtstamp));
+        event.add(new DtStart<>(override.getStartAt().toInstant()));
+        event.add(new DtEnd<>(override.getEndAt().toInstant()));
+        event.add(new Summary(summaryPrefix + mentorName));
+        event.add(ImmutableStatus.VEVENT_CONFIRMED);
+        event.add(transp);
+        return event;
+    }
+
+    private static String displayName(Mentor mentor) {
+        String first = mentor.getFirstName() == null ? "" : mentor.getFirstName();
+        String last = mentor.getLastName() == null ? "" : mentor.getLastName();
+        String joined = (first + " " + last).trim();
+        return joined.isEmpty() ? "Mentor" : joined;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -98,3 +98,13 @@ app.ratelimit.rules.mentor-pair-message-send.pattern=/api/conversations/mentor-p
 app.ratelimit.rules.mentor-pair-message-send.key-strategy=USER
 app.ratelimit.rules.mentor-pair-message-send.capacity=60
 app.ratelimit.rules.mentor-pair-message-send.refill=PT1M
+
+# IP-keyed cap on the anonymous iCalendar export endpoint (#250). The path
+# is permitAll so calendar apps can subscribe; this rule prevents drive-by
+# enumeration of mentor IDs. 30/min per IP is generous for legitimate
+# subscription refreshes (calendar apps poll hourly at most).
+app.ratelimit.rules.availability-ical.method=GET
+app.ratelimit.rules.availability-ical.pattern=/api/availability/*/ical
+app.ratelimit.rules.availability-ical.key-strategy=IP
+app.ratelimit.rules.availability-ical.capacity=30
+app.ratelimit.rules.availability-ical.refill=PT1M

--- a/backend/src/main/resources/db/migration/V18__add_availability_overrides.sql
+++ b/backend/src/main/resources/db/migration/V18__add_availability_overrides.sql
@@ -1,0 +1,23 @@
+-- Mentor availability one-off overrides: ad-hoc AVAILABLE additions and
+-- UNAVAILABLE blocks that override the weekly-recurring schedule for a
+-- specific timestamp range. Layered on top of mentor_availability_slots
+-- (the recurring base); see issue #250.
+
+CREATE TABLE mentor_availability_overrides (
+    id        BIGSERIAL PRIMARY KEY,
+    mentor_id BIGINT NOT NULL REFERENCES mentors(id) ON DELETE CASCADE,
+    kind      VARCHAR(16) NOT NULL,
+    start_at  TIMESTAMPTZ NOT NULL,
+    end_at    TIMESTAMPTZ NOT NULL,
+    -- chk_avail_ovr_kind MUST stay in sync with the AvailabilityOverrideKind
+    -- enum. Adding a new kind requires a new migration that ALTERs this
+    -- constraint; otherwise INSERTs will fail at runtime even though the
+    -- application code passes Hibernate's enum validation.
+    CONSTRAINT chk_avail_ovr_kind CHECK (kind IN ('AVAILABLE', 'UNAVAILABLE')),
+    CONSTRAINT chk_avail_ovr_range CHECK (end_at > start_at)
+);
+
+-- Indexed by (mentor_id, start_at) since lookups are always per-mentor and
+-- ordered by start_at; the listing endpoint pages directly from this index.
+CREATE INDEX idx_avail_ovr_mentor_start
+    ON mentor_availability_overrides (mentor_id, start_at);

--- a/backend/src/test/java/com/group7/backend/controller/AvailabilityControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/AvailabilityControllerTest.java
@@ -3,13 +3,21 @@ package com.group7.backend.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.group7.backend.config.JwtAuthenticationFilter;
 import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.request.AvailabilityOverrideRequest;
 import com.group7.backend.dto.request.AvailabilitySlotRequest;
 import com.group7.backend.dto.request.BulkAvailabilityRequest;
+import com.group7.backend.dto.response.AvailabilityOverrideResponse;
 import com.group7.backend.dto.response.AvailabilitySlotResponse;
+import com.group7.backend.entity.AvailabilityOverrideKind;
 import com.group7.backend.exception.OverlappingSlotException;
+import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.service.AvailabilityOverrideService;
 import com.group7.backend.service.AvailabilityService;
 import com.group7.backend.service.JwtService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +52,9 @@ class AvailabilityControllerTest {
 
     @MockitoBean
     private AvailabilityService availabilityService;
+
+    @MockitoBean
+    private AvailabilityOverrideService overrideService;
 
     @MockitoBean
     private JwtService jwtService;
@@ -278,5 +290,119 @@ class AvailabilityControllerTest {
         mockMvc.perform(delete("/api/availability/99")
                         .header("Authorization", "Bearer mentor-token"))
                 .andExpect(status().isNotFound());
+    }
+
+    // ── /overrides endpoints (issue #250) ───────────────────────────────────
+
+    private AvailabilityOverrideResponse sampleOverride() {
+        AvailabilityOverrideResponse r = new AvailabilityOverrideResponse();
+        r.setId(7L);
+        r.setKind(AvailabilityOverrideKind.UNAVAILABLE);
+        r.setStartAt(OffsetDateTime.parse("2026-06-10T09:00:00Z"));
+        r.setEndAt(OffsetDateTime.parse("2026-06-20T17:00:00Z"));
+        return r;
+    }
+
+    @Test
+    void listOverridesReturns200WithPagedBody() throws Exception {
+        mockMenteeJwt("mentee-token", 1L);
+        Page<AvailabilityOverrideResponse> page = new PageImpl<>(List.of(sampleOverride()));
+        when(overrideService.list(eq(2L), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/availability/2/overrides")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(7))
+                .andExpect(jsonPath("$.content[0].kind").value("UNAVAILABLE"))
+                .andExpect(jsonPath("$.content[0].startAt").value("2026-06-10T09:00:00Z"));
+    }
+
+    @Test
+    void addOverrideReturns201ForMentor() throws Exception {
+        mockMentorJwt("mentor-token", 2L);
+        when(overrideService.add(eq(2L), any(AvailabilityOverrideRequest.class)))
+                .thenReturn(sampleOverride());
+
+        AvailabilityOverrideRequest req = new AvailabilityOverrideRequest();
+        req.setKind(AvailabilityOverrideKind.UNAVAILABLE);
+        req.setStartAt(OffsetDateTime.parse("2026-06-10T09:00:00Z"));
+        req.setEndAt(OffsetDateTime.parse("2026-06-20T17:00:00Z"));
+
+        mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer mentor-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(7));
+    }
+
+    @Test
+    void addOverrideReturns403ForMentee() throws Exception {
+        mockMenteeJwt("mentee-token", 1L);
+        AvailabilityOverrideRequest req = new AvailabilityOverrideRequest();
+        req.setKind(AvailabilityOverrideKind.AVAILABLE);
+        req.setStartAt(OffsetDateTime.parse("2026-06-10T09:00:00Z"));
+        req.setEndAt(OffsetDateTime.parse("2026-06-10T10:00:00Z"));
+
+        mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer mentee-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("400 when endAt is not after startAt — Bean Validation @AssertTrue fires")
+    void addOverrideReturns400WhenEndNotAfterStart() throws Exception {
+        mockMentorJwt("mentor-token", 2L);
+        AvailabilityOverrideRequest req = new AvailabilityOverrideRequest();
+        req.setKind(AvailabilityOverrideKind.AVAILABLE);
+        req.setStartAt(OffsetDateTime.parse("2026-06-10T10:00:00Z"));
+        req.setEndAt(OffsetDateTime.parse("2026-06-10T10:00:00Z")); // equal → not after
+
+        mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer mentor-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void addOverrideReturns409WhenSameKindOverlap() throws Exception {
+        mockMentorJwt("mentor-token", 2L);
+        when(overrideService.add(eq(2L), any(AvailabilityOverrideRequest.class)))
+                .thenThrow(new OverlappingSlotException("Override overlaps existing UNAVAILABLE"));
+
+        AvailabilityOverrideRequest req = new AvailabilityOverrideRequest();
+        req.setKind(AvailabilityOverrideKind.UNAVAILABLE);
+        req.setStartAt(OffsetDateTime.parse("2026-06-10T09:00:00Z"));
+        req.setEndAt(OffsetDateTime.parse("2026-06-20T17:00:00Z"));
+
+        mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer mentor-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void removeOverrideReturns204ForOwner() throws Exception {
+        mockMentorJwt("mentor-token", 2L);
+        doNothing().when(overrideService).remove(2L, 7L);
+
+        mockMvc.perform(delete("/api/availability/overrides/7")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void removeOverrideReturns403ForOtherMentor() throws Exception {
+        mockMentorJwt("mentor-token", 2L);
+        doThrow(new ProfileNotVisibleException("You can only delete your own overrides"))
+                .when(overrideService).remove(2L, 7L);
+
+        mockMvc.perform(delete("/api/availability/overrides/7")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isForbidden());
     }
 }

--- a/backend/src/test/java/com/group7/backend/controller/AvailabilityControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/AvailabilityControllerTest.java
@@ -14,6 +14,7 @@ import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.service.AvailabilityOverrideService;
 import com.group7.backend.service.AvailabilityService;
+import com.group7.backend.service.CalendarExportService;
 import com.group7.backend.service.JwtService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -55,6 +56,9 @@ class AvailabilityControllerTest {
 
     @MockitoBean
     private AvailabilityOverrideService overrideService;
+
+    @MockitoBean
+    private CalendarExportService calendarExportService;
 
     @MockitoBean
     private JwtService jwtService;
@@ -404,5 +408,31 @@ class AvailabilityControllerTest {
         mockMvc.perform(delete("/api/availability/overrides/7")
                         .header("Authorization", "Bearer mentor-token"))
                 .andExpect(status().isForbidden());
+    }
+
+    // ── /ical endpoint (issue #250) ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("GET /ical is anonymous — calendar apps cannot send Authorization headers on subscription URLs")
+    void exportIcalReturns200ForAnonymousCaller() throws Exception {
+        byte[] ics = ("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//test//EN\r\n"
+                + "END:VCALENDAR\r\n").getBytes();
+        when(calendarExportService.exportMentorAvailability(2L)).thenReturn(ics);
+
+        mockMvc.perform(get("/api/availability/2/ical"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "text/calendar;charset=UTF-8"))
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"mentor_2_availability.ics\""))
+                .andExpect(content().bytes(ics));
+    }
+
+    @Test
+    void exportIcalReturns404WhenMentorMissing() throws Exception {
+        when(calendarExportService.exportMentorAvailability(99L))
+                .thenThrow(new ResourceNotFoundException("Mentor not found"));
+
+        mockMvc.perform(get("/api/availability/99/ical"))
+                .andExpect(status().isNotFound());
     }
 }

--- a/backend/src/test/java/com/group7/backend/integration/AvailabilityIcalIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/AvailabilityIcalIntegrationTest.java
@@ -1,0 +1,306 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.AvailabilityOverrideRequest;
+import com.group7.backend.dto.request.AvailabilitySlotRequest;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.AvailabilityOverrideKind;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.AvailabilityOverrideRepository;
+import com.group7.backend.repository.AvailabilitySlotRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import net.fortuna.ical4j.data.CalendarBuilder;
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.component.VEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.ByteArrayInputStream;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the availability override CRUD endpoints and the
+ * iCalendar export (#250) against real Postgres. Each scenario is
+ * self-contained — {@code @BeforeEach cleanDb()} wipes the relevant tables,
+ * then the scenario seeds users and overrides via the public API.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AvailabilityIcalIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private AvailabilitySlotRepository slotRepository;
+    @Autowired private AvailabilityOverrideRepository overrideRepository;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        overrideRepository.deleteAll();
+        slotRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    // ── ICS export ─────────────────────────────────────────────────────────
+
+    @Test
+    void icalExportIsAnonymousAndParsesCleanly() throws Exception {
+        // Mentor with one weekly slot + one AVAILABLE override + one
+        // UNAVAILABLE override. The export must include all three as VEVENTs
+        // and parse cleanly via ical4j on the consumer side.
+        String mentorToken = registerAndLogin("ical_anon_mentor@test.com", true);
+        Long mentorId = userRepository.findByEmail("ical_anon_mentor@test.com")
+                .orElseThrow().getId();
+
+        addWeeklySlot(mentorToken, DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(10, 0));
+        addOverride(mentorToken, AvailabilityOverrideKind.AVAILABLE,
+                "2026-06-15T09:00:00Z", "2026-06-15T12:00:00Z");
+        addOverride(mentorToken, AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-20T00:00:00Z", "2026-06-25T00:00:00Z");
+
+        // No Authorization header — proves the permitAll carve-out works.
+        MvcResult result = mockMvc.perform(get("/api/availability/" + mentorId + "/ical"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "text/calendar;charset=UTF-8"))
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"mentor_" + mentorId + "_availability.ics\""))
+                .andReturn();
+
+        Calendar parsed = new CalendarBuilder()
+                .build(new ByteArrayInputStream(result.getResponse().getContentAsByteArray()));
+        List<VEvent> events = parsed.getComponents("VEVENT");
+        assertThat(events).hasSize(3);
+    }
+
+    @Test
+    void icalExportReturns404ForUnknownMentor() throws Exception {
+        mockMvc.perform(get("/api/availability/99999999/ical"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void icalExportForEmptyMentorIsValidVCalendarWithNoEvents() throws Exception {
+        registerAndLogin("ical_empty_mentor@test.com", true);
+        Long mentorId = userRepository.findByEmail("ical_empty_mentor@test.com")
+                .orElseThrow().getId();
+
+        MvcResult result = mockMvc.perform(get("/api/availability/" + mentorId + "/ical"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Calendar parsed = new CalendarBuilder()
+                .build(new ByteArrayInputStream(result.getResponse().getContentAsByteArray()));
+        assertThat(parsed.<VEvent>getComponents("VEVENT")).isEmpty();
+        // VTIMEZONE is always emitted so consumers without an external TZ
+        // database render correctly.
+        assertThat(parsed.getComponents("VTIMEZONE")).hasSize(1);
+    }
+
+    // ── override CRUD ──────────────────────────────────────────────────────
+
+    @Test
+    void overrideCrudRoundTrip_addListDelete() throws Exception {
+        String mentorToken = registerAndLogin("ical_crud_mentor@test.com", true);
+        Long mentorId = userRepository.findByEmail("ical_crud_mentor@test.com")
+                .orElseThrow().getId();
+
+        // Add one override.
+        AvailabilityOverrideRequest req = override(
+                AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-10T00:00:00Z", "2026-06-20T00:00:00Z");
+        MvcResult addResult = mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.kind").value("UNAVAILABLE"))
+                .andReturn();
+        Long overrideId = objectMapper.readTree(addResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        // List returns it (any authenticated user can read).
+        mockMvc.perform(get("/api/availability/" + mentorId + "/overrides")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(overrideId));
+
+        // Delete it.
+        mockMvc.perform(delete("/api/availability/overrides/" + overrideId)
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isNoContent());
+
+        // List is empty.
+        mockMvc.perform(get("/api/availability/" + mentorId + "/overrides")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(0));
+    }
+
+    @Test
+    void addOverrideReturns409OnSameKindOverlap() throws Exception {
+        String mentorToken = registerAndLogin("ical_overlap_mentor@test.com", true);
+
+        addOverride(mentorToken, AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-10T00:00:00Z", "2026-06-20T00:00:00Z");
+
+        AvailabilityOverrideRequest overlapping = override(
+                AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-15T00:00:00Z", "2026-06-25T00:00:00Z");
+        mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(overlapping)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void addOverrideAllowsCrossKindOverlap() throws Exception {
+        // The whole point of the layered model: an UNAVAILABLE block can sit
+        // on top of an AVAILABLE block (or the recurring weekly schedule).
+        String mentorToken = registerAndLogin("ical_cross_mentor@test.com", true);
+
+        addOverride(mentorToken, AvailabilityOverrideKind.AVAILABLE,
+                "2026-06-15T09:00:00Z", "2026-06-15T17:00:00Z");
+
+        // UNAVAILABLE 12-13 carves a hole out of the AVAILABLE 09-17.
+        AvailabilityOverrideRequest carve = override(
+                AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-15T12:00:00Z", "2026-06-15T13:00:00Z");
+        mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(carve)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void menteeAddingOverrideReturns403() throws Exception {
+        String menteeToken = registerAndLogin("ical_mentee@test.com", false);
+
+        AvailabilityOverrideRequest req = override(
+                AvailabilityOverrideKind.AVAILABLE,
+                "2026-06-15T09:00:00Z", "2026-06-15T10:00:00Z");
+        mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void mentorCannotDeleteAnotherMentorsOverride() throws Exception {
+        String aToken = registerAndLogin("ical_delete_a@test.com", true);
+        String bToken = registerAndLogin("ical_delete_b@test.com", true);
+
+        // A creates an override.
+        MvcResult addResult = mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer " + aToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(override(
+                                AvailabilityOverrideKind.AVAILABLE,
+                                "2026-06-15T09:00:00Z", "2026-06-15T10:00:00Z"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Long overrideId = objectMapper.readTree(addResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        // B tries to delete it → 403 (not 404 — would leak existence).
+        mockMvc.perform(delete("/api/availability/overrides/" + overrideId)
+                        .header("Authorization", "Bearer " + bToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    private AvailabilityOverrideRequest override(AvailabilityOverrideKind kind,
+                                                 String startIso, String endIso) {
+        AvailabilityOverrideRequest r = new AvailabilityOverrideRequest();
+        r.setKind(kind);
+        r.setStartAt(OffsetDateTime.parse(startIso));
+        r.setEndAt(OffsetDateTime.parse(endIso));
+        return r;
+    }
+
+    private void addOverride(String token, AvailabilityOverrideKind kind,
+                             String startIso, String endIso) throws Exception {
+        mockMvc.perform(post("/api/availability/overrides")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(override(kind, startIso, endIso))))
+                .andExpect(status().isCreated());
+    }
+
+    private void addWeeklySlot(String token, DayOfWeek day,
+                               LocalTime start, LocalTime end) throws Exception {
+        AvailabilitySlotRequest req = new AvailabilitySlotRequest();
+        req.setDayOfWeek(day);
+        req.setStartTime(start);
+        req.setEndTime(end);
+        mockMvc.perform(post("/api/availability")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+    }
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName(isMentor ? "Mira" : "Eli");
+        req.setLastName(isMentor ? "Mentor" : "Mentee");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/AvailabilityOverrideServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/AvailabilityOverrideServiceTest.java
@@ -1,0 +1,267 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.request.AvailabilityOverrideRequest;
+import com.group7.backend.dto.response.AvailabilityOverrideResponse;
+import com.group7.backend.entity.AvailabilityOverride;
+import com.group7.backend.entity.AvailabilityOverrideKind;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.OverlappingSlotException;
+import com.group7.backend.exception.ProfileNotVisibleException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.AvailabilityOverrideRepository;
+import com.group7.backend.repository.MentorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit-level coverage of {@link AvailabilityOverrideService}. Pins the
+ * non-overlap rule (same-kind only), the cross-kind allow rule (the whole
+ * point of overrides — UNAVAILABLE can sit on top of recurring AVAILABLE),
+ * the ownership check on delete, and the mentor-not-found 404 paths.
+ */
+@ExtendWith(MockitoExtension.class)
+class AvailabilityOverrideServiceTest {
+
+    private static final Long MENTOR_ID = 100L;
+    private static final Long OTHER_MENTOR_ID = 200L;
+
+    @Mock private AvailabilityOverrideRepository overrideRepository;
+    @Mock private MentorRepository mentorRepository;
+
+    private AvailabilityOverrideService service;
+
+    private Mentor mentor;
+
+    @BeforeEach
+    void setUp() {
+        service = new AvailabilityOverrideService(overrideRepository, mentorRepository);
+        mentor = new Mentor();
+        mentor.setId(MENTOR_ID);
+    }
+
+    // ── add ────────────────────────────────────────────────────────────────
+
+    @Test
+    void add_persistsOverride_whenNoSameKindOverlap() {
+        when(mentorRepository.findById(MENTOR_ID)).thenReturn(Optional.of(mentor));
+        when(overrideRepository.findByMentorIdAndKindOrderByStartAtAscIdAsc(
+                MENTOR_ID, AvailabilityOverrideKind.UNAVAILABLE))
+                .thenReturn(List.of());
+        when(overrideRepository.save(any(AvailabilityOverride.class)))
+                .thenAnswer(inv -> {
+                    AvailabilityOverride o = inv.getArgument(0);
+                    o.setId(1L);
+                    return o;
+                });
+
+        AvailabilityOverrideRequest req = request(
+                AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-10T09:00:00Z", "2026-06-20T17:00:00Z");
+
+        AvailabilityOverrideResponse result = service.add(MENTOR_ID, req);
+
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getKind()).isEqualTo(AvailabilityOverrideKind.UNAVAILABLE);
+        verify(overrideRepository).save(any(AvailabilityOverride.class));
+    }
+
+    @Test
+    void add_rejectsSameKindOverlap() {
+        when(mentorRepository.findById(MENTOR_ID)).thenReturn(Optional.of(mentor));
+        // Existing UNAVAILABLE: 06-15..06-25; new UNAVAILABLE: 06-20..06-30 overlaps.
+        AvailabilityOverride existing = override(
+                7L, AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-15T00:00:00Z", "2026-06-25T00:00:00Z");
+        when(overrideRepository.findByMentorIdAndKindOrderByStartAtAscIdAsc(
+                MENTOR_ID, AvailabilityOverrideKind.UNAVAILABLE))
+                .thenReturn(List.of(existing));
+
+        AvailabilityOverrideRequest req = request(
+                AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-20T00:00:00Z", "2026-06-30T00:00:00Z");
+
+        assertThatThrownBy(() -> service.add(MENTOR_ID, req))
+                .isInstanceOf(OverlappingSlotException.class);
+        verify(overrideRepository, never()).save(any());
+    }
+
+    @Test
+    void add_allowsCrossKindOverlap_thePointOfTheModel() {
+        // Mentor has an AVAILABLE override 09:00–12:00; they want to add an
+        // UNAVAILABLE 10:00–11:00 to carve out the middle. This must succeed
+        // — the whole reason the two-layer model exists is so consumers can
+        // see "available, except this hour".
+        when(mentorRepository.findById(MENTOR_ID)).thenReturn(Optional.of(mentor));
+        // The check is for SAME-kind only — UNAVAILABLE find returns empty
+        // even though an AVAILABLE row exists in the DB at 09:00–12:00 (not
+        // stubbed because the service never queries that side).
+        when(overrideRepository.findByMentorIdAndKindOrderByStartAtAscIdAsc(
+                MENTOR_ID, AvailabilityOverrideKind.UNAVAILABLE))
+                .thenReturn(List.of());
+        when(overrideRepository.save(any(AvailabilityOverride.class)))
+                .thenAnswer(inv -> {
+                    AvailabilityOverride o = inv.getArgument(0);
+                    o.setId(8L);
+                    return o;
+                });
+
+        AvailabilityOverrideRequest req = request(
+                AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-15T10:00:00Z", "2026-06-15T11:00:00Z");
+
+        AvailabilityOverrideResponse result = service.add(MENTOR_ID, req);
+
+        assertThat(result.getId()).isEqualTo(8L);
+        // Confirm we never even queried the AVAILABLE list — only same-kind.
+        verify(overrideRepository).findByMentorIdAndKindOrderByStartAtAscIdAsc(
+                MENTOR_ID, AvailabilityOverrideKind.UNAVAILABLE);
+        verify(overrideRepository, never()).findByMentorIdAndKindOrderByStartAtAscIdAsc(
+                MENTOR_ID, AvailabilityOverrideKind.AVAILABLE);
+    }
+
+    @Test
+    void add_throws404_whenMentorMissing() {
+        when(mentorRepository.findById(MENTOR_ID)).thenReturn(Optional.empty());
+
+        AvailabilityOverrideRequest req = request(
+                AvailabilityOverrideKind.AVAILABLE,
+                "2026-06-15T10:00:00Z", "2026-06-15T11:00:00Z");
+
+        assertThatThrownBy(() -> service.add(MENTOR_ID, req))
+                .isInstanceOf(ResourceNotFoundException.class);
+        verify(overrideRepository, never()).save(any());
+    }
+
+    @Test
+    void add_allowsAdjacentRanges() {
+        // Two ranges that touch at a single instant (end == next start) must
+        // not be considered overlapping. The overlap predicate uses strict
+        // inequality so back-to-back blocks are legal.
+        when(mentorRepository.findById(MENTOR_ID)).thenReturn(Optional.of(mentor));
+        AvailabilityOverride existing = override(
+                7L, AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-15T09:00:00Z", "2026-06-15T10:00:00Z");
+        when(overrideRepository.findByMentorIdAndKindOrderByStartAtAscIdAsc(
+                MENTOR_ID, AvailabilityOverrideKind.UNAVAILABLE))
+                .thenReturn(List.of(existing));
+        when(overrideRepository.save(any(AvailabilityOverride.class)))
+                .thenAnswer(inv -> {
+                    AvailabilityOverride o = inv.getArgument(0);
+                    o.setId(8L);
+                    return o;
+                });
+
+        AvailabilityOverrideRequest req = request(
+                AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-15T10:00:00Z", "2026-06-15T11:00:00Z");
+
+        assertThat(service.add(MENTOR_ID, req).getId()).isEqualTo(8L);
+    }
+
+    // ── remove ─────────────────────────────────────────────────────────────
+
+    @Test
+    void remove_deletesOwnOverride() {
+        AvailabilityOverride existing = override(
+                42L, AvailabilityOverrideKind.AVAILABLE,
+                "2026-06-15T10:00:00Z", "2026-06-15T11:00:00Z");
+        existing.setMentor(mentor);
+        when(overrideRepository.findById(42L)).thenReturn(Optional.of(existing));
+
+        service.remove(MENTOR_ID, 42L);
+
+        verify(overrideRepository).delete(existing);
+    }
+
+    @Test
+    void remove_throws403_whenOverrideBelongsToDifferentMentor() {
+        Mentor other = new Mentor();
+        other.setId(OTHER_MENTOR_ID);
+        AvailabilityOverride existing = override(
+                42L, AvailabilityOverrideKind.AVAILABLE,
+                "2026-06-15T10:00:00Z", "2026-06-15T11:00:00Z");
+        existing.setMentor(other);
+        when(overrideRepository.findById(42L)).thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> service.remove(MENTOR_ID, 42L))
+                .isInstanceOf(ProfileNotVisibleException.class);
+        verify(overrideRepository, never()).delete(any());
+    }
+
+    @Test
+    void remove_throws404_whenOverrideMissing() {
+        when(overrideRepository.findById(42L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.remove(MENTOR_ID, 42L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── list ───────────────────────────────────────────────────────────────
+
+    @Test
+    void list_returnsPagedResponses() {
+        Pageable pageable = PageRequest.of(0, 20);
+        AvailabilityOverride a = override(1L, AvailabilityOverrideKind.AVAILABLE,
+                "2026-06-15T09:00:00Z", "2026-06-15T12:00:00Z");
+        AvailabilityOverride b = override(2L, AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-20T00:00:00Z", "2026-06-25T00:00:00Z");
+        when(mentorRepository.existsById(MENTOR_ID)).thenReturn(true);
+        when(overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(eq(MENTOR_ID), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(a, b), pageable, 2));
+
+        Page<AvailabilityOverrideResponse> result = service.list(MENTOR_ID, pageable);
+
+        assertThat(result.getContent())
+                .extracting(AvailabilityOverrideResponse::getId)
+                .containsExactly(1L, 2L);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    void list_throws404_whenMentorMissing() {
+        when(mentorRepository.existsById(MENTOR_ID)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.list(MENTOR_ID, PageRequest.of(0, 20)))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    private static AvailabilityOverrideRequest request(AvailabilityOverrideKind kind,
+                                                       String startIso, String endIso) {
+        AvailabilityOverrideRequest r = new AvailabilityOverrideRequest();
+        r.setKind(kind);
+        r.setStartAt(OffsetDateTime.parse(startIso));
+        r.setEndAt(OffsetDateTime.parse(endIso));
+        return r;
+    }
+
+    private static AvailabilityOverride override(Long id, AvailabilityOverrideKind kind,
+                                                 String startIso, String endIso) {
+        AvailabilityOverride o = new AvailabilityOverride();
+        o.setId(id);
+        o.setKind(kind);
+        o.setStartAt(OffsetDateTime.parse(startIso));
+        o.setEndAt(OffsetDateTime.parse(endIso));
+        return o;
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/CalendarExportServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/CalendarExportServiceTest.java
@@ -1,0 +1,265 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.AvailabilityOverride;
+import com.group7.backend.entity.AvailabilityOverrideKind;
+import com.group7.backend.entity.AvailabilitySlot;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.AvailabilityOverrideRepository;
+import com.group7.backend.repository.AvailabilitySlotRepository;
+import com.group7.backend.repository.MentorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import net.fortuna.ical4j.data.CalendarBuilder;
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.component.VTimeZone;
+
+/**
+ * Unit-level coverage of {@link CalendarExportService}. Each test parses
+ * the produced ICS bytes via ical4j's own {@link CalendarBuilder} and
+ * inspects the resulting model — that gives both syntactic validation and
+ * structural assertions in one round trip.
+ */
+@ExtendWith(MockitoExtension.class)
+class CalendarExportServiceTest {
+
+    private static final Long MENTOR_ID = 100L;
+
+    @Mock private MentorRepository mentorRepository;
+    @Mock private AvailabilitySlotRepository slotRepository;
+    @Mock private AvailabilityOverrideRepository overrideRepository;
+
+    private CalendarExportService service;
+    private Mentor mentor;
+
+    @BeforeEach
+    void setUp() {
+        service = new CalendarExportService(
+                mentorRepository, slotRepository, overrideRepository);
+        mentor = new Mentor();
+        mentor.setId(MENTOR_ID);
+        mentor.setFirstName("Mira");
+        mentor.setLastName("Mentor");
+    }
+
+    @Test
+    void exportThrows404WhenMentorMissing() {
+        when(mentorRepository.findById(MENTOR_ID)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.exportMentorAvailability(MENTOR_ID))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void emptyMentor_emitsValidVCalendarWithNoEvents() throws Exception {
+        stubMentor();
+        when(slotRepository.findByMentorId(MENTOR_ID)).thenReturn(List.of());
+        when(overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(MENTOR_ID))
+                .thenReturn(List.of());
+
+        Calendar parsed = parse(service.exportMentorAvailability(MENTOR_ID));
+
+        assertThat(parsed.<VEvent>getComponents("VEVENT")).isEmpty();
+        // VTIMEZONE is always emitted so consumers without an external TZ
+        // database render correctly.
+        assertThat(parsed.<VTimeZone>getComponents("VTIMEZONE")).hasSize(1);
+    }
+
+    @Test
+    void recurringSlot_emitsVEventWithRruleWeeklyAndTransparent() throws Exception {
+        stubMentor();
+        AvailabilitySlot mondayMorning = slot(1L, DayOfWeek.MONDAY,
+                LocalTime.of(9, 0), LocalTime.of(10, 0));
+        when(slotRepository.findByMentorId(MENTOR_ID)).thenReturn(List.of(mondayMorning));
+        when(overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(MENTOR_ID))
+                .thenReturn(List.of());
+
+        Calendar parsed = parse(service.exportMentorAvailability(MENTOR_ID));
+
+        List<VEvent> events = parsed.getComponents("VEVENT");
+        assertThat(events).hasSize(1);
+        VEvent event = events.get(0);
+        assertThat(event.getProperty("UID").orElseThrow().getValue())
+                .isEqualTo("availability-slot-1@bounswe2026group7");
+        assertThat(event.getProperty("RRULE").orElseThrow().getValue())
+                .contains("FREQ=WEEKLY");
+        assertThat(event.getProperty("TRANSP").orElseThrow().getValue())
+                .isEqualTo("TRANSPARENT");
+        assertThat(event.getProperty("STATUS").orElseThrow().getValue())
+                .isEqualTo("CONFIRMED");
+        assertThat(event.getProperty("SUMMARY").orElseThrow().getValue())
+                .isEqualTo("Available — Mira Mentor");
+        // DTSTART must be anchored to a Monday since slot.dayOfWeek = MONDAY.
+        // The fixed epoch (2024-01-01) is itself a Monday, so DTSTART falls
+        // exactly on that date.
+        assertThat(event.getProperty("DTSTART").orElseThrow().getValue())
+                .isEqualTo("20240101T090000");
+    }
+
+    @Test
+    void availableOverride_emitsVEventWithoutRruleAndTransparent() throws Exception {
+        stubMentor();
+        when(slotRepository.findByMentorId(MENTOR_ID)).thenReturn(List.of());
+        AvailabilityOverride extra = override(7L, AvailabilityOverrideKind.AVAILABLE,
+                "2026-06-15T09:00:00Z", "2026-06-15T12:00:00Z");
+        when(overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(MENTOR_ID))
+                .thenReturn(List.of(extra));
+
+        Calendar parsed = parse(service.exportMentorAvailability(MENTOR_ID));
+
+        List<VEvent> events = parsed.getComponents("VEVENT");
+        assertThat(events).hasSize(1);
+        VEvent event = events.get(0);
+        assertThat(event.getProperty("UID").orElseThrow().getValue())
+                .isEqualTo("availability-override-7@bounswe2026group7");
+        assertThat(event.getProperty("RRULE")).isEmpty();
+        assertThat(event.getProperty("TRANSP").orElseThrow().getValue())
+                .isEqualTo("TRANSPARENT");
+        assertThat(event.getProperty("SUMMARY").orElseThrow().getValue())
+                .isEqualTo("Available — Mira Mentor");
+    }
+
+    @Test
+    void unavailableOverride_emitsVEventWithOpaqueAndUnavailableSummary() throws Exception {
+        stubMentor();
+        when(slotRepository.findByMentorId(MENTOR_ID)).thenReturn(List.of());
+        AvailabilityOverride vacation = override(8L, AvailabilityOverrideKind.UNAVAILABLE,
+                "2026-06-10T00:00:00Z", "2026-06-20T00:00:00Z");
+        when(overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(MENTOR_ID))
+                .thenReturn(List.of(vacation));
+
+        Calendar parsed = parse(service.exportMentorAvailability(MENTOR_ID));
+
+        List<VEvent> events = parsed.getComponents("VEVENT");
+        assertThat(events).hasSize(1);
+        VEvent event = events.get(0);
+        // OPAQUE so consumers' personal calendars render the block as busy.
+        assertThat(event.getProperty("TRANSP").orElseThrow().getValue())
+                .isEqualTo("OPAQUE");
+        assertThat(event.getProperty("SUMMARY").orElseThrow().getValue())
+                .isEqualTo("Unavailable — Mira Mentor");
+    }
+
+    @Test
+    void mixedSlotsAndOverrides_emitOneVEventEach() throws Exception {
+        stubMentor();
+        when(slotRepository.findByMentorId(MENTOR_ID))
+                .thenReturn(List.of(
+                        slot(1L, DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(10, 0)),
+                        slot(2L, DayOfWeek.WEDNESDAY, LocalTime.of(14, 0), LocalTime.of(16, 0))));
+        when(overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(MENTOR_ID))
+                .thenReturn(List.of(
+                        override(7L, AvailabilityOverrideKind.AVAILABLE,
+                                "2026-06-15T09:00:00Z", "2026-06-15T12:00:00Z"),
+                        override(8L, AvailabilityOverrideKind.UNAVAILABLE,
+                                "2026-06-20T00:00:00Z", "2026-06-25T00:00:00Z")));
+
+        Calendar parsed = parse(service.exportMentorAvailability(MENTOR_ID));
+
+        List<VEvent> events = parsed.getComponents("VEVENT");
+        assertThat(events).hasSize(4);
+    }
+
+    @Test
+    void uidsAreStableAcrossExports() throws Exception {
+        stubMentor();
+        AvailabilitySlot slot = slot(42L, DayOfWeek.FRIDAY, LocalTime.of(10, 0), LocalTime.of(11, 0));
+        when(slotRepository.findByMentorId(MENTOR_ID)).thenReturn(List.of(slot));
+        when(overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(MENTOR_ID))
+                .thenReturn(List.of());
+
+        String first = new String(service.exportMentorAvailability(MENTOR_ID), StandardCharsets.UTF_8);
+        String second = new String(service.exportMentorAvailability(MENTOR_ID), StandardCharsets.UTF_8);
+
+        // UID is the deduplication key for calendar subscribers; re-exports
+        // must produce the same UID for the same source row so consumers
+        // don't see duplicates after refresh.
+        assertThat(first).contains("UID:availability-slot-42@bounswe2026group7");
+        assertThat(second).contains("UID:availability-slot-42@bounswe2026group7");
+    }
+
+    @Test
+    void mentorWithMissingName_fallsBackToGenericLabel() throws Exception {
+        Mentor anonymous = new Mentor();
+        anonymous.setId(MENTOR_ID);
+        // No first/last name set → null/null.
+        when(mentorRepository.findById(MENTOR_ID)).thenReturn(Optional.of(anonymous));
+        when(slotRepository.findByMentorId(MENTOR_ID))
+                .thenReturn(List.of(slot(1L, DayOfWeek.MONDAY,
+                        LocalTime.of(9, 0), LocalTime.of(10, 0))));
+        when(overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(MENTOR_ID))
+                .thenReturn(List.of());
+
+        Calendar parsed = parse(service.exportMentorAvailability(MENTOR_ID));
+
+        VEvent event = parsed.<VEvent>getComponents("VEVENT").get(0);
+        assertThat(event.getProperty("SUMMARY").orElseThrow().getValue())
+                .isEqualTo("Available — Mentor");
+    }
+
+    @Test
+    void calendarHeaderCarriesProductIdVersionAndCalscale() throws Exception {
+        stubMentor();
+        when(slotRepository.findByMentorId(MENTOR_ID)).thenReturn(List.of());
+        when(overrideRepository.findByMentorIdOrderByStartAtAscIdAsc(MENTOR_ID))
+                .thenReturn(List.of());
+
+        String body = new String(service.exportMentorAvailability(MENTOR_ID), StandardCharsets.UTF_8);
+
+        assertThat(body)
+                .startsWith("BEGIN:VCALENDAR")
+                .contains("PRODID:-//Group7 Bounswe//Mentor Availability Export 1.0//EN")
+                .contains("VERSION:2.0")
+                .contains("CALSCALE:GREGORIAN")
+                .endsWith("END:VCALENDAR\r\n");
+        // METHOD is deliberately absent — see CalendarExportService comment
+        // about RFC 5545's METHOD:PUBLISH/ORGANIZER coupling.
+        assertThat(body).doesNotContain("METHOD:");
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    private void stubMentor() {
+        when(mentorRepository.findById(MENTOR_ID)).thenReturn(Optional.of(mentor));
+    }
+
+    private static Calendar parse(byte[] icsBytes) throws Exception {
+        return new CalendarBuilder().build(new ByteArrayInputStream(icsBytes));
+    }
+
+    private static AvailabilitySlot slot(Long id, DayOfWeek day, LocalTime start, LocalTime end) {
+        AvailabilitySlot s = new AvailabilitySlot();
+        s.setId(id);
+        s.setDayOfWeek(day);
+        s.setStartTime(start);
+        s.setEndTime(end);
+        s.setRecurring(true);
+        return s;
+    }
+
+    private static AvailabilityOverride override(Long id, AvailabilityOverrideKind kind,
+                                                 String startIso, String endIso) {
+        AvailabilityOverride o = new AvailabilityOverride();
+        o.setId(id);
+        o.setKind(kind);
+        o.setStartAt(OffsetDateTime.parse(startIso));
+        o.setEndAt(OffsetDateTime.parse(endIso));
+        return o;
+    }
+}


### PR DESCRIPTION
Closes #250. Publishes a mentor's full availability schedule as an RFC 5545 (.ics) file consumable by Google Calendar, Apple Calendar, Outlook, etc.

The existing model only supported weekly recurring slots — there was no way for a mentor to say "I'm on vacation next week" or "I have a one-off opening Saturday morning". This PR adds a second layer (`AvailabilityOverride`) for arbitrary timestamp ranges and exports both layers together as iCalendar.

## Design

Two-layer model — same shape Calendly, Cal.com, and Google Calendar appointments use:
- Layer 1: existing `AvailabilitySlot` (weekly recurring) — untouched
- Layer 2: new `AvailabilityOverride` with `kind ∈ {AVAILABLE, UNAVAILABLE}` and `(start_at, end_at)` timestamptz

Conflict rules: same-kind exceptions can't overlap each other (409); cross-kind can (an UNAVAILABLE block carving a hole out of an AVAILABLE region or out of the recurring schedule is the whole point of the layered model).

Naming: `Override` rather than `Exception` (RFC 5545's term) to avoid cognitive collision with `java.lang.Exception` in service code.

## RFC 5545 mapping

- Recurring slot → VEVENT + `RRULE:FREQ=WEEKLY` + `TRANSP:TRANSPARENT`, anchored to first matching DayOfWeek on/after fixed epoch 2024-01-01, emitted with `TZID=Europe/Istanbul` so wall-clock time survives consumer DST.
- AVAILABLE override → VEVENT no RRULE, `TRANSP:TRANSPARENT`, UTC instants.
- UNAVAILABLE override → VEVENT no RRULE, `TRANSP:OPAQUE` (overlays as busy on consumer's calendar).
- Stable UIDs (`availability-slot-{id}@bounswe2026group7`, `availability-override-{id}@...`) for subscriber deduplication across refreshes.
- ical4j's built-in RFC 5545 validator runs before bytes leave the service.

## Endpoints added

| Method | Path | Auth |
|---|---|---|
| `GET` | `/api/availability/{mentorId}/overrides?page=&size=` | authenticated |
| `POST` | `/api/availability/overrides` | MENTOR |
| `DELETE` | `/api/availability/overrides/{id}` | MENTOR (own only) |
| `GET` | `/api/availability/{mentorId}/ical` | **anonymous** |

The `/ical` endpoint is in `permitAll` because calendar apps cannot send Authorization headers on subscription URLs. Data exposed (mentor name + availability) is already visible to any authenticated user via `GET /{mentorId}`. Drive-by enumeration is rate-limited (30/min/IP via the new `availability-ical` rule).

## Test plan

- [x] `mvn clean test` — 751/751 green (+30 new tests across unit, controller, integration)
- [x] JaCoCo: `AvailabilityOverrideService` 92% branch, `CalendarExportService` 94% branch
- [x] Manual end-to-end against live Postgres: weekly slot + AVAILABLE + UNAVAILABLE override, same-kind overlap 409, bad-range 400, mentee POST 403, anonymous GET /ical 200 with text/calendar + attachment Content-Disposition, unknown mentor 404. Generated ICS parses cleanly via ical4j's CalendarBuilder and contains correct VTIMEZONE + 3 VEVENTs with stable UIDs.
- [x] OpenAPI verified: all 4 new endpoints in `/v3/api-docs` under the `Availability` tag with proper response codes and DTO schemas.

## Commits

1. `feat(backend): V18 migration + AvailabilityOverride entity + repo (#250)`
2. `feat(backend): AvailabilityOverrideService + DTOs + unit tests (#250)`
3. `feat(backend): availability-override CRUD endpoints + controller tests (#250)`
4. `feat(backend): add ical4j dependency (#250 prep)`
5. `feat(backend): CalendarExportService for mentor availability (#250)`
6. `feat(backend): ICS export endpoint, permitAll carve-out, rate limit (#250)`
7. `test(backend): integration coverage for overrides + ICS export (#250)`

## Out of scope (deliberate)

- `GET /effective?from=&to=` server-computed merged view of the layers — natural next step for mentee booking UIs that want concrete time intervals rather than recomputing the merge client-side.
- Cleanup of the dead `recurring` boolean on `AvailabilitySlot` (it's read in one place, branches no business logic, only affects one line of JSON-LD output) — frontend coordination needed; pin as follow-up.
- Mentee-side parity (`MenteeAvailabilitySlot` parallel system).