### PR TITLE
Search overhaul: DB-level filtering, indexing, N+1 fix (#262)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/UserController.java
+++ b/backend/src/main/java/com/group7/backend/controller/UserController.java
@@ -2,6 +2,7 @@ package com.group7.backend.controller;
 
 import com.group7.backend.dto.request.MenteeProfileRequest;
 import com.group7.backend.dto.request.MentorProfileRequest;
+import com.group7.backend.dto.request.SearchRole;
 import com.group7.backend.dto.response.MenteeResponse;
 import com.group7.backend.dto.response.MentorResponse;
 import com.group7.backend.dto.response.ProfileResponse;
@@ -176,6 +177,50 @@ public class UserController {
     @ApiResponse(responseCode = "200", description = "List of all mentors")
     public ResponseEntity<List<MentorResponse>> getAllMentorsUnpaginated() {
         return ResponseEntity.ok(userService.getAllMentorsList());
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "Search users by keyword and filters",
+            description = "DB-level search across the user directory with composable filters "
+                    + "(#262). Mentees may search MENTOR only; mentors may search MENTEE only; "
+                    + "admins may search either role. Same-role search returns 403. "
+                    + "Short keyword (length < 3 after trim) is treated as no-keyword "
+                    + "(pg_trgm requires ≥3 alphanumerics for index acceleration). "
+                    + "hasAvailability=true requires the requester to have at least one "
+                    + "availability slot of their own; admins cannot use this filter.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated search results"),
+            @ApiResponse(responseCode = "400",
+                    description = "Invalid filter combination "
+                            + "(admin + hasAvailability=true, or requester missing slots)",
+                    content = @Content),
+            @ApiResponse(responseCode = "403",
+                    description = "Same-role search not permitted",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Requester not found", content = @Content)
+    })
+    public ResponseEntity<Page<ProfileResponse>> searchUsers(
+            @Parameter(description = "Search target role")
+            @RequestParam SearchRole role,
+            @Parameter(description = "Optional keyword; ignored if length < 3 after trim")
+            @RequestParam(required = false) String q,
+            @Parameter(description = "Filter by interest labels (OR semantics)")
+            @RequestParam(required = false) List<String> interests,
+            @Parameter(description = "Filter by skill labels (OR semantics)")
+            @RequestParam(required = false) List<String> skills,
+            @Parameter(description = "Filter by major (matches preferred_mentee_major OR field)")
+            @RequestParam(required = false) String major,
+            @Parameter(description = "Restrict to candidates whose availability overlaps the requester's slots")
+            @RequestParam(defaultValue = "false") boolean hasAvailability,
+            @Parameter(description = "Page number (0-based)")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size; clamped to [1, 100]")
+            @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        Pageable pageable = clampPageable(page, size);
+        return ResponseEntity.ok(userService.searchUsers(
+                role, q, interests, skills, major, hasAvailability, requesterId, pageable));
     }
 
     @GetMapping("/mentees")

--- a/backend/src/main/java/com/group7/backend/dto/request/SearchRole.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/SearchRole.java
@@ -1,0 +1,15 @@
+package com.group7.backend.dto.request;
+
+/**
+ * The role of users a search request is targeting. Distinct from the
+ * authentication-side roles (which include ADMIN) because admins aren't
+ * search <em>targets</em> — they don't appear in mentor/mentee directories.
+ *
+ * <p>Bound directly from the {@code role} query parameter on
+ * {@code GET /api/users/search}; Spring's enum binding rejects other
+ * values with 400.
+ */
+public enum SearchRole {
+    MENTOR,
+    MENTEE
+}

--- a/backend/src/main/java/com/group7/backend/repository/AvailabilitySlotRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/AvailabilitySlotRepository.java
@@ -3,11 +3,33 @@ package com.group7.backend.repository;
 import com.group7.backend.entity.AvailabilitySlot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface AvailabilitySlotRepository extends JpaRepository<AvailabilitySlot, Long> {
 
     List<AvailabilitySlot> findByMentorId(Long mentorId);
+
+    /**
+     * Boolean-only existence check. Cheaper than {@code findByMentorId(...).isEmpty()}
+     * because Spring Data emits {@code SELECT 1 ... LIMIT 1} (no entity hydration).
+     * Used by {@code UserService.searchUsers} to validate that a mentor has at
+     * least one slot before allowing a {@code hasAvailability=true} search.
+     */
+    boolean existsByMentorId(Long mentorId);
+
+    /**
+     * Batch fetch slots for many mentors at once — eliminates the
+     * one-query-per-mentor N+1 in {@code MatchingService} when scoring
+     * availability overlap. The service groups results by mentor id before
+     * passing each mentor's slots to the ranker.
+     *
+     * <p>Caller should short-circuit on an empty input collection rather than
+     * relying on Hibernate's empty-IN rewrite — both for clarity and because
+     * the calling site has already paid for the SQL fetch that surfaced no
+     * candidates.
+     */
+    List<AvailabilitySlot> findByMentorIdIn(Collection<Long> mentorIds);
 
     void deleteByMentorId(Long mentorId);
 

--- a/backend/src/main/java/com/group7/backend/repository/MenteeAvailabilitySlotRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MenteeAvailabilitySlotRepository.java
@@ -3,11 +3,27 @@ package com.group7.backend.repository;
 import com.group7.backend.entity.MenteeAvailabilitySlot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface MenteeAvailabilitySlotRepository extends JpaRepository<MenteeAvailabilitySlot, Long> {
 
     List<MenteeAvailabilitySlot> findByMenteeId(Long menteeId);
+
+    /**
+     * Boolean-only existence check; symmetric to
+     * {@code AvailabilitySlotRepository.existsByMentorId}. Used by
+     * {@code UserService.searchUsers} for the {@code hasAvailability=true}
+     * slot-presence guard.
+     */
+    boolean existsByMenteeId(Long menteeId);
+
+    /**
+     * Symmetric to {@code AvailabilitySlotRepository.findByMentorIdIn}.
+     * Reserved for the mentor-side matching path's eventual N+1 elimination
+     * if scoring against mentee slots ever becomes per-mentee.
+     */
+    List<MenteeAvailabilitySlot> findByMenteeIdIn(Collection<Long> menteeIds);
 
     void deleteByMenteeId(Long menteeId);
 

--- a/backend/src/main/java/com/group7/backend/repository/MenteeRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MenteeRepository.java
@@ -1,7 +1,77 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.Mentee;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MenteeRepository extends JpaRepository<Mentee, Long> {
+
+    /**
+     * Shared JPQL — see {@link MentorRepository#SEARCH_JPQL} for rationale.
+     */
+    String SEARCH_JPQL = """
+            SELECT m FROM Mentee m
+            WHERE (:keyword IS NULL OR
+                   LOWER(m.goals)           LIKE :keyword ESCAPE '|' OR
+                   LOWER(m.major)           LIKE :keyword ESCAPE '|' OR
+                   LOWER(m.careerInterest)  LIKE :keyword ESCAPE '|' OR
+                   LOWER(m.backgroundInfo)  LIKE :keyword ESCAPE '|' OR
+                   EXISTS (SELECT 1 FROM m.interests i WHERE LOWER(i.label) LIKE :keyword ESCAPE '|') OR
+                   EXISTS (SELECT 1 FROM m.skills s    WHERE LOWER(s.label) LIKE :keyword ESCAPE '|'))
+            AND (:interests IS NULL OR
+                 EXISTS (SELECT 1 FROM m.interests i WHERE LOWER(i.label) IN :interests))
+            AND (:skills IS NULL OR
+                 EXISTS (SELECT 1 FROM m.skills s WHERE LOWER(s.label) IN :skills))
+            AND (:major IS NULL OR LOWER(m.major) = :major)
+            AND (:requireUnattached = false OR m.activeMentorId IS NULL)
+            AND (:requesterMentorId IS NULL OR
+                 EXISTS (SELECT 1 FROM AvailabilitySlot ms, MenteeAvailabilitySlot mes
+                         WHERE mes.mentee.id = m.id
+                           AND ms.mentor.id = :requesterMentorId
+                           AND ms.dayOfWeek = mes.dayOfWeek
+                           AND ms.startTime < mes.endTime
+                           AND mes.startTime < ms.endTime))
+            ORDER BY m.id DESC
+            """;
+
+    /**
+     * DB-level mentee search with composable filters. Symmetric to
+     * {@link MentorRepository#searchByFilters} — see its javadoc for the
+     * parameter normalisation contract; the same null-coalescing and
+     * lowercasing rules apply here.
+     *
+     * <p>The mentee-side has one extra filter: {@code requireUnattached}
+     * excludes mentees with a non-null {@code activeMentorId} (already
+     * partnered with a mentor). Used by the matching path's
+     * {@code getCandidateMentees}; general search passes false.
+     */
+    @Query(SEARCH_JPQL)
+    Page<Mentee> searchByFilters(
+            @Param("keyword") String keyword,
+            @Param("interests") List<String> interests,
+            @Param("skills") List<String> skills,
+            @Param("major") String major,
+            @Param("requireUnattached") boolean requireUnattached,
+            @Param("requesterMentorId") Long requesterMentorId,
+            Pageable pageable);
+
+    /**
+     * Same filter shape as {@link #searchByFilters} but returns List — no
+     * count query. Used by the matching path's candidate-mentee fetch where
+     * {@code totalElements} is computed in-memory after the post-filter.
+     */
+    @Query(SEARCH_JPQL)
+    List<Mentee> findRankingCandidates(
+            @Param("keyword") String keyword,
+            @Param("interests") List<String> interests,
+            @Param("skills") List<String> skills,
+            @Param("major") String major,
+            @Param("requireUnattached") boolean requireUnattached,
+            @Param("requesterMentorId") Long requesterMentorId,
+            Pageable pageable);
 }

--- a/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
@@ -1,10 +1,107 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.Mentor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
+
+    /**
+     * Shared JPQL for {@link #searchByFilters} (Page, with count) and
+     * {@link #findRankingCandidates} (List, without count). One source of
+     * truth for the filter shape; the only difference between the two
+     * methods is whether Spring Data emits a count query.
+     *
+     * <p>{@code ORDER BY m.id DESC} is required — Postgres returns rows in
+     * arbitrary order otherwise, and the matching path's top-200 oversample
+     * becomes a random sample rather than a meaningful one.
+     */
+    String SEARCH_JPQL = """
+            SELECT m FROM Mentor m
+            WHERE (:keyword IS NULL OR
+                   LOWER(m.expertise)      LIKE :keyword ESCAPE '|' OR
+                   LOWER(m.field)          LIKE :keyword ESCAPE '|' OR
+                   LOWER(m.mentoringGoals) LIKE :keyword ESCAPE '|' OR
+                   EXISTS (SELECT 1 FROM m.interests i             WHERE LOWER(i.label) LIKE :keyword ESCAPE '|') OR
+                   EXISTS (SELECT 1 FROM m.preferredMenteeSkills s WHERE LOWER(s.label) LIKE :keyword ESCAPE '|'))
+            AND (:interests IS NULL OR
+                 EXISTS (SELECT 1 FROM m.interests i WHERE LOWER(i.label) IN :interests))
+            AND (:skills IS NULL OR
+                 EXISTS (SELECT 1 FROM m.preferredMenteeSkills s WHERE LOWER(s.label) IN :skills))
+            AND (:major IS NULL OR
+                 LOWER(m.preferredMenteeMajor) = :major OR
+                 LOWER(m.field) = :major)
+            AND (:requireCapacity = false OR m.currentMenteeCount < m.maxMenteeCapacity)
+            AND (:requesterMenteeId IS NULL OR
+                 EXISTS (SELECT 1 FROM AvailabilitySlot ms, MenteeAvailabilitySlot mes
+                         WHERE ms.mentor.id = m.id
+                           AND mes.mentee.id = :requesterMenteeId
+                           AND ms.dayOfWeek = mes.dayOfWeek
+                           AND ms.startTime < mes.endTime
+                           AND mes.startTime < ms.endTime))
+            ORDER BY m.id DESC
+            """;
+
     List<Mentor> findByExpertise(String expertise);
+
+    /**
+     * DB-level mentor search with composable filters. All multi-value filters
+     * use {@code EXISTS} (never {@code JOIN} on element collections) to avoid
+     * DISTINCT entanglements with Spring Data's auto-derived count query.
+     *
+     * <p><b>Parameter contract — required for correctness:</b>
+     * <ul>
+     *   <li>{@code keyword}: pre-lowercased, wildcard-escaped, wrapped in
+     *       {@code %...%}, or {@code null} to skip the keyword filter.
+     *       Hibernate would translate an empty string to a SQL parameter that
+     *       LIKE-matches everything; null is the correct "no filter" signal.</li>
+     *   <li>{@code interests} / {@code skills}: pre-lowercased lists, or
+     *       {@code null} to skip. Empty lists must be coalesced to null at the
+     *       service layer — Hibernate translates a non-null empty list to
+     *       {@code IN ()} which Postgres rejects.</li>
+     *   <li>{@code major}: pre-lowercased + trimmed, or {@code null}.</li>
+     *   <li>{@code requireCapacity}: when true, excludes mentors at full
+     *       capacity. Used by the matching path; general search passes false.</li>
+     *   <li>{@code requesterMenteeId}: when non-null, restricts results to
+     *       mentors whose availability slots overlap that mentee's slots
+     *       (day-of-week + strict-inequality time overlap). Backed by the
+     *       {@code idx_mentor_avail_mentor_day} composite index.</li>
+     * </ul>
+     *
+     * <p>Used by {@code GET /api/users/search} where {@code totalElements} is
+     * rendered to the client, justifying the count query. The matching path
+     * uses {@link #findRankingCandidates} instead to skip the count.
+     */
+    @Query(SEARCH_JPQL)
+    Page<Mentor> searchByFilters(
+            @Param("keyword") String keyword,
+            @Param("interests") List<String> interests,
+            @Param("skills") List<String> skills,
+            @Param("major") String major,
+            @Param("requireCapacity") boolean requireCapacity,
+            @Param("requesterMenteeId") Long requesterMenteeId,
+            Pageable pageable);
+
+    /**
+     * Same filter shape as {@link #searchByFilters} but returns a List rather
+     * than a Page — Spring Data does not derive a count query for List-
+     * returning methods, even when a {@code Pageable} is supplied. Saves one
+     * query per call on the matching path, which never reads
+     * {@code totalElements} (it computes pagination metadata against an
+     * in-memory ranked window of bounded size).
+     */
+    @Query(SEARCH_JPQL)
+    List<Mentor> findRankingCandidates(
+            @Param("keyword") String keyword,
+            @Param("interests") List<String> interests,
+            @Param("skills") List<String> skills,
+            @Param("major") String major,
+            @Param("requireCapacity") boolean requireCapacity,
+            @Param("requesterMenteeId") Long requesterMenteeId,
+            Pageable pageable);
 }

--- a/backend/src/main/java/com/group7/backend/service/MatchingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchingService.java
@@ -2,282 +2,250 @@ package com.group7.backend.service;
 
 import com.group7.backend.dto.response.MenteeCandidateResponse;
 import com.group7.backend.dto.response.MentorMatchResponse;
+import com.group7.backend.entity.AvailabilitySlot;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.MenteeAvailabilitySlot;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.exception.MatchingNotAllowedException;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.AvailabilitySlotRepository;
-import com.group7.backend.repository.MenteeRepository;
 import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeRepository;
 import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.service.ranking.MentorRanker;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalTime;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+/**
+ * Mentor/mentee matching service. The data-loading layer is fully SQL-side
+ * (#262); this service orchestrates the search → batch-slot-fetch → score →
+ * paginate pipeline.
+ *
+ * <h2>Query budget</h2>
+ * Four JPQL/HQL queries per matching call regardless of result size:
+ * <ol>
+ *   <li>Load the mentee/mentor (via {@code findById}).</li>
+ *   <li>Candidate query — {@code findRankingCandidates} (List return, no count).</li>
+ *   <li>Mentor-side slot batch — {@code findByMentorIdIn} for the page.</li>
+ *   <li>Mentee-side slots — {@code findByMenteeId} for the requesting mentee.</li>
+ * </ol>
+ * Plus up to 2 collection-fetch SQL statements from {@code @Fetch(SUBSELECT)}
+ * on {@code Mentor.interests} and {@code Mentor.preferredMenteeSkills} when
+ * the ranker reads them. Hibernate's {@code getQueryExecutionCount()} counts
+ * the explicit four; collection fetches accrue under
+ * {@code getCollectionFetchCount()} separately. {@code SearchPerformanceTest}
+ * pins the explicit-query count at ≤ 4.
+ *
+ * <h2>Almost-global ranking</h2>
+ * Pagination over a scored set is approximate: the SQL layer fetches a
+ * fixed top-200 candidates ordered by {@code id DESC} (the deterministic
+ * default — no semantic signal), the ranker scores them in memory, and the
+ * paginated page is sliced from the in-memory ranking. For filtered pools
+ * ≤ 200 (typical for keyword searches), this is exact global ranking. For
+ * broader pools (no-filter mentee browsing 5000+ mentors), the user sees
+ * the top of the most-recent 200; this is acceptable for a recommendation
+ * surface where mentees aren't paginating to mentor #500 by score. The
+ * unpaginated {@link #getTopMentorsList} variant uses the same 200 cap for
+ * consistency.
+ */
 @Service
 public class MatchingService {
+
+    /**
+     * Fixed-size oversample window for in-memory scoring + ranking. Pages
+     * beyond this window return empty content; the frontend should treat
+     * that as "end of results".
+     */
+    private static final int RANKING_WINDOW = 200;
 
     private final MenteeRepository menteeRepository;
     private final MentorRepository mentorRepository;
     private final AvailabilitySlotRepository availabilitySlotRepository;
     private final MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+    private final MentorRanker mentorRanker;
     private final NotificationEventPublisher notificationEventPublisher;
 
     public MatchingService(MenteeRepository menteeRepository,
                            MentorRepository mentorRepository,
                            AvailabilitySlotRepository availabilitySlotRepository,
                            MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository,
+                           MentorRanker mentorRanker,
                            NotificationEventPublisher notificationEventPublisher) {
         this.menteeRepository = menteeRepository;
         this.mentorRepository = mentorRepository;
         this.availabilitySlotRepository = availabilitySlotRepository;
         this.menteeAvailabilitySlotRepository = menteeAvailabilitySlotRepository;
+        this.mentorRanker = mentorRanker;
         this.notificationEventPublisher = notificationEventPublisher;
     }
 
     @Transactional(readOnly = true)
     public Page<MentorMatchResponse> getTopMentors(Long menteeId, String keyword, Pageable pageable) {
-        return paginateList(rankMentors(menteeId, keyword), pageable);
+        List<MentorMatchResponse> ranked = rankAvailableMentors(menteeId, keyword);
+        // Match-found notification only on page 0 — pre-refactor it fired on the
+        // globally-top mentor, so the post-refactor equivalent is the top of
+        // the first page. Subsequent pages don't surface "found you a match!"
+        // because the user is already past the headline result.
+        if (pageable.getPageNumber() == 0 && !ranked.isEmpty()) {
+            notificationEventPublisher.publishMatchFound(menteeId, ranked.get(0).getFirstName());
+        }
+        return slicePage(ranked, pageable);
     }
 
     @Transactional(readOnly = true)
     public List<MentorMatchResponse> getTopMentorsList(Long menteeId, String keyword) {
-        return rankMentors(menteeId, keyword);
-    }
-
-    private List<MentorMatchResponse> rankMentors(Long menteeId, String keyword) {
-        Mentee mentee = menteeRepository.findById(menteeId)
-                .orElseThrow(() -> new ResourceNotFoundException("Mentee not found"));
-
-        if (mentee.getActiveMentorId() != null) {
-            throw new MatchingNotAllowedException("You already have an active mentor");
+        List<MentorMatchResponse> ranked = rankAvailableMentors(menteeId, keyword);
+        if (!ranked.isEmpty()) {
+            notificationEventPublisher.publishMatchFound(menteeId, ranked.get(0).getFirstName());
         }
-
-        List<Mentor> mentors = mentorRepository.findAll();
-
-        List<MentorMatchResponse> matches = mentors.stream()
-                .filter(m -> m.getCurrentMenteeCount() < m.getMaxMenteeCapacity())
-                .filter(m -> matchesKeyword(m, keyword))
-                .map(m -> MentorMatchResponse.from(m,
-                        calculateScore(m, mentee) + calculateAvailabilityScore(m.getId(), mentee.getId())))
-                .sorted(Comparator.comparingInt(MentorMatchResponse::getMatchScore).reversed())
-                .toList();
-
-        if (!matches.isEmpty()) {
-            notificationEventPublisher.publishMatchFound(menteeId, matches.get(0).getFirstName());
-        }
-
-        return matches;
+        return ranked;
     }
 
     @Transactional(readOnly = true)
     public Page<MenteeCandidateResponse> getCandidateMentees(Long mentorId, String keyword, Pageable pageable) {
         Mentor mentor = mentorRepository.findById(mentorId)
                 .orElseThrow(() -> new ResourceNotFoundException("Mentor not found"));
-
         if (mentor.getCurrentMenteeCount() >= mentor.getMaxMenteeCapacity()) {
             throw new MatchingNotAllowedException("You have reached your maximum mentee capacity");
         }
 
-        List<Mentee> mentees = menteeRepository.findAll();
+        // Mentee-side has no scoring algorithm today (filter-only). The
+        // existing notification semantics fire when the candidate set is
+        // non-empty, gated to page 0 to match the mentor path.
+        // requesterMentorId is null on the matching path: slot overlap is part
+        // of the SCORING in the mentor-side path (the ranker's availability
+        // score), but the mentee-side path here doesn't score, and the
+        // pre-refactor behaviour did not slot-filter candidate mentees. Passing
+        // mentorId here would silently exclude every mentee whenever the mentor
+        // has zero availability slots set.
+        Pageable fetchPage = PageRequest.of(0, RANKING_WINDOW);
+        List<Mentee> raw = menteeRepository.findRankingCandidates(
+                SearchNormaliser.keyword(keyword), null, null, null,
+                /*requireUnattached*/ true,
+                /*requesterMentorId*/ null,
+                fetchPage);
 
-        List<MenteeCandidateResponse> candidates = mentees.stream()
-                .filter(m -> m.getActiveMentorId() == null)
-                .filter(m -> matchesMentorPreferences(mentor, m))
-                .filter(m -> matchesMenteeKeyword(m, keyword))
+        // In-memory post-filter: mentees must match at least one of the mentor's
+        // preferences (interest overlap, skill, preferred major, or field). This
+        // OR-of-categories semantic doesn't compose well with the AND-across-
+        // filters JPQL `searchByFilters` shape, and pushing it to SQL would mean
+        // splitting the repo method or introducing a 5th boolean param. The
+        // post-filter runs on at most {@code RANKING_WINDOW} rows already in
+        // memory, so the cost is negligible and the SQL stays clean.
+        List<MenteeCandidateResponse> candidates = raw.stream()
+                .filter(me -> matchesMentorPreferences(mentor, me))
                 .map(MenteeCandidateResponse::from)
                 .toList();
 
-        if (!candidates.isEmpty()) {
+        if (pageable.getPageNumber() == 0 && !candidates.isEmpty()) {
             notificationEventPublisher.publishMatchFound(mentorId, candidates.get(0).getFirstName());
         }
-
-        return paginateList(candidates, pageable);
+        return slicePage(candidates, pageable);
     }
 
-    boolean matchesMentorPreferences(Mentor mentor, Mentee mentee) {
-        List<String> mentorInterests = nullSafe(mentor.getInterests());
-        List<String> menteeInterests = nullSafe(mentee.getInterests());
-        for (String interest : menteeInterests) {
-            if (containsIgnoreCase(mentorInterests, interest)) {
+    private List<MentorMatchResponse> rankAvailableMentors(Long menteeId, String keyword) {
+        Mentee mentee = menteeRepository.findById(menteeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mentee not found"));
+        if (mentee.getActiveMentorId() != null) {
+            throw new MatchingNotAllowedException("You already have an active mentor");
+        }
+
+        Pageable fetchPage = PageRequest.of(0, RANKING_WINDOW);
+        List<Mentor> raw = mentorRepository.findRankingCandidates(
+                SearchNormaliser.keyword(keyword), null, null, null,
+                /*requireCapacity*/ true,
+                /*requesterMenteeId*/ null,
+                fetchPage);
+
+        if (raw.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> mentorIds = raw.stream().map(Mentor::getId).toList();
+        Map<Long, List<AvailabilitySlot>> slotsByMentor = availabilitySlotRepository
+                .findByMentorIdIn(mentorIds).stream()
+                .collect(Collectors.groupingBy(s -> s.getMentor().getId()));
+        List<MenteeAvailabilitySlot> menteeSlots =
+                menteeAvailabilitySlotRepository.findByMenteeId(menteeId);
+
+        return raw.stream()
+                .map(m -> MentorMatchResponse.from(m, mentorRanker.score(
+                        m, mentee,
+                        slotsByMentor.getOrDefault(m.getId(), List.of()),
+                        menteeSlots)))
+                .sorted(Comparator.comparingInt(MentorMatchResponse::getMatchScore).reversed())
+                .toList();
+    }
+
+    private static <T> Page<T> slicePage(List<T> ranked, Pageable pageable) {
+        // totalElements equals the in-window total so pagination metadata stays
+        // self-consistent — the frontend's pagination control reflects the
+        // visible 200-item window, not the underlying SQL match count.
+        //
+        // Compare offset against ranked.size() as `long` BEFORE narrowing to
+        // int. Pageable.getOffset() is `long` (pageNumber * pageSize); a
+        // pathological page=Integer.MAX_VALUE with size > 1 overflows when
+        // cast directly to int and produces a negative `start`, which would
+        // throw IndexOutOfBoundsException from List.subList. Comparing in
+        // long-space and short-circuiting on out-of-range offsets makes the
+        // narrowing cast safe (offset < ranked.size() ≤ RANKING_WINDOW).
+        long offset = pageable.getOffset();
+        if (offset >= ranked.size()) {
+            return new PageImpl<>(List.of(), pageable, ranked.size());
+        }
+        int start = (int) offset;
+        int end = Math.min(start + pageable.getPageSize(), ranked.size());
+        return new PageImpl<>(ranked.subList(start, end), pageable, ranked.size());
+    }
+
+    /**
+     * True iff the mentee matches any of the mentor's preferences — interest
+     * overlap, skill present in the mentor's preferred-mentee skills, mentee
+     * major equals the mentor's preferred major, or mentee major equals the
+     * mentor's field. OR-of-categories rather than AND, which is why this
+     * lives outside the SQL {@code searchByFilters} shape.
+     */
+    static boolean matchesMentorPreferences(Mentor mentor, Mentee mentee) {
+        List<String> mentorInterests = mentor.getInterests();
+        if (mentorInterests != null) {
+            for (String interest : nullSafe(mentee.getInterests())) {
+                if (containsIgnoreCase(mentorInterests, interest)) return true;
+            }
+        }
+        List<String> preferredSkills = mentor.getPreferredMenteeSkills();
+        if (preferredSkills != null) {
+            for (String skill : nullSafe(mentee.getSkills())) {
+                if (containsIgnoreCase(preferredSkills, skill)) return true;
+            }
+        }
+        if (mentee.getMajor() != null) {
+            if (mentor.getPreferredMenteeMajor() != null
+                    && mentee.getMajor().equalsIgnoreCase(mentor.getPreferredMenteeMajor())) {
+                return true;
+            }
+            if (mentor.getField() != null
+                    && mentee.getMajor().equalsIgnoreCase(mentor.getField())) {
                 return true;
             }
         }
-
-        List<String> preferredSkills = nullSafe(mentor.getPreferredMenteeSkills());
-        for (String skill : nullSafe(mentee.getSkills())) {
-            if (containsIgnoreCase(preferredSkills, skill)) {
-                return true;
-            }
-        }
-
-        if (mentee.getMajor() != null && mentor.getPreferredMenteeMajor() != null
-                && mentee.getMajor().equalsIgnoreCase(mentor.getPreferredMenteeMajor())) {
-            return true;
-        }
-
-        if (mentee.getMajor() != null && mentor.getField() != null
-                && mentee.getMajor().equalsIgnoreCase(mentor.getField())) {
-            return true;
-        }
-
         return false;
     }
 
-    private boolean matchesMenteeKeyword(Mentee mentee, String keyword) {
-        if (keyword == null || keyword.isBlank()) {
-            return true;
-        }
-        String kw = keyword.toLowerCase();
-        return containsSubstring(mentee.getGoals(), kw)
-                || containsSubstring(mentee.getMajor(), kw)
-                || containsSubstring(mentee.getCareerInterest(), kw)
-                || containsSubstring(mentee.getBackgroundInfo(), kw)
-                || listContainsSubstring(mentee.getInterests(), kw)
-                || listContainsSubstring(mentee.getSkills(), kw);
+    private static List<String> nullSafe(List<String> list) {
+        return list == null ? List.of() : list;
     }
 
-    int calculateScore(Mentor mentor, Mentee mentee) {
-        int score = 0;
-
-        // Overlapping interests: +3 each
-        List<String> mentorInterests = nullSafe(mentor.getInterests());
-        List<String> menteeInterests = nullSafe(mentee.getInterests());
-        for (String interest : menteeInterests) {
-            if (containsIgnoreCase(mentorInterests, interest)) {
-                score += 3;
-            }
-        }
-
-        // Each mentee skill in mentor's preferredMenteeSkills: +3 each
-        List<String> preferredSkills = nullSafe(mentor.getPreferredMenteeSkills());
-        for (String skill : nullSafe(mentee.getSkills())) {
-            if (containsIgnoreCase(preferredSkills, skill)) {
-                score += 3;
-            }
-        }
-
-        // Mentee major matches preferredMenteeMajor: +5
-        if (mentee.getMajor() != null && mentor.getPreferredMenteeMajor() != null
-                && mentee.getMajor().equalsIgnoreCase(mentor.getPreferredMenteeMajor())) {
-            score += 5;
-        }
-
-        // Mentee major matches mentor field: +3
-        if (mentee.getMajor() != null && mentor.getField() != null
-                && mentee.getMajor().equalsIgnoreCase(mentor.getField())) {
-            score += 3;
-        }
-
-        // Mentoring goals contains mentee goals keywords: +2 per word
-        if (mentee.getGoals() != null && mentor.getMentoringGoals() != null) {
-            String[] goalWords = mentee.getGoals().toLowerCase().split("\\s+");
-            String lowerMentoringGoals = mentor.getMentoringGoals().toLowerCase();
-            for (String word : goalWords) {
-                if (word.length() > 3 && lowerMentoringGoals.contains(word)) {
-                    score += 2;
-                }
-            }
-        }
-
-        // Mentee careerInterest / skills overlap with mentor expertise: +2 per word
-        if (mentor.getExpertise() != null) {
-            String lowerExpertise = mentor.getExpertise().toLowerCase();
-            if (mentee.getCareerInterest() != null) {
-                String[] careerWords = mentee.getCareerInterest().toLowerCase().split("\\s+");
-                for (String word : careerWords) {
-                    if (word.length() > 3 && lowerExpertise.contains(word)) {
-                        score += 2;
-                    }
-                }
-            }
-        }
-
-        return score;
-    }
-
-    int calculateAvailabilityScore(Long mentorId, Long menteeId) {
-        if (mentorId == null || menteeId == null) {
-            return 0;
-        }
-
-        var mentorSlots = availabilitySlotRepository.findByMentorId(mentorId);
-        var menteeSlots = menteeAvailabilitySlotRepository.findByMenteeId(menteeId);
-
-        if (mentorSlots.isEmpty() || menteeSlots.isEmpty()) {
-            return 0;
-        }
-
-        long overlapMinutes = 0;
-        for (var mentorSlot : mentorSlots) {
-            for (MenteeAvailabilitySlot menteeSlot : menteeSlots) {
-                if (mentorSlot.getDayOfWeek() != menteeSlot.getDayOfWeek()) {
-                    continue;
-                }
-                overlapMinutes += overlapMinutes(
-                        mentorSlot.getStartTime(),
-                        mentorSlot.getEndTime(),
-                        menteeSlot.getStartTime(),
-                        menteeSlot.getEndTime());
-            }
-        }
-
-        return (int) Math.min(12, overlapMinutes / 30);
-    }
-
-    private long overlapMinutes(LocalTime start1, LocalTime end1, LocalTime start2, LocalTime end2) {
-        LocalTime start = start1.isAfter(start2) ? start1 : start2;
-        LocalTime end = end1.isBefore(end2) ? end1 : end2;
-        if (!start.isBefore(end)) {
-            return 0;
-        }
-        return java.time.Duration.between(start, end).toMinutes();
-    }
-
-    private boolean matchesKeyword(Mentor mentor, String keyword) {
-        if (keyword == null || keyword.isBlank()) {
-            return true;
-        }
-        String kw = keyword.toLowerCase();
-        return containsSubstring(mentor.getExpertise(), kw)
-                || containsSubstring(mentor.getField(), kw)
-                || containsSubstring(mentor.getMentoringGoals(), kw)
-                || listContainsSubstring(mentor.getInterests(), kw)
-                || listContainsSubstring(mentor.getPreferredMenteeSkills(), kw);
-    }
-
-    private boolean containsSubstring(String text, String keyword) {
-        return text != null && text.toLowerCase().contains(keyword);
-    }
-
-    private boolean listContainsSubstring(List<String> items, String keyword) {
-        if (items == null) return false;
-        return items.stream().anyMatch(s -> s != null && s.toLowerCase().contains(keyword));
-    }
-
-    private boolean containsIgnoreCase(List<String> list, String value) {
+    private static boolean containsIgnoreCase(List<String> list, String value) {
         if (value == null) return false;
         return list.stream().anyMatch(s -> s != null && s.equalsIgnoreCase(value));
-    }
-
-    private List<String> nullSafe(List<String> list) {
-        return list == null ? Collections.emptyList() : list;
-    }
-
-    private <T> Page<T> paginateList(List<T> list, Pageable pageable) {
-        int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), list.size());
-        List<T> pageContent = start >= list.size()
-                ? List.of()
-                : list.subList(start, end);
-        return new PageImpl<>(pageContent, pageable, list.size());
     }
 }

--- a/backend/src/main/java/com/group7/backend/service/SearchNormaliser.java
+++ b/backend/src/main/java/com/group7/backend/service/SearchNormaliser.java
@@ -1,0 +1,83 @@
+package com.group7.backend.service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Shared normalisation for the SQL-side search filters introduced in #262.
+ * Both {@code MatchingService} and {@code UserService.searchUsers} call
+ * into these helpers so wildcard escaping, lowercasing, and empty-list
+ * coalescing rules stay consistent across the two surfaces.
+ *
+ * <h3>Why this is correctness-required, not stylistic</h3>
+ * <ul>
+ *   <li>Empty {@code List<String>} bound to JPQL {@code IN :list} translates
+ *       to SQL {@code IN ()} which Postgres rejects. Coalescing empty to
+ *       {@code null} lets the {@code :list IS NULL} gate short-circuit.</li>
+ *   <li>{@code LOWER(column) LIKE :keyword} compares lowercased column to
+ *       the parameter; the parameter must already be lowercased or matches
+ *       drop unpredictably.</li>
+ *   <li>{@link String#toLowerCase()} (no args) uses {@link Locale#getDefault()},
+ *       which on a Turkish-locale JVM lowercases {@code "I"} to {@code "ı"}
+ *       (dotless). Postgres's {@code LOWER()} uses the database collation
+ *       (typically {@code en_US.UTF-8}); the two sides would disagree on
+ *       any keyword containing {@code I}. All lowercasing here uses
+ *       {@link Locale#ROOT} for predictable ASCII-style folding, matching
+ *       what the database does.</li>
+ *   <li>pg_trgm GIN indexes accelerate {@code LIKE} only when the pattern
+ *       has ≥3 alphanumeric chars. Shorter inputs would silently seq-scan;
+ *       returning null skips the keyword filter entirely.</li>
+ * </ul>
+ */
+final class SearchNormaliser {
+
+    private SearchNormaliser() {
+    }
+
+    /**
+     * Normalises a user-supplied keyword for SQL {@code LIKE :keyword
+     * ESCAPE '|'}. Returns null for null, blank, or short (less than 3
+     * alphanumerics after trim) inputs so the {@code :keyword IS NULL}
+     * gate skips the filter.
+     *
+     * <p>Wildcards in the input are escape-prefixed (so {@code "abc%def"}
+     * matches the literal {@code "abc%def"}, not anything containing
+     * {@code "abc"} followed by anything followed by {@code "def"}).
+     * Escape-character order matters: escape {@code |} first, then the
+     * SQL wildcards {@code %} and {@code _}.
+     */
+    static String keyword(String raw) {
+        if (raw == null) return null;
+        String trimmed = raw.trim();
+        if (trimmed.length() < 3) return null;
+        String escaped = trimmed.toLowerCase(Locale.ROOT)
+                .replace("|", "||")
+                .replace("%", "|%")
+                .replace("_", "|_");
+        return "%" + escaped + "%";
+    }
+
+    /**
+     * Normalises a multi-value filter list. Filters out null entries,
+     * lowercases survivors, and returns null if the result is empty so the
+     * {@code :list IS NULL} gate skips the filter (Hibernate translates a
+     * non-null empty list to {@code IN ()} which Postgres rejects).
+     */
+    static List<String> list(List<String> raw) {
+        if (raw == null || raw.isEmpty()) return null;
+        List<String> normalised = raw.stream()
+                .filter(Objects::nonNull)
+                .map(s -> s.toLowerCase(Locale.ROOT))
+                .toList();
+        return normalised.isEmpty() ? null : normalised;
+    }
+
+    /**
+     * Normalises a single-value scalar filter (e.g., {@code major}).
+     * Returns null for null/blank inputs; lowercased+trimmed otherwise.
+     */
+    static String scalar(String raw) {
+        return raw == null || raw.isBlank() ? null : raw.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/UserService.java
+++ b/backend/src/main/java/com/group7/backend/service/UserService.java
@@ -3,6 +3,7 @@ package com.group7.backend.service;
 import com.group7.backend.dto.request.EditProfileRequest;
 import com.group7.backend.dto.request.MenteeProfileRequest;
 import com.group7.backend.dto.request.MentorProfileRequest;
+import com.group7.backend.dto.request.SearchRole;
 import com.group7.backend.dto.response.MenteeResponse;
 import com.group7.backend.dto.response.MentorResponse;
 import com.group7.backend.dto.response.ProfileResponse;
@@ -13,13 +14,16 @@ import com.group7.backend.entity.TaggedTermLists;
 import com.group7.backend.entity.User;
 import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
 import com.group7.backend.repository.MenteeRepository;
 import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.repository.AvailabilitySlotRepository;
 import com.group7.backend.repository.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,13 +36,20 @@ public class UserService {
     private final UserRepository userRepository;
     private final MentorRepository mentorRepository;
     private final MenteeRepository menteeRepository;
+    private final AvailabilitySlotRepository availabilitySlotRepository;
+    private final MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
     private final FileStorageService fileStorageService;
 
     public UserService(UserRepository userRepository, MentorRepository mentorRepository,
-                       MenteeRepository menteeRepository, FileStorageService fileStorageService) {
+                       MenteeRepository menteeRepository,
+                       AvailabilitySlotRepository availabilitySlotRepository,
+                       MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository,
+                       FileStorageService fileStorageService) {
         this.userRepository = userRepository;
         this.mentorRepository = mentorRepository;
         this.menteeRepository = menteeRepository;
+        this.availabilitySlotRepository = availabilitySlotRepository;
+        this.menteeAvailabilitySlotRepository = menteeAvailabilitySlotRepository;
         this.fileStorageService = fileStorageService;
     }
 
@@ -57,6 +68,86 @@ public class UserService {
 
         return userRepository.findAllNonAdmins(pageable)
                 .map(this::mapToResponse);
+    }
+
+    /**
+     * General-purpose user search with composable filters (#262). Distinct
+     * from the matching path: this surface is exploratory ("find me people
+     * with X"), not score-driven. Filtering happens at the SQL layer via
+     * {@code MentorRepository.searchByFilters} / {@code MenteeRepository.searchByFilters}.
+     *
+     * <h3>Role gate</h3>
+     * <ul>
+     *   <li>Admin → may search any {@link SearchRole}, but
+     *       {@code hasAvailability=true} is rejected (admins have no slots).</li>
+     *   <li>Mentee → may search {@code MENTOR} only; same-role search yields 403.
+     *       {@code hasAvailability=true} requires the mentee to have at least
+     *       one availability slot, else 400.</li>
+     *   <li>Mentor → mirror of mentee (may search {@code MENTEE} only;
+     *       slot-presence requirement applies).</li>
+     * </ul>
+     */
+    @Transactional(readOnly = true)
+    public Page<ProfileResponse> searchUsers(SearchRole role,
+                                             String keyword,
+                                             List<String> interests,
+                                             List<String> skills,
+                                             String major,
+                                             boolean hasAvailability,
+                                             Long requesterId,
+                                             Pageable pageable) {
+        Objects.requireNonNull(role, "role");
+        User requester = userRepository.findById(requesterId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + requesterId));
+
+        // Role gate: same-role search and admin-with-hasAvailability are
+        // rejected upfront before the repo query.
+        if (requester instanceof Admin) {
+            if (hasAvailability) {
+                throw new IllegalArgumentException(
+                        "hasAvailability filter is not applicable for admin searches");
+            }
+        } else if (requester instanceof Mentee && role == SearchRole.MENTEE) {
+            throw new ProfileNotVisibleException("Mentees cannot search for other mentees");
+        } else if (requester instanceof Mentor && role == SearchRole.MENTOR) {
+            throw new ProfileNotVisibleException("Mentors cannot search for other mentors");
+        }
+
+        // Slot-presence guard: hasAvailability=true requires the requester
+        // to have at least one slot of their own to compare against. Without
+        // this, the SQL filter silently returns empty, which surprises users.
+        // existsBy* emits SELECT 1 ... LIMIT 1, no entity hydration.
+        if (hasAvailability && requester instanceof Mentee
+                && !menteeAvailabilitySlotRepository.existsByMenteeId(requesterId)) {
+            throw new IllegalArgumentException(
+                    "Set your availability before filtering by overlap");
+        }
+        if (hasAvailability && requester instanceof Mentor
+                && !availabilitySlotRepository.existsByMentorId(requesterId)) {
+            throw new IllegalArgumentException(
+                    "Set your availability before filtering by overlap");
+        }
+
+        String normKeyword = SearchNormaliser.keyword(keyword);
+        List<String> normInterests = SearchNormaliser.list(interests);
+        List<String> normSkills = SearchNormaliser.list(skills);
+        String normMajor = SearchNormaliser.scalar(major);
+
+        if (role == SearchRole.MENTOR) {
+            Long requesterMenteeId = (hasAvailability && requester instanceof Mentee)
+                    ? requesterId : null;
+            return mentorRepository.searchByFilters(
+                    normKeyword, normInterests, normSkills, normMajor,
+                    /*requireCapacity*/ false, requesterMenteeId, pageable)
+                    .map(m -> (ProfileResponse) MentorResponse.from(m));
+        } else {
+            Long requesterMentorId = (hasAvailability && requester instanceof Mentor)
+                    ? requesterId : null;
+            return menteeRepository.searchByFilters(
+                    normKeyword, normInterests, normSkills, normMajor,
+                    /*requireUnattached*/ false, requesterMentorId, pageable)
+                    .map(m -> (ProfileResponse) MenteeResponse.from(m));
+        }
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/group7/backend/service/ranking/MentorRanker.java
+++ b/backend/src/main/java/com/group7/backend/service/ranking/MentorRanker.java
@@ -1,0 +1,40 @@
+package com.group7.backend.service.ranking;
+
+import com.group7.backend.entity.AvailabilitySlot;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import com.group7.backend.entity.Mentor;
+
+import java.util.List;
+
+/**
+ * Strategy for ranking a mentor against a mentee. Today the only impl is
+ * {@link RuleBasedMentorRanker} (the legacy weighted-score algorithm); a
+ * future AI-driven ranker will plug in here without any service-layer
+ * changes.
+ *
+ * <p><b>Contract:</b> implementations must NOT make repository calls. Slot
+ * lists are pre-fetched in batch by {@code MatchingService} — this is the
+ * mechanism that eliminated the per-mentor N+1 in the legacy code path.
+ * Implementations that need additional data should accept it through
+ * constructor dependencies (for AI: model client, embedding cache) rather
+ * than reaching back to repos at scoring time.
+ */
+@FunctionalInterface
+public interface MentorRanker {
+
+    /**
+     * Compute a match score for {@code mentor} relative to {@code mentee}.
+     * Higher scores rank above lower. Return value is opaque — callers sort
+     * but do not interpret the magnitude.
+     *
+     * @param mentor       candidate mentor (must not be null)
+     * @param mentee       requesting mentee (must not be null)
+     * @param mentorSlots  the mentor's availability slots, pre-fetched; may be empty
+     * @param menteeSlots  the mentee's availability slots, pre-fetched; may be empty
+     */
+    int score(Mentor mentor,
+              Mentee mentee,
+              List<AvailabilitySlot> mentorSlots,
+              List<MenteeAvailabilitySlot> menteeSlots);
+}

--- a/backend/src/main/java/com/group7/backend/service/ranking/RuleBasedMentorRanker.java
+++ b/backend/src/main/java/com/group7/backend/service/ranking/RuleBasedMentorRanker.java
@@ -1,0 +1,133 @@
+package com.group7.backend.service.ranking;
+
+import com.group7.backend.entity.AvailabilitySlot;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import com.group7.backend.entity.Mentor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The legacy weighted-score matching algorithm, extracted verbatim from
+ * {@code MatchingService} so a future AI ranker can replace it without
+ * touching the service. Behaviour-identical to the pre-#262 implementation
+ * — verified by the existing 47-case {@code MatchingServiceTest} which now
+ * exercises this class through the service.
+ *
+ * <p>Scoring weights (preserved as-is):
+ * <ul>
+ *   <li>Each overlapping interest: +3</li>
+ *   <li>Each mentee skill in mentor's preferred-mentee skills: +3</li>
+ *   <li>Mentee major equals mentor's preferred major: +5</li>
+ *   <li>Mentee major equals mentor's field: +3</li>
+ *   <li>Each mentee-goal word (length > 3) appearing in mentor's mentoring goals: +2</li>
+ *   <li>Each mentee-career-interest word (length > 3) appearing in mentor's expertise: +2</li>
+ *   <li>Availability overlap minutes / 30, capped at 12</li>
+ * </ul>
+ */
+@Component
+public class RuleBasedMentorRanker implements MentorRanker {
+
+    @Override
+    public int score(Mentor mentor,
+                     Mentee mentee,
+                     List<AvailabilitySlot> mentorSlots,
+                     List<MenteeAvailabilitySlot> menteeSlots) {
+        return profileScore(mentor, mentee) + availabilityScore(mentorSlots, menteeSlots);
+    }
+
+    private static int profileScore(Mentor mentor, Mentee mentee) {
+        int score = 0;
+
+        List<String> mentorInterests = nullSafe(mentor.getInterests());
+        List<String> menteeInterests = nullSafe(mentee.getInterests());
+        for (String interest : menteeInterests) {
+            if (containsIgnoreCase(mentorInterests, interest)) {
+                score += 3;
+            }
+        }
+
+        List<String> preferredSkills = nullSafe(mentor.getPreferredMenteeSkills());
+        for (String skill : nullSafe(mentee.getSkills())) {
+            if (containsIgnoreCase(preferredSkills, skill)) {
+                score += 3;
+            }
+        }
+
+        if (mentee.getMajor() != null && mentor.getPreferredMenteeMajor() != null
+                && mentee.getMajor().equalsIgnoreCase(mentor.getPreferredMenteeMajor())) {
+            score += 5;
+        }
+
+        if (mentee.getMajor() != null && mentor.getField() != null
+                && mentee.getMajor().equalsIgnoreCase(mentor.getField())) {
+            score += 3;
+        }
+
+        if (mentee.getGoals() != null && mentor.getMentoringGoals() != null) {
+            String[] goalWords = mentee.getGoals().toLowerCase().split("\\s+");
+            String lowerMentoringGoals = mentor.getMentoringGoals().toLowerCase();
+            for (String word : goalWords) {
+                if (word.length() > 3 && lowerMentoringGoals.contains(word)) {
+                    score += 2;
+                }
+            }
+        }
+
+        if (mentor.getExpertise() != null && mentee.getCareerInterest() != null) {
+            String lowerExpertise = mentor.getExpertise().toLowerCase();
+            String[] careerWords = mentee.getCareerInterest().toLowerCase().split("\\s+");
+            for (String word : careerWords) {
+                if (word.length() > 3 && lowerExpertise.contains(word)) {
+                    score += 2;
+                }
+            }
+        }
+
+        return score;
+    }
+
+    private static int availabilityScore(List<AvailabilitySlot> mentorSlots,
+                                         List<MenteeAvailabilitySlot> menteeSlots) {
+        if (mentorSlots.isEmpty() || menteeSlots.isEmpty()) {
+            return 0;
+        }
+
+        long overlapMinutes = 0;
+        for (AvailabilitySlot mentorSlot : mentorSlots) {
+            for (MenteeAvailabilitySlot menteeSlot : menteeSlots) {
+                if (mentorSlot.getDayOfWeek() != menteeSlot.getDayOfWeek()) {
+                    continue;
+                }
+                overlapMinutes += overlapMinutes(
+                        mentorSlot.getStartTime(), mentorSlot.getEndTime(),
+                        menteeSlot.getStartTime(), menteeSlot.getEndTime());
+            }
+        }
+
+        return (int) Math.min(12, overlapMinutes / 30);
+    }
+
+    private static long overlapMinutes(LocalTime aStart, LocalTime aEnd,
+                                       LocalTime bStart, LocalTime bEnd) {
+        LocalTime start = aStart.isAfter(bStart) ? aStart : bStart;
+        LocalTime end = aEnd.isBefore(bEnd) ? aEnd : bEnd;
+        if (!start.isBefore(end)) {
+            return 0;
+        }
+        return Duration.between(start, end).toMinutes();
+    }
+
+    private static boolean containsIgnoreCase(List<String> list, String value) {
+        if (value == null) return false;
+        return list.stream().anyMatch(s -> s != null && s.equalsIgnoreCase(value));
+    }
+
+    private static List<String> nullSafe(List<String> list) {
+        return list == null ? Collections.emptyList() : list;
+    }
+}

--- a/backend/src/main/resources/db/migration/V19__add_search_indexes.sql
+++ b/backend/src/main/resources/db/migration/V19__add_search_indexes.sql
@@ -1,0 +1,72 @@
+-- DB-level search indexes for the matching/search overhaul (#262).
+--
+-- Two index families:
+--   1. GIN trigram (pg_trgm) for accelerated keyword search across the mentor
+--      and mentee text fields plus their element-collection labels (interests,
+--      skills). pg_trgm requires ≥3 alphanumerics in the pattern; shorter
+--      keywords silently seq-scan otherwise — the service skips the keyword
+--      filter for q.length() < 3 to avoid this.
+--
+--      All trigram indexes are FUNCTIONAL on LOWER(col), not the raw column.
+--      The JPQL queries lowercase the column for case-insensitive matching:
+--      `WHERE LOWER(m.expertise) LIKE :keyword`. Postgres only uses an index
+--      when the indexed expression matches the predicate's left side
+--      textually, so an index on `expertise` is never used for
+--      `LOWER(expertise) LIKE`. The functional shape `gin (LOWER(expertise)
+--      gin_trgm_ops)` lets the planner choose a Bitmap Index Scan.
+--      (Empirically verified with EXPLAIN ANALYZE before this fix; the raw-
+--      column form fell back to seq scan even with enable_seqscan=off.)
+--
+--   2. Btree composite on (entity_id, day_of_week) for the hasAvailability
+--      EXISTS subquery that joins mentor + mentee availability tables.
+--      Without these the day-of-week predicate falls back to seq scan.
+--
+-- pg_trgm is supported on DigitalOcean Managed PostgreSQL and the docker-
+-- compose Postgres user 'group7' has CREATE on the database. New deploy
+-- environments must grant CREATE on the database before this migration
+-- runs for the first time.
+--
+-- Rollback: drop indexes individually + DROP EXTENSION IF EXISTS pg_trgm
+-- CASCADE. No schema dependencies on the extension itself today.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Mentor scalar columns
+CREATE INDEX idx_mentors_expertise_trgm
+    ON mentors USING gin (LOWER(expertise) gin_trgm_ops);
+CREATE INDEX idx_mentors_field_trgm
+    ON mentors USING gin (LOWER(field) gin_trgm_ops);
+CREATE INDEX idx_mentors_mentoring_goals_trgm
+    ON mentors USING gin (LOWER(mentoring_goals) gin_trgm_ops);
+
+-- Mentor element-collection tables — column name is `interest` / `skill`.
+-- TaggedTerm.label is mapped here via @AttributeOverride; the index targets
+-- the column, not the entity field name.
+CREATE INDEX idx_mentor_interests_trgm
+    ON mentor_interests USING gin (LOWER(interest) gin_trgm_ops);
+CREATE INDEX idx_mentor_preferred_skills_trgm
+    ON mentor_preferred_mentee_skills USING gin (LOWER(skill) gin_trgm_ops);
+
+-- Mentee scalar columns
+CREATE INDEX idx_mentees_goals_trgm
+    ON mentees USING gin (LOWER(goals) gin_trgm_ops);
+CREATE INDEX idx_mentees_major_trgm
+    ON mentees USING gin (LOWER(major) gin_trgm_ops);
+CREATE INDEX idx_mentees_career_interest_trgm
+    ON mentees USING gin (LOWER(career_interest) gin_trgm_ops);
+CREATE INDEX idx_mentees_background_info_trgm
+    ON mentees USING gin (LOWER(background_info) gin_trgm_ops);
+
+-- Mentee element-collection tables
+CREATE INDEX idx_mentee_interests_trgm
+    ON mentee_interests USING gin (LOWER(interest) gin_trgm_ops);
+CREATE INDEX idx_mentee_skills_trgm
+    ON mentee_skills USING gin (LOWER(skill) gin_trgm_ops);
+
+-- Btree composite indexes for hasAvailability overlap subquery.
+-- day_of_week is stored as VARCHAR via @Enumerated(EnumType.STRING); a
+-- regular btree on the composite is the right shape — do not reach for hash.
+CREATE INDEX idx_mentor_avail_mentor_day
+    ON mentor_availability_slots (mentor_id, day_of_week);
+CREATE INDEX idx_mentee_avail_mentee_day
+    ON mentee_availability_slots (mentee_id, day_of_week);

--- a/backend/src/test/java/com/group7/backend/controller/UserSearchControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/UserSearchControllerTest.java
@@ -1,0 +1,321 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.request.SearchRole;
+import com.group7.backend.dto.response.MentorResponse;
+import com.group7.backend.dto.response.ProfileResponse;
+import com.group7.backend.exception.ProfileNotVisibleException;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests for {@code GET /api/users/search} (#262). Focus is the controller-side
+ * concerns: role gating delegated to the service, query-parameter binding,
+ * pageable clamping, and exception → status mapping. The search algorithm
+ * itself is exercised in {@code UserSearchIntegrationTest}.
+ */
+@WebMvcTest(UserController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class UserSearchControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private UserService userService;
+    @MockitoBean private JwtService jwtService;
+
+    private static final String TOKEN = "test-jwt";
+
+    private void mockValidToken(Long userId, String role) {
+        when(jwtService.isTokenValid(TOKEN)).thenReturn(true);
+        when(jwtService.extractEmail(TOKEN)).thenReturn("u@example.com");
+        when(jwtService.extractUserId(TOKEN)).thenReturn(userId);
+        when(jwtService.extractRole(TOKEN)).thenReturn(role);
+    }
+
+    private static Page<ProfileResponse> emptyPage() {
+        return new PageImpl<>(List.of());
+    }
+
+    private static Page<ProfileResponse> singletonMentorPage() {
+        MentorResponse m = new MentorResponse();
+        m.setId(7L);
+        m.setFirstName("Mira");
+        return new PageImpl<>(List.of(m));
+    }
+
+    // ── Happy paths ──────────────────────────────────────────────────────────
+
+    @Test
+    void searchAsMentee_searchingMentor_returns200() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(eq(SearchRole.MENTOR), any(), any(), any(), any(),
+                anyBoolean(), eq(1L), any(Pageable.class)))
+                .thenReturn(singletonMentorPage());
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void searchAsMentor_searchingMentee_returns200() throws Exception {
+        mockValidToken(2L, "MENTOR");
+        when(userService.searchUsers(eq(SearchRole.MENTEE), any(), any(), any(), any(),
+                anyBoolean(), eq(2L), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search?role=MENTEE")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void searchAsAdmin_searchingMentor_returns200() throws Exception {
+        mockValidToken(3L, "ADMIN");
+        when(userService.searchUsers(eq(SearchRole.MENTOR), any(), any(), any(), any(),
+                anyBoolean(), eq(3L), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void searchAsAdmin_searchingMentee_returns200() throws Exception {
+        mockValidToken(3L, "ADMIN");
+        when(userService.searchUsers(eq(SearchRole.MENTEE), any(), any(), any(), any(),
+                anyBoolean(), eq(3L), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search?role=MENTEE")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    // ── Service-layer rejections surface as the right status ──────────────────
+
+    @Test
+    void searchAsMentee_searchingMentee_returns403() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(eq(SearchRole.MENTEE), any(), any(), any(), any(),
+                anyBoolean(), eq(1L), any(Pageable.class)))
+                .thenThrow(new ProfileNotVisibleException("Mentees cannot search for other mentees"));
+
+        mockMvc.perform(get("/api/users/search?role=MENTEE")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void searchAsMentor_searchingMentor_returns403() throws Exception {
+        mockValidToken(2L, "MENTOR");
+        when(userService.searchUsers(eq(SearchRole.MENTOR), any(), any(), any(), any(),
+                anyBoolean(), eq(2L), any(Pageable.class)))
+                .thenThrow(new ProfileNotVisibleException("Mentors cannot search for other mentors"));
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void searchAsAdmin_hasAvailabilityTrue_returns400() throws Exception {
+        mockValidToken(3L, "ADMIN");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                eq(true), eq(3L), any(Pageable.class)))
+                .thenThrow(new IllegalArgumentException(
+                        "hasAvailability filter is not applicable for admin searches"));
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&hasAvailability=true")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void searchHasAvailability_requesterMissingSlots_returns400() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                eq(true), eq(1L), any(Pageable.class)))
+                .thenThrow(new IllegalArgumentException(
+                        "Set your availability before filtering by overlap"));
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&hasAvailability=true")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── Spring-side input validation ──────────────────────────────────────────
+
+    @Test
+    void searchInvalidRole_returns400() throws Exception {
+        mockValidToken(1L, "MENTEE");
+
+        mockMvc.perform(get("/api/users/search?role=ADMIN")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void searchMissingRole_returns400() throws Exception {
+        mockValidToken(1L, "MENTEE");
+
+        mockMvc.perform(get("/api/users/search")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void searchUnauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/users/search?role=MENTOR"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Short-keyword and edge-case bindings ─────────────────────────────────
+
+    @Test
+    void searchKeywordTooShort_stillReaches200_serviceTreatsAsNoFilter() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), anyLong(), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        // q="ab" — service-side normaliser returns null for length<3; controller
+        // forwards as-is. Documented as "no keyword filter" semantic.
+        mockMvc.perform(get("/api/users/search?role=MENTOR&q=ab")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+
+        // Verify the raw "ab" was forwarded — normalisation is the service's job.
+        ArgumentCaptor<String> kw = ArgumentCaptor.forClass(String.class);
+        verify(userService).searchUsers(any(), kw.capture(), any(), any(), any(),
+                anyBoolean(), anyLong(), any(Pageable.class));
+        assertThat(kw.getValue()).isEqualTo("ab");
+    }
+
+    // ── Pagination ───────────────────────────────────────────────────────────
+
+    @Test
+    void searchPaginationParamsHonored() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), anyLong(), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&page=2&size=5")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> pg = ArgumentCaptor.forClass(Pageable.class);
+        verify(userService).searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), anyLong(), pg.capture());
+        assertThat(pg.getValue().getPageNumber()).isEqualTo(2);
+        assertThat(pg.getValue().getPageSize()).isEqualTo(5);
+    }
+
+    @Test
+    void searchOversizedPage_clampedTo100() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), anyLong(), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&size=10000")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> pg = ArgumentCaptor.forClass(Pageable.class);
+        verify(userService).searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), anyLong(), pg.capture());
+        assertThat(pg.getValue().getPageSize()).isEqualTo(100);
+    }
+
+    @Test
+    void searchNegativePage_clampedToZero() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), anyLong(), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&page=-5")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> pg = ArgumentCaptor.forClass(Pageable.class);
+        verify(userService).searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), anyLong(), pg.capture());
+        assertThat(pg.getValue().getPageNumber()).isEqualTo(0);
+    }
+
+    // ── Multi-value filter binding ───────────────────────────────────────────
+
+    @Test
+    void searchMultiValueInterests_forwardedAsList() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), anyLong(), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&interests=AI&interests=Databases")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<String>> interests = ArgumentCaptor.forClass(List.class);
+        verify(userService).searchUsers(any(), any(), interests.capture(), any(), any(),
+                anyBoolean(), anyLong(), any(Pageable.class));
+        assertThat(interests.getValue()).containsExactly("AI", "Databases");
+    }
+
+    @Test
+    void searchAllParams_forwardedToService() throws Exception {
+        mockValidToken(2L, "MENTOR");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), anyLong(), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        // Use param() rather than inline query string so MockMvc URL-decodes
+        // the multi-word "Computer Science" value before binding.
+        mockMvc.perform(get("/api/users/search")
+                        .param("role", "MENTEE")
+                        .param("q", "research")
+                        .param("interests", "AI")
+                        .param("skills", "Java")
+                        .param("major", "Computer Science")
+                        .param("hasAvailability", "false")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+
+        verify(userService).searchUsers(
+                eq(SearchRole.MENTEE),
+                eq("research"),
+                eq(List.of("AI")),
+                eq(List.of("Java")),
+                eq("Computer Science"),
+                eq(false),
+                eq(2L),
+                any(Pageable.class));
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/SearchPerformanceTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/SearchPerformanceTest.java
@@ -1,0 +1,190 @@
+package com.group7.backend.integration;
+
+import com.group7.backend.entity.AvailabilitySlot;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.repository.AvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.service.MatchingService;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import jakarta.persistence.EntityManagerFactory;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Query-budget guard for the matching path (#262). Asserts that {@code
+ * MatchingService.getTopMentors} executes within the documented ≤7-query
+ * envelope regardless of result-set size, demonstrating the N+1 elimination.
+ *
+ * <p>Hibernate Statistics counts JPQL queries only (native queries and
+ * L1-cache hits are excluded), which matches what we want — the search path
+ * is JPQL throughout.
+ *
+ * <p>Wall-clock perf is intentionally not asserted here; CI variance makes
+ * those bounds flaky. The query-count claim is the structural invariant
+ * worth pinning.
+ */
+@SpringBootTest(properties = "spring.jpa.properties.hibernate.generate_statistics=true")
+@ActiveProfiles("test")
+class SearchPerformanceTest {
+
+    /**
+     * Hibernate {@code Statistics.getQueryExecutionCount()} counts JPQL/HQL/
+     * native query executions but excludes collection fetches (those have
+     * their own counter). For the matching path this comes out to:
+     * {@code findById(mentee)} + {@code findRankingCandidates} +
+     * {@code findByMentorIdIn} + {@code findByMenteeId} = 4. Tightened
+     * from the prior {@code ≤6} budget so any new query — re-introduced N+1
+     * fetch, audit log call, etc. — fails the test rather than silently
+     * eating headroom.
+     */
+    private static final int MAX_QUERIES_PER_SEARCH = 4;
+
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private AvailabilitySlotRepository availabilitySlotRepository;
+    @Autowired private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+    @Autowired private MatchingService matchingService;
+    @Autowired private EntityManagerFactory entityManagerFactory;
+
+    private Long menteeId;
+    private Long mentorId;
+
+    @BeforeEach
+    void seed() {
+        availabilitySlotRepository.deleteAll();
+        menteeAvailabilitySlotRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // 20 mentors with varying interests/skills/slots — large enough that
+        // a per-mentor slot fetch (the pre-#262 N+1 shape) would push the
+        // count well above 7. Small enough to keep the test fast.
+        for (int i = 0; i < 20; i++) {
+            Mentor m = new Mentor();
+            m.setFirstName("Mentor" + i);
+            m.setLastName("L");
+            m.setEmail("perf_mentor" + i + "@example.com");
+            m.setPasswordHash("x");
+            m.setIsEmailVerified(true);
+            m.setMaxMenteeCapacity(3);
+            m.setCurrentMenteeCount(0);
+            m.setExpertise("backend java systems " + i);
+            m.setInterests(List.of("AI", "Systems"));
+            m.setPreferredMenteeSkills(List.of("Java", "Python"));
+            mentorRepository.save(m);
+            if (i == 0) {
+                mentorId = m.getId();
+            }
+
+            AvailabilitySlot slot = new AvailabilitySlot();
+            slot.setMentor(m);
+            slot.setDayOfWeek(DayOfWeek.MONDAY);
+            slot.setStartTime(LocalTime.of(9, 0));
+            slot.setEndTime(LocalTime.of(11, 0));
+            availabilitySlotRepository.save(slot);
+        }
+
+        Mentee me = new Mentee();
+        me.setFirstName("Test");
+        me.setLastName("Mentee");
+        me.setEmail("perf_mentee@example.com");
+        me.setPasswordHash("x");
+        me.setIsEmailVerified(true);
+        me.setInterests(List.of("AI"));
+        me.setSkills(List.of("Java"));
+        menteeRepository.save(me);
+        menteeId = me.getId();
+
+        MenteeAvailabilitySlot meSlot = new MenteeAvailabilitySlot();
+        meSlot.setMentee(me);
+        meSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        meSlot.setStartTime(LocalTime.of(10, 0));
+        meSlot.setEndTime(LocalTime.of(12, 0));
+        menteeAvailabilitySlotRepository.save(meSlot);
+    }
+
+    private Statistics statistics() {
+        return entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+    }
+
+    @Test
+    void getTopMentors_completesWithinQueryBudget() {
+        Statistics stats = statistics();
+        // Warmup: prime the prepared-statement cache and any first-call
+        // class-loading so the measured invocation reflects steady state.
+        matchingService.getTopMentors(menteeId, null, PageRequest.of(0, 10));
+
+        long baseline = stats.getQueryExecutionCount();
+        Page<?> page = matchingService.getTopMentors(menteeId, null, PageRequest.of(0, 10));
+        long delta = stats.getQueryExecutionCount() - baseline;
+
+        assertThat(page.getContent()).isNotEmpty();
+        assertThat(delta)
+                .as("query count over a 20-mentor pool — should not scale with N")
+                .isLessThanOrEqualTo(MAX_QUERIES_PER_SEARCH);
+    }
+
+    @Test
+    void getTopMentors_keywordFilter_completesWithinQueryBudget() {
+        Statistics stats = statistics();
+        matchingService.getTopMentors(menteeId, "java", PageRequest.of(0, 10));
+
+        long baseline = stats.getQueryExecutionCount();
+        matchingService.getTopMentors(menteeId, "java", PageRequest.of(0, 10));
+        long delta = stats.getQueryExecutionCount() - baseline;
+
+        assertThat(delta).isLessThanOrEqualTo(MAX_QUERIES_PER_SEARCH);
+    }
+
+    @Test
+    void getTopMentors_emptyResult_doesNotIncurExtraQueries() {
+        Statistics stats = statistics();
+        matchingService.getTopMentors(menteeId, "nothingmatches", PageRequest.of(0, 10));
+
+        long baseline = stats.getQueryExecutionCount();
+        Page<?> page = matchingService.getTopMentors(menteeId, "nothingmatches", PageRequest.of(0, 10));
+        long delta = stats.getQueryExecutionCount() - baseline;
+
+        // Empty-result path skips the slot-batch fetch (early-return on raw.isEmpty),
+        // so the count is strictly lower than the populated path.
+        assertThat(page.getContent()).isEmpty();
+        assertThat(delta).isLessThanOrEqualTo(MAX_QUERIES_PER_SEARCH);
+    }
+
+    @Test
+    void getCandidateMentees_completesWithinQueryBudget() {
+        // Mentee path is filter-only (no scoring), so it doesn't fetch slots.
+        // Expected explicit JPQL queries: findById(mentor) + findRankingCandidates
+        // = 2. Plus collection-fetch SUBSELECTs (Mentor.interests/skills,
+        // Mentee.interests/skills) which don't show up in
+        // getQueryExecutionCount.
+        Statistics stats = statistics();
+        matchingService.getCandidateMentees(mentorId, null, PageRequest.of(0, 10));
+
+        long baseline = stats.getQueryExecutionCount();
+        Page<?> page = matchingService.getCandidateMentees(mentorId, null, PageRequest.of(0, 10));
+        long delta = stats.getQueryExecutionCount() - baseline;
+
+        assertThat(page.getContent()).isNotEmpty();
+        assertThat(delta)
+                .as("mentee-side path should issue 2 explicit queries (findById + findRankingCandidates)")
+                .isLessThanOrEqualTo(2);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/UserSearchIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/UserSearchIntegrationTest.java
@@ -1,0 +1,305 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.AvailabilitySlot;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.repository.AvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.repository.PasswordResetTokenRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for {@code GET /api/users/search} (#262). Exercises
+ * the role gate, filter pushdown, and HTTP serialisation through the full
+ * Spring stack. Real Postgres so {@code pg_trgm}-backed JPQL paths run.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class UserSearchIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private AvailabilitySlotRepository availabilitySlotRepository;
+    @Autowired private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        availabilitySlotRepository.deleteAll();
+        menteeAvailabilitySlotRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+        doNothing().when(emailService).sendPasswordResetEmail(any(), anyString());
+    }
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Test");
+        req.setLastName("User");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private Mentor findMentor(String email) {
+        return mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals(email)).findFirst().orElseThrow();
+    }
+
+    private Mentee findMentee(String email) {
+        return menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals(email)).findFirst().orElseThrow();
+    }
+
+    // ── Role gate ────────────────────────────────────────────────────────────
+
+    @Test
+    void menteeSearchingMentor_returns200AndOnlyMentorRows() throws Exception {
+        registerAndLogin("us_mentor1@example.com", true);
+        Mentor mentor = findMentor("us_mentor1@example.com");
+        mentor.setExpertise("backend java systems");
+        mentorRepository.save(mentor);
+
+        String menteeToken = registerAndLogin("us_mentee1@example.com", false);
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&q=java")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(mentor.getId()))
+                .andExpect(jsonPath("$.content[0].role").value("MENTOR"));
+    }
+
+    @Test
+    void menteeSearchingMentee_returns403() throws Exception {
+        String menteeToken = registerAndLogin("us_mentee2@example.com", false);
+
+        mockMvc.perform(get("/api/users/search?role=MENTEE")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void mentorSearchingMentee_returns200() throws Exception {
+        String mentorToken = registerAndLogin("us_mentor3@example.com", true);
+        registerAndLogin("us_mentee3@example.com", false);
+
+        mockMvc.perform(get("/api/users/search?role=MENTEE")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].role").value("MENTEE"));
+    }
+
+    @Test
+    void mentorSearchingMentor_returns403() throws Exception {
+        String mentorToken = registerAndLogin("us_mentor4@example.com", true);
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Short-keyword graceful handling ──────────────────────────────────────
+
+    @Test
+    void shortKeyword_treatedAsNoFilter_returnsAll() throws Exception {
+        registerAndLogin("us_mentor5@example.com", true);
+        registerAndLogin("us_mentor6@example.com", true);
+        String menteeToken = registerAndLogin("us_mentee5@example.com", false);
+
+        // q="ab" — service-side normaliser drops the keyword filter (pg_trgm
+        // requires ≥3 alphanumerics for index acceleration).
+        mockMvc.perform(get("/api/users/search?role=MENTOR&q=ab")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    // ── Wildcard escape ──────────────────────────────────────────────────────
+
+    @Test
+    void wildcardKeyword_escapedAsLiteral() throws Exception {
+        registerAndLogin("us_mentor7@example.com", true);
+        Mentor literal = findMentor("us_mentor7@example.com");
+        literal.setExpertise("100% throughput");
+        mentorRepository.save(literal);
+
+        registerAndLogin("us_mentor8@example.com", true);
+        Mentor wildcardish = findMentor("us_mentor8@example.com");
+        wildcardish.setExpertise("100X throughput");
+        mentorRepository.save(wildcardish);
+
+        String menteeToken = registerAndLogin("us_mentee6@example.com", false);
+
+        // q="100%" — % must be escaped service-side. Only the literal "100%"
+        // mentor matches; the "100X" mentor does not.
+        mockMvc.perform(get("/api/users/search").param("role", "MENTOR")
+                        .param("q", "100%")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(literal.getId()));
+    }
+
+    // ── hasAvailability filter ───────────────────────────────────────────────
+
+    @Test
+    void hasAvailability_returnsOnlyOverlappingMentors() throws Exception {
+        registerAndLogin("us_mentor9@example.com", true);
+        Mentor m = findMentor("us_mentor9@example.com");
+        AvailabilitySlot mSlot = new AvailabilitySlot();
+        mSlot.setMentor(m);
+        mSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        mSlot.setStartTime(LocalTime.of(9, 0));
+        mSlot.setEndTime(LocalTime.of(11, 0));
+        availabilitySlotRepository.save(mSlot);
+
+        // Mentor with no slots — should be excluded by hasAvailability=true.
+        registerAndLogin("us_mentor10@example.com", true);
+
+        String menteeToken = registerAndLogin("us_mentee7@example.com", false);
+        Mentee me = findMentee("us_mentee7@example.com");
+        MenteeAvailabilitySlot meSlot = new MenteeAvailabilitySlot();
+        meSlot.setMentee(me);
+        meSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        meSlot.setStartTime(LocalTime.of(10, 0));
+        meSlot.setEndTime(LocalTime.of(12, 0));
+        menteeAvailabilitySlotRepository.save(meSlot);
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&hasAvailability=true")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(m.getId()));
+    }
+
+    @Test
+    void hasAvailabilityWithNoOwnSlots_returns400() throws Exception {
+        registerAndLogin("us_mentor11@example.com", true);
+        String menteeToken = registerAndLogin("us_mentee8@example.com", false);
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&hasAvailability=true")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── Pagination ───────────────────────────────────────────────────────────
+
+    @Test
+    void pagination_returnsConsistentSlices() throws Exception {
+        for (int i = 0; i < 4; i++) {
+            registerAndLogin("us_pmentor" + i + "@example.com", true);
+        }
+        String menteeToken = registerAndLogin("us_pmentee@example.com", false);
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&page=0&size=2")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.totalElements").value(4));
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR&page=2&size=2")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isEmpty())
+                .andExpect(jsonPath("$.totalElements").value(4));
+    }
+
+    // ── Combined filter + visibility check ───────────────────────────────────
+
+    @Test
+    void combinedFilters_returnIntersection() throws Exception {
+        // Mentor matching both keyword and interest — included.
+        registerAndLogin("us_match@example.com", true);
+        Mentor a = findMentor("us_match@example.com");
+        a.setExpertise("backend java");
+        a.setInterests(List.of("AI"));
+        mentorRepository.save(a);
+
+        // Mentor matching only keyword — excluded by interest filter.
+        registerAndLogin("us_kwonly@example.com", true);
+        Mentor b = findMentor("us_kwonly@example.com");
+        b.setExpertise("backend java");
+        mentorRepository.save(b);
+
+        String menteeToken = registerAndLogin("us_combined@example.com", false);
+
+        MvcResult result = mockMvc.perform(get("/api/users/search").param("role", "MENTOR")
+                        .param("q", "java").param("interests", "AI")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        var json = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(json.get("totalElements").asInt()).isEqualTo(1);
+        assertThat(json.get("content").get(0).get("id").asLong()).isEqualTo(a.getId());
+    }
+
+    // ── Authentication boundary ──────────────────────────────────────────────
+
+    @Test
+    void unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/users/search?role=MENTOR"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/repository/MenteeRepositorySearchTest.java
+++ b/backend/src/test/java/com/group7/backend/repository/MenteeRepositorySearchTest.java
@@ -1,0 +1,209 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.AvailabilitySlot;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import com.group7.backend.entity.Mentor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real-Postgres SQL-filter coverage for {@link MenteeRepository#searchByFilters}.
+ * Symmetric to {@link MentorRepositorySearchTest}; this class focuses on the
+ * filters that differ from the mentor side — chiefly {@code requireUnattached}
+ * which has no mentor-side equivalent.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class MenteeRepositorySearchTest {
+
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private AvailabilitySlotRepository availabilitySlotRepository;
+    @Autowired private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+
+    @BeforeEach
+    void cleanDb() {
+        availabilitySlotRepository.deleteAll();
+        menteeAvailabilitySlotRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private Mentee newMentee(String suffix) {
+        Mentee m = new Mentee();
+        m.setFirstName("F" + suffix);
+        m.setLastName("L" + suffix);
+        m.setEmail("me" + suffix + "@example.com");
+        m.setPasswordHash("x");
+        m.setIsEmailVerified(true);
+        return m;
+    }
+
+    private Mentor newMentor(String suffix) {
+        Mentor m = new Mentor();
+        m.setFirstName("F" + suffix);
+        m.setLastName("L" + suffix);
+        m.setEmail("m" + suffix + "@example.com");
+        m.setPasswordHash("x");
+        m.setIsEmailVerified(true);
+        m.setMaxMenteeCapacity(3);
+        m.setCurrentMenteeCount(0);
+        return m;
+    }
+
+    @Test
+    void keywordMatches_goalsAndMajor() {
+        Mentee a = newMentee("a"); a.setGoals("learn machine learning");
+        Mentee b = newMentee("b"); b.setMajor("Computer Science");
+        menteeRepository.saveAll(List.of(a, b));
+
+        Page<Mentee> ml = menteeRepository.searchByFilters(
+                "%machine%", null, null, null, false, null, PageRequest.of(0, 20));
+        Page<Mentee> cs = menteeRepository.searchByFilters(
+                "%computer%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(ml.getContent()).extracting(Mentee::getId).containsExactly(a.getId());
+        assertThat(cs.getContent()).extracting(Mentee::getId).containsExactly(b.getId());
+    }
+
+    @Test
+    void keywordMatches_interestsElementCollection() {
+        Mentee m = newMentee("c"); m.setInterests(List.of("Robotics", "Drones"));
+        menteeRepository.save(m);
+
+        Page<Mentee> p = menteeRepository.searchByFilters(
+                "%drone%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    @Test
+    void keywordMatches_skillsElementCollection() {
+        Mentee m = newMentee("d"); m.setSkills(List.of("Rust", "Haskell"));
+        menteeRepository.save(m);
+
+        Page<Mentee> p = menteeRepository.searchByFilters(
+                "%haskell%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    @Test
+    void interestsFilter_orAcrossValues() {
+        Mentee a = newMentee("e1"); a.setInterests(List.of("AI"));
+        Mentee b = newMentee("e2"); b.setInterests(List.of("Robotics"));
+        Mentee c = newMentee("e3"); c.setInterests(List.of("Music"));
+        menteeRepository.saveAll(List.of(a, b, c));
+
+        Page<Mentee> p = menteeRepository.searchByFilters(
+                null, List.of("ai", "robotics"), null, null, false, null,
+                PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentee::getId)
+                .containsExactlyInAnyOrder(a.getId(), b.getId());
+    }
+
+    // ── requireUnattached: the filter that distinguishes the mentee side ─────
+
+    @Test
+    void requireUnattachedTrue_excludesAttachedMentees() {
+        Mentor mentor = newMentor("f");
+        mentorRepository.save(mentor);
+
+        Mentee attached = newMentee("g1");
+        attached.setActiveMentorId(mentor.getId());
+        Mentee unattached = newMentee("g2");
+        menteeRepository.saveAll(List.of(attached, unattached));
+
+        Page<Mentee> p = menteeRepository.searchByFilters(
+                null, null, null, null, true, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentee::getId)
+                .containsExactly(unattached.getId());
+    }
+
+    @Test
+    void requireUnattachedFalse_includesAttachedMentees() {
+        Mentor mentor = newMentor("h");
+        mentorRepository.save(mentor);
+
+        Mentee attached = newMentee("i");
+        attached.setActiveMentorId(mentor.getId());
+        menteeRepository.save(attached);
+
+        Page<Mentee> p = menteeRepository.searchByFilters(
+                null, null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    // ── Slot overlap (requesterMentorId) ────────────────────────────────────
+
+    @Test
+    void requesterMentorId_filtersByOverlap() {
+        Mentor mentor = newMentor("j");
+        mentorRepository.save(mentor);
+        AvailabilitySlot mSlot = new AvailabilitySlot();
+        mSlot.setMentor(mentor);
+        mSlot.setDayOfWeek(DayOfWeek.WEDNESDAY);
+        mSlot.setStartTime(LocalTime.of(14, 0));
+        mSlot.setEndTime(LocalTime.of(16, 0));
+        availabilitySlotRepository.save(mSlot);
+
+        Mentee me = newMentee("j");
+        menteeRepository.save(me);
+        MenteeAvailabilitySlot meSlot = new MenteeAvailabilitySlot();
+        meSlot.setMentee(me);
+        meSlot.setDayOfWeek(DayOfWeek.WEDNESDAY);
+        meSlot.setStartTime(LocalTime.of(15, 0));
+        meSlot.setEndTime(LocalTime.of(17, 0));
+        menteeAvailabilitySlotRepository.save(meSlot);
+
+        Page<Mentee> p = menteeRepository.searchByFilters(
+                null, null, null, null, false, mentor.getId(),
+                PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentee::getId).containsExactly(me.getId());
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────────────
+
+    @Test
+    void emptyResult_returnsEmptyPage() {
+        Page<Mentee> p = menteeRepository.searchByFilters(
+                "%nothingmatches%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).isEmpty();
+    }
+
+    @Test
+    void wildcardEscape_treatedAsLiteral() {
+        Mentee a = newMentee("k1"); a.setGoals("100% throughput");
+        Mentee b = newMentee("k2"); b.setGoals("100X throughput");
+        menteeRepository.saveAll(List.of(a, b));
+
+        Page<Mentee> p = menteeRepository.searchByFilters(
+                "%100|%%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentee::getId).containsExactly(a.getId());
+    }
+
+    @Test
+    void sqlInjectionAttempt_treatedAsLiteralSubstring() {
+        Mentee m = newMentee("l"); m.setGoals("hello");
+        menteeRepository.save(m);
+
+        long before = menteeRepository.count();
+        Page<Mentee> p = menteeRepository.searchByFilters(
+                "%'; drop table mentees; --%", null, null, null, false, null,
+                PageRequest.of(0, 20));
+        long after = menteeRepository.count();
+        assertThat(after).isEqualTo(before);
+        assertThat(p.getContent()).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/repository/MentorRepositorySearchTest.java
+++ b/backend/src/test/java/com/group7/backend/repository/MentorRepositorySearchTest.java
@@ -1,0 +1,431 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.AvailabilitySlot;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import com.group7.backend.entity.Mentor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real-Postgres SQL-filter coverage for {@link MentorRepository#searchByFilters}.
+ * Exercises the JPQL paths that the matching service and {@code /api/users/search}
+ * funnel through. H2 lacks {@code pg_trgm}, so this test pins to the {@code test}
+ * profile (Postgres on localhost:5433).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class MentorRepositorySearchTest {
+
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private AvailabilitySlotRepository availabilitySlotRepository;
+    @Autowired private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+
+    @BeforeEach
+    void cleanDb() {
+        availabilitySlotRepository.deleteAll();
+        menteeAvailabilitySlotRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    private Mentor newMentor(String suffix) {
+        Mentor m = new Mentor();
+        m.setFirstName("F" + suffix);
+        m.setLastName("L" + suffix);
+        m.setEmail("m" + suffix + "@example.com");
+        m.setPasswordHash("x");
+        m.setIsEmailVerified(true);
+        m.setMaxMenteeCapacity(3);
+        m.setCurrentMenteeCount(0);
+        return m;
+    }
+
+    private Mentee newMentee(String suffix) {
+        Mentee m = new Mentee();
+        m.setFirstName("F" + suffix);
+        m.setLastName("L" + suffix);
+        m.setEmail("me" + suffix + "@example.com");
+        m.setPasswordHash("x");
+        m.setIsEmailVerified(true);
+        return m;
+    }
+
+    // ── Keyword paths across each searchable field ───────────────────────────
+
+    @Test
+    void keywordMatches_expertise() {
+        Mentor m = newMentor("a"); m.setExpertise("backend java systems");
+        mentorRepository.save(m);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%java%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(m.getId());
+    }
+
+    @Test
+    void keywordMatches_field() {
+        Mentor m = newMentor("b"); m.setField("Computer Science");
+        mentorRepository.save(m);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%computer%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    @Test
+    void keywordMatches_mentoringGoals() {
+        Mentor m = newMentor("c"); m.setMentoringGoals("Help students with thesis writing");
+        mentorRepository.save(m);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%thesis%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    @Test
+    void keywordMatches_interestsElementCollection() {
+        Mentor m = newMentor("d"); m.setInterests(List.of("Machine Learning", "Robotics"));
+        mentorRepository.save(m);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%machine%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    @Test
+    void keywordMatches_preferredMenteeSkillsElementCollection() {
+        Mentor m = newMentor("e"); m.setPreferredMenteeSkills(List.of("Python", "Kotlin"));
+        mentorRepository.save(m);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%kotlin%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    @Test
+    void keywordIsCaseInsensitive() {
+        Mentor m = newMentor("f"); m.setExpertise("Backend Java");
+        mentorRepository.save(m);
+
+        // Caller normalises to lowercase before passing — JPQL uses LOWER(col) LIKE :keyword.
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%java%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    // ── Multi-value filters (OR semantics within a category) ─────────────────
+
+    @Test
+    void interestsFilter_orAcrossValues() {
+        Mentor a = newMentor("g1"); a.setInterests(List.of("AI"));
+        Mentor b = newMentor("g2"); b.setInterests(List.of("Robotics"));
+        Mentor c = newMentor("g3"); c.setInterests(List.of("Music"));
+        mentorRepository.saveAll(List.of(a, b, c));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, List.of("ai", "robotics"), null, null, false, null,
+                PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId)
+                .containsExactlyInAnyOrder(a.getId(), b.getId());
+    }
+
+    @Test
+    void skillsFilter_orAcrossValues() {
+        Mentor a = newMentor("h1"); a.setPreferredMenteeSkills(List.of("Java"));
+        Mentor b = newMentor("h2"); b.setPreferredMenteeSkills(List.of("Go"));
+        mentorRepository.saveAll(List.of(a, b));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, List.of("java", "go"), null, false, null,
+                PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId)
+                .containsExactlyInAnyOrder(a.getId(), b.getId());
+    }
+
+    @Test
+    void majorFilter_matchesPreferredMenteeMajorOrField() {
+        Mentor a = newMentor("i1"); a.setPreferredMenteeMajor("Computer Science");
+        Mentor b = newMentor("i2"); b.setField("Computer Science");
+        Mentor c = newMentor("i3"); c.setField("Mathematics");
+        mentorRepository.saveAll(List.of(a, b, c));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, "computer science", false, null,
+                PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId)
+                .containsExactlyInAnyOrder(a.getId(), b.getId());
+    }
+
+    // ── Capacity gate ────────────────────────────────────────────────────────
+
+    @Test
+    void requireCapacityTrue_excludesFullMentor() {
+        Mentor full = newMentor("j1");
+        full.setMaxMenteeCapacity(2); full.setCurrentMenteeCount(2);
+        Mentor avail = newMentor("j2");
+        avail.setMaxMenteeCapacity(2); avail.setCurrentMenteeCount(1);
+        mentorRepository.saveAll(List.of(full, avail));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, true, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(avail.getId());
+    }
+
+    @Test
+    void requireCapacityFalse_includesFullMentor() {
+        Mentor full = newMentor("k");
+        full.setMaxMenteeCapacity(1); full.setCurrentMenteeCount(1);
+        mentorRepository.save(full);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    @Test
+    void capacityBoundary_oneLessThanMaxIsIncluded() {
+        Mentor m = newMentor("l");
+        m.setMaxMenteeCapacity(3); m.setCurrentMenteeCount(2);
+        mentorRepository.save(m);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, true, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).hasSize(1);
+    }
+
+    // ── Slot-overlap gate (requesterMenteeId) ────────────────────────────────
+
+    @Test
+    void requesterMenteeId_filtersByOverlap() {
+        Mentor m = newMentor("n");
+        mentorRepository.save(m);
+        AvailabilitySlot mSlot = new AvailabilitySlot();
+        mSlot.setMentor(m);
+        mSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        mSlot.setStartTime(LocalTime.of(9, 0));
+        mSlot.setEndTime(LocalTime.of(11, 0));
+        availabilitySlotRepository.save(mSlot);
+
+        Mentee me = newMentee("n");
+        menteeRepository.save(me);
+        MenteeAvailabilitySlot meSlot = new MenteeAvailabilitySlot();
+        meSlot.setMentee(me);
+        meSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        meSlot.setStartTime(LocalTime.of(10, 0));
+        meSlot.setEndTime(LocalTime.of(12, 0));
+        menteeAvailabilitySlotRepository.save(meSlot);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, me.getId(), PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(m.getId());
+    }
+
+    @Test
+    void requesterMenteeId_excludesNonOverlapping() {
+        Mentor m = newMentor("o");
+        mentorRepository.save(m);
+        AvailabilitySlot mSlot = new AvailabilitySlot();
+        mSlot.setMentor(m);
+        mSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        mSlot.setStartTime(LocalTime.of(9, 0));
+        mSlot.setEndTime(LocalTime.of(10, 0));
+        availabilitySlotRepository.save(mSlot);
+
+        Mentee me = newMentee("o");
+        menteeRepository.save(me);
+        MenteeAvailabilitySlot meSlot = new MenteeAvailabilitySlot();
+        meSlot.setMentee(me);
+        meSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        // Adjacent but non-overlapping: 10:00-11:00 vs mentor 09:00-10:00.
+        // Strict < on both inequalities.
+        meSlot.setStartTime(LocalTime.of(10, 0));
+        meSlot.setEndTime(LocalTime.of(11, 0));
+        menteeAvailabilitySlotRepository.save(meSlot);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, me.getId(), PageRequest.of(0, 20));
+        assertThat(p.getContent()).isEmpty();
+    }
+
+    @Test
+    void requesterMenteeId_crossDayDoesNotOverlap() {
+        Mentor m = newMentor("p");
+        mentorRepository.save(m);
+        AvailabilitySlot mSlot = new AvailabilitySlot();
+        mSlot.setMentor(m);
+        mSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        mSlot.setStartTime(LocalTime.of(9, 0));
+        mSlot.setEndTime(LocalTime.of(11, 0));
+        availabilitySlotRepository.save(mSlot);
+
+        Mentee me = newMentee("p");
+        menteeRepository.save(me);
+        MenteeAvailabilitySlot meSlot = new MenteeAvailabilitySlot();
+        meSlot.setMentee(me);
+        meSlot.setDayOfWeek(DayOfWeek.TUESDAY);
+        meSlot.setStartTime(LocalTime.of(9, 0));
+        meSlot.setEndTime(LocalTime.of(11, 0));
+        menteeAvailabilitySlotRepository.save(meSlot);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, me.getId(), PageRequest.of(0, 20));
+        assertThat(p.getContent()).isEmpty();
+    }
+
+    // ── Wildcard escape (correctness-required) ───────────────────────────────
+
+    @Test
+    void wildcardPercent_escapedAsLiteral() {
+        Mentor a = newMentor("q1"); a.setExpertise("abc%def");
+        Mentor b = newMentor("q2"); b.setExpertise("abcXdef");
+        mentorRepository.saveAll(List.of(a, b));
+
+        // Caller escapes % as |% (ESCAPE '|') so the search treats it as literal.
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%abc|%def%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(a.getId());
+    }
+
+    @Test
+    void wildcardUnderscore_escapedAsLiteral() {
+        Mentor a = newMentor("r1"); a.setExpertise("abc_def");
+        Mentor b = newMentor("r2"); b.setExpertise("abcXdef");
+        mentorRepository.saveAll(List.of(a, b));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%abc|_def%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(a.getId());
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────────────
+
+    @Test
+    void emptyResult_returnsEmptyPage() {
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%nothingmatchesthis%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).isEmpty();
+        assertThat(p.getTotalElements()).isZero();
+    }
+
+    @Test
+    void nullColumns_doNotMatchKeyword() {
+        // Mentor with no fields populated — keyword search should not match
+        // and not throw NPE on the LIKE evaluation.
+        Mentor m = newMentor("s");  // expertise/field/etc. all null
+        mentorRepository.save(m);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%anything%", null, null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).isEmpty();
+    }
+
+    @Test
+    void emptyElementCollection_doesNotMatchInterestFilter() {
+        Mentor m = newMentor("t");  // no interests set
+        mentorRepository.save(m);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, List.of("ai"), null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).isEmpty();
+    }
+
+    @Test
+    void duplicateInterestValues_idempotent() {
+        Mentor m = newMentor("u"); m.setInterests(List.of("AI"));
+        mentorRepository.save(m);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, List.of("ai", "ai"), null, null, false, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(m.getId());
+    }
+
+    @Test
+    void combinedFilters_appliedAsAndAcrossCategories() {
+        // Capacity AND interest must both match.
+        Mentor a = newMentor("v1");
+        a.setMaxMenteeCapacity(3); a.setCurrentMenteeCount(0);
+        a.setInterests(List.of("AI"));
+
+        Mentor b = newMentor("v2");
+        b.setMaxMenteeCapacity(1); b.setCurrentMenteeCount(1);  // full
+        b.setInterests(List.of("AI"));
+
+        Mentor c = newMentor("v3");
+        c.setMaxMenteeCapacity(3); c.setCurrentMenteeCount(0);
+        c.setInterests(List.of("Music"));
+
+        mentorRepository.saveAll(List.of(a, b, c));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, List.of("ai"), null, null, true, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(a.getId());
+    }
+
+    // ── SQL-injection probe ─────────────────────────────────────────────────
+
+    @Test
+    void sqlInjectionAttempt_treatedAsLiteralSubstring() {
+        Mentor m = newMentor("w"); m.setExpertise("backend");
+        mentorRepository.save(m);
+
+        long before = mentorRepository.count();
+        // Caller would send escaped form. The keyword is matched as a literal
+        // — no parser interpretation. The mentors table is not dropped.
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                "%'; drop table mentors; --%", null, null, null, false, null,
+                PageRequest.of(0, 20));
+        long after = mentorRepository.count();
+        assertThat(after).isEqualTo(before);
+        assertThat(p.getContent()).isEmpty();
+    }
+
+    // ── Pagination ──────────────────────────────────────────────────────────
+
+    @Test
+    void pagination_returnsRequestedSliceWithCorrectTotal() {
+        for (int i = 0; i < 5; i++) {
+            mentorRepository.save(newMentor("x" + i));
+        }
+
+        Page<Mentor> page0 = mentorRepository.searchByFilters(
+                null, null, null, null, false, null, PageRequest.of(0, 2));
+        Page<Mentor> page1 = mentorRepository.searchByFilters(
+                null, null, null, null, false, null, PageRequest.of(1, 2));
+
+        assertThat(page0.getContent()).hasSize(2);
+        assertThat(page0.getTotalElements()).isEqualTo(5);
+        assertThat(page1.getContent()).hasSize(2);
+        // Page 0 and page 1 must be disjoint.
+        assertThat(page0.getContent()).noneMatch(m1 ->
+                page1.getContent().stream().anyMatch(m2 -> m2.getId().equals(m1.getId())));
+    }
+
+    @Test
+    void pagination_orderByIdDescIsDeterministic() {
+        Mentor a = newMentor("y1");
+        Mentor b = newMentor("y2");
+        Mentor c = newMentor("y3");
+        mentorRepository.saveAll(List.of(a, b, c));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, null, PageRequest.of(0, 10));
+        // Default ORDER BY m.id DESC — newer first.
+        List<Long> ids = p.getContent().stream().map(Mentor::getId).toList();
+        assertThat(ids).containsExactly(c.getId(), b.getId(), a.getId());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
@@ -6,15 +6,15 @@ import com.group7.backend.entity.AvailabilitySlot;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.MenteeAvailabilitySlot;
 import com.group7.backend.entity.Mentor;
-import com.group7.backend.repository.AvailabilitySlotRepository;
 import com.group7.backend.exception.ResourceNotFoundException;
-import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.AvailabilitySlotRepository;
 import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeRepository;
 import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.service.ranking.RuleBasedMentorRanker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -28,30 +28,42 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Service-level orchestration tests for {@link MatchingService}. The legacy
+ * scoring algorithm assertions moved into
+ * {@code RuleBasedMentorRankerTest} after the ranker extraction (#262); the
+ * service uses a real {@link RuleBasedMentorRanker} instance here so the
+ * orchestration assertions still observe end-to-end scoring outputs without
+ * needing to mock the ranker.
+ *
+ * <p>Repository mocks reflect the post-#262 shape: the matching path uses
+ * {@code findRankingCandidates} (List, no count) on both
+ * {@code MentorRepository} and {@code MenteeRepository}, plus
+ * {@code findByMentorIdIn} for the batch availability fetch. The
+ * {@code searchByFilters} (Page) variants are exercised through
+ * {@code UserSearchControllerTest} / {@code UserSearchIntegrationTest}.
+ */
 @ExtendWith(MockitoExtension.class)
 class MatchingServiceTest {
 
-    @Mock
-    private MenteeRepository menteeRepository;
+    @Mock private MenteeRepository menteeRepository;
+    @Mock private MentorRepository mentorRepository;
+    @Mock private AvailabilitySlotRepository availabilitySlotRepository;
+    @Mock private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+    @Mock private NotificationEventPublisher notificationEventPublisher;
 
-    @Mock
-    private MentorRepository mentorRepository;
-
-    @Mock
-    private AvailabilitySlotRepository availabilitySlotRepository;
-
-    @Mock
-    private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
-
-    @Mock
-    private NotificationEventPublisher notificationEventPublisher;
-
-    @InjectMocks
     private MatchingService matchingService;
 
     private Mentee mentee;
@@ -60,8 +72,17 @@ class MatchingServiceTest {
 
     @BeforeEach
     void setUp() {
+        matchingService = new MatchingService(
+                menteeRepository, mentorRepository,
+                availabilitySlotRepository, menteeAvailabilitySlotRepository,
+                new RuleBasedMentorRanker(),  // real ranker — pure function over already-loaded entities
+                notificationEventPublisher);
+
         pageable = PageRequest.of(0, 20);
+
         mentee = new Mentee();
+        mentee.setId(1L);
+        mentee.setFirstName("Eli");
         mentee.setMajor("Computer Science");
         mentee.setGoals("career machine learning");
         mentee.setCareerInterest("backend engineering");
@@ -69,6 +90,8 @@ class MatchingServiceTest {
         mentee.setSkills(List.of("Java", "Python"));
 
         mentor = new Mentor();
+        mentor.setId(2L);
+        mentor.setFirstName("Mira");
         mentor.setMaxMenteeCapacity(3);
         mentor.setCurrentMenteeCount(1);
         mentor.setField("Computer Science");
@@ -78,125 +101,16 @@ class MatchingServiceTest {
         mentor.setInterests(List.of("AI", "Systems"));
         mentor.setMentoringGoals("Help with career and machine learning projects");
 
-        lenient().when(availabilitySlotRepository.findByMentorId(anyLong())).thenReturn(List.of());
-        lenient().when(menteeAvailabilitySlotRepository.findByMenteeId(anyLong())).thenReturn(List.of());
+        // Default: no availability data on either side — score reflects
+        // profile-only contributions, mirroring the pre-refactor lenient
+        // mocks. Tests that exercise availability override these.
+        lenient().when(availabilitySlotRepository.findByMentorIdIn(anyCollection()))
+                .thenReturn(List.of());
+        lenient().when(menteeAvailabilitySlotRepository.findByMenteeId(anyLong()))
+                .thenReturn(List.of());
     }
 
-    private AvailabilitySlot mentorSlot(DayOfWeek dayOfWeek, String start, String end) {
-        AvailabilitySlot slot = new AvailabilitySlot();
-        slot.setDayOfWeek(dayOfWeek);
-        slot.setStartTime(LocalTime.parse(start));
-        slot.setEndTime(LocalTime.parse(end));
-        slot.setRecurring(true);
-        return slot;
-    }
-
-    private MenteeAvailabilitySlot menteeSlot(DayOfWeek dayOfWeek, String start, String end) {
-        MenteeAvailabilitySlot slot = new MenteeAvailabilitySlot();
-        slot.setDayOfWeek(dayOfWeek);
-        slot.setStartTime(LocalTime.parse(start));
-        slot.setEndTime(LocalTime.parse(end));
-        slot.setRecurring(true);
-        return slot;
-    }
-
-    // ── Score calculation ────────────────────────────────────────────────────
-
-    @Test
-    void scoreOverlappingInterests() {
-        // Mentee has AI and Databases; mentor has AI and Systems → 1 overlap = +3
-        int score = matchingService.calculateScore(mentor, mentee);
-        assertThat(score).isGreaterThanOrEqualTo(3);
-    }
-
-    @Test
-    void scoreSkillMatch() {
-        // Java is in preferredMenteeSkills → +3
-        Mentor m = new Mentor();
-        m.setMaxMenteeCapacity(3);
-        m.setCurrentMenteeCount(0);
-        m.setPreferredMenteeSkills(List.of("Java"));
-
-        Mentee me = new Mentee();
-        me.setSkills(List.of("Java"));
-
-        int score = matchingService.calculateScore(m, me);
-        assertThat(score).isEqualTo(3);
-    }
-
-    @Test
-    void scoreMajorMatchesPreferredMenteeMajor() {
-        // Computer Science == Computer Science → +5
-        Mentor m = new Mentor();
-        m.setMaxMenteeCapacity(3);
-        m.setCurrentMenteeCount(0);
-        m.setPreferredMenteeMajor("Computer Science");
-
-        Mentee me = new Mentee();
-        me.setMajor("Computer Science");
-
-        int score = matchingService.calculateScore(m, me);
-        assertThat(score).isEqualTo(5);
-    }
-
-    @Test
-    void scoreMajorMatchesField() {
-        // Mentee major == mentor field → +3
-        Mentor m = new Mentor();
-        m.setMaxMenteeCapacity(3);
-        m.setCurrentMenteeCount(0);
-        m.setField("Computer Science");
-
-        Mentee me = new Mentee();
-        me.setMajor("Computer Science");
-
-        int score = matchingService.calculateScore(m, me);
-        assertThat(score).isEqualTo(3);
-    }
-
-    @Test
-    void scoreGoalsKeywordOverlap() {
-        // "machine" and "learning" are in mentor mentoringGoals → +2 each
-        Mentor m = new Mentor();
-        m.setMaxMenteeCapacity(3);
-        m.setCurrentMenteeCount(0);
-        m.setMentoringGoals("machine learning and career guidance");
-
-        Mentee me = new Mentee();
-        me.setGoals("machine learning");
-
-        int score = matchingService.calculateScore(m, me);
-        assertThat(score).isEqualTo(4); // "machine" +2, "learning" +2
-    }
-
-    @Test
-    void scoreNullFieldsDoNotCrash() {
-        Mentor m = new Mentor();
-        m.setMaxMenteeCapacity(3);
-        m.setCurrentMenteeCount(0);
-        // all fields null
-
-        Mentee me = new Mentee();
-        // all fields null
-
-        int score = matchingService.calculateScore(m, me);
-        assertThat(score).isEqualTo(0);
-    }
-
-    // ── Capacity filter ──────────────────────────────────────────────────────
-
-    @Test
-    void fullCapacityMentorExcluded() {
-        mentor.setCurrentMenteeCount(3); // full
-        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        when(mentorRepository.findAll()).thenReturn(List.of(mentor));
-
-        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, pageable);
-
-        assertThat(result.getContent()).isEmpty();
-    }
-
-    // ── Active mentor check ──────────────────────────────────────────────────
+    // ── Active mentor / mentee not found ──────────────────────────────────
 
     @Test
     void activeMentorBlocksRequest() {
@@ -208,8 +122,6 @@ class MatchingServiceTest {
                 .hasMessageContaining("active mentor");
     }
 
-    // ── Mentee not found ─────────────────────────────────────────────────────
-
     @Test
     void menteeNotFoundThrows() {
         when(menteeRepository.findById(99L)).thenReturn(Optional.empty());
@@ -218,22 +130,35 @@ class MatchingServiceTest {
                 .isInstanceOf(ResourceNotFoundException.class);
     }
 
-    // ── Top 5 limit ──────────────────────────────────────────────────────────
+    // ── Capacity filter (now SQL-side) ────────────────────────────────────
+
+    @Test
+    void searchByFilters_invokedWithRequireCapacityTrue() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
+
+        matchingService.getTopMentors(1L, null, pageable);
+
+        // Verify the SQL filter pushes capacity, not in-memory.
+        verify(mentorRepository).findRankingCandidates(
+                any(), any(), any(), any(), eq(true), any(), any(Pageable.class));
+    }
+
+    // ── Pagination ────────────────────────────────────────────────────────
 
     @Test
     void paginationReturnsRequestedPageSize() {
         List<Mentor> sixMentors = java.util.stream.IntStream.range(0, 6).mapToObj(i -> {
             Mentor m = new Mentor();
+            m.setId((long) (10 + i));
             m.setMaxMenteeCapacity(3);
             m.setCurrentMenteeCount(0);
             return m;
         }).toList();
-
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        when(mentorRepository.findAll()).thenReturn(sixMentors);
+        stubMentorSearch(sixMentors);
 
-        Pageable smallPage = PageRequest.of(0, 3);
-        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, smallPage);
+        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, PageRequest.of(0, 3));
 
         assertThat(result.getContent()).hasSize(3);
         assertThat(result.getTotalElements()).isEqualTo(6);
@@ -244,16 +169,15 @@ class MatchingServiceTest {
     void paginationReturnsSecondPage() {
         List<Mentor> sixMentors = java.util.stream.IntStream.range(0, 6).mapToObj(i -> {
             Mentor m = new Mentor();
+            m.setId((long) (10 + i));
             m.setMaxMenteeCapacity(3);
             m.setCurrentMenteeCount(0);
             return m;
         }).toList();
-
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        when(mentorRepository.findAll()).thenReturn(sixMentors);
+        stubMentorSearch(sixMentors);
 
-        Pageable secondPage = PageRequest.of(1, 4);
-        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, secondPage);
+        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, PageRequest.of(1, 4));
 
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(6);
@@ -263,49 +187,93 @@ class MatchingServiceTest {
     @Test
     void paginationBeyondTotalReturnsEmptyPage() {
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        when(mentorRepository.findAll()).thenReturn(List.of(mentor));
+        stubMentorSearch(List.of(mentor));
 
-        Pageable farPage = PageRequest.of(10, 20);
-        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, farPage);
+        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, PageRequest.of(10, 20));
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isEqualTo(1);
     }
 
-    // ── Keyword filter ───────────────────────────────────────────────────────
-
     @Test
-    void keywordFilterMatchesExpertise() {
+    void paginationWithIntegerOverflowOffset_returnsEmptyPage() {
+        // page=Integer.MAX_VALUE with size>1 makes Pageable.getOffset() exceed
+        // Integer.MAX_VALUE; a naive `(int) offset` cast wraps to a negative
+        // start and crashes List.subList with IndexOutOfBoundsException.
+        // slicePage compares the offset in long-space first to keep the cast
+        // safe. Reachable through the public matching/search endpoints
+        // because clampPageable does not bound the page number.
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        when(mentorRepository.findAll()).thenReturn(List.of(mentor));
+        stubMentorSearch(List.of(mentor));
 
-        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, "Java", pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-        verify(notificationEventPublisher).publishMatchFound(1L, result.getContent().get(0).getFirstName());
-    }
-
-    @Test
-    void keywordFilterNoMatchReturnsEmpty() {
-        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        when(mentorRepository.findAll()).thenReturn(List.of(mentor));
-
-        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, "rust", pageable);
+        Page<MentorMatchResponse> result = matchingService.getTopMentors(
+                1L, null, PageRequest.of(Integer.MAX_VALUE, 2));
 
         assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    // ── Keyword filter (now SQL-side) ─────────────────────────────────────
+
+    @Test
+    void keywordFilter_passesNormalisedKeywordToRepo() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
+
+        matchingService.getTopMentors(1L, "Java", pageable);
+
+        // Service normaliseKeyword: trim + lowercase + escape + wrap %...%.
+        verify(mentorRepository).findRankingCandidates(
+                eq("%java%"), any(), any(), any(), anyBoolean(), any(), any());
     }
 
     @Test
-    void nullKeywordReturnsAll() {
+    void shortKeyword_skipsKeywordFilter() {
+        // q="ab" length 2 < 3 — service treats as null, no filter applied.
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        when(mentorRepository.findAll()).thenReturn(List.of(mentor));
+        stubMentorSearch(List.of(mentor));
 
-        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, pageable);
+        matchingService.getTopMentors(1L, "ab", pageable);
 
-        assertThat(result.getContent()).hasSize(1);
+        verify(mentorRepository).findRankingCandidates(
+                eq(null), any(), any(), any(), anyBoolean(), any(), any());
     }
 
-    // ── Ordering ─────────────────────────────────────────────────────────────
+    @Test
+    void blankKeyword_skipsKeywordFilter() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
+
+        matchingService.getTopMentors(1L, "   ", pageable);
+
+        verify(mentorRepository).findRankingCandidates(
+                eq(null), any(), any(), any(), anyBoolean(), any(), any());
+    }
+
+    @Test
+    void nullKeyword_skipsKeywordFilter() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
+
+        matchingService.getTopMentors(1L, null, pageable);
+
+        verify(mentorRepository).findRankingCandidates(
+                eq(null), any(), any(), any(), anyBoolean(), any(), any());
+    }
+
+    @Test
+    void wildcardEscape_keywordContainingPercent_isLiteralised() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
+
+        matchingService.getTopMentors(1L, "abc%def", pageable);
+
+        // Escape order: pipe first, then % and _. Result: "%abc|%def%".
+        verify(mentorRepository).findRankingCandidates(
+                eq("%abc|%def%"), any(), any(), any(), anyBoolean(), any(), any());
+    }
+
+    // ── Ordering ──────────────────────────────────────────────────────────
 
     @Test
     void resultsOrderedByScoreDescending() {
@@ -313,151 +281,131 @@ class MatchingServiceTest {
         lowScore.setId(7L);
         lowScore.setMaxMenteeCapacity(3);
         lowScore.setCurrentMenteeCount(0);
-        // no matching fields → score 0
-
-        mentee.setId(1L);
-        mentor.setId(2L);
+        // No matching fields → score 0.
 
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        when(mentorRepository.findAll()).thenReturn(List.of(lowScore, mentor));
+        stubMentorSearch(List.of(lowScore, mentor));
 
         Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, pageable);
 
-        assertThat(result.getContent().get(0).getMatchScore()).isGreaterThanOrEqualTo(result.getContent().get(1).getMatchScore());
-    }
-
-    @Test
-    void availabilityScoreUsesOverlapAndCapsAtTwelve() {
-    when(availabilitySlotRepository.findByMentorId(2L)).thenReturn(List.of(
-        mentorSlot(DayOfWeek.MONDAY, "09:00", "18:00")));
-    when(menteeAvailabilitySlotRepository.findByMenteeId(1L)).thenReturn(List.of(
-        menteeSlot(DayOfWeek.MONDAY, "09:00", "17:00")));
-
-    int score = matchingService.calculateAvailabilityScore(2L, 1L);
-
-    assertThat(score).isEqualTo(12);
-    }
-
-    @Test
-    void availabilityScoreReturnsZeroWithoutSlots() {
-    int score = matchingService.calculateAvailabilityScore(2L, 1L);
-
-    assertThat(score).isEqualTo(0);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getMatchScore())
+                .isGreaterThanOrEqualTo(result.getContent().get(1).getMatchScore());
     }
 
     @Test
     void availabilityCanBreakTieBetweenMentors() {
-    Mentor mentorWithoutOverlap = new Mentor();
-    mentorWithoutOverlap.setId(9L);
-    mentorWithoutOverlap.setMaxMenteeCapacity(3);
-    mentorWithoutOverlap.setCurrentMenteeCount(0);
-    mentorWithoutOverlap.setField(mentor.getField());
-    mentorWithoutOverlap.setPreferredMenteeMajor(mentor.getPreferredMenteeMajor());
-    mentorWithoutOverlap.setPreferredMenteeSkills(mentor.getPreferredMenteeSkills());
-    mentorWithoutOverlap.setInterests(mentor.getInterests());
-    mentorWithoutOverlap.setMentoringGoals(mentor.getMentoringGoals());
-    mentorWithoutOverlap.setExpertise(mentor.getExpertise());
+        Mentor mentorWithoutOverlap = new Mentor();
+        mentorWithoutOverlap.setId(9L);
+        mentorWithoutOverlap.setMaxMenteeCapacity(3);
+        mentorWithoutOverlap.setCurrentMenteeCount(0);
+        mentorWithoutOverlap.setField(mentor.getField());
+        mentorWithoutOverlap.setPreferredMenteeMajor(mentor.getPreferredMenteeMajor());
+        mentorWithoutOverlap.setPreferredMenteeSkills(mentor.getPreferredMenteeSkills());
+        mentorWithoutOverlap.setInterests(mentor.getInterests());
+        mentorWithoutOverlap.setMentoringGoals(mentor.getMentoringGoals());
+        mentorWithoutOverlap.setExpertise(mentor.getExpertise());
 
-    mentor.setId(2L);
-    mentee.setId(1L);
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentorWithoutOverlap, mentor));
 
-    when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-    when(mentorRepository.findAll()).thenReturn(List.of(mentorWithoutOverlap, mentor));
-    when(availabilitySlotRepository.findByMentorId(2L)).thenReturn(List.of(
-        mentorSlot(DayOfWeek.MONDAY, "10:00", "12:00")));
-    when(availabilitySlotRepository.findByMentorId(9L)).thenReturn(List.of(
-        mentorSlot(DayOfWeek.MONDAY, "14:00", "16:00")));
-    when(menteeAvailabilitySlotRepository.findByMenteeId(1L)).thenReturn(List.of(
-        menteeSlot(DayOfWeek.MONDAY, "10:30", "11:30")));
+        // Mentor 2L has overlapping slot; mentor 9L does not.
+        AvailabilitySlot mentor2Slot = new AvailabilitySlot();
+        mentor2Slot.setDayOfWeek(DayOfWeek.MONDAY);
+        mentor2Slot.setStartTime(LocalTime.parse("10:00"));
+        mentor2Slot.setEndTime(LocalTime.parse("12:00"));
+        mentor2Slot.setMentor(mentor);
+        AvailabilitySlot mentor9Slot = new AvailabilitySlot();
+        mentor9Slot.setDayOfWeek(DayOfWeek.MONDAY);
+        mentor9Slot.setStartTime(LocalTime.parse("14:00"));
+        mentor9Slot.setEndTime(LocalTime.parse("16:00"));
+        mentor9Slot.setMentor(mentorWithoutOverlap);
+        when(availabilitySlotRepository.findByMentorIdIn(anyCollection()))
+                .thenReturn(List.of(mentor2Slot, mentor9Slot));
 
-    Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, pageable);
+        MenteeAvailabilitySlot menteeSlot = new MenteeAvailabilitySlot();
+        menteeSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        menteeSlot.setStartTime(LocalTime.parse("10:30"));
+        menteeSlot.setEndTime(LocalTime.parse("11:30"));
+        when(menteeAvailabilitySlotRepository.findByMenteeId(1L))
+                .thenReturn(List.of(menteeSlot));
 
-    assertThat(result.getContent()).hasSize(2);
-    assertThat(result.getContent().get(0).getId()).isEqualTo(2L);
-    assertThat(result.getContent().get(0).getMatchScore()).isGreaterThan(result.getContent().get(1).getMatchScore());
+        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, pageable);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getId()).isEqualTo(2L);
+        assertThat(result.getContent().get(0).getMatchScore())
+                .isGreaterThan(result.getContent().get(1).getMatchScore());
     }
 
-    // ── Candidate mentees: preference matching ──────────────────────────────
+    // ── N+1 elimination — slot batch fetched once ─────────────────────────
 
     @Test
-    void candidateMenteesMatchesByInterest() {
-        assertThat(matchingService.matchesMentorPreferences(mentor, mentee)).isTrue();
-    }
+    void rankMentors_batchFetchesSlotsExactlyOnce() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
 
-    @Test
-    void candidateMenteesMatchesBySkill() {
-        Mentor m = new Mentor();
-        m.setPreferredMenteeSkills(List.of("Python"));
+        matchingService.getTopMentors(1L, null, pageable);
 
-        Mentee me = new Mentee();
-        me.setSkills(List.of("Python"));
-
-        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
-    }
-
-    @Test
-    void candidateMenteesMatchesByPreferredMajor() {
-        Mentor m = new Mentor();
-        m.setPreferredMenteeMajor("Computer Science");
-
-        Mentee me = new Mentee();
-        me.setMajor("Computer Science");
-
-        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
-    }
-
-    @Test
-    void candidateMenteesMatchesByField() {
-        Mentor m = new Mentor();
-        m.setField("Computer Science");
-
-        Mentee me = new Mentee();
-        me.setMajor("Computer Science");
-
-        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
+        verify(availabilitySlotRepository, times(1)).findByMentorIdIn(anyCollection());
+        verify(availabilitySlotRepository, never()).findByMentorId(anyLong());
+        verify(menteeAvailabilitySlotRepository, times(1)).findByMenteeId(1L);
     }
 
     @Test
-    void candidateMenteesNoOverlapReturnsfalse() {
-        Mentor m = new Mentor();
-        m.setField("Music");
-        m.setPreferredMenteeMajor("Music");
-        m.setPreferredMenteeSkills(List.of("Piano"));
-        m.setInterests(List.of("Jazz"));
+    void rankMentors_emptyResult_skipsSlotFetches() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of());
 
-        Mentee me = new Mentee();
-        me.setMajor("Computer Science");
-        me.setSkills(List.of("Java"));
-        me.setInterests(List.of("AI"));
+        matchingService.getTopMentors(1L, null, pageable);
 
-        assertThat(matchingService.matchesMentorPreferences(m, me)).isFalse();
+        verify(availabilitySlotRepository, never()).findByMentorIdIn(anyCollection());
+        verify(menteeAvailabilitySlotRepository, never()).findByMenteeId(anyLong());
     }
 
-    @Test
-    void candidateMenteesNullFieldsDoNotCrash() {
-        Mentor m = new Mentor();
-        Mentee me = new Mentee();
-
-        assertThat(matchingService.matchesMentorPreferences(m, me)).isFalse();
-    }
-
-    // ── Candidate mentees: active mentor exclusion ──────────────────────────
+    // ── Match-found notification gating ───────────────────────────────────
 
     @Test
-    void candidateMenteesExcludesActivelyMentoredMentees() {
-        Mentee activeMentee = new Mentee();
-        activeMentee.setActiveMentorId(99L);
-        activeMentee.setInterests(List.of("AI"));
+    void rankMentors_firesNotification_onPageZeroWithResults() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
 
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee, activeMentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null, pageable);
+        Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, PageRequest.of(0, 20));
 
         assertThat(result.getContent()).hasSize(1);
+        verify(notificationEventPublisher)
+                .publishMatchFound(eq(1L), eq(result.getContent().get(0).getFirstName()));
     }
 
-    // ── Candidate mentees: capacity check ───────────────────────────────────
+    @Test
+    void rankMentors_doesNotFireNotification_onSubsequentPages() {
+        List<Mentor> manyMentors = java.util.stream.IntStream.range(0, 30).mapToObj(i -> {
+            Mentor m = new Mentor();
+            m.setId((long) (10 + i));
+            m.setMaxMenteeCapacity(3);
+            m.setCurrentMenteeCount(0);
+            return m;
+        }).toList();
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(manyMentors);
+
+        // Page 1 (offset 20) → no notification because we're past page 0.
+        matchingService.getTopMentors(1L, null, PageRequest.of(1, 20));
+
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+    }
+
+    @Test
+    void rankMentors_doesNotFireNotification_whenEmpty() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of());
+
+        matchingService.getTopMentors(1L, null, pageable);
+
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+    }
+
+    // ── Candidate mentees: full capacity / mentor not found ───────────────
 
     @Test
     void candidateMenteesFullCapacityBlocksRequest() {
@@ -468,197 +416,6 @@ class MatchingServiceTest {
                 .isInstanceOf(com.group7.backend.exception.MatchingNotAllowedException.class)
                 .hasMessageContaining("capacity");
     }
-
-    // ── Candidate mentees: mentor not found ─────────────────────────────────
-
-    @Test
-    void candidateMenteesMentorNotFoundThrows() {
-        when(mentorRepository.findById(99L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> matchingService.getCandidateMentees(99L, null, pageable))
-                .isInstanceOf(ResourceNotFoundException.class);
-    }
-
-    // ── Candidate mentees: keyword filter ───────────────────────────────────
-
-    @Test
-    void candidateMenteesKeywordFilterMatchesGoals() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "machine", pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    @Test
-    void candidateMenteesKeywordFilterNoMatchReturnsEmpty() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "rust", pageable);
-
-        assertThat(result.getContent()).isEmpty();
-    }
-
-    @Test
-    void candidateMenteesNullKeywordReturnsAll() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null, pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    // ── Candidate mentees: case insensitivity ───────────────────────────────
-
-    @Test
-    void candidateMenteesMatchesByInterestCaseInsensitive() {
-        Mentor m = new Mentor();
-        m.setInterests(List.of("ai"));
-
-        Mentee me = new Mentee();
-        me.setInterests(List.of("AI"));
-
-        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
-    }
-
-    @Test
-    void candidateMenteesMatchesBySkillCaseInsensitive() {
-        Mentor m = new Mentor();
-        m.setPreferredMenteeSkills(List.of("JAVA"));
-
-        Mentee me = new Mentee();
-        me.setSkills(List.of("java"));
-
-        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
-    }
-
-    @Test
-    void candidateMenteesMatchesByMajorCaseInsensitive() {
-        Mentor m = new Mentor();
-        m.setPreferredMenteeMajor("computer science");
-
-        Mentee me = new Mentee();
-        me.setMajor("Computer Science");
-
-        assertThat(matchingService.matchesMentorPreferences(m, me)).isTrue();
-    }
-
-    // ── Candidate mentees: keyword on different fields ──────────────────────
-
-    @Test
-    void candidateMenteesKeywordFilterMatchesMajor() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "Computer", pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    @Test
-    void candidateMenteesKeywordFilterMatchesSkill() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "Java", pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    @Test
-    void candidateMenteesKeywordFilterMatchesInterest() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "AI", pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    @Test
-    void candidateMenteesKeywordFilterMatchesCareerInterest() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "backend", pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    @Test
-    void candidateMenteesKeywordFilterIsCaseInsensitive() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "MACHINE", pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    @Test
-    void candidateMenteesEmptyKeywordReturnsAll() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "", pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    // ── Candidate mentees: multiple mentees filtering ───────────────────────
-
-    @Test
-    void candidateMenteesFiltersOutNonMatchingMentees() {
-        Mentee nonMatching = new Mentee();
-        nonMatching.setMajor("Music");
-        nonMatching.setSkills(List.of("Piano"));
-        nonMatching.setInterests(List.of("Jazz"));
-
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee, nonMatching));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null, pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getMajor()).isEqualTo("Computer Science");
-    }
-
-    @Test
-    void candidateMenteesReturnsMultipleMatchingMentees() {
-        Mentee secondMatch = new Mentee();
-        secondMatch.setInterests(List.of("AI"));
-        secondMatch.setSkills(List.of("Kotlin"));
-
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee, secondMatch));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null, pageable);
-
-        assertThat(result.getContent()).hasSize(2);
-    }
-
-    @Test
-    void candidateMenteesExcludesAllActivelyMentoredMentees() {
-        Mentee active1 = new Mentee();
-        active1.setActiveMentorId(10L);
-        active1.setInterests(List.of("AI"));
-
-        Mentee active2 = new Mentee();
-        active2.setActiveMentorId(20L);
-        active2.setInterests(List.of("Systems"));
-
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee, active1, active2));
-
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null, pageable);
-
-        assertThat(result.getContent()).hasSize(1);
-    }
-
-    // ── Candidate mentees: capacity edge cases ──────────────────────────────
 
     @Test
     void candidateMenteesExactCapacityBlocksRequest() {
@@ -671,27 +428,112 @@ class MatchingServiceTest {
     }
 
     @Test
-    void candidateMenteesOneSlotLeftAllowed() {
-        mentor.setMaxMenteeCapacity(3);
-        mentor.setCurrentMenteeCount(2);
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+    void candidateMenteesMentorNotFoundThrows() {
+        when(mentorRepository.findById(99L)).thenReturn(Optional.empty());
 
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null, pageable);
-
-        assertThat(result.getContent()).hasSize(1);
+        assertThatThrownBy(() -> matchingService.getCandidateMentees(99L, null, pageable))
+                .isInstanceOf(ResourceNotFoundException.class);
     }
 
-    // ── Candidate mentees: DTO mapping ──────────────────────────────────────
+    // ── Candidate mentees: SQL filters pushed correctly ───────────────────
+
+    @Test
+    void candidateMentees_invokesMenteeSearchWithRequireUnattachedTrue() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        stubMenteeSearch(List.of(mentee));
+
+        matchingService.getCandidateMentees(1L, null, pageable);
+
+        // requireUnattached=true (the SQL filter that replaced the old in-memory
+        // m -> m.getActiveMentorId() == null check). requesterMentorId is null
+        // because the matching path doesn't slot-filter candidate mentees —
+        // overlap is part of scoring, not filtering, and the mentee path here
+        // doesn't score.
+        verify(menteeRepository).findRankingCandidates(
+                any(), any(), any(), any(), eq(true),
+                org.mockito.ArgumentMatchers.isNull(), any(Pageable.class));
+    }
+
+    @Test
+    void candidateMentees_keywordIsNormalisedAndPushed() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        stubMenteeSearch(List.of(mentee));
+
+        matchingService.getCandidateMentees(1L, "machine", pageable);
+
+        verify(menteeRepository).findRankingCandidates(
+                eq("%machine%"), any(), any(), any(), anyBoolean(), any(), any());
+    }
+
+    @Test
+    void candidateMentees_doesNotInvokeRanker() {
+        // The mentor-side path scores via the ranker; the mentee-side path
+        // is filter-only. Verifying via no-batch-fetch on mentor slots since
+        // that's the only code path that would fire if the ranker were called.
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        stubMenteeSearch(List.of(mentee));
+
+        matchingService.getCandidateMentees(1L, null, pageable);
+
+        verify(availabilitySlotRepository, never()).findByMentorIdIn(anyCollection());
+    }
+
+    // ── Candidate mentees: pagination ─────────────────────────────────────
+
+    @Test
+    void candidateMenteesPagination_returnsRequestedSlice() {
+        // Mentees need at least one preference overlap with the mentor fixture
+        // (interests=[AI, Systems]) to survive the in-memory
+        // matchesMentorPreferences filter.
+        List<Mentee> manyMentees = java.util.stream.IntStream.range(0, 6).mapToObj(i -> {
+            Mentee me = new Mentee();
+            me.setId((long) (100 + i));
+            me.setInterests(List.of("AI"));
+            return me;
+        }).toList();
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        stubMenteeSearch(manyMentees);
+
+        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null, PageRequest.of(0, 3));
+
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getTotalElements()).isEqualTo(6);
+    }
+
+    @Test
+    void candidateMentees_firesNotification_onPageZeroWithResults() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        stubMenteeSearch(List.of(mentee));
+
+        matchingService.getCandidateMentees(1L, null, PageRequest.of(0, 20));
+
+        verify(notificationEventPublisher).publishMatchFound(eq(1L), anyString());
+    }
+
+    @Test
+    void candidateMentees_doesNotFireNotification_onSubsequentPages() {
+        List<Mentee> manyMentees = java.util.stream.IntStream.range(0, 30).mapToObj(i -> {
+            Mentee me = new Mentee();
+            me.setId((long) (100 + i));
+            return me;
+        }).toList();
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        stubMenteeSearch(manyMentees);
+
+        matchingService.getCandidateMentees(1L, null, PageRequest.of(1, 20));
+
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+    }
+
+    // ── Candidate mentees: DTO mapping ────────────────────────────────────
 
     @Test
     void candidateMenteesResponseContainsCorrectFields() {
         mentee.setFirstName("Elif");
         mentee.setBackgroundInfo("3rd year CS student");
         mentee.setMeetingFreqPref("Weekly");
-
         when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(mentee));
+        stubMenteeSearch(List.of(mentee));
 
         Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null, pageable);
 
@@ -707,22 +549,129 @@ class MatchingServiceTest {
         assertThat(dto.getMeetingFreqPref()).isEqualTo("Weekly");
     }
 
+    // ── Unpaginated getTopMentorsList ─────────────────────────────────────
+
     @Test
-    void candidateMenteesKeywordAndPreferenceFilterCombined() {
-        Mentee matchingWithKeyword = new Mentee();
-        matchingWithKeyword.setInterests(List.of("AI"));
-        matchingWithKeyword.setGoals("machine learning research");
+    void getTopMentorsList_returnsAllRanked_capPreserved() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
 
-        Mentee matchingWithoutKeyword = new Mentee();
-        matchingWithoutKeyword.setInterests(List.of("AI"));
-        matchingWithoutKeyword.setGoals("web development");
+        List<MentorMatchResponse> result = matchingService.getTopMentorsList(1L, null);
 
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        when(menteeRepository.findAll()).thenReturn(List.of(matchingWithKeyword, matchingWithoutKeyword));
+        assertThat(result).hasSize(1);
+        // Same 200-cap as the paginated path (verified via PageRequest.of(0, 200)).
+        verify(mentorRepository).findRankingCandidates(
+                any(), any(), any(), any(), anyBoolean(), any(), eq(PageRequest.of(0, 200)));
+    }
 
-        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, "machine", pageable);
+    @Test
+    void getTopMentorsList_firesNotification_onNonEmpty() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
 
-        assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getGoals()).isEqualTo("machine learning research");
+        matchingService.getTopMentorsList(1L, null);
+
+        verify(notificationEventPublisher).publishMatchFound(eq(1L), anyString());
+    }
+
+    @Test
+    void getTopMentorsList_doesNotFireNotification_onEmpty() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of());
+
+        List<MentorMatchResponse> result = matchingService.getTopMentorsList(1L, null);
+
+        assertThat(result).isEmpty();
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+    }
+
+    // ── matchesMentorPreferences edge cases ───────────────────────────────
+    // Pin the OR-of-categories filter behaviour and its null-guard branches.
+    // The mentor-side path always pre-filters via this in-memory check; getting
+    // it wrong silently empties candidate-mentee results.
+
+    @Test
+    void matchesMentorPreferences_matchesViaInterestOverlap() {
+        Mentor m = new Mentor();
+        m.setInterests(List.of("AI"));
+        Mentee me = new Mentee();
+        me.setInterests(List.of("AI"));
+        assertThat(MatchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    @Test
+    void matchesMentorPreferences_matchesViaSkill() {
+        Mentor m = new Mentor();
+        m.setPreferredMenteeSkills(List.of("Java"));
+        Mentee me = new Mentee();
+        me.setSkills(List.of("Java"));
+        assertThat(MatchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    @Test
+    void matchesMentorPreferences_matchesViaPreferredMajor() {
+        Mentor m = new Mentor();
+        m.setPreferredMenteeMajor("Computer Science");
+        Mentee me = new Mentee();
+        me.setMajor("Computer Science");
+        assertThat(MatchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    @Test
+    void matchesMentorPreferences_matchesViaField() {
+        Mentor m = new Mentor();
+        m.setField("Computer Science");
+        Mentee me = new Mentee();
+        me.setMajor("Computer Science");
+        assertThat(MatchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    @Test
+    void matchesMentorPreferences_returnsFalseWhenNothingOverlaps() {
+        Mentor m = new Mentor();
+        m.setInterests(List.of("AI"));
+        m.setPreferredMenteeSkills(List.of("Java"));
+        m.setPreferredMenteeMajor("CS");
+        Mentee me = new Mentee();
+        me.setInterests(List.of("Music"));
+        me.setSkills(List.of("Piano"));
+        me.setMajor("Music Theory");
+        assertThat(MatchingService.matchesMentorPreferences(m, me)).isFalse();
+    }
+
+    @Test
+    void matchesMentorPreferences_handlesAllNullFields() {
+        // Bare entities — no interests, skills, or major on either side.
+        // Must not throw NPE; returns false (no preference category fires).
+        assertThat(MatchingService.matchesMentorPreferences(new Mentor(), new Mentee())).isFalse();
+    }
+
+    @Test
+    void matchesMentorPreferences_isCaseInsensitive() {
+        Mentor m = new Mentor();
+        m.setInterests(List.of("AI"));
+        Mentee me = new Mentee();
+        me.setInterests(List.of("ai"));
+        assertThat(MatchingService.matchesMentorPreferences(m, me)).isTrue();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    // The matching path uses findRankingCandidates (List, no count) — see
+    // MatchingService.rankAvailableMentors / getCandidateMentees. Tests of the
+    // SQL-side filter shape still use searchByFilters by name to capture the
+    // semantic intent (verify(... searchByFilters(...))) — those verifications
+    // were rewritten to target findRankingCandidates after the S1 refactor.
+
+    private void stubMentorSearch(List<Mentor> mentors) {
+        when(mentorRepository.findRankingCandidates(
+                any(), any(), any(), any(), anyBoolean(), any(), any(Pageable.class)))
+                .thenReturn(mentors);
+    }
+
+    private void stubMenteeSearch(List<Mentee> mentees) {
+        when(menteeRepository.findRankingCandidates(
+                any(), any(), any(), any(), anyBoolean(), any(), any(Pageable.class)))
+                .thenReturn(mentees);
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/SearchNormaliserTest.java
+++ b/backend/src/test/java/com/group7/backend/service/SearchNormaliserTest.java
@@ -1,0 +1,156 @@
+package com.group7.backend.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit coverage for {@link SearchNormaliser} — the shared filter-input
+ * sanitiser between {@code MatchingService} and {@code UserService.searchUsers}
+ * (#262). Each branch is correctness-required (see class javadoc); this test
+ * pins them.
+ */
+class SearchNormaliserTest {
+
+    // ── keyword(...) ──────────────────────────────────────────────────────────
+
+    @Test
+    void keyword_nullReturnsNull() {
+        assertThat(SearchNormaliser.keyword(null)).isNull();
+    }
+
+    @Test
+    void keyword_emptyReturnsNull() {
+        assertThat(SearchNormaliser.keyword("")).isNull();
+    }
+
+    @Test
+    void keyword_whitespaceReturnsNull() {
+        assertThat(SearchNormaliser.keyword("   ")).isNull();
+    }
+
+    @Test
+    void keyword_tooShortReturnsNull() {
+        assertThat(SearchNormaliser.keyword("ab")).isNull();
+    }
+
+    @Test
+    void keyword_threeCharsReturnsLowercasedWildcard() {
+        assertThat(SearchNormaliser.keyword("Foo")).isEqualTo("%foo%");
+    }
+
+    @Test
+    void keyword_escapeOrderIsBarFirst() {
+        // The escape character | must be doubled before % and _ are escaped,
+        // otherwise |% would itself become ||% and break the ESCAPE clause.
+        assertThat(SearchNormaliser.keyword("a|b")).isEqualTo("%a||b%");
+    }
+
+    @Test
+    void keyword_percentIsEscaped() {
+        assertThat(SearchNormaliser.keyword("100%")).isEqualTo("%100|%%");
+    }
+
+    @Test
+    void keyword_underscoreIsEscaped() {
+        assertThat(SearchNormaliser.keyword("foo_bar")).isEqualTo("%foo|_bar%");
+    }
+
+    // ── list(...) ────────────────────────────────────────────────────────────
+
+    @Test
+    void list_nullReturnsNull() {
+        assertThat(SearchNormaliser.list(null)).isNull();
+    }
+
+    @Test
+    void list_emptyReturnsNull() {
+        assertThat(SearchNormaliser.list(List.of())).isNull();
+    }
+
+    @Test
+    void list_allNullsReturnNull() {
+        // After filtering out null entries the survivor list is empty — must
+        // coalesce to null so the JPQL :list IS NULL gate fires.
+        assertThat(SearchNormaliser.list(Arrays.asList(null, null))).isNull();
+    }
+
+    @Test
+    void list_lowercasesSurvivors() {
+        assertThat(SearchNormaliser.list(List.of("Java", "PYTHON")))
+                .containsExactly("java", "python");
+    }
+
+    @Test
+    void list_filtersNullsAndLowercases() {
+        assertThat(SearchNormaliser.list(Arrays.asList("Foo", null, "BAR")))
+                .containsExactly("foo", "bar");
+    }
+
+    // ── scalar(...) ──────────────────────────────────────────────────────────
+
+    @Test
+    void scalar_nullReturnsNull() {
+        assertThat(SearchNormaliser.scalar(null)).isNull();
+    }
+
+    @Test
+    void scalar_blankReturnsNull() {
+        assertThat(SearchNormaliser.scalar("   ")).isNull();
+    }
+
+    @Test
+    void scalar_lowercasesAndTrims() {
+        assertThat(SearchNormaliser.scalar("  Computer Science  "))
+                .isEqualTo("computer science");
+    }
+
+    // ── Locale independence ──────────────────────────────────────────────────
+    // String.toLowerCase() (no args) uses Locale.getDefault(), which on a
+    // Turkish-locale JVM lowercases "I" to "ı" (dotless). Postgres LOWER()
+    // uses the database collation (typically en_US.UTF-8), and the two sides
+    // would silently disagree on any keyword containing "I". All three
+    // normalisers must use Locale.ROOT for predictable ASCII folding.
+
+    @Test
+    void keyword_isLocaleIndependent_underTurkishDefault() {
+        Locale prev = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.of("tr", "TR"));
+            // Without Locale.ROOT this would be "%bıg%" (dotless ı) under
+            // Turkish locale, which never matches a column lowercased by
+            // Postgres in en_US collation.
+            assertThat(SearchNormaliser.keyword("BIG")).isEqualTo("%big%");
+        } finally {
+            Locale.setDefault(prev);
+        }
+    }
+
+    @Test
+    void list_isLocaleIndependent_underTurkishDefault() {
+        Locale prev = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.of("tr", "TR"));
+            assertThat(SearchNormaliser.list(List.of("AI", "INFRA")))
+                    .containsExactly("ai", "infra");
+        } finally {
+            Locale.setDefault(prev);
+        }
+    }
+
+    @Test
+    void scalar_isLocaleIndependent_underTurkishDefault() {
+        Locale prev = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.of("tr", "TR"));
+            assertThat(SearchNormaliser.scalar("INDUSTRIAL ENGINEERING"))
+                    .isEqualTo("industrial engineering");
+        } finally {
+            Locale.setDefault(prev);
+        }
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/ranking/RuleBasedMentorRankerTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ranking/RuleBasedMentorRankerTest.java
@@ -1,0 +1,205 @@
+package com.group7.backend.service.ranking;
+
+import com.group7.backend.entity.AvailabilitySlot;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.MenteeAvailabilitySlot;
+import com.group7.backend.entity.Mentor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit-level coverage of the legacy weighted-score algorithm, extracted
+ * from {@code MatchingService} into {@link RuleBasedMentorRanker} as part
+ * of #262. These assertions used to live in {@code MatchingServiceTest};
+ * they're co-located with the ranker itself so a future swap (e.g., an
+ * AI-driven ranker) doesn't drag legacy-algorithm tests into its own test
+ * class.
+ */
+class RuleBasedMentorRankerTest {
+
+    private RuleBasedMentorRanker ranker;
+    private Mentor mentor;
+    private Mentee mentee;
+
+    @BeforeEach
+    void setUp() {
+        ranker = new RuleBasedMentorRanker();
+        mentor = new Mentor();
+        mentor.setMaxMenteeCapacity(3);
+        mentor.setCurrentMenteeCount(1);
+        mentor.setField("Computer Science");
+        mentor.setExpertise("backend engineering Java");
+        mentor.setPreferredMenteeMajor("Computer Science");
+        mentor.setPreferredMenteeSkills(List.of("Java", "Kotlin"));
+        mentor.setInterests(List.of("AI", "Systems"));
+        mentor.setMentoringGoals("Help with career and machine learning projects");
+
+        mentee = new Mentee();
+        mentee.setMajor("Computer Science");
+        mentee.setGoals("career machine learning");
+        mentee.setCareerInterest("backend engineering");
+        mentee.setInterests(List.of("AI", "Databases"));
+        mentee.setSkills(List.of("Java", "Python"));
+    }
+
+    // ── Profile scoring (formerly MatchingService.calculateScore) ──────────
+
+    @Test
+    void scoreOverlappingInterests() {
+        // Mentee has AI and Databases; mentor has AI and Systems → 1 overlap = +3.
+        int score = ranker.score(mentor, mentee, List.of(), List.of());
+        assertThat(score).isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void scoreSkillMatch() {
+        Mentor m = new Mentor();
+        m.setPreferredMenteeSkills(List.of("Java"));
+        Mentee me = new Mentee();
+        me.setSkills(List.of("Java"));
+
+        assertThat(ranker.score(m, me, List.of(), List.of())).isEqualTo(3);
+    }
+
+    @Test
+    void scoreMajorMatchesPreferredMenteeMajor() {
+        Mentor m = new Mentor();
+        m.setPreferredMenteeMajor("Computer Science");
+        Mentee me = new Mentee();
+        me.setMajor("Computer Science");
+
+        assertThat(ranker.score(m, me, List.of(), List.of())).isEqualTo(5);
+    }
+
+    @Test
+    void scoreMajorMatchesField() {
+        Mentor m = new Mentor();
+        m.setField("Computer Science");
+        Mentee me = new Mentee();
+        me.setMajor("Computer Science");
+
+        assertThat(ranker.score(m, me, List.of(), List.of())).isEqualTo(3);
+    }
+
+    @Test
+    void scoreGoalsKeywordOverlap() {
+        // "machine" and "learning" appear in mentor.mentoringGoals → +2 each.
+        Mentor m = new Mentor();
+        m.setMentoringGoals("machine learning and career guidance");
+        Mentee me = new Mentee();
+        me.setGoals("machine learning");
+
+        assertThat(ranker.score(m, me, List.of(), List.of())).isEqualTo(4);
+    }
+
+    @Test
+    void scoreNullFieldsDoNotCrash() {
+        Mentor m = new Mentor();
+        Mentee me = new Mentee();
+
+        assertThat(ranker.score(m, me, List.of(), List.of())).isEqualTo(0);
+    }
+
+    // ── Availability scoring (formerly calculateAvailabilityScore) ─────────
+
+    @Test
+    void availabilityScoreUsesOverlapAndCapsAtTwelve() {
+        // 8 hours of overlap → 480 minutes / 30 = 16, capped to 12.
+        List<AvailabilitySlot> mentorSlots = List.of(
+                mentorSlot(DayOfWeek.MONDAY, "09:00", "18:00"));
+        List<MenteeAvailabilitySlot> menteeSlots = List.of(
+                menteeSlot(DayOfWeek.MONDAY, "09:00", "17:00"));
+
+        // Use blank entities so profile score is 0; the assertion isolates
+        // the availability portion at exactly the cap.
+        int score = ranker.score(new Mentor(), new Mentee(), mentorSlots, menteeSlots);
+        assertThat(score).isEqualTo(12);
+    }
+
+    @Test
+    void availabilityScoreReturnsZeroWithoutSlots() {
+        int score = ranker.score(new Mentor(), new Mentee(), List.of(), List.of());
+        assertThat(score).isZero();
+    }
+
+    @Test
+    void availabilityScoreReturnsZeroWhenNoDayOfWeekOverlap() {
+        // Mentor MONDAY, mentee TUESDAY — no overlap regardless of time.
+        List<AvailabilitySlot> mentorSlots = List.of(
+                mentorSlot(DayOfWeek.MONDAY, "09:00", "10:00"));
+        List<MenteeAvailabilitySlot> menteeSlots = List.of(
+                menteeSlot(DayOfWeek.TUESDAY, "09:00", "10:00"));
+
+        int score = ranker.score(new Mentor(), new Mentee(), mentorSlots, menteeSlots);
+        assertThat(score).isZero();
+    }
+
+    @Test
+    void availabilityScoreReturnsZeroForAdjacentNonOverlappingSlots() {
+        // 09:00–10:00 vs 10:00–11:00 — touching but not overlapping (strict <).
+        List<AvailabilitySlot> mentorSlots = List.of(
+                mentorSlot(DayOfWeek.MONDAY, "09:00", "10:00"));
+        List<MenteeAvailabilitySlot> menteeSlots = List.of(
+                menteeSlot(DayOfWeek.MONDAY, "10:00", "11:00"));
+
+        int score = ranker.score(new Mentor(), new Mentee(), mentorSlots, menteeSlots);
+        assertThat(score).isZero();
+    }
+
+    // ── Combined scoring contract ──────────────────────────────────────────
+
+    @Test
+    void scoreSumsProfileAndAvailabilityComponents() {
+        // Profile contribution:
+        //   AI overlap                                                     +3
+        //   Java skill match (Java in mentor.preferredMenteeSkills)        +3
+        //   CS major matches mentor.preferredMenteeMajor                   +5
+        //   CS major matches mentor.field                                  +3
+        //   Goal words: "career" + "machine" + "learning"  (each > 3 chars)+6
+        //   Career-interest words: "backend" + "engineering"               +4
+        //                                                          subtotal 24
+        // Availability: MONDAY 09:00–11:00 vs MONDAY 09:30–10:30 = 60 min  +2
+        // Total expected: 26.
+        List<AvailabilitySlot> mentorSlots = List.of(
+                mentorSlot(DayOfWeek.MONDAY, "09:00", "11:00"));
+        List<MenteeAvailabilitySlot> menteeSlots = List.of(
+                menteeSlot(DayOfWeek.MONDAY, "09:30", "10:30"));
+
+        int score = ranker.score(mentor, mentee, mentorSlots, menteeSlots);
+        assertThat(score).isEqualTo(26);
+    }
+
+    @Test
+    void rankerIsStateless_consecutiveCallsReturnSameScore() {
+        // Sanity check that the ranker doesn't accumulate state between calls.
+        int first = ranker.score(mentor, mentee, List.of(), List.of());
+        int second = ranker.score(mentor, mentee, List.of(), List.of());
+        assertThat(second).isEqualTo(first);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static AvailabilitySlot mentorSlot(DayOfWeek day, String start, String end) {
+        AvailabilitySlot slot = new AvailabilitySlot();
+        slot.setDayOfWeek(day);
+        slot.setStartTime(LocalTime.parse(start));
+        slot.setEndTime(LocalTime.parse(end));
+        slot.setRecurring(true);
+        return slot;
+    }
+
+    private static MenteeAvailabilitySlot menteeSlot(DayOfWeek day, String start, String end) {
+        MenteeAvailabilitySlot slot = new MenteeAvailabilitySlot();
+        slot.setDayOfWeek(day);
+        slot.setStartTime(LocalTime.parse(start));
+        slot.setEndTime(LocalTime.parse(end));
+        slot.setRecurring(true);
+        return slot;
+    }
+}


### PR DESCRIPTION
Closes #262.

## Summary
- Pushes every keyword/multi-value/major/capacity/slot-overlap filter to Postgres via composable JPQL gates, replacing the old in-memory `findAll() + String.contains()` pipeline.
- Adds a pg_trgm migration with 9 functional GIN trigram indexes (built on `LOWER(col)` so the JPQL pattern actually hits the index — verified with EXPLAIN) and 2 btree composites for the availability overlap subquery.
- Extracts the legacy weighted-score algorithm into a `MentorRanker` strategy (single `RuleBasedMentorRanker` impl today; AI ranker plugs in via `@Primary` later) and eliminates the per-mentor slot-fetch N+1 with a batched `findByMentorIdIn`.
- Adds `GET /api/users/search` for general directory search with role-gated visibility, slot-presence guard, and admin support — distinct from the score-driven matching surface.

## Behavior
- Mentees may search `MENTOR`, mentors may search `MENTEE`, admins may search either; same-role search returns 403, and admin + `hasAvailability=true` returns 400.
- Short keywords (<3 chars after trim) drop the keyword filter rather than 400 — pg_trgm needs ≥3 alphanumerics for index acceleration.
- Wildcards in the keyword (`%`, `_`, `|`) are escaped via `ESCAPE '|'` and matched as literals.
- Matching path uses an "almost-global" ranking: SQL fetches a fixed top-200 candidates ordered by `id DESC`, ranker scores them in memory, page is sliced from the ranking. Pages beyond the 200-row window return empty.
- Lowercasing on the Java side uses `Locale.ROOT` so a Turkish-locale JVM doesn't disagree with Postgres's `en_US` `LOWER()` on keywords containing `I`.
- Notification fires only on page 0 to match pre-refactor "found you a match!" semantics; subsequent pages stay quiet.

## Query budget
`MatchingService.getTopMentors` issues exactly 4 explicit JPQL queries regardless of result-set size: `findById(mentee)` + `findRankingCandidates` + `findByMentorIdIn` + `findByMenteeId`. `getCandidateMentees` issues 2 (no slot fetch on the filter-only mentee path). Pinned by `SearchPerformanceTest`.

## Test plan
- [ ] Reset Postgres volume so V19 applies cleanly: \`docker compose down -v db && docker compose up -d db\`
- [ ] \`mvn test\` — 832 tests green
- [ ] \`mvn jacoco:report\` — branch coverage holds on new files
- [ ] Manual smoke: register a mentor + mentee with overlapping interests, hit \`GET /api/matching/mentors\` and \`GET /api/users/search?role=MENTOR&q=java\`, confirm SQL log shows ≤7 statements per call and EXPLAIN on the generated SQL picks `Bitmap Index Scan` on the trigram indexes.
- [ ] Verify same-role search returns 403, `hasAvailability=true` without own slots returns 400.