### PR TITLE
feat(backend): add follow recommendations endpoint (344)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/FollowRecommendationController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FollowRecommendationController.java
@@ -1,0 +1,63 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.controller.support.PageableSupport;
+import com.group7.backend.dto.response.FollowRecommendationResponse;
+import com.group7.backend.service.FollowRecommendationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Read-only REST surface for follow recommendations (#344). Lives under
+ * the same {@code /api/users} namespace as {@link FollowController} but
+ * uses a {@code /me/} segment so it doesn't collide with the
+ * {@code /{id:\\d+}/...} numeric-id routes there.
+ *
+ * <p>No {@code @PreAuthorize}: the global SecurityConfig already
+ * requires authentication for any non-permitAll path, and any
+ * authenticated user can fetch their own recommendations regardless of
+ * role.
+ */
+@RestController
+@RequestMapping("/api/users/me/follow-recommendations")
+@Tag(name = "Follow Recommendations",
+        description = "Suggested users to follow with explanation factors (#344).")
+public class FollowRecommendationController {
+
+    private final FollowRecommendationService service;
+
+    public FollowRecommendationController(FollowRecommendationService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    @Operation(summary = "List follow recommendations for the caller",
+            description = "Paged list of suggested users to follow, sorted by recommendation score "
+                    + "(higher first). Excludes the caller, users they already follow, and admins. "
+                    + "Each entry carries a `factors` array explaining why it surfaced "
+                    + "(shared interests, follow-graph proximity).")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paged recommendations"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Caller user not found", content = @Content)
+    })
+    public ResponseEntity<Page<FollowRecommendationResponse>> recommend(
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size; clamped to [1, 100]") @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long viewerId = (Long) authentication.getCredentials();
+        Pageable pageable = PageableSupport.clampPageable(page, size);
+        return ResponseEntity.ok(service.recommend(viewerId, pageable));
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/FollowRecommendationResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FollowRecommendationResponse.java
@@ -1,0 +1,76 @@
+package com.group7.backend.dto.response;
+
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import com.group7.backend.service.ranking.ScoreResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Recommended user payload for the follow-recommendation endpoint
+ * (#344). Mirrors {@link UserSummary}'s slim shape (id, firstName,
+ * lastName, profilePhoto, role) so the UI can reuse follow-graph card
+ * components, plus the ranker outputs ({@code score} + {@code factors})
+ * that explain why this candidate surfaced.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Recommended user with compatibility score and explanation factors (#344).")
+public class FollowRecommendationResponse {
+
+    @Schema(description = "User id", example = "42")
+    private Long id;
+
+    @Schema(description = "First name")
+    private String firstName;
+
+    @Schema(description = "Last name")
+    private String lastName;
+
+    @Schema(description = "Profile photo URL", nullable = true)
+    private String profilePhoto;
+
+    @Schema(description = "Role discriminator", example = "MENTOR")
+    private String role;
+
+    @Schema(description = "Recommendation score (higher = stronger match)", example = "11")
+    private int score;
+
+    @Schema(description = "Human-readable factors that contributed to the score",
+            example = "[\"shared-interest:Java\",\"followed-by-2-of-your-follows\"]")
+    private List<String> factors;
+
+    public static FollowRecommendationResponse from(User user, ScoreResult sr) {
+        // Mirrors UserSummary.from's role-discriminator branches; the
+        // candidate query in UserRepository excludes admins so the
+        // ADMIN branch is defence-in-depth.
+        String role;
+        if (user instanceof Mentor) {
+            role = "MENTOR";
+        } else if (user instanceof Mentee) {
+            role = "MENTEE";
+        } else if (user instanceof Admin) {
+            role = "ADMIN";
+        } else {
+            throw new IllegalStateException(
+                    "Unknown User subtype for id=" + user.getId() + ": " + user.getClass().getSimpleName());
+        }
+
+        FollowRecommendationResponse r = new FollowRecommendationResponse();
+        r.setId(user.getId());
+        r.setFirstName(user.getFirstName());
+        r.setLastName(user.getLastName());
+        r.setProfilePhoto(user.getProfilePhoto());
+        r.setRole(role);
+        r.setScore(sr.score());
+        r.setFactors(sr.factors());
+        return r;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/repository/FollowRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FollowRepository.java
@@ -10,6 +10,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Repository for the {@link Follow} graph (#343).
  *
@@ -67,4 +70,18 @@ public interface FollowRepository extends JpaRepository<Follow, FollowId> {
     long countByIdFolloweeId(Long followeeId);
 
     long countByIdFollowerId(Long followerId);
+
+    /**
+     * Bulk fetch of edges keyed by a set of followers — used by the
+     * second-hop step in {@code FollowRecommendationService} (#344) where the
+     * input is the viewer's followee set and the output is "everyone those
+     * followees follow." Returned as a flat list because the service groups
+     * by {@code followeeId} in Java to build a {@code Map<Long,Integer>} of
+     * incoming-edge counts; pushing the GROUP BY into SQL would force a
+     * projection DTO with no precedent in this repository.
+     *
+     * <p>Service-layer caps the input set at 200 to keep the IN-list short;
+     * the repo runs whatever it's handed.
+     */
+    List<Follow> findByIdFollowerIdIn(Collection<Long> followerIds);
 }

--- a/backend/src/main/java/com/group7/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/UserRepository.java
@@ -5,7 +5,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -18,4 +20,26 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     @Query("select u from User u where type(u) <> com.group7.backend.entity.Admin")
     Page<User> findAllNonAdmins(Pageable pageable);
+
+    /**
+     * Candidate window for the follow-recommendation pipeline (#344). Excludes
+     * admins, the viewer themselves, and anyone the viewer already follows in
+     * a single SQL pass; the ranker scores the returned slice in memory and
+     * the service slices the resulting page. Order is {@code id DESC} —
+     * deterministic with no semantic signal — mirroring the matching pipeline
+     * (#262/#273) where the same trade-off applies: pages beyond the window
+     * return empty content.
+     */
+    @Query("""
+            select u from User u
+            where type(u) <> com.group7.backend.entity.Admin
+              and u.id <> :viewerId
+              and not exists (
+                  select 1 from Follow f
+                  where f.id.followerId = :viewerId
+                    and f.id.followeeId = u.id)
+            order by u.id desc
+            """)
+    List<User> findFollowRecommendationCandidates(@Param("viewerId") Long viewerId,
+                                                  Pageable pageable);
 }

--- a/backend/src/main/java/com/group7/backend/service/FollowRecommendationService.java
+++ b/backend/src/main/java/com/group7/backend/service/FollowRecommendationService.java
@@ -1,0 +1,189 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.FollowRecommendationResponse;
+import com.group7.backend.entity.Follow;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.FollowRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.service.ranking.FollowRanker;
+import com.group7.backend.service.ranking.FollowRecommendationContext;
+import com.group7.backend.service.ranking.ScoreResult;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Follow-recommendation pipeline (#344). Orchestrates the load → score →
+ * paginate flow that mirrors {@code MatchingService}: a fixed-size
+ * candidate window is fetched from SQL (excluding admins, the viewer,
+ * and already-followed users), the ranker scores them in memory using a
+ * pre-fetched {@link FollowRecommendationContext}, and the paged page is
+ * sliced from the in-memory ranking. Pages beyond the window return
+ * empty content; the frontend should treat that as "end of results".
+ *
+ * <h2>Query budget</h2>
+ * Three SQL statements per call regardless of page size:
+ * <ol>
+ *   <li>Viewer load — {@link UserRepository#findById}.</li>
+ *   <li>Viewer's followees — {@link FollowRepository#findByIdFollowerIdOrderByCreatedAtDescIdFolloweeIdDesc}
+ *       (capped at {@value #MAX_VIEWER_FOLLOWEES} to bound the second-hop query).</li>
+ *   <li>Second-hop edges — {@link FollowRepository#findByIdFollowerIdIn}
+ *       (skipped when the viewer follows nobody).</li>
+ *   <li>Candidate window — {@link UserRepository#findFollowRecommendationCandidates}.</li>
+ * </ol>
+ * Plus the SUBSELECT collection fetches Hibernate issues to populate
+ * each Mentor/Mentee's {@code interests} list — counted separately by
+ * Hibernate's collection-fetch counter.
+ *
+ * <h2>Out-of-scope today (#344 PR description)</h2>
+ * <ul>
+ *   <li><b>Banned users</b> — the {@code Ban} entity / {@code BanService}
+ *       is introduced by the still-open #134/#380. Once merged, add a
+ *       {@code NOT EXISTS} sub-clause on the candidate query.</li>
+ *   <li><b>Mentee profileVisibility</b> — the field exists on the entity
+ *       but is unenforced everywhere on {@code main}; introducing it
+ *       only here would be inconsistent. Tracked separately.</li>
+ *   <li><b>Recent engagement signal</b> — depends on #348 (FeedPost /
+ *       Comment); the ranker carries a TODO marker for the eventual
+ *       wiring.</li>
+ * </ul>
+ */
+@Service
+public class FollowRecommendationService {
+
+    /**
+     * Hard cap on the viewer's followees expanded by the second-hop
+     * query. A viewer who follows thousands of users would otherwise
+     * push an unbounded {@code IN} list at Postgres; truncating to the
+     * most-recent {@value} preserves the strongest-signal subset (per
+     * {@link FollowRepository}'s "newest first" sort) while keeping the
+     * query budget bounded.
+     */
+    static final int MAX_VIEWER_FOLLOWEES = 200;
+
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+    private final FollowRanker ranker;
+    private final int rankingWindow;
+
+    public FollowRecommendationService(UserRepository userRepository,
+                                       FollowRepository followRepository,
+                                       FollowRanker ranker,
+                                       @Value("${app.matching.ranking-window:200}") int rankingWindow) {
+        this.userRepository = userRepository;
+        this.followRepository = followRepository;
+        this.ranker = ranker;
+        this.rankingWindow = rankingWindow;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<FollowRecommendationResponse> recommend(Long viewerId, Pageable pageable) {
+        User viewer = userRepository.findById(viewerId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + viewerId));
+
+        FollowRecommendationContext ctx = buildContext(viewer);
+
+        List<User> candidates = userRepository.findFollowRecommendationCandidates(
+                viewerId, PageRequest.of(0, rankingWindow));
+
+        if (candidates.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        List<FollowRecommendationResponse> ranked = candidates.stream()
+                .map(c -> {
+                    ScoreResult sr = ranker.score(c, ctx);
+                    return FollowRecommendationResponse.from(c, sr);
+                })
+                .sorted(Comparator
+                        .comparingInt(FollowRecommendationResponse::getScore).reversed()
+                        .thenComparing(Comparator
+                                .comparingLong(FollowRecommendationResponse::getId).reversed()))
+                .toList();
+
+        return slicePage(ranked, pageable);
+    }
+
+    private FollowRecommendationContext buildContext(User viewer) {
+        Set<String> interestLabels = lowercasedInterests(viewer);
+
+        // Viewer's followees, capped. The repo orders newest-first with
+        // a stable id-tiebreaker; truncating the head preserves the
+        // most-recent (and likely strongest-signal) subset.
+        Pageable followeePage = PageRequest.of(0, MAX_VIEWER_FOLLOWEES);
+        List<Follow> myFollows =
+                followRepository.findByIdFollowerIdOrderByCreatedAtDescIdFolloweeIdDesc(
+                        viewer.getId(), followeePage).getContent();
+        Set<Long> followeeIds = new HashSet<>(myFollows.size());
+        for (Follow f : myFollows) {
+            followeeIds.add(f.getId().getFolloweeId());
+        }
+
+        Map<Long, Integer> secondHop;
+        if (followeeIds.isEmpty()) {
+            secondHop = Collections.emptyMap();
+        } else {
+            secondHop = new HashMap<>();
+            List<Follow> hops = followRepository.findByIdFollowerIdIn(followeeIds);
+            for (Follow f : hops) {
+                Long target = f.getId().getFolloweeId();
+                // Don't credit candidates that the viewer is already
+                // following or that *are* the viewer.
+                if (target.equals(viewer.getId()) || followeeIds.contains(target)) {
+                    continue;
+                }
+                secondHop.merge(target, 1, Integer::sum);
+            }
+        }
+
+        return new FollowRecommendationContext(viewer.getId(), interestLabels, followeeIds, secondHop);
+    }
+
+    private static Set<String> lowercasedInterests(User user) {
+        List<String> raw;
+        if (user instanceof Mentor mentor) {
+            raw = mentor.getInterests();
+        } else if (user instanceof Mentee mentee) {
+            raw = mentee.getInterests();
+        } else {
+            return Collections.emptySet();
+        }
+        if (raw == null || raw.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> out = new HashSet<>(raw.size());
+        for (String label : raw) {
+            if (label != null) {
+                out.add(label.toLowerCase());
+            }
+        }
+        return out;
+    }
+
+    /**
+     * In-memory page slicer. Mirrors {@code MatchingService}'s private
+     * helper; rule-of-two so each service keeps its own copy until a
+     * third caller materialises and we extract to {@code support/}.
+     */
+    private static <T> Page<T> slicePage(List<T> ranked, Pageable pageable) {
+        int total = ranked.size();
+        int from = Math.min((int) pageable.getOffset(), total);
+        int to = Math.min(from + pageable.getPageSize(), total);
+        return new PageImpl<>(ranked.subList(from, to), pageable, total);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/ranking/FollowRanker.java
+++ b/backend/src/main/java/com/group7/backend/service/ranking/FollowRanker.java
@@ -1,0 +1,24 @@
+package com.group7.backend.service.ranking;
+
+import com.group7.backend.entity.User;
+
+/**
+ * Strategy interface for scoring a candidate user as a follow
+ * recommendation (#344), paralleling {@link MentorRanker} on the
+ * mentor-discovery side. Implementations score one candidate against a
+ * pre-fetched {@link FollowRecommendationContext} and return a
+ * {@link ScoreResult} carrying both the numeric score and any
+ * explanation factors to surface in the response.
+ *
+ * <p><b>Contract:</b> implementations MUST be pure functions over the
+ * supplied arguments — no repository calls, no I/O, no shared mutable
+ * state between calls. The service guarantees that everything the
+ * ranker needs (viewer interests, follow graph, second-hop counts) is
+ * already populated in {@code ctx}; this keeps scoring O(candidates) in
+ * memory rather than O(candidates) in DB round-trips.
+ */
+@FunctionalInterface
+public interface FollowRanker {
+
+    ScoreResult score(User candidate, FollowRecommendationContext ctx);
+}

--- a/backend/src/main/java/com/group7/backend/service/ranking/FollowRecommendationContext.java
+++ b/backend/src/main/java/com/group7/backend/service/ranking/FollowRecommendationContext.java
@@ -1,0 +1,32 @@
+package com.group7.backend.service.ranking;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Pre-fetched signals consumed by a {@link FollowRanker} when scoring
+ * candidates for the follow-recommendation pipeline (#344). The service
+ * builds this once per request and passes it to the ranker for every
+ * candidate; the ranker MUST NOT make repository calls.
+ *
+ * <ul>
+ *   <li>{@code viewerId} — the requester, never returned as a candidate.</li>
+ *   <li>{@code viewerInterestLabels} — lowercased set of the viewer's
+ *       interest labels (from {@code Mentor.getInterests()} or
+ *       {@code Mentee.getInterests()}); empty for admins or for users
+ *       with no interests on file.</li>
+ *   <li>{@code viewerFolloweeIds} — the set of users the viewer already
+ *       follows, capped at 200 by the service to bound the second-hop
+ *       query.</li>
+ *   <li>{@code secondHopCount} — for each candidate id, the number of
+ *       viewer's followees that follow them (the "followed by N of your
+ *       follows" signal). Already excludes the viewer's own followees;
+ *       a candidate id absent from the map gets a zero contribution.</li>
+ * </ul>
+ */
+public record FollowRecommendationContext(
+        Long viewerId,
+        Set<String> viewerInterestLabels,
+        Set<Long> viewerFolloweeIds,
+        Map<Long, Integer> secondHopCount) {
+}

--- a/backend/src/main/java/com/group7/backend/service/ranking/RuleBasedFollowRanker.java
+++ b/backend/src/main/java/com/group7/backend/service/ranking/RuleBasedFollowRanker.java
@@ -1,0 +1,106 @@
+package com.group7.backend.service.ranking;
+
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Default v1 algorithm for {@link FollowRanker} (#344). Combines two
+ * signals today and leaves a hook for the third (recent engagement) to
+ * land alongside the social-feed entities introduced in #348.
+ *
+ * <p>Scoring weights (configurable via {@code app.recommendations.*}):
+ * <ul>
+ *   <li>Each candidate-interest label that overlaps with the viewer's
+ *       (case-insensitive) → {@code interestWeight}, default {@code 3}.
+ *       Up to three "shared-interest:&lt;label&gt;" factors are emitted
+ *       for display; the score reflects all matches.</li>
+ *   <li>For each follow-graph "follow-of-a-follow" edge into the
+ *       candidate (i.e. number of the viewer's followees that follow
+ *       the candidate) → {@code followGraphWeight}, default {@code 2}.
+ *       A single "followed-by-N-of-your-follows" factor is emitted when
+ *       the count is at least one.</li>
+ *   <li>Recent feed-post / comment activity → score 0 in v1 (entities
+ *       not yet on {@code main}); see the inline TODO marker.</li>
+ * </ul>
+ *
+ * <p>Mirrors {@code RuleBasedMentorRanker}'s
+ * {@code @Component}-without-{@code @Primary} setup so a future
+ * AI-driven ranker can be wired in via {@code @Primary} without
+ * touching this class. The candidate's {@code interests} list is
+ * already exposed as {@code List&lt;String&gt;} on both
+ * {@code Mentor} and {@code Mentee} (label projection over the
+ * underlying {@code TaggedTerm} storage), so this ranker need not
+ * traffic in URIs.
+ */
+@Component
+public class RuleBasedFollowRanker implements FollowRanker {
+
+    static final int DISPLAY_FACTOR_CAP = 3;
+
+    private final int interestWeight;
+    private final int followGraphWeight;
+
+    public RuleBasedFollowRanker(
+            @Value("${app.recommendations.interest-weight:3}") int interestWeight,
+            @Value("${app.recommendations.follow-graph-weight:2}") int followGraphWeight) {
+        this.interestWeight = interestWeight;
+        this.followGraphWeight = followGraphWeight;
+    }
+
+    @Override
+    public ScoreResult score(User candidate, FollowRecommendationContext ctx) {
+        int score = 0;
+        List<String> factors = new ArrayList<>();
+
+        // Signal A — interest overlap.
+        List<String> candidateInterests = nullSafe(interestsOf(candidate));
+        int interestMatches = 0;
+        int factorEmitted = 0;
+        for (String label : candidateInterests) {
+            if (label == null) continue;
+            if (ctx.viewerInterestLabels().contains(label.toLowerCase())) {
+                interestMatches++;
+                if (factorEmitted < DISPLAY_FACTOR_CAP) {
+                    factors.add("shared-interest:" + label);
+                    factorEmitted++;
+                }
+            }
+        }
+        score += interestMatches * interestWeight;
+
+        // Signal B — follow-graph proximity (followed-by-N-of-your-follows).
+        int secondHop = ctx.secondHopCount().getOrDefault(candidate.getId(), 0);
+        if (secondHop > 0) {
+            score += secondHop * followGraphWeight;
+            factors.add("followed-by-" + secondHop + "-of-your-follows");
+        }
+
+        // TODO(#348): once FeedPost / Comment land, score recent
+        // engagement here (e.g., posts or comments by the candidate in
+        // the last 30 days, weighted by recency) and emit a
+        // "active-this-week" factor.
+
+        return new ScoreResult(score, factors);
+    }
+
+    private static List<String> interestsOf(User user) {
+        if (user instanceof Mentor mentor) {
+            return mentor.getInterests();
+        }
+        if (user instanceof Mentee mentee) {
+            return mentee.getInterests();
+        }
+        return null;
+    }
+
+    private static List<String> nullSafe(List<String> list) {
+        return list == null ? Collections.emptyList() : list;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/ranking/ScoreResult.java
+++ b/backend/src/main/java/com/group7/backend/service/ranking/ScoreResult.java
@@ -1,0 +1,27 @@
+package com.group7.backend.service.ranking;
+
+import java.util.List;
+
+/**
+ * Score plus human-readable explanation factors emitted by a ranker. The
+ * follow-recommendation pipeline (#344) attaches these factors to each
+ * candidate so the UI can surface "why are you seeing this" cards
+ * (mirroring the explanation pattern in spec 1.1.2.4).
+ *
+ * <p>Co-located with {@code FollowRanker} rather than nested inside it:
+ * top-level types are easier to discover and don't conflict with Spring's
+ * proxy mechanics on functional interfaces. The mentor-side
+ * {@code MentorRanker} returns a plain {@code int} because mentor
+ * matching has no factor surface yet — when it gains one, this record is
+ * the natural shape to converge on.
+ *
+ * <p>{@code factors} is intended to be small (the ranker may cap its
+ * own output for display) and is treated as immutable by callers; the
+ * record wrapper does not defensively copy.
+ */
+public record ScoreResult(int score, List<String> factors) {
+
+    public static ScoreResult of(int score) {
+        return new ScoreResult(score, List.of());
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -131,7 +131,15 @@ app.ratelimit.rules.availability-ical.refill=PT1M
 # Pages beyond the window return empty content. Tune up if the user base
 # grows and frontend pagination needs to reach further; tune down if memory
 # becomes a concern (each candidate carries its full DTO + collections).
+# Reused by the follow-recommendation pipeline (#344) under the same trade-off.
 app.matching.ranking-window=${MATCH_RANKING_WINDOW:200}
+
+# Follow-recommendation scoring weights (#344). Per-signal multipliers used
+# by RuleBasedFollowRanker; tune to bias the algorithm without code changes.
+#   interest-weight       — score added per shared interest label.
+#   follow-graph-weight   — score added per "viewer's-followee follows them" edge.
+app.recommendations.interest-weight=${RECOMMENDATIONS_INTEREST_WEIGHT:3}
+app.recommendations.follow-graph-weight=${RECOMMENDATIONS_FOLLOW_GRAPH_WEIGHT:2}
 
 # Scheduled match-found notification job (#273). Daily 09:00 UTC by default.
 # `enabled=false` skips bean creation entirely; `cron=-` keeps the bean wired

--- a/backend/src/test/java/com/group7/backend/controller/FollowRecommendationControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FollowRecommendationControllerTest.java
@@ -1,0 +1,152 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.FollowRecommendationResponse;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.service.FollowRecommendationService;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.ranking.ScoreResult;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-layer coverage for {@link FollowRecommendationController}: HTTP
+ * shape, page-size clamp, and the auth gate. The
+ * {@link FollowRecommendationService} is mocked so this test focuses on
+ * controller wiring rather than scoring behaviour (covered by the
+ * ranker + service tests).
+ */
+@WebMvcTest(FollowRecommendationController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class FollowRecommendationControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private FollowRecommendationService service;
+    @MockitoBean private JwtService jwtService;
+
+    private void mockMenteeJwt(String token, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn("alice@test.com");
+        when(jwtService.extractRole(token)).thenReturn("MENTEE");
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    @Test
+    void recommend_returnsPagedBodyShape() throws Exception {
+        mockMenteeJwt("alice-token", 1L);
+        FollowRecommendationResponse rec = FollowRecommendationResponse.from(
+                mentor(42L, "Mira"),
+                new ScoreResult(11, List.of("shared-interest:AI", "followed-by-2-of-your-follows")));
+        Page<FollowRecommendationResponse> page = new PageImpl<>(List.of(rec));
+        when(service.recommend(eq(1L), any(Pageable.class))).thenReturn(page);
+
+        mockMvc.perform(get("/api/users/me/follow-recommendations")
+                        .header("Authorization", "Bearer alice-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(42))
+                .andExpect(jsonPath("$.content[0].firstName").value("Mira"))
+                .andExpect(jsonPath("$.content[0].lastName").value("L"))
+                .andExpect(jsonPath("$.content[0].role").value("MENTOR"))
+                .andExpect(jsonPath("$.content[0].score").value(11))
+                .andExpect(jsonPath("$.content[0].factors[0]").value("shared-interest:AI"))
+                .andExpect(jsonPath("$.content[0].factors[1]").value("followed-by-2-of-your-follows"));
+    }
+
+    @Test
+    void recommend_clampsExcessiveSize() throws Exception {
+        mockMenteeJwt("alice-token", 1L);
+        when(service.recommend(eq(1L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/users/me/follow-recommendations")
+                        .param("size", "100000")
+                        .header("Authorization", "Bearer alice-token"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(service).recommend(eq(1L), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isLessThanOrEqualTo(100);
+    }
+
+    @Test
+    void recommend_passesPageNumberThrough() throws Exception {
+        mockMenteeJwt("alice-token", 1L);
+        when(service.recommend(eq(1L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/users/me/follow-recommendations")
+                        .param("page", "3")
+                        .param("size", "5")
+                        .header("Authorization", "Bearer alice-token"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(service).recommend(eq(1L), captor.capture());
+        assertThat(captor.getValue().getPageNumber()).isEqualTo(3);
+        assertThat(captor.getValue().getPageSize()).isEqualTo(5);
+    }
+
+    @Test
+    void recommend_unauthenticated_returns403() throws Exception {
+        // Mirrors FollowControllerTest's expectation for unauthenticated
+        // calls under the SecurityConfig in this project.
+        mockMvc.perform(get("/api/users/me/follow-recommendations"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void recommend_viewerNotFound_returns404() throws Exception {
+        mockMenteeJwt("alice-token", 1L);
+        when(service.recommend(eq(1L), any(Pageable.class)))
+                .thenThrow(new ResourceNotFoundException("User not found with id: 1"));
+
+        mockMvc.perform(get("/api/users/me/follow-recommendations")
+                        .header("Authorization", "Bearer alice-token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("Not Found"));
+    }
+
+    @Test
+    void recommend_routeDoesNotCollideWithFollowGraphRoutes() throws Exception {
+        // The /me path segment must not match FollowController's
+        // /{id:\\d+}/... regex; this is a sanity check that adding
+        // /api/users/me/... didn't break the existing routing.
+        mockMenteeJwt("alice-token", 1L);
+        when(service.recommend(eq(1L), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/users/me/follow-recommendations")
+                        .header("Authorization", "Bearer alice-token"))
+                .andExpect(status().isOk());
+    }
+
+    private static Mentor mentor(Long id, String firstName) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName(firstName);
+        m.setLastName("L");
+        m.setEmail(firstName.toLowerCase() + "@ex.com");
+        return m;
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/FollowRecommendationServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FollowRecommendationServiceTest.java
@@ -1,0 +1,396 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.FollowRecommendationResponse;
+import com.group7.backend.entity.Follow;
+import com.group7.backend.entity.FollowId;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.FollowRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.service.ranking.RuleBasedFollowRanker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Service-level orchestration tests for {@link FollowRecommendationService}.
+ * Uses a real {@link RuleBasedFollowRanker} (mirroring
+ * {@code MatchingServiceTest}'s shape) so the orchestration assertions
+ * observe actual scoring outputs without mocking the ranker.
+ */
+@ExtendWith(MockitoExtension.class)
+class FollowRecommendationServiceTest {
+
+    private static final int INTEREST_WEIGHT = 3;
+    private static final int FOLLOW_GRAPH_WEIGHT = 2;
+    private static final int RANKING_WINDOW = 200;
+    private static final Long VIEWER_ID = 1L;
+
+    @Mock private UserRepository userRepository;
+    @Mock private FollowRepository followRepository;
+
+    private FollowRecommendationService service;
+    private Pageable firstPage;
+
+    @BeforeEach
+    void setUp() {
+        service = new FollowRecommendationService(
+                userRepository, followRepository,
+                new RuleBasedFollowRanker(INTEREST_WEIGHT, FOLLOW_GRAPH_WEIGHT),
+                RANKING_WINDOW);
+        firstPage = PageRequest.of(0, 20);
+
+        // Sane defaults for the empty-graph viewer; individual tests
+        // override the followee page when they want a non-empty graph.
+        lenient().when(followRepository
+                        .findByIdFollowerIdOrderByCreatedAtDescIdFolloweeIdDesc(anyLong(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+        lenient().when(followRepository.findByIdFollowerIdIn(anyCollection()))
+                .thenReturn(List.of());
+    }
+
+    // ── Errors ──────────────────────────────────────────────────────────────
+
+    @Test
+    void viewerMissing_throws404() {
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.recommend(VIEWER_ID, firstPage))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("User not found");
+    }
+
+    @Test
+    void noCandidates_returnsEmptyPage() {
+        Mentee viewer = mentee(VIEWER_ID, List.of("ai"));
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        Page<FollowRecommendationResponse> result = service.recommend(VIEWER_ID, firstPage);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        // No second-hop query when the candidate query returned nothing —
+        // but the service still made the followee fetch (cheap, single
+        // index hit) before checking the candidate set.
+        verify(followRepository, never()).findByIdFollowerIdIn(anyCollection());
+    }
+
+    // ── Scoring & ordering ─────────────────────────────────────────────────
+
+    @Test
+    void candidatesAreSortedByScoreDescThenIdDesc() {
+        Mentee viewer = mentee(VIEWER_ID, List.of("AI", "Java"));
+        Mentor c10 = mentor(10L, List.of("AI"));            // 1 overlap × 3 = 3
+        Mentor c20 = mentor(20L, List.of("AI", "Java"));    // 2 overlaps × 3 = 6
+        Mentor c30 = mentor(30L, List.of());                // score 0
+        Mentor c40 = mentor(40L, List.of("Java"));          // score 3 — same as c10
+
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of(c10, c20, c30, c40));
+
+        Page<FollowRecommendationResponse> result = service.recommend(VIEWER_ID, firstPage);
+
+        // Expected order: c20 (6) → c40 (3, id=40) → c10 (3, id=10) → c30 (0)
+        assertThat(result.getContent())
+                .extracting(FollowRecommendationResponse::getId)
+                .containsExactly(20L, 40L, 10L, 30L);
+        assertThat(result.getTotalElements()).isEqualTo(4);
+    }
+
+    @Test
+    void emptyInterests_stillReturnsCandidates_orderedByIdDesc() {
+        Mentee viewer = mentee(VIEWER_ID, List.of());
+        Mentor c10 = mentor(10L, List.of("AI"));
+        Mentor c20 = mentor(20L, List.of("Java"));
+
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of(c10, c20));
+
+        Page<FollowRecommendationResponse> result = service.recommend(VIEWER_ID, firstPage);
+
+        // Both score 0, tied → id-DESC tiebreaker → c20 before c10
+        assertThat(result.getContent())
+                .extracting(FollowRecommendationResponse::getId)
+                .containsExactly(20L, 10L);
+        assertThat(result.getContent())
+                .allSatisfy(r -> assertThat(r.getScore()).isZero());
+    }
+
+    @Test
+    void interestsCaseInsensitive_lowercasedBeforeRanking() {
+        // Viewer's labels are "AI" and "Databases"; the ranker receives
+        // them lowercased, candidate's labels are unchanged in factor
+        // strings.
+        Mentee viewer = mentee(VIEWER_ID, List.of("AI", "Databases"));
+        Mentor candidate = mentor(10L, List.of("ai", "DATABASES"));
+
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+
+        Page<FollowRecommendationResponse> result = service.recommend(VIEWER_ID, firstPage);
+
+        FollowRecommendationResponse only = result.getContent().get(0);
+        assertThat(only.getScore()).isEqualTo(2 * INTEREST_WEIGHT);
+        assertThat(only.getFactors())
+                .containsExactly("shared-interest:ai", "shared-interest:DATABASES");
+    }
+
+    // ── Follow-graph (second-hop) ──────────────────────────────────────────
+
+    @Test
+    void secondHopCount_creditsCandidatesFollowedByMyFollows() {
+        // viewer follows 100, 101
+        // 100 follows 200; 101 follows 200, 300
+        // → second-hop: 200 → 2, 300 → 1
+        Mentee viewer = mentee(VIEWER_ID, List.of());
+        Mentor c200 = mentor(200L, List.of());
+        Mentor c300 = mentor(300L, List.of());
+
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(followRepository.findByIdFollowerIdOrderByCreatedAtDescIdFolloweeIdDesc(
+                eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(
+                        followEdge(VIEWER_ID, 100L),
+                        followEdge(VIEWER_ID, 101L))));
+        when(followRepository.findByIdFollowerIdIn(anyCollection()))
+                .thenReturn(List.of(
+                        followEdge(100L, 200L),
+                        followEdge(101L, 200L),
+                        followEdge(101L, 300L)));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of(c200, c300));
+
+        Page<FollowRecommendationResponse> result = service.recommend(VIEWER_ID, firstPage);
+
+        // c200 = 2 × 2 = 4, c300 = 1 × 2 = 2
+        assertThat(result.getContent().get(0).getId()).isEqualTo(200L);
+        assertThat(result.getContent().get(0).getScore()).isEqualTo(2 * FOLLOW_GRAPH_WEIGHT);
+        assertThat(result.getContent().get(0).getFactors())
+                .contains("followed-by-2-of-your-follows");
+        assertThat(result.getContent().get(1).getId()).isEqualTo(300L);
+        assertThat(result.getContent().get(1).getScore()).isEqualTo(FOLLOW_GRAPH_WEIGHT);
+    }
+
+    @Test
+    void secondHopExcludesAlreadyFollowedAndViewerSelf() {
+        // viewer follows 100; 100 follows 100 (no-op self-loop guard
+        // not relevant here), follows the viewer (1) and follows 200.
+        // Already-followed (100) and self (1) must not appear in
+        // secondHopCount, so the candidate query result for 200 only
+        // gets the 200 edge counted.
+        Mentee viewer = mentee(VIEWER_ID, List.of());
+        Mentor c200 = mentor(200L, List.of());
+
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(followRepository.findByIdFollowerIdOrderByCreatedAtDescIdFolloweeIdDesc(
+                eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(followEdge(VIEWER_ID, 100L))));
+        when(followRepository.findByIdFollowerIdIn(anyCollection()))
+                .thenReturn(List.of(
+                        followEdge(100L, VIEWER_ID),  // would credit the viewer
+                        followEdge(100L, 100L),       // would credit already-followed
+                        followEdge(100L, 200L)));     // legitimate second-hop
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of(c200));
+
+        Page<FollowRecommendationResponse> result = service.recommend(VIEWER_ID, firstPage);
+
+        FollowRecommendationResponse only = result.getContent().get(0);
+        assertThat(only.getScore()).isEqualTo(FOLLOW_GRAPH_WEIGHT);
+        assertThat(only.getFactors()).containsExactly("followed-by-1-of-your-follows");
+    }
+
+    @Test
+    void emptyFolloweeSet_skipsSecondHopQuery() {
+        Mentee viewer = mentee(VIEWER_ID, List.of("ai"));
+        Mentor c10 = mentor(10L, List.of("ai"));
+
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(followRepository.findByIdFollowerIdOrderByCreatedAtDescIdFolloweeIdDesc(
+                eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of(c10));
+
+        service.recommend(VIEWER_ID, firstPage);
+
+        verify(followRepository, never()).findByIdFollowerIdIn(anyCollection());
+    }
+
+    // ── Pagination & windowing ─────────────────────────────────────────────
+
+    @Test
+    void candidateQueryUsesRankingWindow() {
+        Mentee viewer = mentee(VIEWER_ID, List.of());
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        service.recommend(VIEWER_ID, firstPage);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(userRepository).findFollowRecommendationCandidates(eq(VIEWER_ID), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isEqualTo(RANKING_WINDOW);
+        assertThat(captor.getValue().getPageNumber()).isZero();
+    }
+
+    @Test
+    void pageSlicingReturnsRequestedSlice() {
+        Mentee viewer = mentee(VIEWER_ID, List.of());
+        // 5 zero-score candidates → id-DESC ordering: 50, 40, 30, 20, 10
+        List<User> candidates = new ArrayList<>();
+        for (long id = 10L; id <= 50L; id += 10L) {
+            candidates.add(mentor(id, List.of()));
+        }
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(candidates);
+
+        Page<FollowRecommendationResponse> page1 = service.recommend(VIEWER_ID, PageRequest.of(0, 2));
+        Page<FollowRecommendationResponse> page2 = service.recommend(VIEWER_ID, PageRequest.of(1, 2));
+        Page<FollowRecommendationResponse> page3 = service.recommend(VIEWER_ID, PageRequest.of(2, 2));
+
+        assertThat(page1.getContent())
+                .extracting(FollowRecommendationResponse::getId)
+                .containsExactly(50L, 40L);
+        assertThat(page2.getContent())
+                .extracting(FollowRecommendationResponse::getId)
+                .containsExactly(30L, 20L);
+        assertThat(page3.getContent())
+                .extracting(FollowRecommendationResponse::getId)
+                .containsExactly(10L);
+        assertThat(page1.getTotalElements()).isEqualTo(5);
+    }
+
+    @Test
+    void pageBeyondTotalReturnsEmpty() {
+        Mentee viewer = mentee(VIEWER_ID, List.of());
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of(mentor(1L, List.of())));
+
+        Page<FollowRecommendationResponse> result =
+                service.recommend(VIEWER_ID, PageRequest.of(5, 20));
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    void responseShapeMirrorsUserSummary() {
+        Mentee viewer = mentee(VIEWER_ID, List.of("AI"));
+        Mentor c = mentor(42L, List.of("AI"));
+        c.setLastName("Surname");
+        c.setProfilePhoto("https://cdn/x.png");
+
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of(c));
+
+        FollowRecommendationResponse only = service.recommend(VIEWER_ID, firstPage)
+                .getContent().get(0);
+
+        assertThat(only.getId()).isEqualTo(42L);
+        assertThat(only.getFirstName()).isEqualTo("M42");
+        assertThat(only.getLastName()).isEqualTo("Surname");
+        assertThat(only.getProfilePhoto()).isEqualTo("https://cdn/x.png");
+        assertThat(only.getRole()).isEqualTo("MENTOR");
+        assertThat(only.getScore()).isEqualTo(INTEREST_WEIGHT);
+        assertThat(only.getFactors()).containsExactly("shared-interest:AI");
+    }
+
+    @Test
+    void menteeViewerRoleDiscriminator_returnsMENTEE() {
+        Mentee viewer = mentee(VIEWER_ID, List.of());
+        Mentee candidate = mentee(99L, List.of());
+
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+
+        FollowRecommendationResponse only = service.recommend(VIEWER_ID, firstPage)
+                .getContent().get(0);
+
+        assertThat(only.getRole()).isEqualTo("MENTEE");
+    }
+
+    // ── Followee-set cap ───────────────────────────────────────────────────
+
+    @Test
+    void followeeFetchUsesMaxViewerFolloweesPageSize() {
+        Mentee viewer = mentee(VIEWER_ID, List.of());
+        when(userRepository.findById(VIEWER_ID)).thenReturn(Optional.of(viewer));
+        when(userRepository.findFollowRecommendationCandidates(eq(VIEWER_ID), any(Pageable.class)))
+                .thenReturn(Collections.emptyList());
+
+        service.recommend(VIEWER_ID, firstPage);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(followRepository).findByIdFollowerIdOrderByCreatedAtDescIdFolloweeIdDesc(
+                eq(VIEWER_ID), captor.capture());
+        assertThat(captor.getValue().getPageSize())
+                .isEqualTo(FollowRecommendationService.MAX_VIEWER_FOLLOWEES);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static Mentor mentor(Long id, List<String> interests) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName("M" + id);
+        m.setLastName("L");
+        m.setEmail("m" + id + "@ex.com");
+        if (interests != null) {
+            m.setInterests(interests);
+        }
+        return m;
+    }
+
+    private static Mentee mentee(Long id, List<String> interests) {
+        Mentee m = new Mentee();
+        m.setId(id);
+        m.setFirstName("Me" + id);
+        m.setLastName("L");
+        m.setEmail("me" + id + "@ex.com");
+        if (interests != null) {
+            m.setInterests(interests);
+        }
+        return m;
+    }
+
+    private static Follow followEdge(Long followerId, Long followeeId) {
+        Follow f = new Follow();
+        f.setId(new FollowId(followerId, followeeId));
+        return f;
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/ranking/RuleBasedFollowRankerTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ranking/RuleBasedFollowRankerTest.java
@@ -1,0 +1,211 @@
+package com.group7.backend.service.ranking;
+
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pure unit coverage of the v1 follow-recommendation algorithm. Mirrors
+ * {@code RuleBasedMentorRankerTest}'s shape: weights are pinned via the
+ * constructor so the assertions stay deterministic regardless of
+ * application.properties tuning.
+ */
+class RuleBasedFollowRankerTest {
+
+    private static final int INTEREST_WEIGHT = 3;
+    private static final int FOLLOW_GRAPH_WEIGHT = 2;
+
+    private final RuleBasedFollowRanker ranker =
+            new RuleBasedFollowRanker(INTEREST_WEIGHT, FOLLOW_GRAPH_WEIGHT);
+
+    // ── Signal A: interest overlap ───────────────────────────────────────────
+
+    @Test
+    void noOverlap_scoresZeroAndNoFactors() {
+        Mentor candidate = mentor(1L, List.of("Rust", "Networking"));
+        FollowRecommendationContext ctx = ctx(Set.of("ai", "databases"), Set.of(), Map.of());
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        assertThat(sr.score()).isZero();
+        assertThat(sr.factors()).isEmpty();
+    }
+
+    @Test
+    void singleInterestOverlap_addsWeightAndEmitsFactor() {
+        Mentor candidate = mentor(1L, List.of("AI", "Networking"));
+        FollowRecommendationContext ctx = ctx(Set.of("ai"), Set.of(), Map.of());
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        assertThat(sr.score()).isEqualTo(INTEREST_WEIGHT);
+        assertThat(sr.factors()).containsExactly("shared-interest:AI");
+    }
+
+    @Test
+    void interestOverlapIsCaseInsensitive() {
+        Mentor candidate = mentor(1L, List.of("Java"));
+        // viewer's labels arrive lowercased from the service layer
+        FollowRecommendationContext ctx = ctx(Set.of("java"), Set.of(), Map.of());
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        assertThat(sr.score()).isEqualTo(INTEREST_WEIGHT);
+        assertThat(sr.factors()).containsExactly("shared-interest:Java");
+    }
+
+    @Test
+    void manyInterestOverlaps_scoreReflectsAll_factorsCappedAtThree() {
+        Mentor candidate = mentor(1L,
+                List.of("AI", "Databases", "Systems", "ML", "Networking"));
+        FollowRecommendationContext ctx = ctx(
+                Set.of("ai", "databases", "systems", "ml", "networking"),
+                Set.of(), Map.of());
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        // 5 overlaps × weight; factor list capped to 3 for display
+        assertThat(sr.score()).isEqualTo(5 * INTEREST_WEIGHT);
+        assertThat(sr.factors()).hasSize(RuleBasedFollowRanker.DISPLAY_FACTOR_CAP);
+        assertThat(sr.factors())
+                .containsExactly("shared-interest:AI", "shared-interest:Databases", "shared-interest:Systems");
+    }
+
+    @Test
+    void menteeCandidate_alsoUsesInterests() {
+        Mentee candidate = mentee(2L, List.of("Java"));
+        FollowRecommendationContext ctx = ctx(Set.of("java"), Set.of(), Map.of());
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        assertThat(sr.score()).isEqualTo(INTEREST_WEIGHT);
+        assertThat(sr.factors()).containsExactly("shared-interest:Java");
+    }
+
+    @Test
+    void candidateWithNullInterests_doesNotCrash() {
+        Mentor candidate = mentor(1L, null);
+        FollowRecommendationContext ctx = ctx(Set.of("ai"), Set.of(), Map.of());
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        assertThat(sr.score()).isZero();
+        assertThat(sr.factors()).isEmpty();
+    }
+
+    // ── Signal B: follow-graph proximity ─────────────────────────────────────
+
+    @Test
+    void noSecondHopEdges_scoresZeroAndNoFactor() {
+        Mentor candidate = mentor(1L, List.of());
+        FollowRecommendationContext ctx = ctx(Set.of(), Set.of(), Map.of());
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        assertThat(sr.score()).isZero();
+        assertThat(sr.factors()).isEmpty();
+    }
+
+    @Test
+    void singleSecondHop_addsWeightAndEmitsFactor() {
+        Mentor candidate = mentor(1L, List.of());
+        FollowRecommendationContext ctx = ctx(Set.of(), Set.of(99L), Map.of(1L, 1));
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        assertThat(sr.score()).isEqualTo(FOLLOW_GRAPH_WEIGHT);
+        assertThat(sr.factors()).containsExactly("followed-by-1-of-your-follows");
+    }
+
+    @Test
+    void multipleSecondHops_scoreScalesAndFactorReportsCount() {
+        Mentor candidate = mentor(1L, List.of());
+        FollowRecommendationContext ctx = ctx(Set.of(), Set.of(), Map.of(1L, 4));
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        assertThat(sr.score()).isEqualTo(4 * FOLLOW_GRAPH_WEIGHT);
+        assertThat(sr.factors()).containsExactly("followed-by-4-of-your-follows");
+    }
+
+    // ── Combined ────────────────────────────────────────────────────────────
+
+    @Test
+    void combinedSignals_sumIndependentContributions() {
+        Mentor candidate = mentor(1L, List.of("AI", "Java"));
+        FollowRecommendationContext ctx = ctx(
+                Set.of("ai", "java"), Set.of(99L), Map.of(1L, 2));
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        // 2 interest overlaps × 3 + 2 second-hops × 2 = 6 + 4 = 10
+        assertThat(sr.score()).isEqualTo(2 * INTEREST_WEIGHT + 2 * FOLLOW_GRAPH_WEIGHT);
+        assertThat(sr.factors())
+                .containsExactly(
+                        "shared-interest:AI",
+                        "shared-interest:Java",
+                        "followed-by-2-of-your-follows");
+    }
+
+    @Test
+    void rankerIsStateless_consecutiveCallsReturnSameScore() {
+        Mentor candidate = mentor(1L, List.of("AI"));
+        FollowRecommendationContext ctx = ctx(Set.of("ai"), Set.of(), Map.of(1L, 1));
+
+        ScoreResult first = ranker.score(candidate, ctx);
+        ScoreResult second = ranker.score(candidate, ctx);
+
+        assertThat(second.score()).isEqualTo(first.score());
+        assertThat(second.factors()).isEqualTo(first.factors());
+    }
+
+    @Test
+    void unknownUserSubtype_isHandledAsZeroInterestContribution() {
+        // Defensive: User is abstract, but if a future subtype reaches the
+        // ranker (e.g., admin slipping past upstream filters) we score the
+        // graph signal cleanly rather than throwing.
+        User candidate = new User() {};
+        candidate.setId(1L);
+        FollowRecommendationContext ctx = ctx(Set.of("ai"), Set.of(), Map.of(1L, 1));
+
+        ScoreResult sr = ranker.score(candidate, ctx);
+
+        assertThat(sr.score()).isEqualTo(FOLLOW_GRAPH_WEIGHT);
+        assertThat(sr.factors()).containsExactly("followed-by-1-of-your-follows");
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static Mentor mentor(Long id, List<String> interests) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName("M" + id);
+        if (interests != null) {
+            m.setInterests(interests);
+        }
+        return m;
+    }
+
+    private static Mentee mentee(Long id, List<String> interests) {
+        Mentee m = new Mentee();
+        m.setId(id);
+        m.setFirstName("Me" + id);
+        if (interests != null) {
+            m.setInterests(interests);
+        }
+        return m;
+    }
+
+    private static FollowRecommendationContext ctx(Set<String> labels,
+                                                   Set<Long> followeeIds,
+                                                   Map<Long, Integer> secondHop) {
+        return new FollowRecommendationContext(42L, labels, followeeIds, secondHop);
+    }
+}


### PR DESCRIPTION
Closes #344.

## Summary
- Adds `GET /api/users/me/follow-recommendations` — paged, scored list of users to follow with explanation factors (`shared-interest:<label>`, `followed-by-N-of-your-follows`).
- Introduces a `FollowRanker` strategy interface (parallel to `MentorRanker`) with a default rule-based implementation combining interest overlap (weight 3) and follow-graph proximity (weight 2); weights configurable via `app.recommendations.*`.
- Reuses the follow graph from #343 (merged) and the matching pipeline's oversample-→-rank-→-slice pattern (`app.matching.ranking-window=200`).
- Excludes self, already-followed users, and admins at the SQL layer (`UserRepository.findFollowRecommendationCandidates`).

## Out of scope (intentional)
- **Banned-user filter** — `Ban` entity is in the still-open #380; will follow once that lands on `dev`.
- **Recent-engagement signal** — depends on `FeedPost` / `Comment` from #348; the ranker carries a `// TODO(#348)` stub so the third signal lands as an in-place upgrade.
- **`Mentee.profileVisibility`** — currently unenforced everywhere on `dev`; not introduced here to avoid endpoint-only inconsistency.

## Test plan
- [x] `RuleBasedFollowRankerTest` — 12 unit tests (signal scoring, factor cap of 3, case-insensitivity)
- [x] `FollowRecommendationServiceTest` — 14 tests (ordering, page slicing, exclusions, second-hop dedup, viewer-not-found 404)
- [x] `FollowRecommendationControllerTest` — 6 tests (body shape, page-size clamp, 401, 404)
- [x] Full backend suite green (996/996) — no regressions
- [x] Manual smoke against running backend with a real JWT
