### PR TITLE
Decouple match-found notification from browse/rank (#273)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/UserController.java
+++ b/backend/src/main/java/com/group7/backend/controller/UserController.java
@@ -218,7 +218,7 @@ public class UserController {
             @RequestParam(defaultValue = "20") int size,
             Authentication authentication) {
         Long requesterId = (Long) authentication.getCredentials();
-        Pageable pageable = clampPageable(page, size);
+        Pageable pageable = PageableSupport.clampPageable(page, size);
         return ResponseEntity.ok(userService.searchUsers(
                 role, q, interests, skills, major, hasAvailability, requesterId, pageable));
     }

--- a/backend/src/main/java/com/group7/backend/dto/response/MatchSummary.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MatchSummary.java
@@ -1,0 +1,21 @@
+package com.group7.backend.dto.response;
+
+/**
+ * Common shape for match-list response DTOs. Both {@link MentorMatchResponse}
+ * (mentor's view of a candidate match) and {@link MenteeCandidateResponse}
+ * (mentor's view of a candidate mentee) implement this interface so the
+ * scheduled match-notification processor (#273) can run a single generic
+ * change-detection algorithm against either side without casts.
+ *
+ * <p>Both methods are already exposed by Lombok's {@code @Getter} on the
+ * concrete DTOs — declaring this interface only documents the contract
+ * those getters already satisfy.
+ */
+public interface MatchSummary {
+
+    /** The matched user's id; non-null on a well-formed DTO. */
+    Long getId();
+
+    /** The matched user's first name; non-null on a well-formed DTO. */
+    String getFirstName();
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MenteeCandidateResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MenteeCandidateResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @Schema(description = "Privacy-safe mentee candidate visible to mentors during matching")
-public class MenteeCandidateResponse {
+public class MenteeCandidateResponse implements MatchSummary {
 
     @Schema(description = "Mentee user ID", example = "7")
     private Long id;

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorMatchResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorMatchResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @Schema(description = "Privacy-safe mentor match result with compatibility score")
-public class MentorMatchResponse {
+public class MentorMatchResponse implements MatchSummary {
 
     @Schema(description = "Mentor user ID", example = "42")
     private Long id;

--- a/backend/src/main/java/com/group7/backend/entity/LastMatchNotification.java
+++ b/backend/src/main/java/com/group7/backend/entity/LastMatchNotification.java
@@ -1,0 +1,66 @@
+package com.group7.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Per-recipient dedup state for the scheduled match-found notification path (#273).
+ * One row per user who has ever been notified, keyed by recipient {@code user_id}.
+ * The {@code notified_match_user_id} column carries the id of whichever counterpart
+ * (mentor for mentee recipients, mentee for mentor recipients) was the top match
+ * at the time of the last publish.
+ *
+ * <p>The scheduler re-ranks each eligible user daily and compares the current
+ * top match's id to {@code notifiedMatchUserId}. Equal → no notification. Different
+ * (or row absent) → publish + upsert.
+ *
+ * <p>Deliberately flat: no {@code @ManyToOne} associations, no derived helpers.
+ * The scheduler only needs equality comparison, so keeping the entity flat avoids
+ * accidental lazy-load surprises in the per-user transaction.
+ */
+@Entity
+@Table(name = "last_match_notifications")
+@Getter
+@Setter
+@NoArgsConstructor
+public class LastMatchNotification {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
+
+    /**
+     * The counterpart's id we last notified about. Nullable to defend the
+     * table against a counterpart-row deletion that happens between two
+     * scheduler runs (no FK on this column — see V20 migration comment for
+     * the rationale). On a fresh row this is the current top-match id; if
+     * a manual SQL clears it to NULL, the next run treats the recipient as
+     * first-time and fires.
+     */
+    @Column(name = "notified_match_user_id")
+    private Long notifiedMatchUserId;
+
+    @Column(name = "sent_at", nullable = false)
+    private OffsetDateTime sentAt;
+
+    /**
+     * Initialised to 0L explicitly so {@code Hibernate.isNew(entity)} returns
+     * the same answer for both freshly-constructed and persisted entities,
+     * making {@code save()} reliably take the merge() path. Concurrent
+     * UPDATE from two scheduler instances → loser throws
+     * {@code OptimisticLockException} → its transaction rolls back →
+     * AFTER_COMMIT skips, no duplicate notification. PK uniqueness handles
+     * the symmetric race for INSERTs.
+     */
+    @Version
+    @Column(nullable = false)
+    private Long version = 0L;
+}

--- a/backend/src/main/java/com/group7/backend/repository/LastMatchNotificationRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/LastMatchNotificationRepository.java
@@ -1,0 +1,13 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.LastMatchNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Spring Data repository for {@link LastMatchNotification}. The entity's PK is
+ * the recipient {@code user_id}, so {@code findById}/{@code save} are sufficient
+ * for the scheduler's read-compare-upsert flow — no custom queries needed.
+ */
+public interface LastMatchNotificationRepository
+        extends JpaRepository<LastMatchNotification, Long> {
+}

--- a/backend/src/main/java/com/group7/backend/repository/MenteeRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MenteeRepository.java
@@ -12,6 +12,16 @@ import java.util.List;
 public interface MenteeRepository extends JpaRepository<Mentee, Long> {
 
     /**
+     * IDs of all unattached mentees, ordered for test determinism. Used by
+     * {@code MatchNotificationScheduler} as the eligibility list — only
+     * unattached mentees are candidates for a "match found" notification.
+     * Returns just IDs to keep the per-tick memory bounded; the processor
+     * re-loads each mentee in its own transaction for the race re-check.
+     */
+    @Query("SELECT m.id FROM Mentee m WHERE m.activeMentorId IS NULL ORDER BY m.id")
+    List<Long> findUnattachedIds();
+
+    /**
      * Shared JPQL — see {@link MentorRepository#SEARCH_JPQL} for rationale.
      */
     String SEARCH_JPQL = """

--- a/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
@@ -12,6 +12,16 @@ import java.util.List;
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
 
     /**
+     * IDs of all mentors with spare capacity, ordered for test determinism.
+     * Used by {@code MatchNotificationScheduler} as the eligibility list —
+     * only mentors who can accept new mentees are candidates for a "match
+     * found" notification. Returns just IDs to keep the per-tick memory
+     * bounded; the processor re-loads each mentor in its own transaction.
+     */
+    @Query("SELECT m.id FROM Mentor m WHERE m.currentMenteeCount < m.maxMenteeCapacity ORDER BY m.id")
+    List<Long> findIdsWithCapacity();
+
+    /**
      * Shared JPQL for {@link #searchByFilters} (Page, with count) and
      * {@link #findRankingCandidates} (List, without count). One source of
      * truth for the filter shape; the only difference between the two

--- a/backend/src/main/java/com/group7/backend/scheduler/MatchNotificationScheduler.java
+++ b/backend/src/main/java/com/group7/backend/scheduler/MatchNotificationScheduler.java
@@ -1,0 +1,204 @@
+package com.group7.backend.scheduler;
+
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.service.MatchNotificationProcessor;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.function.LongPredicate;
+import java.util.function.Supplier;
+
+/**
+ * Daily cron driver for the change-detection match-notification path (#273).
+ * For each eligible user (mentees with no active mentor; mentors with spare
+ * capacity), invokes {@link MatchNotificationProcessor} in its own
+ * {@code REQUIRES_NEW} transaction. The processor compares the current top
+ * match's id to a per-user state row and publishes a {@code MATCH_FOUND}
+ * event only when the value changed.
+ *
+ * <p><b>System component.</b> Bypasses controller-layer authorization
+ * deliberately. Does not run in any authenticated user's context.
+ *
+ * <p><b>Failure isolation.</b> Each user is wrapped in its own try/catch:
+ * a thrown exception logs and the loop continues with the next user.
+ * {@code IllegalStateException} (a precondition violation in the
+ * processor's pure-rank delegate) is logged at ERROR — it indicates a
+ * caller bug, not a transient operational problem. Other exceptions
+ * (transient DB errors, etc.) are logged at WARN; the next scheduler tick
+ * naturally retries since the user's state row was not advanced.
+ * Each side ({@code notifyMentees}, {@code notifyMentors}) is additionally
+ * wrapped in {@code runSafely} so a failure in the eligibility query for
+ * one side does not skip the other.
+ *
+ * <p><b>Multi-instance.</b> Two instances ticking at the same cron time
+ * race harmlessly: PK uniqueness on {@code last_match_notifications}
+ * resolves the INSERT race; {@code @Version} resolves the UPDATE race;
+ * the loser's transaction rolls back, AFTER_COMMIT skips, no duplicate
+ * notification persists. The listener's 24h body-string dedup is the
+ * third layer. ShedLock would tighten "exactly-once-across-nodes" but is
+ * deferred until multi-instance becomes real for this app.
+ *
+ * <p><b>Missed ticks are not back-filled.</b> If the application is down
+ * during a cron firing, that day's notifications are skipped — the next
+ * tick handles whatever changed since. Spring's {@code @Scheduled} fires
+ * from the next tick after startup; it does not catch up missed firings.
+ * At most 24h of latency after a deploy that overlaps the cron time.
+ *
+ * <p><b>Cron + zone.</b> Defaults to 09:00 UTC daily. UTC is immune to
+ * DST transitions; if a deployment overrides {@code zone} to a local
+ * timezone, the operator must avoid scheduling between 01:00–03:00 local
+ * time on transition days (cron jobs can be skipped or double-fire across
+ * DST boundaries). Set {@code app.matching.notification.cron=-} to
+ * suppress firing without removing the bean (Spring 5.1+ documented the
+ * {@code "-"} cron value as the official disable marker).
+ */
+@Component
+@ConditionalOnProperty(
+        name = "app.matching.notification.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class MatchNotificationScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(MatchNotificationScheduler.class);
+
+    private final MatchNotificationProcessor processor;
+    private final MenteeRepository menteeRepository;
+    private final MentorRepository mentorRepository;
+    private final String cronExpression;
+    private final String zone;
+
+    /**
+     * Cron + zone are constructor-injected (rather than field {@code @Value})
+     * so unit tests must explicitly supply values — matching the
+     * {@code rankingWindow} pattern in {@code MatchingService}. Field injection
+     * here would let a test instantiate the bean with null cron/zone and the
+     * {@link #logStartupConfig} call would print {@code (cron=null, zone=null)},
+     * a confusing operational signal.
+     */
+    public MatchNotificationScheduler(
+            MatchNotificationProcessor processor,
+            MenteeRepository menteeRepository,
+            MentorRepository mentorRepository,
+            @Value("${app.matching.notification.cron:0 0 9 * * *}") String cronExpression,
+            @Value("${app.matching.notification.zone:UTC}") String zone) {
+        this.processor = processor;
+        this.menteeRepository = menteeRepository;
+        this.mentorRepository = mentorRepository;
+        this.cronExpression = cronExpression;
+        this.zone = zone;
+    }
+
+    /**
+     * Logs the resolved cron + zone once at startup. Without this line operators
+     * have no signal that the scheduler is wired correctly until the first
+     * firing — which, in the worst case, means waiting up to 24 hours after a
+     * deploy to confirm config. The {@code @ConditionalOnProperty} gate already
+     * keeps the bean out of the context when the feature is disabled, so this
+     * method only fires when notifications are actually expected to run.
+     */
+    @PostConstruct
+    void logStartupConfig() {
+        log.info("Match-notification scheduler enabled (cron={}, zone={})", cronExpression, zone);
+    }
+
+    /**
+     * Runs daily at 09:00 UTC by default. Both sides processed sequentially
+     * inside one cron firing; each side's eligibility query and per-user loop
+     * is isolated by {@link #runSafely(String, Supplier)} so one side's
+     * failure does not skip the other.
+     */
+    @Scheduled(
+            cron = "${app.matching.notification.cron:0 0 9 * * *}",
+            zone = "${app.matching.notification.zone:UTC}")
+    public void notifyChangedMatches() {
+        BatchResult mentees = runSafely("mentees", this::notifyMentees);
+        BatchResult mentors = runSafely("mentors", this::notifyMentors);
+        log.info(
+                "Match-notification check complete: "
+                        + "mentee_eligible={} mentee_publishes={} "
+                        + "mentor_eligible={} mentor_publishes={}",
+                mentees.eligible(), mentees.published(),
+                mentors.eligible(), mentors.published());
+    }
+
+    /**
+     * Iterates eligible mentees and dispatches each to the processor.
+     * Package-private so integration tests can invoke a single side without
+     * waiting for a cron tick.
+     */
+    BatchResult notifyMentees() {
+        return processBatch("mentee", menteeRepository::findUnattachedIds, processor::processMentee);
+    }
+
+    /**
+     * Symmetric to {@link #notifyMentees} for the mentor side.
+     */
+    BatchResult notifyMentors() {
+        return processBatch("mentor", mentorRepository::findIdsWithCapacity, processor::processMentor);
+    }
+
+    /**
+     * Iterates an eligibility list, dispatching each id to {@code processor}.
+     * Two-tier exception handling: {@code IllegalStateException} (caller bug
+     * surfacing from the processor's preconditions) is logged at ERROR;
+     * everything else (transient DB errors, etc.) at WARN. Both are swallowed
+     * so the loop keeps moving — the next tick naturally retries since the
+     * user's state row was not advanced.
+     *
+     * @param label    used in log messages ({@code "mentee"} / {@code "mentor"}).
+     * @param eligibilityQuery supplier for the list of ids to process.
+     * @param processor returns true iff a notification was published.
+     * @return eligible count (size of the list) and published count (true returns).
+     */
+    private BatchResult processBatch(String label,
+                                     Supplier<List<Long>> eligibilityQuery,
+                                     LongPredicate processor) {
+        List<Long> ids = eligibilityQuery.get();
+        int published = 0;
+        for (Long id : ids) {
+            try {
+                if (processor.test(id)) published++;
+            } catch (IllegalStateException e) {
+                log.error("Programmer-error processing {} {}: {}", label, id, e.getMessage(), e);
+            } catch (Exception e) {
+                log.warn("Failed to process {} {} for match notification", label, id, e);
+            }
+        }
+        return new BatchResult(ids.size(), published);
+    }
+
+    /**
+     * Wraps a per-side batch so a failure in the eligibility query (e.g., a
+     * transient DB outage) does not abort the entire run — the other side
+     * still gets its turn.
+     */
+    private BatchResult runSafely(String label, Supplier<BatchResult> batch) {
+        try {
+            return batch.get();
+        } catch (Exception e) {
+            log.error("Match-notification batch failed for {}", label, e);
+            return BatchResult.empty();
+        }
+    }
+
+    /**
+     * Per-side outcome reported in the run-summary log: {@code eligible} is
+     * the count of users considered (size of the eligibility list);
+     * {@code published} is the count of notifications actually fired (top
+     * match changed). Operations can distinguish "all eligible, none changed"
+     * (healthy steady-state) from "few eligible, all changed" (eligibility
+     * query may be misbehaving) just from the log line.
+     */
+    record BatchResult(int eligible, int published) {
+        static BatchResult empty() {
+            return new BatchResult(0, 0);
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MatchNotificationProcessor.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchNotificationProcessor.java
@@ -1,0 +1,187 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.MatchSummary;
+import com.group7.backend.entity.LastMatchNotification;
+import com.group7.backend.repository.LastMatchNotificationRepository;
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Per-user transactional unit for the scheduled match-found notification path
+ * (#273). Driven by {@code MatchNotificationScheduler}: for each eligible user
+ * the scheduler invokes {@link #processMentee(Long)} or {@link #processMentor(Long)},
+ * which re-ranks the user's matches, compares the current top match's id to
+ * the persisted dedup state, and publishes a {@code MATCH_FOUND} event only
+ * when the value changed.
+ *
+ * <p><b>System component.</b> Bypasses controller-layer authorization
+ * deliberately — the scheduler is not invoked in any authenticated user's
+ * context. Authorization checks belong on the controllers; this code path
+ * has access to all eligible users by design.
+ *
+ * <p><b>Why a separate bean from the scheduler.</b> Spring's default proxy-
+ * based AOP ignores {@code @Transactional} when methods are called via
+ * self-invocation. Putting the {@code REQUIRES_NEW} per-user transaction on
+ * a separate bean (this one) and having the scheduler invoke it across the
+ * proxy boundary is what makes the propagation hint actually take effect.
+ *
+ * <p><b>Failure isolation.</b> Each public method runs in its own
+ * {@code REQUIRES_NEW} transaction. If processing user A throws, A's
+ * transaction rolls back (state row not updated, AFTER_COMMIT skipped, no
+ * notification persisted), and the scheduler's per-user try/catch logs and
+ * continues with user B. The next scheduler tick will retry A naturally
+ * (state is unchanged from A's perspective).
+ *
+ * <p><b>Layered duplicate protection</b> against multi-instance and crash
+ * scenarios:
+ * <ol>
+ *   <li>State-row equality check below — primary gate, skips publish when
+ *       the top match is unchanged since the last notification.</li>
+ *   <li>{@code @Version} on {@link LastMatchNotification} — concurrent
+ *       UPDATE from two instances → loser throws
+ *       {@code OptimisticLockException}, transaction rolls back,
+ *       AFTER_COMMIT skips. PK uniqueness handles the symmetric INSERT race.</li>
+ *   <li>{@code NotificationEventListener}'s 24h body-string dedup — final
+ *       safety net for any duplicate that slips past the first two layers
+ *       (e.g., a same-firstName collision across distinct counterparts).</li>
+ * </ol>
+ *
+ * <p><b>Implementation note.</b> The mentee and mentor sides run the same
+ * change-detection algorithm against different entity types. The shared
+ * algorithm lives in {@link #processUser}; the public {@code processMentee}
+ * / {@code processMentor} are thin adapters that supply the load /
+ * eligibility / rank functions per side. Keeping the algorithm in one
+ * place means a future addition (metrics, tracing, alternative dedup) is
+ * applied once.
+ */
+@Service
+public class MatchNotificationProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(MatchNotificationProcessor.class);
+
+    private final MatchingService matchingService;
+    private final MenteeRepository menteeRepository;
+    private final MentorRepository mentorRepository;
+    private final LastMatchNotificationRepository stateRepository;
+    private final NotificationEventPublisher notificationEventPublisher;
+    private final Clock clock;
+
+    public MatchNotificationProcessor(MatchingService matchingService,
+                                      MenteeRepository menteeRepository,
+                                      MentorRepository mentorRepository,
+                                      LastMatchNotificationRepository stateRepository,
+                                      NotificationEventPublisher notificationEventPublisher,
+                                      Clock clock) {
+        this.matchingService = matchingService;
+        this.menteeRepository = menteeRepository;
+        this.mentorRepository = mentorRepository;
+        this.stateRepository = stateRepository;
+        this.notificationEventPublisher = notificationEventPublisher;
+        this.clock = clock;
+    }
+
+    /**
+     * Re-rank top mentors for a single mentee and publish a notification only
+     * when the top mentor's id differs from the previously notified one.
+     *
+     * @return {@code true} iff a notification event was published (used by the
+     *         scheduler for the per-run summary log).
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean processMentee(Long menteeId) {
+        return processUser(
+                menteeId,
+                "mentor",
+                menteeRepository::findById,
+                m -> m.getActiveMentorId() == null,
+                m -> matchingService.rankMentorsFor(m, null));
+    }
+
+    /**
+     * Symmetric to {@link #processMentee} for the mentor side. Re-ranks the
+     * mentor's candidate-mentees, fires only when the top candidate changed.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean processMentor(Long mentorId) {
+        return processUser(
+                mentorId,
+                "mentee",
+                mentorRepository::findById,
+                m -> m.getCurrentMenteeCount() < m.getMaxMenteeCapacity(),
+                m -> matchingService.findCandidateMenteesFor(m, null));
+    }
+
+    /**
+     * Generic change-detection: load the user, re-check eligibility (race
+     * window since the scheduler's snapshot), rank, compare top match's id
+     * against the persisted state, and fire-and-upsert if it changed.
+     *
+     * @param userId       recipient id (mentee for mentor-matches, mentor for mentee-matches).
+     * @param matchLabel   human-readable role of the matched user ({@code "mentor"} / {@code "mentee"}),
+     *                     used in the null-id error log.
+     * @param loader       entity loader keyed by {@code userId}.
+     * @param isEligible   second-chance eligibility predicate (race re-check).
+     * @param ranker       pure rank function returning a list whose first element is the top match.
+     */
+    private <T> boolean processUser(
+            Long userId,
+            String matchLabel,
+            Function<Long, Optional<T>> loader,
+            Predicate<T> isEligible,
+            Function<T, List<? extends MatchSummary>> ranker) {
+
+        // Race re-check against the eligibility-list snapshot: the user may
+        // have been deleted, or had eligibility revoked, between the
+        // scheduler's eligibility query and this transaction.
+        T user = loader.apply(userId).orElse(null);
+        if (user == null || !isEligible.test(user)) {
+            return false;
+        }
+
+        List<? extends MatchSummary> ranked = ranker.apply(user);
+        if (ranked.isEmpty()) {
+            return false;
+        }
+
+        MatchSummary top = ranked.get(0);
+        Long topId = top.getId();
+        if (topId == null) {
+            // The DTO factory (MentorMatchResponse.from / MenteeCandidateResponse.from)
+            // explicitly sets id from the entity. A null here means the ranker
+            // contract is broken — surface loudly so monitoring catches it,
+            // and skip so the rest of the batch keeps moving.
+            log.error("Top {} for user {} has null id; skipping (DTO mapping bug)", matchLabel, userId);
+            return false;
+        }
+
+        // Single load: `row` serves both the change-detection check and the
+        // upsert mutation. {@code Objects.equals(null, X)} returns false for
+        // a fresh row (notifiedMatchUserId is null), so first-time recipients
+        // fall through to the publish path.
+        LastMatchNotification row = stateRepository.findById(userId)
+                .orElseGet(LastMatchNotification::new);
+        if (Objects.equals(row.getNotifiedMatchUserId(), topId)) {
+            return false;  // top match unchanged since last notification
+        }
+
+        notificationEventPublisher.publishMatchFound(userId, top.getFirstName());
+        row.setUserId(userId);
+        row.setNotifiedMatchUserId(topId);
+        row.setSentAt(OffsetDateTime.now(clock));
+        stateRepository.save(row);
+        return true;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MatchingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchingService.java
@@ -13,6 +13,7 @@ import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
 import com.group7.backend.repository.MenteeRepository;
 import com.group7.backend.repository.MentorRepository;
 import com.group7.backend.service.ranking.MentorRanker;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -29,6 +30,13 @@ import java.util.stream.Collectors;
  * Mentor/mentee matching service. The data-loading layer is fully SQL-side
  * (#262); this service orchestrates the search → batch-slot-fetch → score →
  * paginate pipeline.
+ *
+ * <p>Read-only after #273. The match-found notification was previously
+ * fired from this service on every page-0 browse; that side effect moved to
+ * {@code MatchNotificationProcessor}, which is invoked daily by
+ * {@code MatchNotificationScheduler} only when the user's top match has
+ * actually changed since the last notification. Pagination, page refreshes,
+ * and deep-links no longer publish anything.
  *
  * <h2>Query budget</h2>
  * Four JPQL/HQL queries per matching call regardless of result size:
@@ -61,53 +69,42 @@ import java.util.stream.Collectors;
 public class MatchingService {
 
     /**
-     * Fixed-size oversample window for in-memory scoring + ranking. Pages
-     * beyond this window return empty content; the frontend should treat
-     * that as "end of results".
+     * Default oversample window if {@code app.matching.ranking-window} is
+     * absent. Pages beyond the window return empty content; the frontend
+     * should treat that as "end of results".
      */
-    private static final int RANKING_WINDOW = 200;
+    private static final int DEFAULT_RANKING_WINDOW = 200;
 
     private final MenteeRepository menteeRepository;
     private final MentorRepository mentorRepository;
     private final AvailabilitySlotRepository availabilitySlotRepository;
     private final MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
     private final MentorRanker mentorRanker;
-    private final NotificationEventPublisher notificationEventPublisher;
+    private final int rankingWindow;
 
     public MatchingService(MenteeRepository menteeRepository,
                            MentorRepository mentorRepository,
                            AvailabilitySlotRepository availabilitySlotRepository,
                            MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository,
                            MentorRanker mentorRanker,
-                           NotificationEventPublisher notificationEventPublisher) {
+                           @Value("${app.matching.ranking-window:" + DEFAULT_RANKING_WINDOW + "}")
+                           int rankingWindow) {
         this.menteeRepository = menteeRepository;
         this.mentorRepository = mentorRepository;
         this.availabilitySlotRepository = availabilitySlotRepository;
         this.menteeAvailabilitySlotRepository = menteeAvailabilitySlotRepository;
         this.mentorRanker = mentorRanker;
-        this.notificationEventPublisher = notificationEventPublisher;
+        this.rankingWindow = rankingWindow;
     }
 
     @Transactional(readOnly = true)
     public Page<MentorMatchResponse> getTopMentors(Long menteeId, String keyword, Pageable pageable) {
-        List<MentorMatchResponse> ranked = rankAvailableMentors(menteeId, keyword);
-        // Match-found notification only on page 0 — pre-refactor it fired on the
-        // globally-top mentor, so the post-refactor equivalent is the top of
-        // the first page. Subsequent pages don't surface "found you a match!"
-        // because the user is already past the headline result.
-        if (pageable.getPageNumber() == 0 && !ranked.isEmpty()) {
-            notificationEventPublisher.publishMatchFound(menteeId, ranked.get(0).getFirstName());
-        }
-        return slicePage(ranked, pageable);
+        return slicePage(rankMentorsForId(menteeId, keyword), pageable);
     }
 
     @Transactional(readOnly = true)
     public List<MentorMatchResponse> getTopMentorsList(Long menteeId, String keyword) {
-        List<MentorMatchResponse> ranked = rankAvailableMentors(menteeId, keyword);
-        if (!ranked.isEmpty()) {
-            notificationEventPublisher.publishMatchFound(menteeId, ranked.get(0).getFirstName());
-        }
-        return ranked;
+        return rankMentorsForId(menteeId, keyword);
     }
 
     @Transactional(readOnly = true)
@@ -117,49 +114,61 @@ public class MatchingService {
         if (mentor.getCurrentMenteeCount() >= mentor.getMaxMenteeCapacity()) {
             throw new MatchingNotAllowedException("You have reached your maximum mentee capacity");
         }
-
-        // Mentee-side has no scoring algorithm today (filter-only). The
-        // existing notification semantics fire when the candidate set is
-        // non-empty, gated to page 0 to match the mentor path.
-        // requesterMentorId is null on the matching path: slot overlap is part
-        // of the SCORING in the mentor-side path (the ranker's availability
-        // score), but the mentee-side path here doesn't score, and the
-        // pre-refactor behaviour did not slot-filter candidate mentees. Passing
-        // mentorId here would silently exclude every mentee whenever the mentor
-        // has zero availability slots set.
-        Pageable fetchPage = PageRequest.of(0, RANKING_WINDOW);
-        List<Mentee> raw = menteeRepository.findRankingCandidates(
-                SearchNormaliser.keyword(keyword), null, null, null,
-                /*requireUnattached*/ true,
-                /*requesterMentorId*/ null,
-                fetchPage);
-
-        // In-memory post-filter: mentees must match at least one of the mentor's
-        // preferences (interest overlap, skill, preferred major, or field). This
-        // OR-of-categories semantic doesn't compose well with the AND-across-
-        // filters JPQL `searchByFilters` shape, and pushing it to SQL would mean
-        // splitting the repo method or introducing a 5th boolean param. The
-        // post-filter runs on at most {@code RANKING_WINDOW} rows already in
-        // memory, so the cost is negligible and the SQL stays clean.
-        List<MenteeCandidateResponse> candidates = raw.stream()
-                .filter(me -> matchesMentorPreferences(mentor, me))
-                .map(MenteeCandidateResponse::from)
-                .toList();
-
-        if (pageable.getPageNumber() == 0 && !candidates.isEmpty()) {
-            notificationEventPublisher.publishMatchFound(mentorId, candidates.get(0).getFirstName());
-        }
-        return slicePage(candidates, pageable);
+        return slicePage(findCandidateMenteesFor(mentor, keyword), pageable);
     }
 
-    private List<MentorMatchResponse> rankAvailableMentors(Long menteeId, String keyword) {
+    /**
+     * ID-based wrapper: loads the mentee, verifies eligibility, then delegates
+     * to {@link #rankMentorsFor(Mentee, String)}. Used by the public matching
+     * methods. Throws {@link MatchingNotAllowedException} when the mentee
+     * already has an active mentor (a business condition mapped to HTTP 403
+     * by the global handler) and {@link ResourceNotFoundException} (HTTP 404)
+     * when the mentee row is missing.
+     *
+     * <p>Naming parallels the pure variant {@link #rankMentorsFor(Mentee, String)}
+     * — same root verb, the {@code ForId} suffix signals "give me a Long, I'll
+     * handle the load + check."
+     *
+     * <p>No {@code @Transactional} annotation on purpose: Spring AOP's default
+     * proxies do not apply transaction advice to package-private methods, and
+     * the public callers ({@code getTopMentors}, {@code getTopMentorsList})
+     * already declare {@code readOnly = true} which propagates here. A future
+     * caller that needs a different transaction shape should declare it on
+     * their own public entry point and pass through.
+     */
+    List<MentorMatchResponse> rankMentorsForId(Long menteeId, String keyword) {
         Mentee mentee = menteeRepository.findById(menteeId)
                 .orElseThrow(() -> new ResourceNotFoundException("Mentee not found"));
         if (mentee.getActiveMentorId() != null) {
             throw new MatchingNotAllowedException("You already have an active mentor");
         }
+        return rankMentorsFor(mentee, keyword);
+    }
 
-        Pageable fetchPage = PageRequest.of(0, RANKING_WINDOW);
+    /**
+     * Pure ranking core for an already-loaded eligible mentee. Skips the
+     * {@code findById} + active-mentor check, so callers who have a Mentee
+     * in hand (e.g., {@code MatchNotificationProcessor.processMentee}) avoid
+     * a redundant DB round-trip.
+     *
+     * <p><b>Precondition:</b> the mentee must be non-null and have no active
+     * mentor. Violations throw {@link IllegalStateException} (programmer
+     * error, not a business condition — not mapped to HTTP).
+     *
+     * <p>No {@code @Transactional}: package-private method advice is ignored
+     * by Spring's proxy. Runs inside the caller's transaction.
+     */
+    List<MentorMatchResponse> rankMentorsFor(Mentee mentee, String keyword) {
+        if (mentee == null) {
+            throw new IllegalStateException("rankMentorsFor: mentee must not be null");
+        }
+        if (mentee.getActiveMentorId() != null) {
+            throw new IllegalStateException(
+                    "rankMentorsFor: mentee " + mentee.getId()
+                            + " has an active mentor; caller must check eligibility first");
+        }
+
+        Pageable fetchPage = PageRequest.of(0, rankingWindow);
         List<Mentor> raw = mentorRepository.findRankingCandidates(
                 SearchNormaliser.keyword(keyword), null, null, null,
                 /*requireCapacity*/ true,
@@ -175,7 +184,7 @@ public class MatchingService {
                 .findByMentorIdIn(mentorIds).stream()
                 .collect(Collectors.groupingBy(s -> s.getMentor().getId()));
         List<MenteeAvailabilitySlot> menteeSlots =
-                menteeAvailabilitySlotRepository.findByMenteeId(menteeId);
+                menteeAvailabilitySlotRepository.findByMenteeId(mentee.getId());
 
         return raw.stream()
                 .map(m -> MentorMatchResponse.from(m, mentorRanker.score(
@@ -183,6 +192,48 @@ public class MatchingService {
                         slotsByMentor.getOrDefault(m.getId(), List.of()),
                         menteeSlots)))
                 .sorted(Comparator.comparingInt(MentorMatchResponse::getMatchScore).reversed())
+                .toList();
+    }
+
+    /**
+     * Pure candidate-mentee filter for an already-loaded eligible mentor.
+     * Skips the {@code findById} + capacity check; caller must verify.
+     *
+     * <p><b>Precondition:</b> the mentor must be non-null and have spare
+     * capacity. Violations throw {@link IllegalStateException}.
+     */
+    List<MenteeCandidateResponse> findCandidateMenteesFor(Mentor mentor, String keyword) {
+        if (mentor == null) {
+            throw new IllegalStateException("findCandidateMenteesFor: mentor must not be null");
+        }
+        if (mentor.getCurrentMenteeCount() >= mentor.getMaxMenteeCapacity()) {
+            throw new IllegalStateException(
+                    "findCandidateMenteesFor: mentor " + mentor.getId()
+                            + " is at full capacity; caller must check eligibility first");
+        }
+
+        // requesterMentorId is null on the matching path: slot overlap is part
+        // of the SCORING in the mentor-side path (the ranker's availability
+        // score), but the mentee-side path here doesn't score. Passing
+        // mentor.id would silently exclude every mentee whenever the mentor
+        // has zero availability slots set — not the intended behaviour.
+        Pageable fetchPage = PageRequest.of(0, rankingWindow);
+        List<Mentee> raw = menteeRepository.findRankingCandidates(
+                SearchNormaliser.keyword(keyword), null, null, null,
+                /*requireUnattached*/ true,
+                /*requesterMentorId*/ null,
+                fetchPage);
+
+        // In-memory post-filter: mentees must match at least one of the mentor's
+        // preferences (interest overlap, skill, preferred major, or field). This
+        // OR-of-categories semantic doesn't compose well with the AND-across-
+        // filters JPQL `searchByFilters` shape, and pushing it to SQL would mean
+        // splitting the repo method or introducing a 5th boolean param. The
+        // post-filter runs on at most {@code RANKING_WINDOW} rows already in
+        // memory, so the cost is negligible and the SQL stays clean.
+        return raw.stream()
+                .filter(me -> matchesMentorPreferences(mentor, me))
+                .map(MenteeCandidateResponse::from)
                 .toList();
     }
 
@@ -197,7 +248,7 @@ public class MatchingService {
         // cast directly to int and produces a negative `start`, which would
         // throw IndexOutOfBoundsException from List.subList. Comparing in
         // long-space and short-circuiting on out-of-range offsets makes the
-        // narrowing cast safe (offset < ranked.size() ≤ RANKING_WINDOW).
+        // narrowing cast safe (offset < ranked.size() ≤ rankingWindow).
         long offset = pageable.getOffset();
         if (offset >= ranked.size()) {
             return new PageImpl<>(List.of(), pageable, ranked.size());

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -108,3 +108,11 @@ app.ratelimit.rules.availability-ical.pattern=/api/availability/*/ical
 app.ratelimit.rules.availability-ical.key-strategy=IP
 app.ratelimit.rules.availability-ical.capacity=30
 app.ratelimit.rules.availability-ical.refill=PT1M
+
+# In-memory oversample window for the matching pipeline (#262/#273). The SQL
+# layer fetches up to this many candidates ordered by id DESC, the ranker
+# scores them in memory, and the page is sliced from the in-memory ranking.
+# Pages beyond the window return empty content. Tune up if the user base
+# grows and frontend pagination needs to reach further; tune down if memory
+# becomes a concern (each candidate carries its full DTO + collections).
+app.matching.ranking-window=${MATCH_RANKING_WINDOW:200}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -116,3 +116,12 @@ app.ratelimit.rules.availability-ical.refill=PT1M
 # grows and frontend pagination needs to reach further; tune down if memory
 # becomes a concern (each candidate carries its full DTO + collections).
 app.matching.ranking-window=${MATCH_RANKING_WINDOW:200}
+
+# Scheduled match-found notification job (#273). Daily 09:00 UTC by default.
+# `enabled=false` skips bean creation entirely; `cron=-` keeps the bean wired
+# but suppresses firings (Spring 5.1+ documents "-" as the disable marker).
+# The cron property must be a valid six-field cron expression OR "-"; empty
+# or invalid values fail Spring's CronExpression.parse at startup.
+app.matching.notification.enabled=${MATCH_NOTIFICATION_ENABLED:true}
+app.matching.notification.cron=${MATCH_NOTIFICATION_CRON:0 0 9 * * *}
+app.matching.notification.zone=${MATCH_NOTIFICATION_ZONE:UTC}

--- a/backend/src/main/resources/db/migration/V20__last_match_notifications.sql
+++ b/backend/src/main/resources/db/migration/V20__last_match_notifications.sql
@@ -1,0 +1,31 @@
+-- Per-user dedup state for the scheduled match-notification job (#273).
+--
+-- One row per recipient (mentee or mentor). The scheduler re-ranks each
+-- eligible user daily, compares the current top match's id to
+-- `notified_match_user_id`, and publishes a MATCH_FOUND notification only
+-- when the value changed (or no row exists yet).
+--
+-- Schema choices, deliberate:
+--   * `user_id` PK + ON DELETE CASCADE — recipient deletion drops the row.
+--     The tiny race window during processing is handled by the per-user
+--     try/catch in MatchNotificationScheduler; next run skips the deleted
+--     user via the eligibility query.
+--   * `notified_match_user_id` carries NO foreign key. Without it, an
+--     INSERT cannot fail with DataIntegrityViolationException when the
+--     counterpart is deleted between rank-fetch and state-save in the same
+--     scheduler tick. We never JOIN through this column — only compare for
+--     equality (`stale_id != current_top_id` → fire as if first-time), so
+--     losing referential integrity here costs nothing.
+--   * `version` for JPA optimistic locking. Concurrent UPDATE from two
+--     scheduler instances → loser throws OptimisticLockException, its
+--     transaction rolls back, AFTER_COMMIT skips, no duplicate notification.
+--     PK uniqueness handles the same race for INSERTs.
+--
+-- Rollback: `DROP TABLE last_match_notifications` — no other schema
+-- depends on this table.
+CREATE TABLE last_match_notifications (
+    user_id                BIGINT       PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    notified_match_user_id BIGINT,
+    sent_at                TIMESTAMPTZ  NOT NULL,
+    version                BIGINT       NOT NULL DEFAULT 0
+);

--- a/backend/src/test/java/com/group7/backend/integration/MatchNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MatchNotificationIntegrationTest.java
@@ -1,0 +1,222 @@
+package com.group7.backend.integration;
+
+import com.group7.backend.entity.LastMatchNotification;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.NotificationType;
+import com.group7.backend.repository.LastMatchNotificationRepository;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.repository.NotificationRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.scheduler.MatchNotificationScheduler;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end coverage for the scheduled match-notification path (#273) against
+ * a real Postgres. Overrides the default test profile (which disables the
+ * scheduler) to instantiate the scheduler bean while keeping the cron disabled
+ * via {@code cron="-"} — tests invoke {@code scheduler.notifyChangedMatches()}
+ * directly and never wait for an actual cron firing.
+ *
+ * <p>The {@code AFTER_COMMIT} listener that persists Notification rows runs
+ * on a different thread (it's {@code @Async}), so assertions on the
+ * notifications table are wrapped in {@link Awaitility} to wait briefly for
+ * the listener to catch up.
+ */
+@SpringBootTest(properties = {
+        "app.matching.notification.enabled=true",
+        "app.matching.notification.cron=-"
+})
+@ActiveProfiles("test")
+class MatchNotificationIntegrationTest {
+
+    @Autowired private MatchNotificationScheduler scheduler;
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private LastMatchNotificationRepository stateRepository;
+    @Autowired private NotificationRepository notificationRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+
+    @BeforeEach
+    void cleanDb() {
+        notificationRepository.deleteAll();
+        stateRepository.deleteAll();
+        menteeAvailabilitySlotRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    private Mentor newMentor(String suffix, String firstName) {
+        Mentor m = new Mentor();
+        m.setFirstName(firstName);
+        m.setLastName("L");
+        m.setEmail("mn273_m_" + suffix + "@example.com");
+        m.setPasswordHash("x");
+        m.setIsEmailVerified(true);
+        m.setMaxMenteeCapacity(3);
+        m.setCurrentMenteeCount(0);
+        m.setInterests(List.of("AI", "Systems"));
+        m.setPreferredMenteeSkills(List.of("Java", "Python"));
+        m.setField("Computer Science");
+        return m;
+    }
+
+    private Mentee newMentee(String suffix, String firstName) {
+        Mentee m = new Mentee();
+        m.setFirstName(firstName);
+        m.setLastName("L");
+        m.setEmail("mn273_me_" + suffix + "@example.com");
+        m.setPasswordHash("x");
+        m.setIsEmailVerified(true);
+        m.setInterests(List.of("AI"));
+        m.setSkills(List.of("Java"));
+        m.setMajor("Computer Science");
+        return m;
+    }
+
+    private long countMatchFoundFor(Long recipientId) {
+        return notificationRepository.findAll().stream()
+                .filter(n -> n.getRecipient().getId().equals(recipientId))
+                .filter(n -> n.getType() == NotificationType.MATCH_FOUND)
+                .count();
+    }
+
+    private void awaitNotificationsFor(Long recipientId, long expected) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(countMatchFoundFor(recipientId)).isEqualTo(expected));
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    @Test
+    void firstRun_publishesAndUpsertsForEachEligibleUser() {
+        Mentee mentee = menteeRepository.save(newMentee("a", "Alice"));
+        Mentor mentor = mentorRepository.save(newMentor("a", "Bob"));
+
+        scheduler.notifyChangedMatches();
+
+        // Mentee got notified about the only mentor; mentor got notified about
+        // the only mentee. Both state rows are populated with the counterpart's id.
+        awaitNotificationsFor(mentee.getId(), 1);
+        awaitNotificationsFor(mentor.getId(), 1);
+
+        LastMatchNotification menteeState = stateRepository.findById(mentee.getId()).orElseThrow();
+        assertThat(menteeState.getNotifiedMatchUserId()).isEqualTo(mentor.getId());
+        LastMatchNotification mentorState = stateRepository.findById(mentor.getId()).orElseThrow();
+        assertThat(mentorState.getNotifiedMatchUserId()).isEqualTo(mentee.getId());
+    }
+
+    @Test
+    void secondRun_skipsWhenTopMatchUnchanged() {
+        Mentee mentee = menteeRepository.save(newMentee("b", "Alice"));
+        mentorRepository.save(newMentor("b", "Bob"));
+
+        scheduler.notifyChangedMatches();
+        awaitNotificationsFor(mentee.getId(), 1);
+
+        scheduler.notifyChangedMatches();
+
+        // No new notification — top match hasn't changed since the first run.
+        // Wait briefly to confirm no late-firing listener bumps the count.
+        Awaitility.await().pollDelay(Duration.ofMillis(500))
+                .atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(countMatchFoundFor(mentee.getId())).isEqualTo(1));
+    }
+
+    @Test
+    void run_publishesAgainWhenTopMatchChanges() {
+        Mentee mentee = menteeRepository.save(newMentee("c", "Alice"));
+        mentorRepository.save(newMentor("c1", "Bob"));
+
+        scheduler.notifyChangedMatches();
+        awaitNotificationsFor(mentee.getId(), 1);
+
+        // A new mentor with a stronger profile registers (matches mentee on
+        // both interest AND skill, which the rule-based ranker scores higher
+        // than just-interest match).
+        Mentor stronger = newMentor("c2", "Carol");
+        stronger.setPreferredMenteeMajor("Computer Science");  // adds another match category
+        mentorRepository.save(stronger);
+
+        scheduler.notifyChangedMatches();
+
+        awaitNotificationsFor(mentee.getId(), 2);
+        LastMatchNotification state = stateRepository.findById(mentee.getId()).orElseThrow();
+        assertThat(state.getNotifiedMatchUserId()).isEqualTo(stronger.getId());
+    }
+
+    @Test
+    void run_skipsMenteeWithActiveMentor() {
+        Mentee mentee = newMentee("d", "Alice");
+        Mentor mentor = mentorRepository.save(newMentor("d", "Bob"));
+        mentee.setActiveMentorId(mentor.getId());  // already partnered → ineligible
+        menteeRepository.save(mentee);
+
+        scheduler.notifyChangedMatches();
+
+        // Mentee is excluded by findUnattachedIds; no notification, no state row.
+        Awaitility.await().pollDelay(Duration.ofMillis(500))
+                .atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> {
+                    assertThat(countMatchFoundFor(mentee.getId())).isZero();
+                    assertThat(stateRepository.findById(mentee.getId())).isEmpty();
+                });
+    }
+
+    @Test
+    void run_skipsMentorAtFullCapacity() {
+        Mentor mentor = newMentor("e", "Bob");
+        mentor.setMaxMenteeCapacity(1);
+        mentor.setCurrentMenteeCount(1);  // full → ineligible
+        mentorRepository.save(mentor);
+        menteeRepository.save(newMentee("e", "Alice"));
+
+        scheduler.notifyChangedMatches();
+
+        // Mentor is excluded by findIdsWithCapacity; no notification, no state row.
+        Awaitility.await().pollDelay(Duration.ofMillis(500))
+                .atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> {
+                    assertThat(countMatchFoundFor(mentor.getId())).isZero();
+                    assertThat(stateRepository.findById(mentor.getId())).isEmpty();
+                });
+    }
+
+    @Test
+    void firstNotificationFiresWhenStateRowReferencesDeletedCounterpart() {
+        // Simulates the "no FK on notified_match_user_id" rationale: the
+        // previously-notified counterpart was deleted at some point. The
+        // column carries a stale id; the next run sees stale != current_top
+        // and fires (correctly treated as first-time-for-the-new-top).
+        Mentee mentee = menteeRepository.save(newMentee("f", "Alice"));
+        Mentor mentor = mentorRepository.save(newMentor("f", "Bob"));
+
+        // Pre-seed state pointing at a non-existent user id.
+        LastMatchNotification stale = new LastMatchNotification();
+        stale.setUserId(mentee.getId());
+        stale.setNotifiedMatchUserId(99_999L);  // never existed
+        stale.setSentAt(java.time.OffsetDateTime.parse("2026-01-01T00:00:00Z"));
+        stateRepository.save(stale);
+
+        scheduler.notifyChangedMatches();
+
+        awaitNotificationsFor(mentee.getId(), 1);
+        LastMatchNotification refreshed = stateRepository.findById(mentee.getId()).orElseThrow();
+        assertThat(refreshed.getNotifiedMatchUserId()).isEqualTo(mentor.getId());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/NotificationIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/NotificationIntegrationTest.java
@@ -177,7 +177,13 @@ class NotificationIntegrationTest {
     }
 
     @Test
-    void matchingEndpointCreatesMatchFoundNotification() throws Exception {
+    void matchingEndpointDoesNotCreateMatchFoundNotification_post273() throws Exception {
+        // Regression for #273. Before the fix, hitting the matching endpoint
+        // fired a publishMatchFound on every page-0 browse — wasting queries
+        // and conflating browsing with notification opt-in. The notification
+        // path is now driven by MatchNotificationScheduler, so a read-only
+        // browse must NEVER persist a Notification row. The scheduler's
+        // own behaviour is covered by MatchNotificationIntegrationTest.
         registerAndLogin("notif_mentor2@test.com", true);
         Mentor mentor = mentorRepository.findAll().stream()
                 .filter(m -> m.getEmail().equals("notif_mentor2@test.com"))
@@ -202,8 +208,22 @@ class NotificationIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].firstName").value("Ayse"));
 
-        Notification created = waitForNotification(mentee.getId(), NotificationType.MATCH_FOUND);
-        assertThat(created).isNotNull();
+        // Wait briefly then assert absence — pollDelay covers the case of a
+        // late-firing @Async listener catching up after our initial check.
+        // Awaitility.untilAsserted re-runs until the assertion passes; for an
+        // "expect zero" we set an upper bound and require the absence to hold
+        // across the polling window. Robust against slow CI compared to a
+        // fixed Thread.sleep.
+        org.awaitility.Awaitility.await()
+                .pollDelay(java.time.Duration.ofMillis(500))
+                .atMost(java.time.Duration.ofSeconds(2))
+                .untilAsserted(() -> {
+                    long matchFoundCount = notificationRepository.findAll().stream()
+                            .filter(n -> n.getRecipient().getId().equals(mentee.getId()))
+                            .filter(n -> n.getType() == NotificationType.MATCH_FOUND)
+                            .count();
+                    assertThat(matchFoundCount).isZero();
+                });
     }
 
         @Test

--- a/backend/src/test/java/com/group7/backend/repository/MatchNotificationEligibilityQueriesTest.java
+++ b/backend/src/test/java/com/group7/backend/repository/MatchNotificationEligibilityQueriesTest.java
@@ -1,0 +1,259 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.LastMatchNotification;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Real-Postgres coverage for the eligibility queries added in #273
+ * ({@link MenteeRepository#findUnattachedIds()},
+ * {@link MentorRepository#findIdsWithCapacity()}) plus the
+ * {@link LastMatchNotificationRepository} round-trip.
+ *
+ * <p>Pinned to the {@code test} profile because the migrations expect Postgres
+ * (Flyway-validated). {@code @Transactional} rolls back DB writes between
+ * tests; the explicit {@code cleanDb()} prevents leakage from other test
+ * classes that don't roll back.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class MatchNotificationEligibilityQueriesTest {
+
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private LastMatchNotificationRepository stateRepository;
+    @Autowired private EntityManager entityManager;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDb() {
+        stateRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ── findUnattachedIds (mentee eligibility) ───────────────────────────────
+
+    @Test
+    void findUnattachedIds_returnsOnlyMenteesWithoutActiveMentor() {
+        // Set up: 1 attached mentee, 2 unattached. Plus a mentor (just to seed
+        // a real users.id for the activeMentorId FK target).
+        Mentor mentor = saveMentor("mn273_eligm@example.com");
+        Mentee attached = newMentee("mn273_elig_a", "Alice");
+        attached.setActiveMentorId(mentor.getId());
+        menteeRepository.save(attached);
+        Mentee unattached1 = menteeRepository.save(newMentee("mn273_elig_b", "Bob"));
+        Mentee unattached2 = menteeRepository.save(newMentee("mn273_elig_c", "Cara"));
+
+        List<Long> ids = menteeRepository.findUnattachedIds();
+
+        assertThat(ids)
+                .as("only mentees with activeMentorId IS NULL show up")
+                .containsExactlyInAnyOrder(unattached1.getId(), unattached2.getId());
+    }
+
+    @Test
+    void findUnattachedIds_isOrderedByIdAscending() {
+        // Test determinism: scheduler iterates this list, so we want a stable order.
+        Mentee a = menteeRepository.save(newMentee("mn273_eord_a", "A"));
+        Mentee b = menteeRepository.save(newMentee("mn273_eord_b", "B"));
+        Mentee c = menteeRepository.save(newMentee("mn273_eord_c", "C"));
+
+        List<Long> ids = menteeRepository.findUnattachedIds();
+
+        assertThat(ids).containsExactly(a.getId(), b.getId(), c.getId());
+    }
+
+    @Test
+    void findUnattachedIds_returnsEmptyListWhenNoMenteesExist() {
+        assertThat(menteeRepository.findUnattachedIds()).isEmpty();
+    }
+
+    // ── findIdsWithCapacity (mentor eligibility) ─────────────────────────────
+
+    @Test
+    void findIdsWithCapacity_returnsOnlyMentorsBelowCapacity() {
+        Mentor empty = saveMentorWithCapacity("mn273_capa_a@example.com", 3, 0);
+        Mentor partial = saveMentorWithCapacity("mn273_capa_b@example.com", 3, 2);
+        saveMentorWithCapacity("mn273_capa_c@example.com", 2, 2);  // at cap → excluded
+
+        List<Long> ids = mentorRepository.findIdsWithCapacity();
+
+        assertThat(ids).containsExactlyInAnyOrder(empty.getId(), partial.getId());
+    }
+
+    @Test
+    void findIdsWithCapacity_excludesMentorsAtExactlyMaxCapacity() {
+        // Boundary: currentMenteeCount == maxMenteeCapacity → strictly excluded
+        // (we use < not <=). Otherwise a mentor who *just* filled would receive
+        // a confusing notification.
+        saveMentorWithCapacity("mn273_capb@example.com", 3, 3);
+
+        assertThat(mentorRepository.findIdsWithCapacity()).isEmpty();
+    }
+
+    @Test
+    void findIdsWithCapacity_isOrderedByIdAscending() {
+        Mentor a = saveMentorWithCapacity("mn273_cord_a@example.com", 3, 0);
+        Mentor b = saveMentorWithCapacity("mn273_cord_b@example.com", 3, 0);
+        Mentor c = saveMentorWithCapacity("mn273_cord_c@example.com", 3, 0);
+
+        List<Long> ids = mentorRepository.findIdsWithCapacity();
+
+        assertThat(ids).containsExactly(a.getId(), b.getId(), c.getId());
+    }
+
+    // ── LastMatchNotificationRepository round-trip ───────────────────────────
+
+    @Test
+    void lastMatchNotification_savesAndReloadsCleanly() {
+        Mentee user = menteeRepository.save(newMentee("mn273_state_u", "Sam"));
+        Mentor counterpart = saveMentor("mn273_state_c@example.com");
+
+        LastMatchNotification row = new LastMatchNotification();
+        row.setUserId(user.getId());
+        row.setNotifiedMatchUserId(counterpart.getId());
+        row.setSentAt(OffsetDateTime.parse("2026-05-07T09:00:00Z"));
+        stateRepository.save(row);
+
+        LastMatchNotification loaded = stateRepository.findById(user.getId()).orElseThrow();
+        assertThat(loaded.getUserId()).isEqualTo(user.getId());
+        assertThat(loaded.getNotifiedMatchUserId()).isEqualTo(counterpart.getId());
+        assertThat(loaded.getSentAt()).isEqualTo(OffsetDateTime.parse("2026-05-07T09:00:00Z"));
+        assertThat(loaded.getVersion()).isEqualTo(0L);
+    }
+
+    @Test
+    void lastMatchNotification_versionIncrementsOnUpdate() {
+        // Defends the @Version annotation against a future Lombok / JPA refactor
+        // that accidentally drops it. Without a working @Version, two scheduler
+        // instances racing on UPDATE would silently double-publish.
+        Mentee user = menteeRepository.save(newMentee("mn273_ver_u", "Ver"));
+        LastMatchNotification row = new LastMatchNotification();
+        row.setUserId(user.getId());
+        row.setNotifiedMatchUserId(99L);
+        row.setSentAt(OffsetDateTime.parse("2026-05-07T09:00:00Z"));
+        // saveAndFlush returns the merged/managed copy. Capturing it gives us
+        // the entity Hibernate has wired into the persistence context, which
+        // is what carries the post-write @Version value.
+        LastMatchNotification managed = stateRepository.saveAndFlush(row);
+        long initialVersion = managed.getVersion();
+
+        managed.setNotifiedMatchUserId(100L);
+        managed = stateRepository.saveAndFlush(managed);
+
+        assertThat(managed.getVersion())
+                .as("@Version increments on UPDATE")
+                .isEqualTo(initialVersion + 1);
+    }
+
+    @Test
+    void lastMatchNotification_cascadesOnUserDelete() {
+        // ON DELETE CASCADE on user_id PK — when the recipient is deleted, the
+        // state row is reaped automatically. Defends the V20 migration's FK
+        // choice; if a reviewer ever drops the cascade clause, this test fails.
+        //
+        // Hibernate's L1 cache holds the state row after we save it; checking
+        // via the repository's findById would return the cached entity even
+        // after the DB-side cascade has fired. We bypass the cache by querying
+        // through JdbcTemplate (raw SQL — sees actual DB state) after clearing
+        // the persistence context to flush pending writes.
+        Mentee user = menteeRepository.save(newMentee("mn273_casc", "Cas"));
+        LastMatchNotification row = new LastMatchNotification();
+        row.setUserId(user.getId());
+        row.setNotifiedMatchUserId(99L);
+        row.setSentAt(OffsetDateTime.parse("2026-05-07T09:00:00Z"));
+        stateRepository.saveAndFlush(row);
+
+        userRepository.delete(user);
+        userRepository.flush();
+        entityManager.clear();   // drop L1 cache so subsequent reads hit the DB
+
+        Integer remaining = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM last_match_notifications WHERE user_id = ?",
+                Integer.class, user.getId());
+        assertThat(remaining).isZero();
+    }
+
+    @Test
+    void lastMatchNotification_acceptsStaleNotifiedMatchUserId() {
+        // No FK on notified_match_user_id by design — see V20 migration comment.
+        // The column tolerates stale values that point at deleted users; the
+        // scheduler's equality check treats stale != current as "fire as if
+        // first-time". Asserting the schema actually allows it.
+        Mentee user = menteeRepository.save(newMentee("mn273_stale", "Sta"));
+        LastMatchNotification row = new LastMatchNotification();
+        row.setUserId(user.getId());
+        row.setNotifiedMatchUserId(99_999L);  // never existed
+        row.setSentAt(OffsetDateTime.parse("2026-05-07T09:00:00Z"));
+
+        // Should not throw — no FK to violate.
+        assertThat(stateRepository.saveAndFlush(row)).isNotNull();
+    }
+
+    @Test
+    void lastMatchNotification_userIdFkBlocksOrphanInsert() {
+        // The recipient PK *does* have a FK; inserting for a non-existent user
+        // must be rejected so we don't accumulate dead state rows. Defends the
+        // user_id REFERENCES users(id) clause.
+        LastMatchNotification orphan = new LastMatchNotification();
+        orphan.setUserId(98_765L);  // never existed
+        orphan.setNotifiedMatchUserId(1L);
+        orphan.setSentAt(OffsetDateTime.parse("2026-05-07T09:00:00Z"));
+
+        assertThatThrownBy(() -> stateRepository.saveAndFlush(orphan))
+                .hasRootCauseInstanceOf(java.sql.SQLException.class)
+                .hasMessageContaining("foreign key");
+    }
+
+    // ── Fixtures ─────────────────────────────────────────────────────────────
+
+    private Mentee newMentee(String suffix, String firstName) {
+        Mentee m = new Mentee();
+        m.setFirstName(firstName);
+        m.setLastName("L");
+        m.setEmail(suffix + "@example.com");
+        m.setPasswordHash("x");
+        m.setIsEmailVerified(true);
+        return m;
+    }
+
+    private Mentor saveMentor(String email) {
+        Mentor m = new Mentor();
+        m.setFirstName("M");
+        m.setLastName("L");
+        m.setEmail(email);
+        m.setPasswordHash("x");
+        m.setIsEmailVerified(true);
+        m.setMaxMenteeCapacity(3);
+        m.setCurrentMenteeCount(0);
+        return mentorRepository.save(m);
+    }
+
+    private Mentor saveMentorWithCapacity(String email, int max, int current) {
+        Mentor m = new Mentor();
+        m.setFirstName("M");
+        m.setLastName("L");
+        m.setEmail(email);
+        m.setPasswordHash("x");
+        m.setIsEmailVerified(true);
+        m.setMaxMenteeCapacity(max);
+        m.setCurrentMenteeCount(current);
+        return mentorRepository.save(m);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/scheduler/MatchNotificationSchedulerTest.java
+++ b/backend/src/test/java/com/group7/backend/scheduler/MatchNotificationSchedulerTest.java
@@ -1,0 +1,219 @@
+package com.group7.backend.scheduler;
+
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.scheduler.MatchNotificationScheduler.BatchResult;
+import com.group7.backend.service.MatchNotificationProcessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for {@link MatchNotificationScheduler}'s loop semantics.
+ * Asserts: (a) every eligible id from the repos reaches the processor;
+ * (b) per-user exceptions are caught + logged + the loop continues;
+ * (c) per-side eligibility-query failures don't skip the other side;
+ * (d) the {@link BatchResult} surfaced for the run-summary log carries the
+ * eligibility-list size alongside the publish count.
+ *
+ * <p>We don't try to assert that the cron fires on time — that's Spring's
+ * responsibility. Tests invoke the package-private {@code notifyMentees()}
+ * / {@code notifyMentors()} directly, matching the
+ * {@link com.group7.backend.scheduler.AttachmentOrphanCleanupScheduler}
+ * test idiom.
+ */
+@ExtendWith(MockitoExtension.class)
+class MatchNotificationSchedulerTest {
+
+    @Mock private MatchNotificationProcessor processor;
+    @Mock private MenteeRepository menteeRepository;
+    @Mock private MentorRepository mentorRepository;
+
+    private MatchNotificationScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new MatchNotificationScheduler(
+                processor, menteeRepository, mentorRepository,
+                "0 0 9 * * *", "UTC");
+    }
+
+    @Test
+    void notifyMentees_iteratesAllEligibleIds() {
+        when(menteeRepository.findUnattachedIds()).thenReturn(List.of(1L, 2L, 3L));
+        when(processor.processMentee(1L)).thenReturn(true);
+        when(processor.processMentee(2L)).thenReturn(false);
+        when(processor.processMentee(3L)).thenReturn(true);
+
+        BatchResult result = scheduler.notifyMentees();
+
+        assertThat(result.eligible()).isEqualTo(3);
+        assertThat(result.published()).isEqualTo(2);
+        verify(processor).processMentee(1L);
+        verify(processor).processMentee(2L);
+        verify(processor).processMentee(3L);
+    }
+
+    @Test
+    void notifyMentors_iteratesAllEligibleIds() {
+        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of(10L, 20L));
+        when(processor.processMentor(10L)).thenReturn(true);
+        when(processor.processMentor(20L)).thenReturn(true);
+
+        BatchResult result = scheduler.notifyMentors();
+
+        assertThat(result.eligible()).isEqualTo(2);
+        assertThat(result.published()).isEqualTo(2);
+        verify(processor).processMentor(10L);
+        verify(processor).processMentor(20L);
+    }
+
+    @Test
+    void notifyMentees_swallowsPerUserExceptionsAndContinues() {
+        when(menteeRepository.findUnattachedIds()).thenReturn(List.of(1L, 2L, 3L));
+        when(processor.processMentee(1L)).thenReturn(true);
+        when(processor.processMentee(2L)).thenThrow(new RuntimeException("transient DB error"));
+        when(processor.processMentee(3L)).thenReturn(true);
+
+        BatchResult result = scheduler.notifyMentees();
+
+        // Eligible count is still the full list — failures don't subtract.
+        // Published count reflects only the successful publishes.
+        assertThat(result.eligible()).isEqualTo(3);
+        assertThat(result.published()).isEqualTo(2);
+        verify(processor).processMentee(1L);
+        verify(processor).processMentee(2L);
+        verify(processor).processMentee(3L);
+    }
+
+    @Test
+    void notifyMentees_logsIllegalStateAtErrorButContinues() {
+        when(menteeRepository.findUnattachedIds()).thenReturn(List.of(1L, 2L));
+        // IllegalStateException = precondition violation (programmer bug).
+        // Different log path from a transient exception, but both are caught
+        // and the loop proceeds.
+        when(processor.processMentee(1L)).thenThrow(new IllegalStateException("precondition broken"));
+        when(processor.processMentee(2L)).thenReturn(true);
+
+        BatchResult result = scheduler.notifyMentees();
+
+        assertThat(result.eligible()).isEqualTo(2);
+        assertThat(result.published()).isEqualTo(1);
+        verify(processor).processMentee(2L);
+    }
+
+    @Test
+    void notifyChangedMatches_isolatesMenteeSideFailureFromMentorSide() {
+        // findUnattachedIds throws — without runSafely, notifyMentors would
+        // never run. With runSafely, we still process the mentor side.
+        when(menteeRepository.findUnattachedIds()).thenThrow(new RuntimeException("DB outage"));
+        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of(10L));
+        when(processor.processMentor(10L)).thenReturn(true);
+
+        scheduler.notifyChangedMatches();
+
+        verify(processor, never()).processMentee(anyLong());
+        verify(processor).processMentor(10L);
+    }
+
+    @Test
+    void notifyChangedMatches_isolatesMentorSideFailureFromMenteeSide() {
+        when(menteeRepository.findUnattachedIds()).thenReturn(List.of(1L));
+        when(processor.processMentee(1L)).thenReturn(true);
+        when(mentorRepository.findIdsWithCapacity()).thenThrow(new RuntimeException("DB outage"));
+
+        scheduler.notifyChangedMatches();
+
+        verify(processor).processMentee(1L);
+        verify(processor, never()).processMentor(anyLong());
+    }
+
+    @Test
+    void notifyMentees_emptyEligibilityListIsNoOp() {
+        when(menteeRepository.findUnattachedIds()).thenReturn(List.of());
+
+        BatchResult result = scheduler.notifyMentees();
+
+        assertThat(result.eligible()).isZero();
+        assertThat(result.published()).isZero();
+        verify(processor, never()).processMentee(anyLong());
+    }
+
+    // ── Symmetric mentor-side coverage ───────────────────────────────────────
+
+    @Test
+    void notifyMentors_swallowsPerUserExceptionsAndContinues() {
+        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of(10L, 20L, 30L));
+        when(processor.processMentor(10L)).thenReturn(true);
+        when(processor.processMentor(20L)).thenThrow(new RuntimeException("transient DB error"));
+        when(processor.processMentor(30L)).thenReturn(true);
+
+        BatchResult result = scheduler.notifyMentors();
+
+        assertThat(result.eligible()).isEqualTo(3);
+        assertThat(result.published()).isEqualTo(2);
+        verify(processor).processMentor(10L);
+        verify(processor).processMentor(20L);
+        verify(processor).processMentor(30L);
+    }
+
+    @Test
+    void notifyMentors_logsIllegalStateAtErrorButContinues() {
+        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of(10L, 20L));
+        when(processor.processMentor(10L)).thenThrow(new IllegalStateException("precondition broken"));
+        when(processor.processMentor(20L)).thenReturn(true);
+
+        BatchResult result = scheduler.notifyMentors();
+
+        assertThat(result.eligible()).isEqualTo(2);
+        assertThat(result.published()).isEqualTo(1);
+        verify(processor).processMentor(20L);
+    }
+
+    @Test
+    void notifyMentors_emptyEligibilityListIsNoOp() {
+        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of());
+
+        BatchResult result = scheduler.notifyMentors();
+
+        assertThat(result.eligible()).isZero();
+        assertThat(result.published()).isZero();
+        verify(processor, never()).processMentor(anyLong());
+    }
+
+    // ── Run-summary semantics ────────────────────────────────────────────────
+
+    @Test
+    void notifyChangedMatches_sumsBothSidesAndCompletesEvenWithZeroPublishes() {
+        when(menteeRepository.findUnattachedIds()).thenReturn(List.of());
+        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of());
+
+        scheduler.notifyChangedMatches();
+
+        // Both eligibility queries ran exactly once; processor never invoked.
+        verify(menteeRepository).findUnattachedIds();
+        verify(mentorRepository).findIdsWithCapacity();
+        verify(processor, never()).processMentee(anyLong());
+        verify(processor, never()).processMentor(anyLong());
+    }
+
+    // ── Startup config log ───────────────────────────────────────────────────
+
+    @Test
+    void logStartupConfig_doesNotThrowWithProvidedConfig() {
+        // Constructor-injected cron + zone — proves the @PostConstruct line
+        // doesn't NPE when invoked outside Spring (it would if cron/zone
+        // were field-injected and tests forgot to set them).
+        scheduler.logStartupConfig();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MatchNotificationProcessorTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MatchNotificationProcessorTest.java
@@ -1,0 +1,361 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.MenteeCandidateResponse;
+import com.group7.backend.dto.response.MentorMatchResponse;
+import com.group7.backend.entity.LastMatchNotification;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.repository.LastMatchNotificationRepository;
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for {@link MatchNotificationProcessor}'s per-user transactional
+ * logic. Mocks the matching service + repositories + publisher; the real {@code
+ * RuleBasedMentorRanker} is irrelevant here because we never exercise scoring —
+ * only the publish-vs-skip decision based on state-row equality. Pattern matches
+ * the existing {@link com.group7.backend.scheduler.AttachmentOrphanCleanupScheduler}
+ * test convention: {@code @ExtendWith(MockitoExtension.class)}, fixed Clock,
+ * manual constructor, AssertJ.
+ */
+@ExtendWith(MockitoExtension.class)
+class MatchNotificationProcessorTest {
+
+    @Mock private MatchingService matchingService;
+    @Mock private MenteeRepository menteeRepository;
+    @Mock private MentorRepository mentorRepository;
+    @Mock private LastMatchNotificationRepository stateRepository;
+    @Mock private NotificationEventPublisher notificationEventPublisher;
+
+    private final Clock fixedClock =
+            Clock.fixed(Instant.parse("2026-05-07T09:00:00Z"), ZoneOffset.UTC);
+
+    private MatchNotificationProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new MatchNotificationProcessor(
+                matchingService,
+                menteeRepository,
+                mentorRepository,
+                stateRepository,
+                notificationEventPublisher,
+                fixedClock);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private Mentee eligibleMentee(Long id) {
+        Mentee m = new Mentee();
+        m.setId(id);
+        m.setFirstName("Mentee" + id);
+        m.setActiveMentorId(null);   // eligible
+        return m;
+    }
+
+    private Mentor eligibleMentor(Long id) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName("Mentor" + id);
+        m.setMaxMenteeCapacity(3);
+        m.setCurrentMenteeCount(0);  // has capacity
+        return m;
+    }
+
+    private MentorMatchResponse mentorMatch(Long id, String firstName) {
+        MentorMatchResponse r = new MentorMatchResponse();
+        r.setId(id);
+        r.setFirstName(firstName);
+        return r;
+    }
+
+    private MenteeCandidateResponse menteeCandidate(Long id, String firstName) {
+        MenteeCandidateResponse r = new MenteeCandidateResponse();
+        r.setId(id);
+        r.setFirstName(firstName);
+        return r;
+    }
+
+    private LastMatchNotification stateRow(Long userId, Long notifiedId) {
+        LastMatchNotification row = new LastMatchNotification();
+        row.setUserId(userId);
+        row.setNotifiedMatchUserId(notifiedId);
+        row.setSentAt(OffsetDateTime.parse("2026-05-06T09:00:00Z"));
+        return row;
+    }
+
+    // ── Mentee side ──────────────────────────────────────────────────────────
+
+    @Test
+    void processMentee_publishesAndUpserts_whenStateRowAbsent() {
+        Mentee me = eligibleMentee(1L);
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(me));
+        when(matchingService.rankMentorsFor(me, null))
+                .thenReturn(List.of(mentorMatch(99L, "Ali")));
+        when(stateRepository.findById(1L)).thenReturn(Optional.empty());
+
+        boolean published = processor.processMentee(1L);
+
+        assertThat(published).isTrue();
+        verify(notificationEventPublisher).publishMatchFound(1L, "Ali");
+        ArgumentCaptor<LastMatchNotification> saved = ArgumentCaptor.forClass(LastMatchNotification.class);
+        verify(stateRepository).save(saved.capture());
+        assertThat(saved.getValue().getUserId()).isEqualTo(1L);
+        assertThat(saved.getValue().getNotifiedMatchUserId()).isEqualTo(99L);
+        assertThat(saved.getValue().getSentAt())
+                .isEqualTo(OffsetDateTime.parse("2026-05-07T09:00:00Z"));
+    }
+
+    @Test
+    void processMentee_publishesAndUpserts_whenTopMatchDiffers() {
+        Mentee me = eligibleMentee(1L);
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(me));
+        when(matchingService.rankMentorsFor(me, null))
+                .thenReturn(List.of(mentorMatch(200L, "Bob")));
+        when(stateRepository.findById(1L))
+                .thenReturn(Optional.of(stateRow(1L, /*previously notified*/ 99L)));
+
+        boolean published = processor.processMentee(1L);
+
+        assertThat(published).isTrue();
+        verify(notificationEventPublisher).publishMatchFound(1L, "Bob");
+        ArgumentCaptor<LastMatchNotification> saved = ArgumentCaptor.forClass(LastMatchNotification.class);
+        verify(stateRepository).save(saved.capture());
+        assertThat(saved.getValue().getNotifiedMatchUserId()).isEqualTo(200L);
+    }
+
+    @Test
+    void processMentee_skips_whenTopMatchUnchanged() {
+        Mentee me = eligibleMentee(1L);
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(me));
+        when(matchingService.rankMentorsFor(me, null))
+                .thenReturn(List.of(mentorMatch(99L, "Ali")));
+        when(stateRepository.findById(1L)).thenReturn(Optional.of(stateRow(1L, 99L)));
+
+        boolean published = processor.processMentee(1L);
+
+        assertThat(published).isFalse();
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+        verify(stateRepository, never()).save(any());
+    }
+
+    @Test
+    void processMentee_skips_whenMenteeRaceDeleted() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.empty());
+
+        boolean published = processor.processMentee(1L);
+
+        assertThat(published).isFalse();
+        verify(matchingService, never()).rankMentorsFor(any(), any());
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+        verify(stateRepository, never()).save(any());
+    }
+
+    @Test
+    void processMentee_skips_whenMenteeRaceAcquiredActiveMentor() {
+        Mentee me = eligibleMentee(1L);
+        me.setActiveMentorId(42L);   // raced: now has an active mentor
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(me));
+
+        boolean published = processor.processMentee(1L);
+
+        assertThat(published).isFalse();
+        verify(matchingService, never()).rankMentorsFor(any(), any());
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+        verify(stateRepository, never()).save(any());
+    }
+
+    @Test
+    void processMentee_skips_whenRankReturnsEmpty() {
+        Mentee me = eligibleMentee(1L);
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(me));
+        when(matchingService.rankMentorsFor(me, null)).thenReturn(List.of());
+
+        boolean published = processor.processMentee(1L);
+
+        assertThat(published).isFalse();
+        verify(stateRepository, never()).findById(anyLong());
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+        verify(stateRepository, never()).save(any());
+    }
+
+    @Test
+    void processMentee_skips_whenTopMatchHasNullId() {
+        Mentee me = eligibleMentee(1L);
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(me));
+        // Defensive guard against DTO-mapping bugs — ranker emits a response
+        // with id=null. We log + skip rather than NPE downstream.
+        when(matchingService.rankMentorsFor(me, null))
+                .thenReturn(List.of(mentorMatch(null, "Ali")));
+
+        boolean published = processor.processMentee(1L);
+
+        assertThat(published).isFalse();
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+        verify(stateRepository, never()).save(any());
+    }
+
+    // ── Mentor side ──────────────────────────────────────────────────────────
+
+    @Test
+    void processMentor_publishesAndUpserts_whenStateRowAbsent() {
+        Mentor mentor = eligibleMentor(7L);
+        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
+        when(matchingService.findCandidateMenteesFor(mentor, null))
+                .thenReturn(List.of(menteeCandidate(101L, "Cara")));
+        when(stateRepository.findById(7L)).thenReturn(Optional.empty());
+
+        boolean published = processor.processMentor(7L);
+
+        assertThat(published).isTrue();
+        verify(notificationEventPublisher).publishMatchFound(7L, "Cara");
+        ArgumentCaptor<LastMatchNotification> saved = ArgumentCaptor.forClass(LastMatchNotification.class);
+        verify(stateRepository).save(saved.capture());
+        assertThat(saved.getValue().getUserId()).isEqualTo(7L);
+        assertThat(saved.getValue().getNotifiedMatchUserId()).isEqualTo(101L);
+    }
+
+    @Test
+    void processMentor_skips_whenTopMatchUnchanged() {
+        Mentor mentor = eligibleMentor(7L);
+        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
+        when(matchingService.findCandidateMenteesFor(mentor, null))
+                .thenReturn(List.of(menteeCandidate(101L, "Cara")));
+        when(stateRepository.findById(7L)).thenReturn(Optional.of(stateRow(7L, 101L)));
+
+        boolean published = processor.processMentor(7L);
+
+        assertThat(published).isFalse();
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+        verify(stateRepository, never()).save(any());
+    }
+
+    @Test
+    void processMentor_skips_whenMentorRaceDeleted() {
+        when(mentorRepository.findById(7L)).thenReturn(Optional.empty());
+
+        boolean published = processor.processMentor(7L);
+
+        assertThat(published).isFalse();
+        verify(matchingService, never()).findCandidateMenteesFor(any(), any());
+    }
+
+    @Test
+    void processMentor_skips_whenMentorRaceFilledCapacity() {
+        Mentor mentor = eligibleMentor(7L);
+        mentor.setCurrentMenteeCount(mentor.getMaxMenteeCapacity());  // raced: now full
+        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
+
+        boolean published = processor.processMentor(7L);
+
+        assertThat(published).isFalse();
+        verify(matchingService, never()).findCandidateMenteesFor(any(), any());
+    }
+
+    @Test
+    void processMentor_skips_whenCandidateListEmpty() {
+        Mentor mentor = eligibleMentor(7L);
+        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
+        when(matchingService.findCandidateMenteesFor(mentor, null)).thenReturn(List.of());
+
+        boolean published = processor.processMentor(7L);
+
+        assertThat(published).isFalse();
+        verify(stateRepository, never()).findById(eq(7L));
+    }
+
+    @Test
+    void processMentor_publishesAndUpserts_whenTopMatchDiffers() {
+        Mentor mentor = eligibleMentor(7L);
+        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
+        when(matchingService.findCandidateMenteesFor(mentor, null))
+                .thenReturn(List.of(menteeCandidate(202L, "Dana")));
+        when(stateRepository.findById(7L))
+                .thenReturn(Optional.of(stateRow(7L, /*previously notified*/ 101L)));
+
+        boolean published = processor.processMentor(7L);
+
+        assertThat(published).isTrue();
+        verify(notificationEventPublisher).publishMatchFound(7L, "Dana");
+        ArgumentCaptor<LastMatchNotification> saved = ArgumentCaptor.forClass(LastMatchNotification.class);
+        verify(stateRepository).save(saved.capture());
+        assertThat(saved.getValue().getNotifiedMatchUserId()).isEqualTo(202L);
+    }
+
+    @Test
+    void processMentor_skips_whenTopMatchHasNullId() {
+        Mentor mentor = eligibleMentor(7L);
+        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
+        // Symmetric to the mentee-side defensive guard: a DTO emit with id=null
+        // is logged + skipped rather than NPE-ing through equality compare.
+        when(matchingService.findCandidateMenteesFor(mentor, null))
+                .thenReturn(List.of(menteeCandidate(null, "Dana")));
+
+        boolean published = processor.processMentor(7L);
+
+        assertThat(published).isFalse();
+        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+        verify(stateRepository, never()).save(any());
+    }
+
+    // ── Upsert correctness (sentAt timestamp + state-row carry) ──────────────
+
+    @Test
+    void processMentee_setsSentAtFromInjectedClock() {
+        Mentee me = eligibleMentee(1L);
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(me));
+        when(matchingService.rankMentorsFor(me, null))
+                .thenReturn(List.of(mentorMatch(99L, "Ali")));
+        when(stateRepository.findById(1L)).thenReturn(Optional.empty());
+
+        processor.processMentee(1L);
+
+        ArgumentCaptor<LastMatchNotification> saved = ArgumentCaptor.forClass(LastMatchNotification.class);
+        verify(stateRepository).save(saved.capture());
+        // Asserts the Clock dependency is wired through, not OffsetDateTime.now()
+        // sneaking in via field initializers or static helpers.
+        assertThat(saved.getValue().getSentAt())
+                .isEqualTo(OffsetDateTime.parse("2026-05-07T09:00:00Z"));
+    }
+
+    @Test
+    void processMentee_preservesEntityIdentityWhenUpdatingExistingStateRow() {
+        Mentee me = eligibleMentee(1L);
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(me));
+        when(matchingService.rankMentorsFor(me, null))
+                .thenReturn(List.of(mentorMatch(200L, "Bob")));
+        LastMatchNotification existing = stateRow(1L, 99L);
+        when(stateRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+        processor.processMentee(1L);
+
+        // The same managed instance is saved (mutated in place) — not a fresh
+        // entity that would trigger an insert + PK collision.
+        ArgumentCaptor<LastMatchNotification> saved = ArgumentCaptor.forClass(LastMatchNotification.class);
+        verify(stateRepository).save(saved.capture());
+        assertThat(saved.getValue()).isSameAs(existing);
+        assertThat(saved.getValue().getNotifiedMatchUserId()).isEqualTo(200L);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
@@ -32,7 +32,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
@@ -62,7 +61,6 @@ class MatchingServiceTest {
     @Mock private MentorRepository mentorRepository;
     @Mock private AvailabilitySlotRepository availabilitySlotRepository;
     @Mock private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
-    @Mock private NotificationEventPublisher notificationEventPublisher;
 
     private MatchingService matchingService;
 
@@ -76,7 +74,7 @@ class MatchingServiceTest {
                 menteeRepository, mentorRepository,
                 availabilitySlotRepository, menteeAvailabilitySlotRepository,
                 new RuleBasedMentorRanker(),  // real ranker — pure function over already-loaded entities
-                notificationEventPublisher);
+                /*rankingWindow*/ 200);
 
         pageable = PageRequest.of(0, 20);
 
@@ -363,46 +361,44 @@ class MatchingServiceTest {
         verify(menteeAvailabilitySlotRepository, never()).findByMenteeId(anyLong());
     }
 
-    // ── Match-found notification gating ───────────────────────────────────
+    // ── Read paths are side-effect-free (#273 regression) ─────────────────
+    // Removing the publishMatchFound dependency from MatchingService is a
+    // structural change: the service no longer holds a NotificationEventPublisher
+    // field, so it cannot publish anything regardless of input. The tests below
+    // confirm the public methods still return the expected output without
+    // throwing; the runtime "no notification row appears" assertion lives in
+    // MatchNotificationIntegrationTest, where the full Spring stack confirms
+    // browse never persists a Notification row. The seven previous notification-
+    // firing tests moved to MatchNotificationProcessorTest.
 
     @Test
-    void rankMentors_firesNotification_onPageZeroWithResults() {
+    void getTopMentors_returnsRankedListWithoutSideEffects() {
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
         stubMentorSearch(List.of(mentor));
 
         Page<MentorMatchResponse> result = matchingService.getTopMentors(1L, null, PageRequest.of(0, 20));
 
         assertThat(result.getContent()).hasSize(1);
-        verify(notificationEventPublisher)
-                .publishMatchFound(eq(1L), eq(result.getContent().get(0).getFirstName()));
     }
 
     @Test
-    void rankMentors_doesNotFireNotification_onSubsequentPages() {
-        List<Mentor> manyMentors = java.util.stream.IntStream.range(0, 30).mapToObj(i -> {
-            Mentor m = new Mentor();
-            m.setId((long) (10 + i));
-            m.setMaxMenteeCapacity(3);
-            m.setCurrentMenteeCount(0);
-            return m;
-        }).toList();
+    void getTopMentorsList_returnsRankedListWithoutSideEffects() {
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        stubMentorSearch(manyMentors);
+        stubMentorSearch(List.of(mentor));
 
-        // Page 1 (offset 20) → no notification because we're past page 0.
-        matchingService.getTopMentors(1L, null, PageRequest.of(1, 20));
+        List<MentorMatchResponse> result = matchingService.getTopMentorsList(1L, null);
 
-        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+        assertThat(result).hasSize(1);
     }
 
     @Test
-    void rankMentors_doesNotFireNotification_whenEmpty() {
-        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        stubMentorSearch(List.of());
+    void getCandidateMentees_returnsCandidateListWithoutSideEffects() {
+        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        stubMenteeSearch(List.of(mentee));
 
-        matchingService.getTopMentors(1L, null, pageable);
+        Page<MenteeCandidateResponse> result = matchingService.getCandidateMentees(1L, null, pageable);
 
-        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
+        assertThat(result.getContent()).hasSize(1);
     }
 
     // ── Candidate mentees: full capacity / mentor not found ───────────────
@@ -500,31 +496,6 @@ class MatchingServiceTest {
         assertThat(result.getTotalElements()).isEqualTo(6);
     }
 
-    @Test
-    void candidateMentees_firesNotification_onPageZeroWithResults() {
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        stubMenteeSearch(List.of(mentee));
-
-        matchingService.getCandidateMentees(1L, null, PageRequest.of(0, 20));
-
-        verify(notificationEventPublisher).publishMatchFound(eq(1L), anyString());
-    }
-
-    @Test
-    void candidateMentees_doesNotFireNotification_onSubsequentPages() {
-        List<Mentee> manyMentees = java.util.stream.IntStream.range(0, 30).mapToObj(i -> {
-            Mentee me = new Mentee();
-            me.setId((long) (100 + i));
-            return me;
-        }).toList();
-        when(mentorRepository.findById(1L)).thenReturn(Optional.of(mentor));
-        stubMenteeSearch(manyMentees);
-
-        matchingService.getCandidateMentees(1L, null, PageRequest.of(1, 20));
-
-        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
-    }
-
     // ── Candidate mentees: DTO mapping ────────────────────────────────────
 
     @Test
@@ -565,24 +536,13 @@ class MatchingServiceTest {
     }
 
     @Test
-    void getTopMentorsList_firesNotification_onNonEmpty() {
-        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
-        stubMentorSearch(List.of(mentor));
-
-        matchingService.getTopMentorsList(1L, null);
-
-        verify(notificationEventPublisher).publishMatchFound(eq(1L), anyString());
-    }
-
-    @Test
-    void getTopMentorsList_doesNotFireNotification_onEmpty() {
+    void getTopMentorsList_returnsEmptyListWhenNoCandidates() {
         when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
         stubMentorSearch(List.of());
 
         List<MentorMatchResponse> result = matchingService.getTopMentorsList(1L, null);
 
         assertThat(result).isEmpty();
-        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
     }
 
     // ── matchesMentorPreferences edge cases ───────────────────────────────
@@ -655,10 +615,76 @@ class MatchingServiceTest {
         assertThat(MatchingService.matchesMentorPreferences(m, me)).isTrue();
     }
 
+    // ── Pure rank methods: precondition guards (#273) ─────────────────────
+    // The package-private rankMentorsFor / findCandidateMenteesFor were
+    // introduced so MatchNotificationProcessor can skip the redundant
+    // findById + eligibility check that the public path already does. The
+    // precondition guards turn caller-side bugs into loud IllegalStateExceptions
+    // rather than letting the methods silently rank for an ineligible user.
+
+    @Test
+    void rankMentorsFor_throwsIllegalStateException_whenMenteeIsNull() {
+        assertThatThrownBy(() -> matchingService.rankMentorsFor(null, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("must not be null");
+    }
+
+    @Test
+    void rankMentorsFor_throwsIllegalStateException_whenMenteeHasActiveMentor() {
+        Mentee ineligible = new Mentee();
+        ineligible.setId(42L);
+        ineligible.setActiveMentorId(99L);
+
+        assertThatThrownBy(() -> matchingService.rankMentorsFor(ineligible, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("active mentor");
+    }
+
+    @Test
+    void rankMentorsFor_returnsRankedListForEligibleMentee() {
+        // Sanity: with a valid mentee the method delegates to the same SQL +
+        // ranker pipeline that getTopMentors uses.
+        stubMentorSearch(List.of(mentor));
+
+        List<MentorMatchResponse> result = matchingService.rankMentorsFor(mentee, null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(mentor.getId());
+    }
+
+    @Test
+    void findCandidateMenteesFor_throwsIllegalStateException_whenMentorIsNull() {
+        assertThatThrownBy(() -> matchingService.findCandidateMenteesFor(null, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("must not be null");
+    }
+
+    @Test
+    void findCandidateMenteesFor_throwsIllegalStateException_whenMentorAtFullCapacity() {
+        Mentor ineligible = new Mentor();
+        ineligible.setId(42L);
+        ineligible.setMaxMenteeCapacity(2);
+        ineligible.setCurrentMenteeCount(2);  // at cap
+
+        assertThatThrownBy(() -> matchingService.findCandidateMenteesFor(ineligible, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("full capacity");
+    }
+
+    @Test
+    void findCandidateMenteesFor_returnsCandidatesForEligibleMentor() {
+        stubMenteeSearch(List.of(mentee));
+
+        List<MenteeCandidateResponse> result = matchingService.findCandidateMenteesFor(mentor, null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(mentee.getId());
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────
 
     // The matching path uses findRankingCandidates (List, no count) — see
-    // MatchingService.rankAvailableMentors / getCandidateMentees. Tests of the
+    // MatchingService.rankMentorsForId / getCandidateMentees. Tests of the
     // SQL-side filter shape still use searchByFilters by name to capture the
     // semantic intent (verify(... searchByFilters(...))) — those verifications
     // were rewritten to target findRankingCandidates after the S1 refactor.

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -36,3 +36,10 @@ app.admin-bootstrap.enabled=false
 # }) — see RateLimitIntegrationTest for the canonical setup. Do NOT flip this
 # on globally; it would couple every other integration test to the limiter.
 app.ratelimit.enabled=false
+
+# Scheduled match-notification job (#273) is OFF in the default test profile so
+# @SpringBootTest contexts don't spin up the bean and risk a stray cron firing
+# during a test run. The dedicated MatchNotificationIntegrationTest overrides
+# this via @TestPropertySource to enable the bean while keeping the cron
+# disabled (cron="-").
+app.matching.notification.enabled=false


### PR DESCRIPTION
Closes #273.

## Problem

`MatchingService.getTopMentors` / `getTopMentorsList` / `getCandidateMentees` each call `notificationEventPublisher.publishMatchFound(...)` whenever the result list is non-empty. Pagination, page refreshes, deep links, and ordinary browsing all fire the event. The 24h body dedup in `NotificationEventListener` prevents the duplicate from reaching the user, but the wasted SQL still happens and the design conflates "I'm browsing" with "I want a match notification".

## Approach (Option A from the issue)

Browse becomes side-effect-free. A daily scheduled job re-ranks each eligible user, compares the current top match's id to a per-user state row, and publishes only on change.

- `MatchingService` no longer depends on `NotificationEventPublisher`. The three `publishMatchFound` call sites are deleted.
- New `last_match_notifications` table stores `(user_id PK, notified_match_user_id, sent_at, @Version)`.
- `MatchNotificationProcessor` owns per-user logic in `REQUIRES_NEW`; `MatchNotificationScheduler` drives the cron loop.
- Two repository helpers (`findUnattachedIds`, `findIdsWithCapacity`) supply the eligibility lists.
- A small `MatchSummary` interface lets the processor share its change-detection algorithm across both response DTOs.

## Layered duplicate protection

1. State-row equality check is the primary gate.
2. `@Version` turns concurrent UPDATE races into `OptimisticLockException` -> rollback -> AFTER_COMMIT skipped.
3. PK uniqueness handles the symmetric INSERT race.
4. Existing 24h listener body-dedup stays as the third safety net.

## Operational notes

- Defaults: `app.matching.notification.enabled=true`, `cron=0 0 9 * * *`, `zone=UTC` (DST-immune).
- Rollback: flip `enabled=false` and restart, or set `cron=-` to suppress firings without removing the bean.
- Failure isolation: per-user try/catch (IllegalStateException at ERROR, transient at WARN); per-side `runSafely` so a failure in one eligibility query doesn't skip the other side.
- Run summary log: `mentee_eligible=N mentee_publishes=M mentor_eligible=N mentor_publishes=M` distinguishes "all eligible, none changed" from "few eligible, all changed" at a glance.
- ShedLock and Spring Modulith Event Publication Registry are documented as the canonical follow-ups for stricter multi-instance and crash-safe semantics; deferred.

## Stacked PR

Targets `feature/262-search-overhaul` because the pure-rank methods this work exposes are post-#262 artefacts. Will retarget to `dev` once #262 merges.

## Verification

- 880 tests green; branch coverage met on new files.
- Manual end-to-end against local Postgres confirmed the four scenarios that matter:
  1. `GET /api/matching/mentors` does not persist a Notification row.
  2. Scheduler tick fires one notification per eligible user; state row written with `version=0`.
  3. Idempotent ticks log `publishes=0` while still seeing eligible users; no UPDATE attempted.
  4. Adding a stronger-scoring counterpart triggers a new fire on the next tick; state row's `version` bumps to 1.

## Test plan

- [ ] Reviewer confirms the migration applies cleanly on a fresh dev DB.
- [ ] Reviewer confirms the scheduler property toggles (`enabled=false`, `cron=-`) behave as documented.
- [ ] Reviewer confirms the regression test in `NotificationIntegrationTest` (browse must not publish) is the right shape.
- [ ] CI green.

## Out of scope

Admin "scan now" trigger (depends on #280); event-driven instant notifications on signup; counterpart-id-based listener dedup (requires `Notification` schema change); per-user notification preferences; ShedLock for multi-instance.