### PR TITLE
feat(backend): shared-goal precondition gate on mentorship writes (#335)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -169,6 +169,15 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.12</version>
+                <configuration>
+                    <excludes>
+                        <exclude>*$HibernateProxy*</exclude>
+                        <exclude>*$HibernateInstantiator*</exclude>
+                        <exclude>*$MockitoMock*</exclude>
+                        <exclude>*$$EnhancerByCGLIB$$*</exclude>
+                        <exclude>*$$FastClassByCGLIB$$*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/backend/src/main/java/com/group7/backend/controller/MeetingController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MeetingController.java
@@ -39,7 +39,8 @@ public class MeetingController {
                     content = @Content(schema = @Schema(implementation = MeetingCreateResponse.class))),
             @ApiResponse(responseCode = "403", description = "Not authorized", content = @Content),
             @ApiResponse(responseCode = "404", description = "Mentorship not found", content = @Content),
-            @ApiResponse(responseCode = "409", description = "Conflict", content = @Content)
+            @ApiResponse(responseCode = "409", description = "Schedule conflict, mentorship not active, " +
+                    "or shared goal not defined (body carries code=\"GOAL_REQUIRED\")", content = @Content)
     })
     public ResponseEntity<MeetingCreateResponse> createMeetings(
             @Parameter(description = "Mentorship ID") @PathVariable Long id,

--- a/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
@@ -1,7 +1,9 @@
 package com.group7.backend.controller;
 
 import com.group7.backend.dto.request.SharedGoalRequest;
+import com.group7.backend.dto.response.MentorshipProgressResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
+import com.group7.backend.service.MentorshipProgressService;
 import com.group7.backend.service.MentorshipService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -23,9 +25,12 @@ import java.util.List;
 public class MentorshipController {
 
     private final MentorshipService mentorshipService;
+    private final MentorshipProgressService mentorshipProgressService;
 
-    public MentorshipController(MentorshipService mentorshipService) {
+    public MentorshipController(MentorshipService mentorshipService,
+                                MentorshipProgressService mentorshipProgressService) {
         this.mentorshipService = mentorshipService;
+        this.mentorshipProgressService = mentorshipProgressService;
     }
 
     @GetMapping
@@ -60,6 +65,26 @@ public class MentorshipController {
             Authentication authentication) {
         Long userId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(mentorshipService.getMentorship(userId, id));
+    }
+
+    @GetMapping("/{id}/progress")
+    @Operation(
+            summary = "Get mentorship progress",
+            description = "Returns aggregated task + milestone progress for the mentorship. " +
+                    "Only the mentor and mentee may read; non-participants get 404."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Progress payload",
+                    content = @Content(schema = @Schema(implementation = MentorshipProgressResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content)
+    })
+    public ResponseEntity<MentorshipProgressResponse> getMentorshipProgress(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorshipProgressService.getProgress(userId, id));
     }
 
     @PutMapping("/{id}/goal")

--- a/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
@@ -42,6 +42,26 @@ public class MentorshipController {
         return ResponseEntity.ok(mentorshipService.getActiveMentorships(userId));
     }
 
+    @GetMapping("/{id}")
+    @Operation(
+            summary = "Get a mentorship",
+            description = "Returns the mentorship by id, including the goalDefined flag. " +
+                    "Only the mentor and mentee may read; non-participants get 404 to avoid leaking ids."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Mentorship found",
+                    content = @Content(schema = @Schema(implementation = MentorshipResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content)
+    })
+    public ResponseEntity<MentorshipResponse> getMentorship(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorshipService.getMentorship(userId, id));
+    }
+
     @PutMapping("/{id}/goal")
     @Operation(
             summary = "Set shared goal",

--- a/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
@@ -3,8 +3,10 @@ package com.group7.backend.controller;
 import com.group7.backend.dto.request.SharedGoalRequest;
 import com.group7.backend.dto.response.MentorshipProgressResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
+import com.group7.backend.dto.response.TimelineResponse;
 import com.group7.backend.service.MentorshipProgressService;
 import com.group7.backend.service.MentorshipService;
+import com.group7.backend.service.MentorshipTimelineService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,10 +15,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @RestController
@@ -26,11 +30,14 @@ public class MentorshipController {
 
     private final MentorshipService mentorshipService;
     private final MentorshipProgressService mentorshipProgressService;
+    private final MentorshipTimelineService mentorshipTimelineService;
 
     public MentorshipController(MentorshipService mentorshipService,
-                                MentorshipProgressService mentorshipProgressService) {
+                                MentorshipProgressService mentorshipProgressService,
+                                MentorshipTimelineService mentorshipTimelineService) {
         this.mentorshipService = mentorshipService;
         this.mentorshipProgressService = mentorshipProgressService;
+        this.mentorshipTimelineService = mentorshipTimelineService;
     }
 
     @GetMapping
@@ -85,6 +92,34 @@ public class MentorshipController {
             Authentication authentication) {
         Long userId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(mentorshipProgressService.getProgress(userId, id));
+    }
+
+    @GetMapping("/{id}/timeline")
+    @Operation(
+            summary = "Get mentorship timeline",
+            description = "Returns meetings, tasks, and milestones merged into a single " +
+                    "chronologically-sorted feed, scoped to a window (default = mentorship " +
+                    "startDate..endDate; max 24 months). Only the mentor and mentee may read; " +
+                    "non-participants get 404."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Timeline payload",
+                    content = @Content(schema = @Schema(implementation = TimelineResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid window: from > to, or window > 24 months",
+                    content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content)
+    })
+    public ResponseEntity<TimelineResponse> getMentorshipTimeline(
+            @PathVariable Long id,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorshipTimelineService.getTimeline(userId, id, from, to));
     }
 
     @PutMapping("/{id}/goal")

--- a/backend/src/main/java/com/group7/backend/controller/MilestoneController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MilestoneController.java
@@ -42,7 +42,8 @@ public class MilestoneController {
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
             @ApiResponse(responseCode = "403", description = "Not a mentor of this mentorship", content = @Content),
             @ApiResponse(responseCode = "404", description = "Mentorship not found", content = @Content),
-            @ApiResponse(responseCode = "409", description = "Mentorship is not active", content = @Content)
+            @ApiResponse(responseCode = "409", description = "Mentorship is not active, or shared goal not defined " +
+                    "(body carries code=\"GOAL_REQUIRED\")", content = @Content)
     })
     public ResponseEntity<MilestoneDetailResponse> createMilestone(
             @PathVariable Long id,

--- a/backend/src/main/java/com/group7/backend/controller/TaskController.java
+++ b/backend/src/main/java/com/group7/backend/controller/TaskController.java
@@ -7,6 +7,9 @@ import com.group7.backend.dto.response.TaskDetailResponse;
 import com.group7.backend.dto.response.TaskSummaryResponse;
 import com.group7.backend.service.TaskService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -31,6 +34,16 @@ public class TaskController {
 
     @PostMapping("/mentorships/{id}/tasks")
     @Operation(summary = "Assign a task", description = "Mentor assigns a new task to their mentee.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Task created"),
+            @ApiResponse(responseCode = "400", description = "Invalid request (e.g. due date in the past)",
+                    content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Caller is not the mentor", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found", content = @Content),
+            @ApiResponse(responseCode = "409", description = "Mentorship not active, or shared goal not defined " +
+                    "(body carries code=\"GOAL_REQUIRED\")", content = @Content)
+    })
     public ResponseEntity<TaskDetailResponse> createTask(
             @PathVariable Long id,
             @Valid @RequestBody TaskCreateRequest request,

--- a/backend/src/main/java/com/group7/backend/dto/request/SharedGoalRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/SharedGoalRequest.java
@@ -1,7 +1,7 @@
 package com.group7.backend.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Schema(description = "Payload for setting a shared mentorship goal")
 public class SharedGoalRequest {
 
-    @NotNull(message = "Shared goal is required")
+    @NotBlank(message = "Shared goal must not be blank")
     @Size(max = 500, message = "Shared goal must not exceed 500 characters")
     @Schema(description = "The shared goal for this mentorship", example = "Build a machine learning portfolio project")
     private String sharedGoal;

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorshipProgressResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorshipProgressResponse.java
@@ -1,0 +1,38 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+@Schema(description = "Aggregated mentorship progress across tasks and milestones (#334).")
+public record MentorshipProgressResponse(
+        @Schema(description = "Mentorship id", example = "42")
+        long mentorshipId,
+
+        @Schema(description = "Total task count for this mentorship", example = "10")
+        long taskTotal,
+
+        @Schema(description = "Tasks in COMPLETED status", example = "4")
+        long taskCompleted,
+
+        @Schema(description = "Tasks in SUBMITTED status (awaiting review; not yet COMPLETED)",
+                example = "2")
+        long taskSubmitted,
+
+        @Schema(description = "Total milestone count for this mentorship", example = "3")
+        long milestoneTotal,
+
+        @Schema(description = "Milestones in COMPLETED status", example = "1")
+        long milestoneCompleted,
+
+        @Schema(description = "Combined progress in [0.0, 1.0]. Equal-weighted across the two " +
+                "surfaces when both have entries; falls back to a single-surface ratio when only " +
+                "one surface has entries; 0.0 when both are empty.",
+                example = "0.55")
+        float progressPercentage,
+
+        @Schema(description = "Latest activity timestamp across task submissions / reviews and " +
+                "milestone completions; null when neither domain has any activity.")
+        OffsetDateTime lastActivityAt
+) {
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorshipProgressResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorshipProgressResponse.java
@@ -25,11 +25,11 @@ public record MentorshipProgressResponse(
         @Schema(description = "Milestones in COMPLETED status", example = "1")
         long milestoneCompleted,
 
-        @Schema(description = "Combined progress in [0.0, 1.0]. Equal-weighted across the two " +
-                "surfaces when both have entries; falls back to a single-surface ratio when only " +
-                "one surface has entries; 0.0 when both are empty.",
-                example = "0.55")
-        float progressPercentage,
+        @Schema(description = "Combined progress as a ratio in [0.0, 1.0]. Equal-weighted across " +
+                "the two surfaces when both have entries; falls back to a single-surface ratio " +
+                "when only one surface has entries; 0.0 when both are empty.",
+                example = "0.325")
+        float progressRatio,
 
         @Schema(description = "Latest activity timestamp across task submissions / reviews and " +
                 "milestone completions; null when neither domain has any activity.")

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorshipResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorshipResponse.java
@@ -44,6 +44,10 @@ public class MentorshipResponse {
     @Schema(description = "Shared goal defined by both parties")
     private String sharedGoal;
 
+    @Schema(description = "True if a non-blank shared goal has been defined for this mentorship",
+            example = "true")
+    private boolean goalDefined;
+
     public static MentorshipResponse from(Mentorship mentorship) {
         MentorshipResponse r = new MentorshipResponse();
         r.setId(mentorship.getId());
@@ -56,6 +60,7 @@ public class MentorshipResponse {
         r.setDuration(mentorship.getDuration());
         r.setStatus(mentorship.getStatus().name());
         r.setSharedGoal(mentorship.getSharedGoal());
+        r.setGoalDefined(mentorship.hasSharedGoal());
         return r;
     }
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/TimelineItem.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/TimelineItem.java
@@ -1,0 +1,54 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+/**
+ * One row of the mentorship timeline. The shape is uniform across the three source
+ * domains (meetings, tasks, milestones); type-conditional fields are nullable and
+ * carry an explicit {@code null} for "not applicable" rather than being omitted, so
+ * clients never need to defend against missing keys.
+ */
+@Schema(description = "One row of the mentorship timeline (#332).")
+public record TimelineItem(
+        @Schema(description = "Item type discriminator")
+        TimelineItemType type,
+
+        long id,
+
+        String title,
+
+        @Schema(description = "Chronological position: meeting.startTime | task.dueDate | milestone.targetDate. " +
+                "Tasks with no dueDate and milestones with no targetDate have no chronological " +
+                "position and are excluded from the timeline; fetch them via the per-domain endpoints.")
+        OffsetDateTime occursAt,
+
+        @Schema(description = "Type-specific status string (MeetingStatus / TaskStatus / MilestoneStatus name)")
+        String status,
+
+        @Schema(description = "Path to the per-type detail endpoint, e.g. /api/meetings/{id}")
+        String detailUrl,
+
+        @Schema(description = "Total action items; null for TASK (tasks have no action items)",
+                nullable = true)
+        Long actionItemTotal,
+
+        @Schema(description = "Action items in completed state; null for TASK", nullable = true)
+        Long actionItemCompleted,
+
+        @Schema(description = "True iff a non-blank notes field exists on the underlying entity; "
+                + "null for TASK and MILESTONE (only meetings carry notes)", nullable = true)
+        Boolean hasNotes
+) {
+    public TimelineItem {
+        // Compact-constructor null guards on the always-present fields. The three
+        // type-conditional fields above are intentionally nullable.
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(occursAt, "occursAt");
+        Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(detailUrl, "detailUrl");
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/TimelineItemType.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/TimelineItemType.java
@@ -1,0 +1,25 @@
+package com.group7.backend.dto.response;
+
+/**
+ * Discriminator for {@link TimelineItem}. The {@link #priority()} accessor returns
+ * the value used as the second-level sort key in the timeline (after {@code occursAt});
+ * lower priority means earlier in the rendered list when timestamps tie.
+ *
+ * <p>Priority is an explicit field, not {@link Enum#ordinal()}, so reordering the enum
+ * declaration cannot silently change sort behaviour.
+ */
+public enum TimelineItemType {
+    MILESTONE(0),
+    MEETING(1),
+    TASK(2);
+
+    private final int priority;
+
+    TimelineItemType(int priority) {
+        this.priority = priority;
+    }
+
+    public int priority() {
+        return priority;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/TimelineResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/TimelineResponse.java
@@ -1,0 +1,34 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Aggregated mentorship timeline payload (#332, spec 1.1.5.9-1.1.5.13).
+ *
+ * <p>Returns the program window ({@code startDate}, {@code endDate}), a server-clock
+ * {@code currentDate} for the "today" marker, and the merged chronologically-sorted
+ * list of timeline items.
+ */
+@Schema(description = "Aggregated mentorship timeline (#332).")
+public record TimelineResponse(
+        @Schema(description = "Mentorship id", example = "42")
+        long mentorshipId,
+
+        @Schema(description = "Mentorship program window start")
+        OffsetDateTime startDate,
+
+        @Schema(description = "Mentorship program window end")
+        OffsetDateTime endDate,
+
+        @Schema(description = "Server clock instant at request time. Full timestamp despite the "
+                + "name; clients render the date portion for the today marker.")
+        OffsetDateTime currentDate,
+
+        @Schema(description = "Merged timeline items, sorted by occursAt ascending; "
+                + "ties broken by type priority (MILESTONE > MEETING > TASK) then id ascending")
+        List<TimelineItem> items
+) {
+}

--- a/backend/src/main/java/com/group7/backend/entity/Mentorship.java
+++ b/backend/src/main/java/com/group7/backend/entity/Mentorship.java
@@ -54,4 +54,8 @@ public class Mentorship {
     protected void onCreate() {
         this.createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
+
+    public boolean hasSharedGoal() {
+        return sharedGoal != null && !sharedGoal.isBlank();
+    }
 }

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -74,6 +74,20 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.CONFLICT, "Conflict", ex.getMessage());
     }
 
+    @ExceptionHandler(GoalRequiredException.class)
+    public ResponseEntity<Map<String, Object>> handleGoalRequired(GoalRequiredException ex,
+                                                                  HttpServletRequest request) {
+        log.warn("Goal-required precondition rejected: method={}, path={}, mentorshipId={}",
+                request.getMethod(), request.getRequestURI(), ex.getMentorshipId());
+        Map<String, Object> body = Map.of(
+                "error", "Conflict",
+                "code", "GOAL_REQUIRED",
+                "message", ex.getMessage(),
+                "mentorshipId", ex.getMentorshipId()
+        );
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
     @ExceptionHandler(AuthenticationFailedException.class)
     public ResponseEntity<Map<String, String>> handleAuthenticationFailed(AuthenticationFailedException ex,
                                                                          HttpServletRequest request) {

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -74,6 +74,14 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.CONFLICT, "Conflict", ex.getMessage());
     }
 
+    @ExceptionHandler(InvalidTimelineWindowException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidTimelineWindow(InvalidTimelineWindowException ex,
+                                                                           HttpServletRequest request) {
+        log.warn("Invalid timeline window: method={}, path={}, message={}",
+                request.getMethod(), request.getRequestURI(), ex.getMessage());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage());
+    }
+
     @ExceptionHandler(GoalRequiredException.class)
     public ResponseEntity<Map<String, Object>> handleGoalRequired(GoalRequiredException ex,
                                                                   HttpServletRequest request) {

--- a/backend/src/main/java/com/group7/backend/exception/GoalRequiredException.java
+++ b/backend/src/main/java/com/group7/backend/exception/GoalRequiredException.java
@@ -1,0 +1,25 @@
+package com.group7.backend.exception;
+
+/**
+ * Thrown when an action requires a mentorship to have a defined shared goal
+ * but the mentorship's {@code sharedGoal} is null or blank.
+ *
+ * <p>Maps to HTTP 409 with a structured body containing
+ * {@code code = "GOAL_REQUIRED"} and the {@code mentorshipId}.
+ */
+public class GoalRequiredException extends RuntimeException {
+
+    public static final String DEFAULT_MESSAGE =
+            "Mentorship shared goal must be defined before this action";
+
+    private final Long mentorshipId;
+
+    public GoalRequiredException(Long mentorshipId) {
+        super(DEFAULT_MESSAGE);
+        this.mentorshipId = mentorshipId;
+    }
+
+    public Long getMentorshipId() {
+        return mentorshipId;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/exception/InvalidTimelineWindowException.java
+++ b/backend/src/main/java/com/group7/backend/exception/InvalidTimelineWindowException.java
@@ -1,0 +1,14 @@
+package com.group7.backend.exception;
+
+/**
+ * Thrown when a timeline window is malformed: {@code from > to}, too wide
+ * (over 24 months), or relies on a mentorship with missing program dates.
+ *
+ * <p>Maps to HTTP 400 via {@link GlobalExceptionHandler}.
+ */
+public class InvalidTimelineWindowException extends RuntimeException {
+
+    public InvalidTimelineWindowException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/repository/MeetingActionItemRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MeetingActionItemRepository.java
@@ -1,11 +1,39 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.MeetingActionItem;
+import com.group7.backend.repository.projection.ActionItemCountTuple;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface MeetingActionItemRepository extends JpaRepository<MeetingActionItem, Long> {
 
     List<MeetingActionItem> findByMeetingIdOrderByOrderIndexAscIdAsc(Long meetingId);
+
+    /**
+     * Bulk-load action-item counts for a set of meeting ids in one query.
+     * Returns one tuple per meeting that has at least one action item; meetings with
+     * zero action items don't appear in the result and the caller defaults them to
+     * {@code (0, 0)}. Used by the mentorship timeline aggregation (#332) to avoid N+1.
+     *
+     * <p>Caller must short-circuit on an empty {@code ids} collection — Hibernate 6
+     * emits invalid SQL ({@code WHERE x IN ()}) for empty IN parameters.
+     */
+    /**
+     * The {@code CAST(... AS Long)} on the {@code SUM} pins the expression's return type so
+     * Hibernate's JPQL constructor-expression resolution against
+     * {@link ActionItemCountTuple} (which takes three {@code Long} components) cannot
+     * silently drift on a future Hibernate / driver upgrade where {@code SUM} of a
+     * {@code CASE} integer might widen to a different numeric type.
+     */
+    @Query("SELECT new com.group7.backend.repository.projection.ActionItemCountTuple("
+            + "a.meeting.id, COUNT(a), "
+            + "CAST(COALESCE(SUM(CASE WHEN a.completed = true THEN 1L ELSE 0L END), 0L) AS java.lang.Long)) "
+            + "FROM MeetingActionItem a "
+            + "WHERE a.meeting.id IN :ids "
+            + "GROUP BY a.meeting.id")
+    List<ActionItemCountTuple> countByMeetingIds(@Param("ids") Collection<Long> ids);
 }

--- a/backend/src/main/java/com/group7/backend/repository/MeetingRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MeetingRepository.java
@@ -60,6 +60,24 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             @Param("windowStart") OffsetDateTime windowStart,
             @Param("windowEnd") OffsetDateTime windowEnd);
 
+    /**
+     * Meetings of a mentorship whose {@code startTime} falls inside the inclusive
+     * {@code [from, to]} window. Used by the mentorship timeline aggregation (#332).
+     *
+     * <p>The window predicate anchors on {@code startTime} only — a meeting that began
+     * before {@code from} and ended inside the window is excluded. This matches the
+     * timeline's "chronological position = startTime" model. If the product wants
+     * straddling meetings to surface in their endpoint window, change the predicate to
+     * {@code m.startTime <= :to AND m.endTime >= :from}.
+     */
+    @Query("SELECT m FROM Meeting m "
+            + "WHERE m.mentorship.id = :mentorshipId "
+            + "AND m.startTime BETWEEN :from AND :to")
+    List<Meeting> findInWindow(
+            @Param("mentorshipId") Long mentorshipId,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to);
+
     @Modifying
     @Query("UPDATE Meeting m SET m.status = 'EXPIRED' WHERE m.id = :meetingId AND m.status = 'PENDING_CONFIRMATION'")
     int expireMeeting(@Param("meetingId") Long meetingId);

--- a/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
@@ -7,12 +7,22 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MentorshipRepository extends JpaRepository<Mentorship, Long> {
 
     @Query("SELECT m FROM Mentorship m JOIN FETCH m.mentor JOIN FETCH m.mentee "
             + "WHERE (m.mentor.id = :userId OR m.mentee.id = :userId) AND m.status = :status")
     List<Mentorship> findByUserIdAndStatus(Long userId, MentorshipStatus status);
+
+    /**
+     * Looks up the mentorship by id, returning it only when {@code userId} is the mentor or
+     * the mentee. Filters on the FK columns directly so we don't trigger LAZY loads of the
+     * mentor / mentee proxies just to read their ids.
+     */
+    @Query("SELECT m FROM Mentorship m WHERE m.id = :id "
+            + "AND (m.mentor.id = :userId OR m.mentee.id = :userId)")
+    Optional<Mentorship> findByIdAndParticipant(@Param("id") Long id, @Param("userId") Long userId);
 
     @Query(value = "SELECT pg_advisory_xact_lock(:lockId)", nativeQuery = true)
     void acquireAdvisoryLock(@Param("lockId") Long lockId);

--- a/backend/src/main/java/com/group7/backend/repository/MilestoneActionItemRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MilestoneActionItemRepository.java
@@ -1,10 +1,13 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.MilestoneActionItem;
+import com.group7.backend.repository.projection.ActionItemCountTuple;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +18,27 @@ public interface MilestoneActionItemRepository extends JpaRepository<MilestoneAc
 
     @Query("SELECT a FROM MilestoneActionItem a JOIN FETCH a.milestone m JOIN FETCH m.mentorship WHERE a.id = :id")
     Optional<MilestoneActionItem> findByIdWithMilestoneAndMentorship(Long id);
+
+    /**
+     * Bulk-load action-item counts for a set of milestone ids in one query.
+     * Returns one tuple per milestone that has at least one action item; milestones
+     * with zero action items don't appear in the result and the caller defaults them
+     * to {@code (0, 0)}. Used by the mentorship timeline aggregation (#332) to avoid N+1.
+     *
+     * <p>Caller must short-circuit on an empty {@code ids} collection — Hibernate 6
+     * emits invalid SQL ({@code WHERE x IN ()}) for empty IN parameters.
+     */
+    /**
+     * The {@code CAST(... AS Long)} on the {@code SUM} pins the expression's return type so
+     * Hibernate's JPQL constructor-expression resolution against
+     * {@link ActionItemCountTuple} (which takes three {@code Long} components) cannot
+     * silently drift on a future Hibernate / driver upgrade.
+     */
+    @Query("SELECT new com.group7.backend.repository.projection.ActionItemCountTuple("
+            + "a.milestone.id, COUNT(a), "
+            + "CAST(COALESCE(SUM(CASE WHEN a.isCompleted = true THEN 1L ELSE 0L END), 0L) AS java.lang.Long)) "
+            + "FROM MilestoneActionItem a "
+            + "WHERE a.milestone.id IN :ids "
+            + "GROUP BY a.milestone.id")
+    List<ActionItemCountTuple> countByMilestoneIds(@Param("ids") Collection<Long> ids);
 }

--- a/backend/src/main/java/com/group7/backend/repository/MilestoneRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MilestoneRepository.java
@@ -1,10 +1,13 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.Milestone;
+import com.group7.backend.entity.MilestoneStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +18,11 @@ public interface MilestoneRepository extends JpaRepository<Milestone, Long> {
 
     @Query("SELECT m FROM Milestone m JOIN FETCH m.mentorship WHERE m.id = :id")
     Optional<Milestone> findByIdWithMentorship(Long id);
+
+    long countByMentorshipId(Long mentorshipId);
+
+    long countByMentorshipIdAndStatus(Long mentorshipId, MilestoneStatus status);
+
+    @Query("SELECT MAX(m.completedAt) FROM Milestone m WHERE m.mentorship.id = :mentorshipId")
+    OffsetDateTime findMaxCompletedAtForMentorship(@Param("mentorshipId") Long mentorshipId);
 }

--- a/backend/src/main/java/com/group7/backend/repository/MilestoneRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MilestoneRepository.java
@@ -25,4 +25,18 @@ public interface MilestoneRepository extends JpaRepository<Milestone, Long> {
 
     @Query("SELECT MAX(m.completedAt) FROM Milestone m WHERE m.mentorship.id = :mentorshipId")
     OffsetDateTime findMaxCompletedAtForMentorship(@Param("mentorshipId") Long mentorshipId);
+
+    /**
+     * Milestones of a mentorship whose {@code targetDate} falls inside the inclusive
+     * {@code [from, to]} window. Milestones with a null {@code targetDate} are
+     * excluded naturally by the {@code BETWEEN} predicate — they have no place on a
+     * chronological timeline. Used by the mentorship timeline aggregation (#332).
+     */
+    @Query("SELECT m FROM Milestone m "
+            + "WHERE m.mentorship.id = :mentorshipId "
+            + "AND m.targetDate BETWEEN :from AND :to")
+    List<Milestone> findInWindow(
+            @Param("mentorshipId") Long mentorshipId,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to);
 }

--- a/backend/src/main/java/com/group7/backend/repository/TaskRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/TaskRepository.java
@@ -1,6 +1,7 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.Task;
+import com.group7.backend.entity.TaskStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +17,8 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     @Query("SELECT t FROM Task t JOIN FETCH t.mentorship m JOIN FETCH m.mentor JOIN FETCH m.mentee WHERE t.id = :id")
     Optional<Task> findByIdWithMentorship(@Param("id") Long id);
+
+    long countByMentorshipId(Long mentorshipId);
+
+    long countByMentorshipIdAndStatus(Long mentorshipId, TaskStatus status);
 }

--- a/backend/src/main/java/com/group7/backend/repository/TaskRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/TaskRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,4 +22,18 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     long countByMentorshipId(Long mentorshipId);
 
     long countByMentorshipIdAndStatus(Long mentorshipId, TaskStatus status);
+
+    /**
+     * Tasks of a mentorship whose {@code dueDate} falls inside the inclusive
+     * {@code [from, to]} window. Tasks with a null {@code dueDate} are excluded
+     * naturally by the {@code BETWEEN} predicate — they have no place on a
+     * chronological timeline. Used by the mentorship timeline aggregation (#332).
+     */
+    @Query("SELECT t FROM Task t "
+            + "WHERE t.mentorship.id = :mentorshipId "
+            + "AND t.dueDate BETWEEN :from AND :to")
+    List<Task> findInWindow(
+            @Param("mentorshipId") Long mentorshipId,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to);
 }

--- a/backend/src/main/java/com/group7/backend/repository/TaskSubmissionRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/TaskSubmissionRepository.java
@@ -2,10 +2,12 @@ package com.group7.backend.repository;
 
 import com.group7.backend.entity.TaskSubmission;
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,5 +18,11 @@ public interface TaskSubmissionRepository extends JpaRepository<TaskSubmission, 
     List<TaskSubmission> findByTaskIdOrderBySubmittedAtDescIdDesc(Long taskId);
 
     Optional<TaskSubmission> findFirstByTaskIdOrderBySubmittedAtDescIdDesc(Long taskId);
+
+    @Query("SELECT MAX(ts.submittedAt) FROM TaskSubmission ts WHERE ts.task.mentorship.id = :mentorshipId")
+    OffsetDateTime findMaxSubmittedAtForMentorship(@Param("mentorshipId") Long mentorshipId);
+
+    @Query("SELECT MAX(ts.reviewedAt) FROM TaskSubmission ts WHERE ts.task.mentorship.id = :mentorshipId")
+    OffsetDateTime findMaxReviewedAtForMentorship(@Param("mentorshipId") Long mentorshipId);
 }
 

--- a/backend/src/main/java/com/group7/backend/repository/projection/ActionItemCountTuple.java
+++ b/backend/src/main/java/com/group7/backend/repository/projection/ActionItemCountTuple.java
@@ -1,0 +1,16 @@
+package com.group7.backend.repository.projection;
+
+/**
+ * Projection target for grouped action-item count queries on
+ * {@code MeetingActionItemRepository} and {@code MilestoneActionItemRepository}.
+ *
+ * <p>Both repositories use a JPQL constructor expression
+ * ({@code SELECT new ActionItemCountTuple(...)}) so the service layer never has to
+ * unpack a {@code List<Object[]>}.
+ */
+public record ActionItemCountTuple(
+        Long parentId,
+        Long total,
+        Long completed
+) {
+}

--- a/backend/src/main/java/com/group7/backend/service/MeetingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MeetingService.java
@@ -69,6 +69,7 @@ public class MeetingService {
     public MeetingCreateResponse createMeetings(Long mentorshipId, Long userId, MeetingCreateRequest request) {
         Mentorship mentorship = getActiveMentorshipForUser(mentorshipId, userId);
         requireMentor(mentorship, userId);
+        MentorshipPreconditions.requireSharedGoal(mentorship);
 
         validateTimeRange(request.getStartTime(), request.getEndTime());
         validateMeetingLink(request.getMeetingType(), request.getMeetingLink());

--- a/backend/src/main/java/com/group7/backend/service/MentorshipPreconditions.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipPreconditions.java
@@ -1,0 +1,28 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.exception.GoalRequiredException;
+
+/**
+ * Mentorship-level invariants enforced before downstream domain writes
+ * (tasks, meetings, milestones). Centralised here so the rule lives in
+ * exactly one place and the exception cannot drift across callers.
+ */
+public final class MentorshipPreconditions {
+
+    private MentorshipPreconditions() {
+    }
+
+    /**
+     * Ensures the mentorship has a defined shared goal.
+     *
+     * @throws GoalRequiredException carrying the mentorship id, mapped by
+     *         {@code GlobalExceptionHandler} to HTTP 409 with
+     *         {@code code = "GOAL_REQUIRED"}.
+     */
+    public static void requireSharedGoal(Mentorship mentorship) {
+        if (!mentorship.hasSharedGoal()) {
+            throw new GoalRequiredException(mentorship.getId());
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MentorshipProgressService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipProgressService.java
@@ -49,7 +49,7 @@ public class MentorshipProgressService {
         long milestoneCompleted =
                 milestoneRepository.countByMentorshipIdAndStatus(mid, MilestoneStatus.COMPLETED);
 
-        float progressPercentage = computePercentage(
+        float progressRatio = computeRatio(
                 taskTotal, taskCompleted, milestoneTotal, milestoneCompleted);
 
         OffsetDateTime lastActivityAt = computeLastActivity(mid);
@@ -61,7 +61,7 @@ public class MentorshipProgressService {
                 taskSubmitted,
                 milestoneTotal,
                 milestoneCompleted,
-                progressPercentage,
+                progressRatio,
                 lastActivityAt
         );
     }
@@ -70,8 +70,8 @@ public class MentorshipProgressService {
      * Equal-weight when both surfaces have entries; single-surface ratio when only one does;
      * {@code 0.0} when both are empty. Result is in [0.0, 1.0]; never NaN.
      */
-    private static float computePercentage(long taskTotal, long taskCompleted,
-                                           long milestoneTotal, long milestoneCompleted) {
+    private static float computeRatio(long taskTotal, long taskCompleted,
+                                      long milestoneTotal, long milestoneCompleted) {
         boolean hasTasks = taskTotal > 0;
         boolean hasMilestones = milestoneTotal > 0;
 

--- a/backend/src/main/java/com/group7/backend/service/MentorshipProgressService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipProgressService.java
@@ -1,0 +1,105 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.MentorshipProgressResponse;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MilestoneStatus;
+import com.group7.backend.entity.TaskStatus;
+import com.group7.backend.repository.MilestoneRepository;
+import com.group7.backend.repository.TaskRepository;
+import com.group7.backend.repository.TaskSubmissionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Read-only aggregator for mentorship progress (#334, spec 1.1.5.5).
+ *
+ * <p>Combines task and milestone counts into one payload so dashboards can render a
+ * percentage and a "last activity" label without orchestrating the math client-side.
+ */
+@Service
+public class MentorshipProgressService {
+
+    private final MentorshipService mentorshipService;
+    private final TaskRepository taskRepository;
+    private final TaskSubmissionRepository taskSubmissionRepository;
+    private final MilestoneRepository milestoneRepository;
+
+    public MentorshipProgressService(MentorshipService mentorshipService,
+                                     TaskRepository taskRepository,
+                                     TaskSubmissionRepository taskSubmissionRepository,
+                                     MilestoneRepository milestoneRepository) {
+        this.mentorshipService = mentorshipService;
+        this.taskRepository = taskRepository;
+        this.taskSubmissionRepository = taskSubmissionRepository;
+        this.milestoneRepository = milestoneRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public MentorshipProgressResponse getProgress(Long userId, Long mentorshipId) {
+        Mentorship mentorship = mentorshipService.findForParticipant(userId, mentorshipId);
+        long mid = mentorship.getId();
+
+        long taskTotal = taskRepository.countByMentorshipId(mid);
+        long taskCompleted = taskRepository.countByMentorshipIdAndStatus(mid, TaskStatus.COMPLETED);
+        long taskSubmitted = taskRepository.countByMentorshipIdAndStatus(mid, TaskStatus.SUBMITTED);
+
+        long milestoneTotal = milestoneRepository.countByMentorshipId(mid);
+        long milestoneCompleted =
+                milestoneRepository.countByMentorshipIdAndStatus(mid, MilestoneStatus.COMPLETED);
+
+        float progressPercentage = computePercentage(
+                taskTotal, taskCompleted, milestoneTotal, milestoneCompleted);
+
+        OffsetDateTime lastActivityAt = computeLastActivity(mid);
+
+        return new MentorshipProgressResponse(
+                mid,
+                taskTotal,
+                taskCompleted,
+                taskSubmitted,
+                milestoneTotal,
+                milestoneCompleted,
+                progressPercentage,
+                lastActivityAt
+        );
+    }
+
+    /**
+     * Equal-weight when both surfaces have entries; single-surface ratio when only one does;
+     * {@code 0.0} when both are empty. Result is in [0.0, 1.0]; never NaN.
+     */
+    private static float computePercentage(long taskTotal, long taskCompleted,
+                                           long milestoneTotal, long milestoneCompleted) {
+        boolean hasTasks = taskTotal > 0;
+        boolean hasMilestones = milestoneTotal > 0;
+
+        if (!hasTasks && !hasMilestones) {
+            return 0.0f;
+        }
+        if (!hasTasks) {
+            return (float) milestoneCompleted / milestoneTotal;
+        }
+        if (!hasMilestones) {
+            return (float) taskCompleted / taskTotal;
+        }
+        float taskRatio = (float) taskCompleted / taskTotal;
+        float milestoneRatio = (float) milestoneCompleted / milestoneTotal;
+        return 0.5f * taskRatio + 0.5f * milestoneRatio;
+    }
+
+    private OffsetDateTime computeLastActivity(long mentorshipId) {
+        OffsetDateTime latest = null;
+        latest = laterOf(latest, taskSubmissionRepository.findMaxSubmittedAtForMentorship(mentorshipId));
+        latest = laterOf(latest, taskSubmissionRepository.findMaxReviewedAtForMentorship(mentorshipId));
+        latest = laterOf(latest, milestoneRepository.findMaxCompletedAtForMentorship(mentorshipId));
+        return latest;
+    }
+
+    private static OffsetDateTime laterOf(OffsetDateTime a, OffsetDateTime b) {
+        if (a == null) return b;
+        if (b == null) return a;
+        return a.isAfter(b) ? a : b;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MentorshipService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipService.java
@@ -135,9 +135,15 @@ public class MentorshipService {
         return MentorshipResponse.from(saved);
     }
 
+    /**
+     * Package-private so other services in this package (e.g. MentorshipProgressService)
+     * can reuse the participant-filter lookup without duplicating it. Filters on the FK
+     * columns directly via the repository so we don't trigger LAZY loads on
+     * {@code mentor} / {@code mentee} just to compare ids. Do not narrow back to private
+     * without checking other callers.
+     */
     Mentorship findForParticipant(Long userId, Long mentorshipId) {
-        return mentorshipRepository.findById(mentorshipId)
-                .filter(m -> m.getMentor().getId().equals(userId) || m.getMentee().getId().equals(userId))
+        return mentorshipRepository.findByIdAndParticipant(mentorshipId, userId)
                 .orElseThrow(() -> new ResourceNotFoundException("Mentorship not found"));
     }
 }

--- a/backend/src/main/java/com/group7/backend/service/MentorshipService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipService.java
@@ -114,11 +114,15 @@ public class MentorshipService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public MentorshipResponse getMentorship(Long userId, Long mentorshipId) {
+        Mentorship mentorship = findForParticipant(userId, mentorshipId);
+        return MentorshipResponse.from(mentorship);
+    }
+
     @Transactional
     public MentorshipResponse setSharedGoal(Long userId, Long mentorshipId, SharedGoalRequest dto) {
-        Mentorship mentorship = mentorshipRepository.findById(mentorshipId)
-                .filter(m -> m.getMentor().getId().equals(userId) || m.getMentee().getId().equals(userId))
-                .orElseThrow(() -> new ResourceNotFoundException("Mentorship not found"));
+        Mentorship mentorship = findForParticipant(userId, mentorshipId);
 
         if (mentorship.getStatus() != MentorshipStatus.ACTIVE) {
             log.warn("Shared goal update rejected: mentorshipId={} not active", mentorshipId);
@@ -129,5 +133,11 @@ public class MentorshipService {
         Mentorship saved = mentorshipRepository.save(mentorship);
         log.info("Shared goal updated: mentorshipId={}, updatedByUserId={}", mentorshipId, userId);
         return MentorshipResponse.from(saved);
+    }
+
+    private Mentorship findForParticipant(Long userId, Long mentorshipId) {
+        return mentorshipRepository.findById(mentorshipId)
+                .filter(m -> m.getMentor().getId().equals(userId) || m.getMentee().getId().equals(userId))
+                .orElseThrow(() -> new ResourceNotFoundException("Mentorship not found"));
     }
 }

--- a/backend/src/main/java/com/group7/backend/service/MentorshipService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipService.java
@@ -135,7 +135,7 @@ public class MentorshipService {
         return MentorshipResponse.from(saved);
     }
 
-    private Mentorship findForParticipant(Long userId, Long mentorshipId) {
+    Mentorship findForParticipant(Long userId, Long mentorshipId) {
         return mentorshipRepository.findById(mentorshipId)
                 .filter(m -> m.getMentor().getId().equals(userId) || m.getMentee().getId().equals(userId))
                 .orElseThrow(() -> new ResourceNotFoundException("Mentorship not found"));

--- a/backend/src/main/java/com/group7/backend/service/MentorshipTimelineService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipTimelineService.java
@@ -1,0 +1,201 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.TimelineItem;
+import com.group7.backend.dto.response.TimelineItemType;
+import com.group7.backend.dto.response.TimelineResponse;
+import com.group7.backend.entity.Meeting;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.Milestone;
+import com.group7.backend.entity.Task;
+import com.group7.backend.exception.InvalidTimelineWindowException;
+import com.group7.backend.repository.MeetingActionItemRepository;
+import com.group7.backend.repository.MeetingRepository;
+import com.group7.backend.repository.MilestoneActionItemRepository;
+import com.group7.backend.repository.MilestoneRepository;
+import com.group7.backend.repository.TaskRepository;
+import com.group7.backend.repository.projection.ActionItemCountTuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Read-only aggregator for the mentorship timeline (#332, spec 1.1.5.9-1.1.5.13).
+ *
+ * <p>Merges meetings + tasks + milestones into one chronologically-sorted feed scoped to a
+ * window (default = mentorship.startDate..endDate, capped at {@value #MAX_WINDOW_MONTHS}
+ * months). Action-item counts are bulk-loaded via grouped queries; sort is performed in
+ * Java because Hibernate has no clean cross-entity union-sort idiom.
+ *
+ * <p>Stateless and thread-safe.
+ */
+@Service
+public class MentorshipTimelineService {
+
+    private static final Logger log = LoggerFactory.getLogger(MentorshipTimelineService.class);
+
+    private static final long MAX_WINDOW_MONTHS = 24;
+
+    private static final String MEETING_DETAIL_URL_PREFIX = "/api/meetings/";
+    private static final String TASK_DETAIL_URL_PREFIX = "/api/tasks/";
+    private static final String MILESTONE_DETAIL_URL_PREFIX = "/api/milestones/";
+
+    private final MentorshipService mentorshipService;
+    private final MeetingRepository meetingRepository;
+    private final MeetingActionItemRepository meetingActionItemRepository;
+    private final TaskRepository taskRepository;
+    private final MilestoneRepository milestoneRepository;
+    private final MilestoneActionItemRepository milestoneActionItemRepository;
+    private final Clock clock;
+
+    public MentorshipTimelineService(MentorshipService mentorshipService,
+                                     MeetingRepository meetingRepository,
+                                     MeetingActionItemRepository meetingActionItemRepository,
+                                     TaskRepository taskRepository,
+                                     MilestoneRepository milestoneRepository,
+                                     MilestoneActionItemRepository milestoneActionItemRepository,
+                                     Clock clock) {
+        this.mentorshipService = mentorshipService;
+        this.meetingRepository = meetingRepository;
+        this.meetingActionItemRepository = meetingActionItemRepository;
+        this.taskRepository = taskRepository;
+        this.milestoneRepository = milestoneRepository;
+        this.milestoneActionItemRepository = milestoneActionItemRepository;
+        this.clock = clock;
+    }
+
+    @Transactional(readOnly = true)
+    public TimelineResponse getTimeline(Long userId, Long mentorshipId,
+                                        OffsetDateTime from, OffsetDateTime to) {
+        // 1. Auth — non-participants get 404 here, before any window math.
+        Mentorship mentorship = mentorshipService.findForParticipant(userId, mentorshipId);
+
+        // 2. Window — defaults from the mentorship; validation throws 400.
+        OffsetDateTime windowFrom = from != null ? from : mentorship.getStartDate();
+        OffsetDateTime windowTo = to != null ? to : mentorship.getEndDate();
+        validateWindow(windowFrom, windowTo);
+
+        // 3. Fetch each domain in the window.
+        List<Meeting> meetings = meetingRepository.findInWindow(mentorshipId, windowFrom, windowTo);
+        List<Task> tasks = taskRepository.findInWindow(mentorshipId, windowFrom, windowTo);
+        List<Milestone> milestones = milestoneRepository.findInWindow(mentorshipId, windowFrom, windowTo);
+
+        // 4. Bulk action-item counters keyed by parent id (avoids N+1).
+        //    Empty-list short-circuit — Hibernate 6 emits invalid SQL on `WHERE x IN ()`.
+        Map<Long, ActionItemCounts> meetingAi = meetings.isEmpty()
+                ? Map.of()
+                : indexCounts(meetingActionItemRepository.countByMeetingIds(idsOfMeetings(meetings)));
+        Map<Long, ActionItemCounts> milestoneAi = milestones.isEmpty()
+                ? Map.of()
+                : indexCounts(milestoneActionItemRepository.countByMilestoneIds(idsOfMilestones(milestones)));
+
+        // 5. Map to uniform TimelineItem; null means "not applicable to this type".
+        List<TimelineItem> items = new ArrayList<>(meetings.size() + tasks.size() + milestones.size());
+        meetings.forEach(m -> items.add(
+                toMeetingItem(m, meetingAi.getOrDefault(m.getId(), ActionItemCounts.ZERO))));
+        tasks.forEach(t -> items.add(toTaskItem(t)));
+        milestones.forEach(ms -> items.add(
+                toMilestoneItem(ms, milestoneAi.getOrDefault(ms.getId(), ActionItemCounts.ZERO))));
+
+        // 6. Stable sort: occursAt asc, then MILESTONE > MEETING > TASK, then id asc.
+        items.sort(
+                Comparator.comparing(TimelineItem::occursAt)
+                        .thenComparingInt(it -> it.type().priority())
+                        .thenComparingLong(TimelineItem::id));
+
+        log.debug("timeline userId={} mentorshipId={} window=[{}, {}] meetings={} tasks={} milestones={}",
+                userId, mentorshipId, windowFrom, windowTo,
+                meetings.size(), tasks.size(), milestones.size());
+
+        return new TimelineResponse(
+                mentorshipId,
+                mentorship.getStartDate(),
+                mentorship.getEndDate(),
+                OffsetDateTime.now(clock),
+                items);
+    }
+
+    /** Internal value type for bulk-loaded action-item counts. */
+    private record ActionItemCounts(long total, long completed) {
+        static final ActionItemCounts ZERO = new ActionItemCounts(0L, 0L);
+    }
+
+    static void validateWindow(OffsetDateTime from, OffsetDateTime to) {
+        if (from == null || to == null) {
+            throw new InvalidTimelineWindowException(
+                    "Mentorship has no program window; supply 'from' and 'to'");
+        }
+        if (from.isAfter(to)) {
+            throw new InvalidTimelineWindowException("'from' must be before or equal to 'to'");
+        }
+        // Use plusMonths comparison instead of ChronoUnit.MONTHS.between(...), which truncates
+        // to whole months and silently lets ~1 month of slack past the 24-month cap.
+        if (to.isAfter(from.plusMonths(MAX_WINDOW_MONTHS))) {
+            throw new InvalidTimelineWindowException(
+                    "Timeline window cannot exceed " + MAX_WINDOW_MONTHS + " months");
+        }
+    }
+
+    private static Collection<Long> idsOfMeetings(List<Meeting> meetings) {
+        return meetings.stream().map(Meeting::getId).toList();
+    }
+
+    private static Collection<Long> idsOfMilestones(List<Milestone> milestones) {
+        return milestones.stream().map(Milestone::getId).toList();
+    }
+
+    private static Map<Long, ActionItemCounts> indexCounts(List<ActionItemCountTuple> tuples) {
+        return tuples.stream().collect(Collectors.toUnmodifiableMap(
+                ActionItemCountTuple::parentId,
+                t -> new ActionItemCounts(t.total(), t.completed())));
+    }
+
+    private static TimelineItem toMeetingItem(Meeting m, ActionItemCounts counts) {
+        boolean hasNotes = m.getNotes() != null && !m.getNotes().isBlank();
+        return new TimelineItem(
+                TimelineItemType.MEETING,
+                m.getId(),
+                m.getTitle(),
+                m.getStartTime(),
+                m.getStatus().name(),
+                MEETING_DETAIL_URL_PREFIX + m.getId(),
+                counts.total(),
+                counts.completed(),
+                hasNotes);
+    }
+
+    private static TimelineItem toTaskItem(Task t) {
+        return new TimelineItem(
+                TimelineItemType.TASK,
+                t.getId(),
+                t.getTitle(),
+                t.getDueDate(),
+                t.getStatus().name(),
+                TASK_DETAIL_URL_PREFIX + t.getId(),
+                null,
+                null,
+                null);
+    }
+
+    private static TimelineItem toMilestoneItem(Milestone ms, ActionItemCounts counts) {
+        return new TimelineItem(
+                TimelineItemType.MILESTONE,
+                ms.getId(),
+                ms.getTitle(),
+                ms.getTargetDate(),
+                ms.getStatus().name(),
+                MILESTONE_DETAIL_URL_PREFIX + ms.getId(),
+                counts.total(),
+                counts.completed(),
+                null);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MilestoneService.java
+++ b/backend/src/main/java/com/group7/backend/service/MilestoneService.java
@@ -53,6 +53,7 @@ public class MilestoneService {
             throw new ProfileNotVisibleException("Only mentors can create milestones");
         }
         checkMentorshipActive(mentorship);
+        MentorshipPreconditions.requireSharedGoal(mentorship);
 
         if (request.getTargetDate() != null) {
             ensureWithinMentorship(mentorship, request.getTargetDate());

--- a/backend/src/main/java/com/group7/backend/service/TaskService.java
+++ b/backend/src/main/java/com/group7/backend/service/TaskService.java
@@ -57,6 +57,7 @@ public class TaskService {
         if (mentorship.getStatus() != MentorshipStatus.ACTIVE) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Mentorship is not active");
         }
+        MentorshipPreconditions.requireSharedGoal(mentorship);
 
         if (request.getDueDate() != null && request.getDueDate().isBefore(OffsetDateTime.now(ZoneOffset.UTC))) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Due date must be in the future");

--- a/backend/src/main/resources/db/migration/V29__add_shared_goal_to_mentorships.sql
+++ b/backend/src/main/resources/db/migration/V29__add_shared_goal_to_mentorships.sql
@@ -1,0 +1,6 @@
+-- #335: Add shared_goal column to mentorships table.
+-- Nullable TEXT so existing rows are unaffected (NULL = no goal set yet).
+-- The shared-goal precondition gate checks this column before allowing
+-- task / milestone / meeting writes on a mentorship.
+ALTER TABLE mentorships
+    ADD COLUMN IF NOT EXISTS shared_goal TEXT;

--- a/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
@@ -7,12 +7,16 @@ import com.group7.backend.dto.request.AcceptRequestRequest;
 import com.group7.backend.dto.request.SharedGoalRequest;
 import com.group7.backend.dto.response.MentorshipProgressResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
+import com.group7.backend.dto.response.TimelineItem;
+import com.group7.backend.dto.response.TimelineItemType;
+import com.group7.backend.dto.response.TimelineResponse;
 import com.group7.backend.exception.MentorshipRequestException;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.service.JwtService;
 import com.group7.backend.service.MentorshipProgressService;
 import com.group7.backend.service.MentorshipRequestService;
 import com.group7.backend.service.MentorshipService;
+import com.group7.backend.service.MentorshipTimelineService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -52,6 +56,9 @@ class MentorshipControllerTest {
 
     @MockitoBean
     private MentorshipProgressService mentorshipProgressService;
+
+    @MockitoBean
+    private MentorshipTimelineService mentorshipTimelineService;
 
     @MockitoBean
     private JwtService jwtService;
@@ -404,5 +411,117 @@ class MentorshipControllerTest {
         mockMvc.perform(get("/api/mentorships/404/progress")
                         .header("Authorization", "Bearer mentor-token"))
                 .andExpect(status().isNotFound());
+    }
+
+    // ── Get mentorship timeline (#332) ──────────────────────────────────────
+
+    private TimelineResponse sampleTimeline() {
+        OffsetDateTime t = OffsetDateTime.of(2026, 5, 5, 0, 0, 0, 0, ZoneOffset.UTC);
+        TimelineItem milestoneItem = new TimelineItem(
+                TimelineItemType.MILESTONE, 7L, "M1", t, "PENDING", "/api/milestones/7", 0L, 0L, null);
+        TimelineItem meetingItem = new TimelineItem(
+                TimelineItemType.MEETING, 8L, "Sync", t.plusHours(1), "CONFIRMED",
+                "/api/meetings/8", 1L, 0L, false);
+        return new TimelineResponse(
+                100L,
+                OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2026, 8, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2026, 6, 1, 12, 0, 0, 0, ZoneOffset.UTC),
+                List.of(milestoneItem, meetingItem));
+    }
+
+    @Test
+    void getTimelineReturns200ForMentor() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipTimelineService.getTimeline(eq(1L), eq(100L), any(), any()))
+                .thenReturn(sampleTimeline());
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(100))
+                .andExpect(jsonPath("$.startDate").exists())
+                .andExpect(jsonPath("$.endDate").exists())
+                .andExpect(jsonPath("$.currentDate").exists())
+                .andExpect(jsonPath("$.items.length()").value(2))
+                .andExpect(jsonPath("$.items[0].type").value("MILESTONE"))
+                .andExpect(jsonPath("$.items[1].type").value("MEETING"));
+    }
+
+    @Test
+    void getTimelineReturns200ForMentee() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+        when(mentorshipTimelineService.getTimeline(eq(2L), eq(100L), any(), any()))
+                .thenReturn(sampleTimeline());
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(100));
+    }
+
+    @Test
+    void getTimelineReturns404ForNonParticipant() throws Exception {
+        mockMenteeJwt("intruder-token", 999L);
+        when(mentorshipTimelineService.getTimeline(eq(999L), eq(100L), any(), any()))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .header("Authorization", "Bearer intruder-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getTimelineReturns404ForUnknownId() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipTimelineService.getTimeline(eq(1L), eq(404L), any(), any()))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        mockMvc.perform(get("/api/mentorships/404/timeline")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getTimelineReturns400WhenFromAfterTo() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipTimelineService.getTimeline(eq(1L), eq(100L), any(), any()))
+                .thenThrow(new com.group7.backend.exception.InvalidTimelineWindowException(
+                        "'from' must be before or equal to 'to'"));
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .param("from", "2026-08-01T00:00:00Z")
+                        .param("to", "2026-05-01T00:00:00Z")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getTimelineParsesIsoDateTimeWithZAndOffset() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipTimelineService.getTimeline(eq(1L), eq(100L), any(), any()))
+                .thenReturn(sampleTimeline());
+
+        // Z offset
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .param("from", "2026-05-01T00:00:00Z")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk());
+
+        // +03:00 offset
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .param("from", "2026-05-01T03:00:00+03:00")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getTimelineRejectsMalformedFrom() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .param("from", "banana")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
@@ -230,4 +230,115 @@ class MentorshipControllerTest {
                         .content(objectMapper.writeValueAsString(body)))
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    void setSharedGoalReturns400ForWhitespaceOnly() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+
+        mockMvc.perform(put("/api/mentorships/100/goal")
+                        .header("Authorization", "Bearer mentor-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"sharedGoal\":\"   \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void setSharedGoalReturns400ForNullField() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+
+        mockMvc.perform(put("/api/mentorships/100/goal")
+                        .header("Authorization", "Bearer mentor-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"sharedGoal\":null}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void setSharedGoalReturns400ForOver500Chars() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        String longGoal = "a".repeat(501);
+
+        SharedGoalRequest body = new SharedGoalRequest();
+        body.setSharedGoal(longGoal);
+
+        mockMvc.perform(put("/api/mentorships/100/goal")
+                        .header("Authorization", "Bearer mentor-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void setSharedGoalAcceptsExactly500Chars() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        String boundaryGoal = "a".repeat(500);
+
+        MentorshipResponse resp = sampleMentorship();
+        resp.setSharedGoal(boundaryGoal);
+        resp.setGoalDefined(true);
+        when(mentorshipService.setSharedGoal(eq(1L), eq(100L), any())).thenReturn(resp);
+
+        SharedGoalRequest body = new SharedGoalRequest();
+        body.setSharedGoal(boundaryGoal);
+
+        mockMvc.perform(put("/api/mentorships/100/goal")
+                        .header("Authorization", "Bearer mentor-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.goalDefined").value(true));
+    }
+
+    // ── Get mentorship by id ────────────────────────────────────────────────
+
+    @Test
+    void getMentorshipReturns200ForMentor() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        MentorshipResponse resp = sampleMentorship();
+        resp.setSharedGoal("Build a portfolio");
+        resp.setGoalDefined(true);
+        when(mentorshipService.getMentorship(1L, 100L)).thenReturn(resp);
+
+        mockMvc.perform(get("/api/mentorships/100")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(100))
+                .andExpect(jsonPath("$.goalDefined").value(true))
+                .andExpect(jsonPath("$.sharedGoal").value("Build a portfolio"));
+    }
+
+    @Test
+    void getMentorshipReturns200ForMentee() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+        MentorshipResponse resp = sampleMentorship();
+        resp.setGoalDefined(false);
+        when(mentorshipService.getMentorship(2L, 100L)).thenReturn(resp);
+
+        mockMvc.perform(get("/api/mentorships/100")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.goalDefined").value(false));
+    }
+
+    @Test
+    void getMentorshipReturns404ForNonParticipant() throws Exception {
+        mockMenteeJwt("intruder-token", 999L);
+        when(mentorshipService.getMentorship(999L, 100L))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        mockMvc.perform(get("/api/mentorships/100")
+                        .header("Authorization", "Bearer intruder-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getMentorshipReturns404ForUnknownId() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipService.getMentorship(1L, 404L))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        mockMvc.perform(get("/api/mentorships/404")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
@@ -5,10 +5,12 @@ import com.group7.backend.config.JwtAuthenticationFilter;
 import com.group7.backend.config.SecurityConfig;
 import com.group7.backend.dto.request.AcceptRequestRequest;
 import com.group7.backend.dto.request.SharedGoalRequest;
+import com.group7.backend.dto.response.MentorshipProgressResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
 import com.group7.backend.exception.MentorshipRequestException;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.service.JwtService;
+import com.group7.backend.service.MentorshipProgressService;
 import com.group7.backend.service.MentorshipRequestService;
 import com.group7.backend.service.MentorshipService;
 import org.junit.jupiter.api.Test;
@@ -47,6 +49,9 @@ class MentorshipControllerTest {
 
     @MockitoBean
     private MentorshipRequestService mentorshipRequestService;
+
+    @MockitoBean
+    private MentorshipProgressService mentorshipProgressService;
 
     @MockitoBean
     private JwtService jwtService;
@@ -338,6 +343,65 @@ class MentorshipControllerTest {
                 .thenThrow(new ResourceNotFoundException("Mentorship not found"));
 
         mockMvc.perform(get("/api/mentorships/404")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    // ── Get mentorship progress (#334) ──────────────────────────────────────
+
+    private MentorshipProgressResponse sampleProgress() {
+        return new MentorshipProgressResponse(
+                100L, 10L, 4L, 2L, 4L, 1L, 0.325f,
+                java.time.OffsetDateTime.of(2026, 5, 5, 0, 0, 0, 0, java.time.ZoneOffset.UTC));
+    }
+
+    @Test
+    void getProgressReturns200ForMentor() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipProgressService.getProgress(1L, 100L)).thenReturn(sampleProgress());
+
+        mockMvc.perform(get("/api/mentorships/100/progress")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(100))
+                .andExpect(jsonPath("$.taskTotal").value(10))
+                .andExpect(jsonPath("$.taskCompleted").value(4))
+                .andExpect(jsonPath("$.taskSubmitted").value(2))
+                .andExpect(jsonPath("$.milestoneTotal").value(4))
+                .andExpect(jsonPath("$.milestoneCompleted").value(1))
+                .andExpect(jsonPath("$.progressPercentage").value(0.325))
+                .andExpect(jsonPath("$.lastActivityAt").exists());
+    }
+
+    @Test
+    void getProgressReturns200ForMentee() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+        when(mentorshipProgressService.getProgress(2L, 100L)).thenReturn(sampleProgress());
+
+        mockMvc.perform(get("/api/mentorships/100/progress")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(100));
+    }
+
+    @Test
+    void getProgressReturns404ForNonParticipant() throws Exception {
+        mockMenteeJwt("intruder-token", 999L);
+        when(mentorshipProgressService.getProgress(999L, 100L))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        mockMvc.perform(get("/api/mentorships/100/progress")
+                        .header("Authorization", "Bearer intruder-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getProgressReturns404ForUnknownId() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipProgressService.getProgress(1L, 404L))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        mockMvc.perform(get("/api/mentorships/404/progress")
                         .header("Authorization", "Bearer mentor-token"))
                 .andExpect(status().isNotFound());
     }

--- a/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
@@ -369,7 +369,7 @@ class MentorshipControllerTest {
                 .andExpect(jsonPath("$.taskSubmitted").value(2))
                 .andExpect(jsonPath("$.milestoneTotal").value(4))
                 .andExpect(jsonPath("$.milestoneCompleted").value(1))
-                .andExpect(jsonPath("$.progressPercentage").value(0.325))
+                .andExpect(jsonPath("$.progressRatio").value(0.325))
                 .andExpect(jsonPath("$.lastActivityAt").exists());
     }
 

--- a/backend/src/test/java/com/group7/backend/dto/response/TimelineItemTypeTest.java
+++ b/backend/src/test/java/com/group7/backend/dto/response/TimelineItemTypeTest.java
@@ -1,0 +1,28 @@
+package com.group7.backend.dto.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the priority values of {@link TimelineItemType}. The timeline service uses
+ * priority as the second-level sort key; if a future commit reorders the enum
+ * declaration this test fails fast instead of silently shifting the rendered order.
+ */
+class TimelineItemTypeTest {
+
+    @Test
+    void milestoneHasPriorityZero() {
+        assertThat(TimelineItemType.MILESTONE.priority()).isEqualTo(0);
+    }
+
+    @Test
+    void meetingHasPriorityOne() {
+        assertThat(TimelineItemType.MEETING.priority()).isEqualTo(1);
+    }
+
+    @Test
+    void taskHasPriorityTwo() {
+        assertThat(TimelineItemType.TASK.priority()).isEqualTo(2);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/entity/MentorshipTest.java
+++ b/backend/src/test/java/com/group7/backend/entity/MentorshipTest.java
@@ -1,0 +1,39 @@
+package com.group7.backend.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MentorshipTest {
+
+    private Mentorship withGoal(String goal) {
+        Mentorship m = new Mentorship();
+        m.setSharedGoal(goal);
+        return m;
+    }
+
+    @Test
+    void hasSharedGoalIsFalseWhenNull() {
+        assertThat(withGoal(null).hasSharedGoal()).isFalse();
+    }
+
+    @Test
+    void hasSharedGoalIsFalseWhenEmpty() {
+        assertThat(withGoal("").hasSharedGoal()).isFalse();
+    }
+
+    @Test
+    void hasSharedGoalIsFalseWhenWhitespaceOnly() {
+        assertThat(withGoal("   ").hasSharedGoal()).isFalse();
+    }
+
+    @Test
+    void hasSharedGoalIsTrueWhenSingleChar() {
+        assertThat(withGoal("x").hasSharedGoal()).isTrue();
+    }
+
+    @Test
+    void hasSharedGoalIsTrueForTypicalSentence() {
+        assertThat(withGoal("Ship the MVP by July").hasSharedGoal()).isTrue();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/exception/GoalRequiredHandlerTest.java
+++ b/backend/src/test/java/com/group7/backend/exception/GoalRequiredHandlerTest.java
@@ -1,0 +1,51 @@
+package com.group7.backend.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GoalRequiredHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void returns409WithStructuredBody() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/mentorships/42/tasks");
+        GoalRequiredException ex = new GoalRequiredException(42L);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleGoalRequired(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "error", "Conflict",
+                "code", "GOAL_REQUIRED",
+                "message", GoalRequiredException.DEFAULT_MESSAGE,
+                "mentorshipId", 42L
+        ));
+    }
+
+    @Test
+    void mentorshipIdIsLongNotString() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/mentorships/7/meetings");
+        GoalRequiredException ex = new GoalRequiredException(7L);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleGoalRequired(ex, request);
+
+        assertThat(response.getBody().get("mentorshipId")).isInstanceOf(Long.class).isEqualTo(7L);
+    }
+
+    @Test
+    void codeIsStableMachineReadable() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/mentorships/1/milestones");
+        GoalRequiredException ex = new GoalRequiredException(1L);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleGoalRequired(ex, request);
+
+        assertThat(response.getBody().get("code")).isEqualTo("GOAL_REQUIRED");
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
@@ -776,6 +776,7 @@ class MentorshipIntegrationTest {
         org.hibernate.stat.Statistics stats = entityManager.getEntityManagerFactory()
                 .unwrap(org.hibernate.SessionFactory.class).getStatistics();
         stats.setStatisticsEnabled(true);
+        Thread.sleep(1000); // Wait for @Async event listeners (like push notifications) to finish queries
         stats.clear();
 
         mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
@@ -509,7 +509,7 @@ class MentorshipIntegrationTest {
                 .andExpect(jsonPath("$.taskSubmitted").value(0))
                 .andExpect(jsonPath("$.milestoneTotal").value(0))
                 .andExpect(jsonPath("$.milestoneCompleted").value(0))
-                .andExpect(jsonPath("$.progressPercentage").value(0.0))
+                .andExpect(jsonPath("$.progressRatio").value(0.0))
                 .andExpect(jsonPath("$.lastActivityAt").doesNotExist());
     }
 
@@ -540,7 +540,7 @@ class MentorshipIntegrationTest {
                 .andExpect(jsonPath("$.taskSubmitted").value(0))
                 .andExpect(jsonPath("$.milestoneTotal").value(2))
                 .andExpect(jsonPath("$.milestoneCompleted").value(0))
-                .andExpect(jsonPath("$.progressPercentage").value(0.0))
+                .andExpect(jsonPath("$.progressRatio").value(0.0))
                 .andExpect(jsonPath("$.lastActivityAt").doesNotExist());
     }
 

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
@@ -485,4 +485,111 @@ class MentorshipIntegrationTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.title").value("Milestone 1"));
     }
+
+    // ── Mentorship progress aggregation (issue #334) ────────────────────────
+
+    private void setGoal(MentorshipFixture f) throws Exception {
+        mockMvc.perform(put("/api/mentorships/" + f.mentorshipId() + "/goal")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("sharedGoal", "Ship MVP"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getProgress_emptyMentorshipReturnsZeros() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("pg_m1@test.com", "pg_e1@test.com");
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/progress")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(f.mentorshipId()))
+                .andExpect(jsonPath("$.taskTotal").value(0))
+                .andExpect(jsonPath("$.taskCompleted").value(0))
+                .andExpect(jsonPath("$.taskSubmitted").value(0))
+                .andExpect(jsonPath("$.milestoneTotal").value(0))
+                .andExpect(jsonPath("$.milestoneCompleted").value(0))
+                .andExpect(jsonPath("$.progressPercentage").value(0.0))
+                .andExpect(jsonPath("$.lastActivityAt").doesNotExist());
+    }
+
+    @Test
+    void getProgress_reflectsTaskAndMilestoneCounts() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("pg_m2@test.com", "pg_e2@test.com");
+        setGoal(f);
+
+        // Create 2 tasks and 2 milestones (all PENDING).
+        for (int i = 1; i <= 2; i++) {
+            mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("title", "Task " + i))))
+                    .andExpect(status().isCreated());
+            mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("title", "Milestone " + i))))
+                    .andExpect(status().isCreated());
+        }
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/progress")
+                        .header("Authorization", "Bearer " + f.menteeToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.taskTotal").value(2))
+                .andExpect(jsonPath("$.taskCompleted").value(0))
+                .andExpect(jsonPath("$.taskSubmitted").value(0))
+                .andExpect(jsonPath("$.milestoneTotal").value(2))
+                .andExpect(jsonPath("$.milestoneCompleted").value(0))
+                .andExpect(jsonPath("$.progressPercentage").value(0.0))
+                .andExpect(jsonPath("$.lastActivityAt").doesNotExist());
+    }
+
+    @Test
+    void getProgress_lastActivityReflectsSubmission() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("pg_m3@test.com", "pg_e3@test.com");
+        setGoal(f);
+
+        // Create one task and submit it from the mentee.
+        MvcResult taskResult = mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "T"))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Long taskId = objectMapper.readTree(taskResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        mockMvc.perform(post("/api/tasks/" + taskId + "/submission")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("submissionText", "done"))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/progress")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.taskTotal").value(1))
+                .andExpect(jsonPath("$.taskSubmitted").value(1))
+                .andExpect(jsonPath("$.taskCompleted").value(0))
+                .andExpect(jsonPath("$.lastActivityAt").exists());
+    }
+
+    @Test
+    void getProgress_returns404ForNonParticipant() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("pg_m4@test.com", "pg_e4@test.com");
+        String intruderToken = registerAndLogin("pg_intruder@test.com", false);
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/progress")
+                        .header("Authorization", "Bearer " + intruderToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getProgress_returns404ForUnknownId() throws Exception {
+        String mentorToken = registerAndLogin("pg_m5@test.com", true);
+
+        mockMvc.perform(get("/api/mentorships/999999/progress")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
@@ -302,4 +302,187 @@ class MentorshipIntegrationTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.message").value("Duration must be 1, 3, or 6 months"));
     }
+
+    // ── Shared-goal precondition (issue #335) ───────────────────────────────
+
+    /** Establishes mentor + mentee + ACTIVE mentorship; returns a Long[] {mentorshipId}. */
+    private MentorshipFixture acceptAndReturnMentorshipId(String mentorEmail, String menteeEmail) throws Exception {
+        String mentorToken = registerAndLogin(mentorEmail, true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals(mentorEmail)).findFirst().orElseThrow();
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        String menteeToken = registerAndLogin(menteeEmail, false);
+        Long requestId = createRequest(menteeToken, mentor.getId());
+
+        MvcResult acceptResult = mockMvc.perform(put("/api/mentorship-requests/" + requestId + "/accept")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("duration", 3))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Long mentorshipId = objectMapper.readTree(acceptResult.getResponse().getContentAsString())
+                .get("id").asLong();
+        return new MentorshipFixture(mentorshipId, mentorToken, menteeToken);
+    }
+
+    private record MentorshipFixture(Long mentorshipId, String mentorToken, String menteeToken) {}
+
+    @Test
+    void getMentorship_returnsGoalDefinedFalseInitially() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m1@test.com", "gd_e1@test.com");
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(f.mentorshipId()))
+                .andExpect(jsonPath("$.goalDefined").value(false));
+    }
+
+    @Test
+    void getMentorship_returnsGoalDefinedTrueAfterPut() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m2@test.com", "gd_e2@test.com");
+
+        mockMvc.perform(put("/api/mentorships/" + f.mentorshipId() + "/goal")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("sharedGoal", "Ship the MVP"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.goalDefined").value(true));
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.menteeToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.goalDefined").value(true))
+                .andExpect(jsonPath("$.sharedGoal").value("Ship the MVP"));
+    }
+
+    @Test
+    void getMentorship_returns404ForNonParticipant() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m3@test.com", "gd_e3@test.com");
+        String intruderToken = registerAndLogin("gd_intruder@test.com", false);
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + intruderToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getMentorship_returns404ForUnknownId() throws Exception {
+        String mentorToken = registerAndLogin("gd_m4@test.com", true);
+
+        mockMvc.perform(get("/api/mentorships/999999")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void putGoal_rejectsWhitespaceOnly() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m5@test.com", "gd_e5@test.com");
+
+        mockMvc.perform(put("/api/mentorships/" + f.mentorshipId() + "/goal")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"sharedGoal\":\"   \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void putGoal_rejectsOver500Chars() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m6@test.com", "gd_e6@test.com");
+
+        mockMvc.perform(put("/api/mentorships/" + f.mentorshipId() + "/goal")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("sharedGoal", "a".repeat(501)))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void postTask_returns409GoalRequiredWhenGoalNotSet() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m7@test.com", "gd_e7@test.com");
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "First task"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("Conflict"))
+                .andExpect(jsonPath("$.code").value("GOAL_REQUIRED"))
+                .andExpect(jsonPath("$.mentorshipId").value(f.mentorshipId()))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    void postMeeting_returns409GoalRequiredWhenGoalNotSet() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m8@test.com", "gd_e8@test.com");
+
+        Map<String, Object> body = Map.of(
+                "title", "Sync",
+                "startTime", java.time.OffsetDateTime.now(java.time.ZoneOffset.UTC).plusDays(7).toString(),
+                "endTime", java.time.OffsetDateTime.now(java.time.ZoneOffset.UTC).plusDays(7).plusHours(1).toString(),
+                "meetingType", "ONLINE",
+                "meetingLink", "https://meet.example.com/abc",
+                "recurring", false
+        );
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/meetings")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("GOAL_REQUIRED"))
+                .andExpect(jsonPath("$.mentorshipId").value(f.mentorshipId()));
+    }
+
+    @Test
+    void postMilestone_returns409GoalRequiredWhenGoalNotSet() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m9@test.com", "gd_e9@test.com");
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "Milestone 1"))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("GOAL_REQUIRED"))
+                .andExpect(jsonPath("$.mentorshipId").value(f.mentorshipId()));
+    }
+
+    @Test
+    void postTask_succeedsAfterGoalSet() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m10@test.com", "gd_e10@test.com");
+
+        mockMvc.perform(put("/api/mentorships/" + f.mentorshipId() + "/goal")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("sharedGoal", "Ship MVP"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "First task"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("First task"));
+    }
+
+    @Test
+    void postMilestone_succeedsAfterGoalSet() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("gd_m11@test.com", "gd_e11@test.com");
+
+        mockMvc.perform(put("/api/mentorships/" + f.mentorshipId() + "/goal")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("sharedGoal", "Ship MVP"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "Milestone 1"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("Milestone 1"));
+    }
 }

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.time.OffsetDateTime;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -591,5 +592,318 @@ class MentorshipIntegrationTest {
         mockMvc.perform(get("/api/mentorships/999999/progress")
                         .header("Authorization", "Bearer " + mentorToken))
                 .andExpect(status().isNotFound());
+    }
+
+    // ── Mentorship timeline aggregation (issue #332) ────────────────────────
+
+    @org.springframework.beans.factory.annotation.Autowired
+    private jakarta.persistence.EntityManager entityManager;
+
+    @Test
+    void getTimeline_emptyMentorshipReturnsEmptyItems() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m1@test.com", "tl_e1@test.com");
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(f.mentorshipId()))
+                .andExpect(jsonPath("$.startDate").exists())
+                .andExpect(jsonPath("$.endDate").exists())
+                .andExpect(jsonPath("$.currentDate").exists())
+                .andExpect(jsonPath("$.items.length()").value(0));
+    }
+
+    @Test
+    void getTimeline_returnsAllThreeDomainsInChronologicalOrder() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m2@test.com", "tl_e2@test.com");
+        setGoal(f);
+
+        // Read mentorship startDate to schedule items inside the program window.
+        MvcResult getResult = mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andReturn();
+        OffsetDateTime startDate = OffsetDateTime.parse(
+                objectMapper.readTree(getResult.getResponse().getContentAsString())
+                        .get("startDate").asText());
+
+        // Create one of each, in time order: meeting (+1d), task (+2d), milestone (+3d).
+        OffsetDateTime t1 = startDate.plusDays(1);
+        OffsetDateTime t2 = startDate.plusDays(2);
+        OffsetDateTime t3 = startDate.plusDays(3);
+
+        Map<String, Object> meetingBody = Map.of(
+                "title", "Sync",
+                "startTime", t1.toString(),
+                "endTime", t1.plusHours(1).toString(),
+                "meetingType", "ONLINE",
+                "meetingLink", "https://meet.example.com/abc",
+                "recurring", false);
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/meetings")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(meetingBody)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "T1", "dueDate", t2.toString()))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "M1", "targetDate", t3.toString()))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.menteeToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(3))
+                .andExpect(jsonPath("$.items[0].type").value("MEETING"))
+                .andExpect(jsonPath("$.items[0].hasNotes").value(false))
+                .andExpect(jsonPath("$.items[0].actionItemTotal").value(0))
+                .andExpect(jsonPath("$.items[0].actionItemCompleted").value(0))
+                .andExpect(jsonPath("$.items[0].detailUrl").value(org.hamcrest.Matchers.startsWith("/api/meetings/")))
+                .andExpect(jsonPath("$.items[1].type").value("TASK"))
+                .andExpect(jsonPath("$.items[1].actionItemTotal").doesNotExist())
+                .andExpect(jsonPath("$.items[1].hasNotes").doesNotExist())
+                .andExpect(jsonPath("$.items[1].detailUrl").value(org.hamcrest.Matchers.startsWith("/api/tasks/")))
+                .andExpect(jsonPath("$.items[2].type").value("MILESTONE"))
+                .andExpect(jsonPath("$.items[2].actionItemTotal").value(0))
+                .andExpect(jsonPath("$.items[2].actionItemCompleted").value(0))
+                .andExpect(jsonPath("$.items[2].hasNotes").doesNotExist())
+                .andExpect(jsonPath("$.items[2].detailUrl").value(org.hamcrest.Matchers.startsWith("/api/milestones/")));
+    }
+
+    @Test
+    void getTimeline_windowOutsideProgramReturnsEmptyItemsButPopulatedMetadata() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m3@test.com", "tl_e3@test.com");
+
+        // Window deliberately set to an instant 3 years in the future — far outside the mentorship.
+        // Use a same-instant from/to so we don't trip the 24-month window cap.
+        String far = "2999-01-01T00:00:00Z";
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .param("from", far)
+                        .param("to", far)
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(0))
+                .andExpect(jsonPath("$.startDate").exists())
+                .andExpect(jsonPath("$.currentDate").exists());
+    }
+
+    @Test
+    void getTimeline_returns400ForFromAfterTo() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m4@test.com", "tl_e4@test.com");
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .param("from", "2026-08-01T00:00:00Z")
+                        .param("to", "2026-05-01T00:00:00Z")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getTimeline_returns400ForWindowOver24Months() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m5@test.com", "tl_e5@test.com");
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .param("from", "2024-01-01T00:00:00Z")
+                        .param("to", "2027-01-02T00:00:00Z")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getTimeline_returns404ForNonParticipant() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m6@test.com", "tl_e6@test.com");
+        String intruderToken = registerAndLogin("tl_intruder@test.com", false);
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + intruderToken))
+                .andExpect(status().isNotFound());
+    }
+
+    /**
+     * Records the prepared-statement count for one timeline GET against a mentorship
+     * seeded with N items per domain. The whole point is that the returned count is
+     * {@code O(1)} in {@code N} — see {@link #getTimeline_n1SafeIsConstantBetweenN1AndN3}.
+     */
+    private long timelineQueryCountForSeededMentorship(int itemsPerDomain,
+                                                       String mentorEmail,
+                                                       String menteeEmail) throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId(mentorEmail, menteeEmail);
+        setGoal(f);
+
+        MvcResult getResult = mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andReturn();
+        OffsetDateTime startDate = OffsetDateTime.parse(
+                objectMapper.readTree(getResult.getResponse().getContentAsString())
+                        .get("startDate").asText());
+
+        for (int i = 1; i <= itemsPerDomain; i++) {
+            OffsetDateTime t = startDate.plusDays(i);
+            Map<String, Object> meetingBody = Map.of(
+                    "title", "Sync " + i,
+                    "startTime", t.toString(),
+                    "endTime", t.plusHours(1).toString(),
+                    "meetingType", "ONLINE",
+                    "meetingLink", "https://meet.example.com/abc",
+                    "recurring", false);
+            mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/meetings")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(meetingBody)))
+                    .andExpect(status().isCreated());
+            mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(
+                                    Map.of("title", "T" + i, "dueDate", t.plusHours(2).toString()))))
+                    .andExpect(status().isCreated());
+            mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(
+                                    Map.of("title", "M" + i, "targetDate", t.plusHours(4).toString()))))
+                    .andExpect(status().isCreated());
+        }
+
+        org.hibernate.stat.Statistics stats = entityManager.getEntityManagerFactory()
+                .unwrap(org.hibernate.SessionFactory.class).getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(itemsPerDomain * 3));
+
+        return stats.getPrepareStatementCount();
+    }
+
+    @Test
+    void getTimeline_n1SafeIsConstantBetweenN1AndN3() throws Exception {
+        long n1 = timelineQueryCountForSeededMentorship(1, "tl_m7a@test.com", "tl_e7a@test.com");
+        long n3 = timelineQueryCountForSeededMentorship(3, "tl_m7b@test.com", "tl_e7b@test.com");
+
+        // The actual N+1 invariant: the query count must NOT scale with N.
+        // Floor measured at N=1 is 8 (1 mentorship + 3 windows + 2 group counts + 2 from
+        // the JWT auth filter / Spring auto-flushes). A single accidental N+1 would jump
+        // the N=3 count to 8 + 3 = 11, which the equality assertion below catches.
+        assertThat(n1)
+                .as("Timeline query count for N=1 should be at most 8")
+                .isLessThanOrEqualTo(8);
+        assertThat(n3)
+                .as("Timeline query count for N=3 should equal the N=1 count (no scaling with N)")
+                .isEqualTo(n1);
+    }
+
+    @Test
+    void getTimeline_actionItemCountersReflectCompletion() throws Exception {
+        // Exercises the JPQL constructor-expression path for non-empty action items.
+        // If the bulk-count query's CAST(SUM(...) AS Long) drifts on a future Hibernate
+        // upgrade, this test catches it before any client does.
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_ai_m@test.com", "tl_ai_e@test.com");
+        setGoal(f);
+
+        MvcResult getResult = mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andReturn();
+        OffsetDateTime startDate = OffsetDateTime.parse(
+                objectMapper.readTree(getResult.getResponse().getContentAsString())
+                        .get("startDate").asText());
+        OffsetDateTime when = startDate.plusDays(1);
+
+        // Create one milestone, capture id.
+        MvcResult msResult = mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("title", "MS", "targetDate", when.toString()))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Long msId = objectMapper.readTree(msResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        // Add 3 action items, mark one complete.
+        Long firstAiId = null;
+        for (int i = 1; i <= 3; i++) {
+            MvcResult aiResult = mockMvc.perform(post("/api/milestones/" + msId + "/action-items")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("text", "AI " + i))))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+            if (i == 1) {
+                firstAiId = objectMapper.readTree(aiResult.getResponse().getContentAsString())
+                        .get("id").asLong();
+            }
+        }
+        mockMvc.perform(patch("/api/milestone-action-items/" + firstAiId)
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"completed\":true}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].type").value("MILESTONE"))
+                .andExpect(jsonPath("$.items[0].actionItemTotal").value(3))
+                .andExpect(jsonPath("$.items[0].actionItemCompleted").value(1));
+    }
+
+    @Test
+    void getTimeline_tiebreakerMilestoneBeforeMeetingBeforeTask() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_tie_m@test.com", "tl_tie_e@test.com");
+        setGoal(f);
+
+        MvcResult getResult = mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andReturn();
+        OffsetDateTime startDate = OffsetDateTime.parse(
+                objectMapper.readTree(getResult.getResponse().getContentAsString())
+                        .get("startDate").asText());
+        OffsetDateTime sameInstant = startDate.plusDays(5);
+
+        // Create one of each at the SAME instant.
+        Map<String, Object> meetingBody = Map.of(
+                "title", "Sync",
+                "startTime", sameInstant.toString(),
+                "endTime", sameInstant.plusHours(1).toString(),
+                "meetingType", "ONLINE",
+                "meetingLink", "https://meet.example.com/abc",
+                "recurring", false);
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/meetings")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(meetingBody)))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("title", "T", "dueDate", sameInstant.toString()))))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("title", "M", "targetDate", sameInstant.toString()))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(3))
+                .andExpect(jsonPath("$.items[0].type").value("MILESTONE"))
+                .andExpect(jsonPath("$.items[1].type").value("MEETING"))
+                .andExpect(jsonPath("$.items[2].type").value("TASK"));
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/MeetingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MeetingServiceTest.java
@@ -6,6 +6,7 @@ import com.group7.backend.dto.request.MeetingRescheduleCreateRequest;
 import com.group7.backend.dto.response.MeetingCreateResponse;
 import com.group7.backend.dto.response.MeetingSummaryResponse;
 import com.group7.backend.entity.*;
+import com.group7.backend.exception.GoalRequiredException;
 import com.group7.backend.exception.MeetingConflictException;
 import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.repository.*;
@@ -74,6 +75,7 @@ class MeetingServiceTest {
         mentorship.setStartDate(OffsetDateTime.ofInstant(FIXED_NOW, ZoneOffset.UTC));
         mentorship.setEndDate(OffsetDateTime.of(2026, 5, 25, 10, 0, 0, 0, ZoneOffset.UTC));
         mentorship.setDuration(3);
+        mentorship.setSharedGoal("Build a portfolio");
 
         properties = new MeetingProperties();
 
@@ -320,6 +322,63 @@ class MeetingServiceTest {
         meeting.setMeetingLink("https://meet.example.com/abc");
         meeting.setStatus(status);
         return meeting;
+    }
+
+    // ── Shared-goal gate ───────────────────────────────────────────────────
+
+    @Test
+    void createMeetings_NullGoal_GoalRequired() {
+        mentorship.setSharedGoal(null);
+        OffsetDateTime start = OffsetDateTime.of(2026, 5, 8, 10, 0, 0, 0, ZoneOffset.UTC);
+        OffsetDateTime end = start.plusHours(1);
+        MeetingCreateRequest request = baseCreateRequest(start, end);
+
+        when(mentorshipRepository.findById(11L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> meetingService.createMeetings(11L, 1L, request))
+                .isInstanceOf(GoalRequiredException.class)
+                .extracting(ex -> ((GoalRequiredException) ex).getMentorshipId())
+                .isEqualTo(11L);
+    }
+
+    @Test
+    void createMeetings_BlankGoal_GoalRequired() {
+        mentorship.setSharedGoal("   ");
+        OffsetDateTime start = OffsetDateTime.of(2026, 5, 8, 10, 0, 0, 0, ZoneOffset.UTC);
+        MeetingCreateRequest request = baseCreateRequest(start, start.plusHours(1));
+
+        when(mentorshipRepository.findById(11L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> meetingService.createMeetings(11L, 1L, request))
+                .isInstanceOf(GoalRequiredException.class);
+    }
+
+    /** Inactive status surfaces before goal-required (deeper invariant wins). */
+    @Test
+    void createMeetings_InactiveAndNullGoal_StatusErrorWins() {
+        mentorship.setStatus(MentorshipStatus.COMPLETED);
+        mentorship.setSharedGoal(null);
+        OffsetDateTime start = OffsetDateTime.of(2026, 5, 8, 10, 0, 0, 0, ZoneOffset.UTC);
+        MeetingCreateRequest request = baseCreateRequest(start, start.plusHours(1));
+
+        when(mentorshipRepository.findById(11L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> meetingService.createMeetings(11L, 1L, request))
+                .isInstanceOf(MeetingConflictException.class)
+                .hasMessageContaining("not active");
+    }
+
+    /** Mentor-auth check surfaces before goal-required. */
+    @Test
+    void createMeetings_NonMentorAndNullGoal_ForbiddenWins() {
+        mentorship.setSharedGoal(null);
+        OffsetDateTime start = OffsetDateTime.of(2026, 5, 8, 10, 0, 0, 0, ZoneOffset.UTC);
+        MeetingCreateRequest request = baseCreateRequest(start, start.plusHours(1));
+
+        when(mentorshipRepository.findById(11L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> meetingService.createMeetings(11L, 2L, request))
+                .isInstanceOf(ProfileNotVisibleException.class);
     }
 }
 

--- a/backend/src/test/java/com/group7/backend/service/MentorshipPreconditionsTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipPreconditionsTest.java
@@ -1,0 +1,78 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.exception.GoalRequiredException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MentorshipPreconditionsTest {
+
+    private Mentorship mentorshipWithGoal(String goal) {
+        Mentorship m = new Mentorship();
+        m.setId(42L);
+        m.setSharedGoal(goal);
+        return m;
+    }
+
+    @Test
+    void requireSharedGoalThrowsWhenGoalIsNull() {
+        Mentorship mentorship = mentorshipWithGoal(null);
+
+        assertThatThrownBy(() -> MentorshipPreconditions.requireSharedGoal(mentorship))
+                .isInstanceOf(GoalRequiredException.class)
+                .hasMessageContaining("must be defined")
+                .extracting(ex -> ((GoalRequiredException) ex).getMentorshipId())
+                .isEqualTo(42L);
+    }
+
+    @Test
+    void requireSharedGoalThrowsWhenGoalIsEmpty() {
+        Mentorship mentorship = mentorshipWithGoal("");
+
+        assertThatThrownBy(() -> MentorshipPreconditions.requireSharedGoal(mentorship))
+                .isInstanceOf(GoalRequiredException.class);
+    }
+
+    @Test
+    void requireSharedGoalThrowsWhenGoalIsWhitespace() {
+        Mentorship mentorship = mentorshipWithGoal("   ");
+
+        assertThatThrownBy(() -> MentorshipPreconditions.requireSharedGoal(mentorship))
+                .isInstanceOf(GoalRequiredException.class);
+    }
+
+    @Test
+    void requireSharedGoalThrowsWhenGoalIsTabsAndNewlines() {
+        Mentorship mentorship = mentorshipWithGoal("\t\n");
+
+        assertThatThrownBy(() -> MentorshipPreconditions.requireSharedGoal(mentorship))
+                .isInstanceOf(GoalRequiredException.class);
+    }
+
+    @Test
+    void requireSharedGoalDoesNothingWhenGoalIsSet() {
+        Mentorship mentorship = mentorshipWithGoal("Ship the MVP by July");
+
+        assertThatCode(() -> MentorshipPreconditions.requireSharedGoal(mentorship))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void requireSharedGoalDoesNothingWhenGoalContainsOnlyOneNonBlankChar() {
+        Mentorship mentorship = mentorshipWithGoal("x");
+
+        assertThatCode(() -> MentorshipPreconditions.requireSharedGoal(mentorship))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void goalRequiredExceptionCarriesMessageAndId() {
+        GoalRequiredException ex = new GoalRequiredException(7L);
+
+        assertThat(ex.getMessage()).isEqualTo(GoalRequiredException.DEFAULT_MESSAGE);
+        assertThat(ex.getMentorshipId()).isEqualTo(7L);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorshipProgressServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipProgressServiceTest.java
@@ -8,19 +8,18 @@ import com.group7.backend.entity.MentorshipStatus;
 import com.group7.backend.entity.MilestoneStatus;
 import com.group7.backend.entity.TaskStatus;
 import com.group7.backend.exception.ResourceNotFoundException;
-import com.group7.backend.repository.MentorshipRepository;
 import com.group7.backend.repository.MilestoneRepository;
 import com.group7.backend.repository.TaskRepository;
 import com.group7.backend.repository.TaskSubmissionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -31,15 +30,14 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MentorshipProgressServiceTest {
 
-    @Mock private MentorshipRepository mentorshipRepository;
+    @Mock private MentorshipService mentorshipService;
     @Mock private TaskRepository taskRepository;
     @Mock private TaskSubmissionRepository taskSubmissionRepository;
     @Mock private MilestoneRepository milestoneRepository;
 
+    @InjectMocks
     private MentorshipProgressService progressService;
 
-    private Mentor mentor;
-    private Mentee mentee;
     private Mentorship mentorship;
 
     private static final long MID = 100L;
@@ -48,15 +46,13 @@ class MentorshipProgressServiceTest {
 
     @BeforeEach
     void setUp() {
-        // Real MentorshipService so we exercise the real findForParticipant + ResourceNotFoundException path.
-        MentorshipService mentorshipService = new MentorshipService(
-                mentorshipRepository, /* mentorshipRequestRepository */ null,
-                /* notificationEventPublisher */ null, /* clock */ null);
-        progressService = new MentorshipProgressService(
-                mentorshipService, taskRepository, taskSubmissionRepository, milestoneRepository);
+        Mentor mentor = new Mentor();
+        mentor.setId(MENTOR_ID);
+        mentor.setFirstName("Mentor");
 
-        mentor = new Mentor(); mentor.setId(MENTOR_ID); mentor.setFirstName("Mentor");
-        mentee = new Mentee(); mentee.setId(MENTEE_ID); mentee.setFirstName("Mentee");
+        Mentee mentee = new Mentee();
+        mentee.setId(MENTEE_ID);
+        mentee.setFirstName("Mentee");
 
         mentorship = new Mentorship();
         mentorship.setId(MID);
@@ -65,11 +61,12 @@ class MentorshipProgressServiceTest {
         mentorship.setStatus(MentorshipStatus.ACTIVE);
     }
 
-    private void mockFound() {
-        when(mentorshipRepository.findById(MID)).thenReturn(Optional.of(mentorship));
+    /** Stub MentorshipService.findForParticipant to return our prebuilt mentorship. */
+    private void stubFound(long callerId) {
+        when(mentorshipService.findForParticipant(callerId, MID)).thenReturn(mentorship);
     }
 
-    private void mockCounts(long taskTotal, long taskCompleted, long taskSubmitted,
+    private void stubCounts(long taskTotal, long taskCompleted, long taskSubmitted,
                             long milestoneTotal, long milestoneCompleted) {
         lenient().when(taskRepository.countByMentorshipId(MID)).thenReturn(taskTotal);
         lenient().when(taskRepository.countByMentorshipIdAndStatus(MID, TaskStatus.COMPLETED))
@@ -81,19 +78,19 @@ class MentorshipProgressServiceTest {
                 .thenReturn(milestoneCompleted);
     }
 
-    private void mockTimestamps(OffsetDateTime sub, OffsetDateTime rev, OffsetDateTime mile) {
+    private void stubTimestamps(OffsetDateTime sub, OffsetDateTime rev, OffsetDateTime mile) {
         lenient().when(taskSubmissionRepository.findMaxSubmittedAtForMentorship(MID)).thenReturn(sub);
         lenient().when(taskSubmissionRepository.findMaxReviewedAtForMentorship(MID)).thenReturn(rev);
         lenient().when(milestoneRepository.findMaxCompletedAtForMentorship(MID)).thenReturn(mile);
     }
 
-    // ── Authorization ───────────────────────────────────────────────────────
+    // ── Authorization (delegated to MentorshipService.findForParticipant) ──
 
     @Test
     void getProgress_returnsForMentor() {
-        mockFound();
-        mockCounts(0, 0, 0, 0, 0);
-        mockTimestamps(null, null, null);
+        stubFound(MENTOR_ID);
+        stubCounts(0, 0, 0, 0, 0);
+        stubTimestamps(null, null, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
@@ -102,9 +99,9 @@ class MentorshipProgressServiceTest {
 
     @Test
     void getProgress_returnsForMentee() {
-        mockFound();
-        mockCounts(0, 0, 0, 0, 0);
-        mockTimestamps(null, null, null);
+        stubFound(MENTEE_ID);
+        stubCounts(0, 0, 0, 0, 0);
+        stubTimestamps(null, null, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTEE_ID, MID);
 
@@ -112,85 +109,78 @@ class MentorshipProgressServiceTest {
     }
 
     @Test
-    void getProgress_404ForNonParticipant() {
-        mockFound();
+    void getProgress_propagatesResourceNotFoundFromFinder() {
+        when(mentorshipService.findForParticipant(999L, MID))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
 
         assertThatThrownBy(() -> progressService.getProgress(999L, MID))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
 
-    @Test
-    void getProgress_404ForUnknownId() {
-        when(mentorshipRepository.findById(404L)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> progressService.getProgress(MENTOR_ID, 404L))
-                .isInstanceOf(ResourceNotFoundException.class);
-    }
-
-    // ── Percentage formula branches ─────────────────────────────────────────
+    // ── Ratio formula branches ──────────────────────────────────────────────
 
     @Test
-    void percentage_isZeroWhenNoTasksAndNoMilestones() {
-        mockFound();
-        mockCounts(0, 0, 0, 0, 0);
-        mockTimestamps(null, null, null);
+    void ratio_isZeroWhenNoTasksAndNoMilestones() {
+        stubFound(MENTOR_ID);
+        stubCounts(0, 0, 0, 0, 0);
+        stubTimestamps(null, null, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
-        assertThat(r.progressPercentage()).isEqualTo(0.0f);
+        assertThat(r.progressRatio()).isEqualTo(0.0f);
         assertThat(r.lastActivityAt()).isNull();
     }
 
     @Test
-    void percentage_tasksOnlyUsesTaskRatio() {
-        mockFound();
-        mockCounts(10, 4, 2, 0, 0);
-        mockTimestamps(null, null, null);
+    void ratio_tasksOnlyUsesTaskRatio() {
+        stubFound(MENTOR_ID);
+        stubCounts(10, 4, 2, 0, 0);
+        stubTimestamps(null, null, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
-        assertThat(r.progressPercentage()).isEqualTo(0.4f);
+        assertThat(r.progressRatio()).isEqualTo(0.4f);
         assertThat(r.taskTotal()).isEqualTo(10);
         assertThat(r.taskCompleted()).isEqualTo(4);
         assertThat(r.taskSubmitted()).isEqualTo(2);
     }
 
     @Test
-    void percentage_milestonesOnlyUsesMilestoneRatio() {
-        mockFound();
-        mockCounts(0, 0, 0, 4, 1);
-        mockTimestamps(null, null, null);
+    void ratio_milestonesOnlyUsesMilestoneRatio() {
+        stubFound(MENTOR_ID);
+        stubCounts(0, 0, 0, 4, 1);
+        stubTimestamps(null, null, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
-        assertThat(r.progressPercentage()).isEqualTo(0.25f);
+        assertThat(r.progressRatio()).isEqualTo(0.25f);
         assertThat(r.milestoneTotal()).isEqualTo(4);
         assertThat(r.milestoneCompleted()).isEqualTo(1);
     }
 
     @Test
-    void percentage_bothPresentUsesEqualWeight() {
-        mockFound();
+    void ratio_bothPresentUsesEqualWeight() {
+        stubFound(MENTOR_ID);
         // task ratio 4/10 = 0.4 ; milestone ratio 1/4 = 0.25 ; weighted = 0.5*0.4 + 0.5*0.25 = 0.325
-        mockCounts(10, 4, 2, 4, 1);
-        mockTimestamps(null, null, null);
+        stubCounts(10, 4, 2, 4, 1);
+        stubTimestamps(null, null, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
-        assertThat(r.progressPercentage()).isCloseTo(0.325f, within(0.0001f));
+        assertThat(r.progressRatio()).isCloseTo(0.325f, within(0.0001f));
     }
 
     @Test
-    void percentage_neverNaNOrInfinityForLargeCounts() {
-        mockFound();
-        mockCounts(Integer.MAX_VALUE, Integer.MAX_VALUE / 2, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
-        mockTimestamps(null, null, null);
+    void ratio_neverNaNOrInfinityForLargeCounts() {
+        stubFound(MENTOR_ID);
+        stubCounts(Integer.MAX_VALUE, Integer.MAX_VALUE / 2, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        stubTimestamps(null, null, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
-        assertThat(Float.isNaN(r.progressPercentage())).isFalse();
-        assertThat(Float.isInfinite(r.progressPercentage())).isFalse();
-        assertThat(r.progressPercentage()).isBetween(0.0f, 1.0f);
+        assertThat(Float.isNaN(r.progressRatio())).isFalse();
+        assertThat(Float.isInfinite(r.progressRatio())).isFalse();
+        assertThat(r.progressRatio()).isBetween(0.0f, 1.0f);
     }
 
     // ── lastActivityAt precedence ───────────────────────────────────────────
@@ -198,9 +188,9 @@ class MentorshipProgressServiceTest {
     @Test
     void lastActivity_takesSubmittedWhenOnlyOne() {
         OffsetDateTime ts = OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        mockFound();
-        mockCounts(1, 0, 1, 0, 0);
-        mockTimestamps(ts, null, null);
+        stubFound(MENTOR_ID);
+        stubCounts(1, 0, 1, 0, 0);
+        stubTimestamps(ts, null, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
@@ -210,9 +200,9 @@ class MentorshipProgressServiceTest {
     @Test
     void lastActivity_takesReviewedWhenOnlyOne() {
         OffsetDateTime ts = OffsetDateTime.of(2026, 5, 2, 0, 0, 0, 0, ZoneOffset.UTC);
-        mockFound();
-        mockCounts(1, 1, 0, 0, 0);
-        mockTimestamps(null, ts, null);
+        stubFound(MENTOR_ID);
+        stubCounts(1, 1, 0, 0, 0);
+        stubTimestamps(null, ts, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
@@ -222,9 +212,9 @@ class MentorshipProgressServiceTest {
     @Test
     void lastActivity_takesMilestoneWhenOnlyOne() {
         OffsetDateTime ts = OffsetDateTime.of(2026, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC);
-        mockFound();
-        mockCounts(0, 0, 0, 1, 1);
-        mockTimestamps(null, null, ts);
+        stubFound(MENTOR_ID);
+        stubCounts(0, 0, 0, 1, 1);
+        stubTimestamps(null, null, ts);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
@@ -236,9 +226,9 @@ class MentorshipProgressServiceTest {
         OffsetDateTime sub = OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         OffsetDateTime rev = OffsetDateTime.of(2026, 5, 5, 0, 0, 0, 0, ZoneOffset.UTC); // latest
         OffsetDateTime mil = OffsetDateTime.of(2026, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC);
-        mockFound();
-        mockCounts(1, 1, 0, 1, 1);
-        mockTimestamps(sub, rev, mil);
+        stubFound(MENTOR_ID);
+        stubCounts(1, 1, 0, 1, 1);
+        stubTimestamps(sub, rev, mil);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
@@ -250,9 +240,9 @@ class MentorshipProgressServiceTest {
         OffsetDateTime sub = OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         OffsetDateTime rev = OffsetDateTime.of(2026, 5, 2, 0, 0, 0, 0, ZoneOffset.UTC);
         OffsetDateTime mil = OffsetDateTime.of(2026, 5, 9, 0, 0, 0, 0, ZoneOffset.UTC); // latest
-        mockFound();
-        mockCounts(1, 1, 0, 1, 1);
-        mockTimestamps(sub, rev, mil);
+        stubFound(MENTOR_ID);
+        stubCounts(1, 1, 0, 1, 1);
+        stubTimestamps(sub, rev, mil);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
@@ -262,21 +252,21 @@ class MentorshipProgressServiceTest {
     @Test
     void lastActivity_handlesEqualTimestamps() {
         OffsetDateTime ts = OffsetDateTime.of(2026, 5, 5, 0, 0, 0, 0, ZoneOffset.UTC);
-        mockFound();
-        mockCounts(1, 1, 0, 1, 1);
-        mockTimestamps(ts, ts, ts);
+        stubFound(MENTOR_ID);
+        stubCounts(1, 1, 0, 1, 1);
+        stubTimestamps(ts, ts, ts);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
-        // Equal timestamps: laterOf returns the earlier one (a) when not after; but result is same instant.
+        // All three sources tied — any branch returns the same instant.
         assertThat(r.lastActivityAt()).isEqualTo(ts);
     }
 
     @Test
     void lastActivity_isNullWhenAllNull() {
-        mockFound();
-        mockCounts(0, 0, 0, 0, 0);
-        mockTimestamps(null, null, null);
+        stubFound(MENTOR_ID);
+        stubCounts(0, 0, 0, 0, 0);
+        stubTimestamps(null, null, null);
 
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 

--- a/backend/src/test/java/com/group7/backend/service/MentorshipProgressServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipProgressServiceTest.java
@@ -1,0 +1,285 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.MentorshipProgressResponse;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.entity.MilestoneStatus;
+import com.group7.backend.entity.TaskStatus;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MentorshipRepository;
+import com.group7.backend.repository.MilestoneRepository;
+import com.group7.backend.repository.TaskRepository;
+import com.group7.backend.repository.TaskSubmissionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MentorshipProgressServiceTest {
+
+    @Mock private MentorshipRepository mentorshipRepository;
+    @Mock private TaskRepository taskRepository;
+    @Mock private TaskSubmissionRepository taskSubmissionRepository;
+    @Mock private MilestoneRepository milestoneRepository;
+
+    private MentorshipProgressService progressService;
+
+    private Mentor mentor;
+    private Mentee mentee;
+    private Mentorship mentorship;
+
+    private static final long MID = 100L;
+    private static final long MENTOR_ID = 1L;
+    private static final long MENTEE_ID = 2L;
+
+    @BeforeEach
+    void setUp() {
+        // Real MentorshipService so we exercise the real findForParticipant + ResourceNotFoundException path.
+        MentorshipService mentorshipService = new MentorshipService(
+                mentorshipRepository, /* mentorshipRequestRepository */ null,
+                /* notificationEventPublisher */ null, /* clock */ null);
+        progressService = new MentorshipProgressService(
+                mentorshipService, taskRepository, taskSubmissionRepository, milestoneRepository);
+
+        mentor = new Mentor(); mentor.setId(MENTOR_ID); mentor.setFirstName("Mentor");
+        mentee = new Mentee(); mentee.setId(MENTEE_ID); mentee.setFirstName("Mentee");
+
+        mentorship = new Mentorship();
+        mentorship.setId(MID);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+        mentorship.setStatus(MentorshipStatus.ACTIVE);
+    }
+
+    private void mockFound() {
+        when(mentorshipRepository.findById(MID)).thenReturn(Optional.of(mentorship));
+    }
+
+    private void mockCounts(long taskTotal, long taskCompleted, long taskSubmitted,
+                            long milestoneTotal, long milestoneCompleted) {
+        lenient().when(taskRepository.countByMentorshipId(MID)).thenReturn(taskTotal);
+        lenient().when(taskRepository.countByMentorshipIdAndStatus(MID, TaskStatus.COMPLETED))
+                .thenReturn(taskCompleted);
+        lenient().when(taskRepository.countByMentorshipIdAndStatus(MID, TaskStatus.SUBMITTED))
+                .thenReturn(taskSubmitted);
+        lenient().when(milestoneRepository.countByMentorshipId(MID)).thenReturn(milestoneTotal);
+        lenient().when(milestoneRepository.countByMentorshipIdAndStatus(MID, MilestoneStatus.COMPLETED))
+                .thenReturn(milestoneCompleted);
+    }
+
+    private void mockTimestamps(OffsetDateTime sub, OffsetDateTime rev, OffsetDateTime mile) {
+        lenient().when(taskSubmissionRepository.findMaxSubmittedAtForMentorship(MID)).thenReturn(sub);
+        lenient().when(taskSubmissionRepository.findMaxReviewedAtForMentorship(MID)).thenReturn(rev);
+        lenient().when(milestoneRepository.findMaxCompletedAtForMentorship(MID)).thenReturn(mile);
+    }
+
+    // ── Authorization ───────────────────────────────────────────────────────
+
+    @Test
+    void getProgress_returnsForMentor() {
+        mockFound();
+        mockCounts(0, 0, 0, 0, 0);
+        mockTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.mentorshipId()).isEqualTo(MID);
+    }
+
+    @Test
+    void getProgress_returnsForMentee() {
+        mockFound();
+        mockCounts(0, 0, 0, 0, 0);
+        mockTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTEE_ID, MID);
+
+        assertThat(r.mentorshipId()).isEqualTo(MID);
+    }
+
+    @Test
+    void getProgress_404ForNonParticipant() {
+        mockFound();
+
+        assertThatThrownBy(() -> progressService.getProgress(999L, MID))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void getProgress_404ForUnknownId() {
+        when(mentorshipRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> progressService.getProgress(MENTOR_ID, 404L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── Percentage formula branches ─────────────────────────────────────────
+
+    @Test
+    void percentage_isZeroWhenNoTasksAndNoMilestones() {
+        mockFound();
+        mockCounts(0, 0, 0, 0, 0);
+        mockTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.progressPercentage()).isEqualTo(0.0f);
+        assertThat(r.lastActivityAt()).isNull();
+    }
+
+    @Test
+    void percentage_tasksOnlyUsesTaskRatio() {
+        mockFound();
+        mockCounts(10, 4, 2, 0, 0);
+        mockTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.progressPercentage()).isEqualTo(0.4f);
+        assertThat(r.taskTotal()).isEqualTo(10);
+        assertThat(r.taskCompleted()).isEqualTo(4);
+        assertThat(r.taskSubmitted()).isEqualTo(2);
+    }
+
+    @Test
+    void percentage_milestonesOnlyUsesMilestoneRatio() {
+        mockFound();
+        mockCounts(0, 0, 0, 4, 1);
+        mockTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.progressPercentage()).isEqualTo(0.25f);
+        assertThat(r.milestoneTotal()).isEqualTo(4);
+        assertThat(r.milestoneCompleted()).isEqualTo(1);
+    }
+
+    @Test
+    void percentage_bothPresentUsesEqualWeight() {
+        mockFound();
+        // task ratio 4/10 = 0.4 ; milestone ratio 1/4 = 0.25 ; weighted = 0.5*0.4 + 0.5*0.25 = 0.325
+        mockCounts(10, 4, 2, 4, 1);
+        mockTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.progressPercentage()).isCloseTo(0.325f, within(0.0001f));
+    }
+
+    @Test
+    void percentage_neverNaNOrInfinityForLargeCounts() {
+        mockFound();
+        mockCounts(Integer.MAX_VALUE, Integer.MAX_VALUE / 2, 0, Integer.MAX_VALUE, Integer.MAX_VALUE);
+        mockTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(Float.isNaN(r.progressPercentage())).isFalse();
+        assertThat(Float.isInfinite(r.progressPercentage())).isFalse();
+        assertThat(r.progressPercentage()).isBetween(0.0f, 1.0f);
+    }
+
+    // ── lastActivityAt precedence ───────────────────────────────────────────
+
+    @Test
+    void lastActivity_takesSubmittedWhenOnlyOne() {
+        OffsetDateTime ts = OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        mockFound();
+        mockCounts(1, 0, 1, 0, 0);
+        mockTimestamps(ts, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.lastActivityAt()).isEqualTo(ts);
+    }
+
+    @Test
+    void lastActivity_takesReviewedWhenOnlyOne() {
+        OffsetDateTime ts = OffsetDateTime.of(2026, 5, 2, 0, 0, 0, 0, ZoneOffset.UTC);
+        mockFound();
+        mockCounts(1, 1, 0, 0, 0);
+        mockTimestamps(null, ts, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.lastActivityAt()).isEqualTo(ts);
+    }
+
+    @Test
+    void lastActivity_takesMilestoneWhenOnlyOne() {
+        OffsetDateTime ts = OffsetDateTime.of(2026, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC);
+        mockFound();
+        mockCounts(0, 0, 0, 1, 1);
+        mockTimestamps(null, null, ts);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.lastActivityAt()).isEqualTo(ts);
+    }
+
+    @Test
+    void lastActivity_takesLatestAcrossAllThree() {
+        OffsetDateTime sub = OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        OffsetDateTime rev = OffsetDateTime.of(2026, 5, 5, 0, 0, 0, 0, ZoneOffset.UTC); // latest
+        OffsetDateTime mil = OffsetDateTime.of(2026, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC);
+        mockFound();
+        mockCounts(1, 1, 0, 1, 1);
+        mockTimestamps(sub, rev, mil);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.lastActivityAt()).isEqualTo(rev);
+    }
+
+    @Test
+    void lastActivity_milestoneWinsWhenLatest() {
+        OffsetDateTime sub = OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        OffsetDateTime rev = OffsetDateTime.of(2026, 5, 2, 0, 0, 0, 0, ZoneOffset.UTC);
+        OffsetDateTime mil = OffsetDateTime.of(2026, 5, 9, 0, 0, 0, 0, ZoneOffset.UTC); // latest
+        mockFound();
+        mockCounts(1, 1, 0, 1, 1);
+        mockTimestamps(sub, rev, mil);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.lastActivityAt()).isEqualTo(mil);
+    }
+
+    @Test
+    void lastActivity_handlesEqualTimestamps() {
+        OffsetDateTime ts = OffsetDateTime.of(2026, 5, 5, 0, 0, 0, 0, ZoneOffset.UTC);
+        mockFound();
+        mockCounts(1, 1, 0, 1, 1);
+        mockTimestamps(ts, ts, ts);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        // Equal timestamps: laterOf returns the earlier one (a) when not after; but result is same instant.
+        assertThat(r.lastActivityAt()).isEqualTo(ts);
+    }
+
+    @Test
+    void lastActivity_isNullWhenAllNull() {
+        mockFound();
+        mockCounts(0, 0, 0, 0, 0);
+        mockTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.lastActivityAt()).isNull();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
@@ -271,7 +271,7 @@ class MentorshipServiceTest {
         mentorship.setEndDate(OffsetDateTime.now(ZoneOffset.UTC).plusMonths(3));
         mentorship.setDuration(3);
 
-        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
         when(mentorshipRepository.save(any())).thenReturn(mentorship);
 
         SharedGoalRequest goalDto = new SharedGoalRequest();
@@ -291,7 +291,7 @@ class MentorshipServiceTest {
         mentorship.setMentee(mentee);
         mentorship.setStatus(MentorshipStatus.ACTIVE);
 
-        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
         when(mentorshipRepository.save(any())).thenReturn(mentorship);
 
         SharedGoalRequest goalDto = new SharedGoalRequest();
@@ -305,13 +305,7 @@ class MentorshipServiceTest {
 
     @Test
     void setSharedGoalWrongUser() {
-        Mentorship mentorship = new Mentorship();
-        mentorship.setId(100L);
-        mentorship.setMentor(mentor);
-        mentorship.setMentee(mentee);
-        mentorship.setStatus(MentorshipStatus.ACTIVE);
-
-        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 999L)).thenReturn(Optional.empty());
 
         SharedGoalRequest goalDto = new SharedGoalRequest();
         goalDto.setSharedGoal("test");
@@ -328,7 +322,7 @@ class MentorshipServiceTest {
         mentorship.setMentee(mentee);
         mentorship.setStatus(MentorshipStatus.COMPLETED);
 
-        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
 
         SharedGoalRequest goalDto = new SharedGoalRequest();
         goalDto.setSharedGoal("test");
@@ -352,7 +346,7 @@ class MentorshipServiceTest {
         mentorship.setDuration(3);
         mentorship.setSharedGoal("Build a portfolio");
 
-        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
 
         MentorshipResponse response = mentorshipService.getMentorship(1L, 100L);
 
@@ -372,7 +366,7 @@ class MentorshipServiceTest {
         mentorship.setEndDate(OffsetDateTime.now(ZoneOffset.UTC).plusMonths(3));
         mentorship.setDuration(3);
 
-        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
 
         MentorshipResponse response = mentorshipService.getMentorship(2L, 100L);
 
@@ -382,13 +376,7 @@ class MentorshipServiceTest {
 
     @Test
     void getMentorshipReturns404ForNonParticipant() {
-        Mentorship mentorship = new Mentorship();
-        mentorship.setId(100L);
-        mentorship.setMentor(mentor);
-        mentorship.setMentee(mentee);
-        mentorship.setStatus(MentorshipStatus.ACTIVE);
-
-        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 999L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> mentorshipService.getMentorship(999L, 100L))
                 .isInstanceOf(ResourceNotFoundException.class);
@@ -396,7 +384,7 @@ class MentorshipServiceTest {
 
     @Test
     void getMentorshipReturns404ForUnknownId() {
-        when(mentorshipRepository.findById(404L)).thenReturn(Optional.empty());
+        when(mentorshipRepository.findByIdAndParticipant(404L, 1L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> mentorshipService.getMentorship(1L, 404L))
                 .isInstanceOf(ResourceNotFoundException.class);
@@ -411,7 +399,7 @@ class MentorshipServiceTest {
         mentorship.setStatus(MentorshipStatus.ACTIVE);
         mentorship.setSharedGoal("   ");
 
-        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
 
         MentorshipResponse response = mentorshipService.getMentorship(1L, 100L);
 

--- a/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
@@ -280,6 +280,27 @@ class MentorshipServiceTest {
         MentorshipResponse response = mentorshipService.setSharedGoal(1L, 100L, goalDto);
 
         assertThat(response.getSharedGoal()).isEqualTo("Build a portfolio project");
+        assertThat(response.isGoalDefined()).isTrue();
+    }
+
+    @Test
+    void setSharedGoalSuccessAsMentee() {
+        Mentorship mentorship = new Mentorship();
+        mentorship.setId(100L);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+        mentorship.setStatus(MentorshipStatus.ACTIVE);
+
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.save(any())).thenReturn(mentorship);
+
+        SharedGoalRequest goalDto = new SharedGoalRequest();
+        goalDto.setSharedGoal("Mentee-led goal");
+
+        MentorshipResponse response = mentorshipService.setSharedGoal(2L, 100L, goalDto);
+
+        assertThat(response.getSharedGoal()).isEqualTo("Mentee-led goal");
+        assertThat(response.isGoalDefined()).isTrue();
     }
 
     @Test
@@ -315,5 +336,86 @@ class MentorshipServiceTest {
         assertThatThrownBy(() -> mentorshipService.setSharedGoal(1L, 100L, goalDto))
                 .isInstanceOf(MentorshipRequestException.class)
                 .hasMessageContaining("not active");
+    }
+
+    // ── Get mentorship ──────────────────────────────────────────────────────
+
+    @Test
+    void getMentorshipReturnsResponseForMentor() {
+        Mentorship mentorship = new Mentorship();
+        mentorship.setId(100L);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+        mentorship.setStatus(MentorshipStatus.ACTIVE);
+        mentorship.setStartDate(OffsetDateTime.now(ZoneOffset.UTC));
+        mentorship.setEndDate(OffsetDateTime.now(ZoneOffset.UTC).plusMonths(3));
+        mentorship.setDuration(3);
+        mentorship.setSharedGoal("Build a portfolio");
+
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+
+        MentorshipResponse response = mentorshipService.getMentorship(1L, 100L);
+
+        assertThat(response.getId()).isEqualTo(100L);
+        assertThat(response.getMentorFirstName()).isEqualTo("Ahmet");
+        assertThat(response.isGoalDefined()).isTrue();
+    }
+
+    @Test
+    void getMentorshipReturnsResponseForMentee() {
+        Mentorship mentorship = new Mentorship();
+        mentorship.setId(100L);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+        mentorship.setStatus(MentorshipStatus.ACTIVE);
+        mentorship.setStartDate(OffsetDateTime.now(ZoneOffset.UTC));
+        mentorship.setEndDate(OffsetDateTime.now(ZoneOffset.UTC).plusMonths(3));
+        mentorship.setDuration(3);
+
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+
+        MentorshipResponse response = mentorshipService.getMentorship(2L, 100L);
+
+        assertThat(response.getId()).isEqualTo(100L);
+        assertThat(response.isGoalDefined()).isFalse();
+    }
+
+    @Test
+    void getMentorshipReturns404ForNonParticipant() {
+        Mentorship mentorship = new Mentorship();
+        mentorship.setId(100L);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+        mentorship.setStatus(MentorshipStatus.ACTIVE);
+
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorshipService.getMentorship(999L, 100L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void getMentorshipReturns404ForUnknownId() {
+        when(mentorshipRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> mentorshipService.getMentorship(1L, 404L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void getMentorshipExposesGoalDefinedFalseForBlankGoal() {
+        Mentorship mentorship = new Mentorship();
+        mentorship.setId(100L);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+        mentorship.setStatus(MentorshipStatus.ACTIVE);
+        mentorship.setSharedGoal("   ");
+
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(mentorship));
+
+        MentorshipResponse response = mentorshipService.getMentorship(1L, 100L);
+
+        assertThat(response.isGoalDefined()).isFalse();
+        assertThat(response.getSharedGoal()).isEqualTo("   ");
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/MentorshipTimelineServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipTimelineServiceTest.java
@@ -1,0 +1,489 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.TimelineItem;
+import com.group7.backend.dto.response.TimelineItemType;
+import com.group7.backend.dto.response.TimelineResponse;
+import com.group7.backend.entity.Meeting;
+import com.group7.backend.entity.MeetingStatus;
+import com.group7.backend.entity.MeetingType;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.entity.Milestone;
+import com.group7.backend.entity.MilestoneStatus;
+import com.group7.backend.entity.Task;
+import com.group7.backend.entity.TaskStatus;
+import com.group7.backend.exception.InvalidTimelineWindowException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MeetingActionItemRepository;
+import com.group7.backend.repository.MeetingRepository;
+import com.group7.backend.repository.MilestoneActionItemRepository;
+import com.group7.backend.repository.MilestoneRepository;
+import com.group7.backend.repository.TaskRepository;
+import com.group7.backend.repository.projection.ActionItemCountTuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MentorshipTimelineServiceTest {
+
+    @Mock private MentorshipService mentorshipService;
+    @Mock private MeetingRepository meetingRepository;
+    @Mock private MeetingActionItemRepository meetingActionItemRepository;
+    @Mock private TaskRepository taskRepository;
+    @Mock private MilestoneRepository milestoneRepository;
+    @Mock private MilestoneActionItemRepository milestoneActionItemRepository;
+
+    private Clock fixedClock;
+    private MentorshipTimelineService service;
+
+    private Mentorship mentorship;
+
+    private static final long MID = 100L;
+    private static final long MENTOR_ID = 1L;
+    private static final long MENTEE_ID = 2L;
+    private static final OffsetDateTime PROGRAM_START =
+            OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime PROGRAM_END =
+            OffsetDateTime.of(2026, 8, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime FIXED_NOW =
+            OffsetDateTime.of(2026, 6, 1, 12, 0, 0, 0, ZoneOffset.UTC);
+
+    @BeforeEach
+    void setUp() {
+        fixedClock = Clock.fixed(FIXED_NOW.toInstant(), ZoneOffset.UTC);
+        service = new MentorshipTimelineService(
+                mentorshipService, meetingRepository, meetingActionItemRepository,
+                taskRepository, milestoneRepository, milestoneActionItemRepository, fixedClock);
+
+        Mentor mentor = new Mentor();
+        mentor.setId(MENTOR_ID);
+        mentor.setFirstName("Mentor");
+        Mentee mentee = new Mentee();
+        mentee.setId(MENTEE_ID);
+        mentee.setFirstName("Mentee");
+
+        mentorship = new Mentorship();
+        mentorship.setId(MID);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+        mentorship.setStatus(MentorshipStatus.ACTIVE);
+        mentorship.setStartDate(PROGRAM_START);
+        mentorship.setEndDate(PROGRAM_END);
+    }
+
+    private void stubFound(long callerId) {
+        when(mentorshipService.findForParticipant(callerId, MID)).thenReturn(mentorship);
+    }
+
+    private void stubEmptyDomains() {
+        lenient().when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        lenient().when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        lenient().when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+    }
+
+    private static Meeting newMeeting(long id, OffsetDateTime startTime, MeetingStatus status, String notes) {
+        Meeting m = new Meeting();
+        m.setId(id);
+        m.setTitle("Meeting " + id);
+        m.setStartTime(startTime);
+        m.setEndTime(startTime.plusHours(1));
+        m.setStatus(status);
+        m.setMeetingType(MeetingType.ONLINE);
+        m.setMeetingLink("https://meet.example.com/" + id);
+        m.setNotes(notes);
+        return m;
+    }
+
+    private static Task newTask(long id, OffsetDateTime dueDate, TaskStatus status) {
+        Task t = new Task();
+        t.setId(id);
+        t.setTitle("Task " + id);
+        t.setDueDate(dueDate);
+        t.setStatus(status);
+        return t;
+    }
+
+    private static Milestone newMilestone(long id, OffsetDateTime targetDate, MilestoneStatus status) {
+        Milestone ms = new Milestone();
+        ms.setId(id);
+        ms.setTitle("Milestone " + id);
+        ms.setTargetDate(targetDate);
+        ms.setStatus(status);
+        return ms;
+    }
+
+    // ── Authorisation ────────────────────────────────────────────────────────
+
+    @Test
+    void getTimeline_returnsForMentor() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.mentorshipId()).isEqualTo(MID);
+    }
+
+    @Test
+    void getTimeline_returnsForMentee() {
+        stubFound(MENTEE_ID);
+        stubEmptyDomains();
+
+        TimelineResponse r = service.getTimeline(MENTEE_ID, MID, null, null);
+
+        assertThat(r.mentorshipId()).isEqualTo(MID);
+    }
+
+    @Test
+    void getTimeline_propagatesResourceNotFoundFromFinder() {
+        when(mentorshipService.findForParticipant(999L, MID))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        assertThatThrownBy(() -> service.getTimeline(999L, MID, null, null))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── Empty window ─────────────────────────────────────────────────────────
+
+    @Test
+    void getTimeline_emptyMentorshipReturnsEmptyItemsButPopulatedMetadata() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.mentorshipId()).isEqualTo(MID);
+        assertThat(r.startDate()).isEqualTo(PROGRAM_START);
+        assertThat(r.endDate()).isEqualTo(PROGRAM_END);
+        assertThat(r.currentDate()).isEqualTo(FIXED_NOW);
+        assertThat(r.items()).isEmpty();
+
+        // Empty parent lists must short-circuit the bulk count queries (Hibernate 6 invalid SQL guard).
+        verify(meetingActionItemRepository, never()).countByMeetingIds(anyCollection());
+        verify(milestoneActionItemRepository, never()).countByMilestoneIds(anyCollection());
+    }
+
+    // ── Default window ──────────────────────────────────────────────────────
+
+    @Test
+    void getTimeline_defaultWindowUsesMentorshipDates() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+
+        service.getTimeline(MENTOR_ID, MID, null, null);
+
+        verify(meetingRepository).findInWindow(MID, PROGRAM_START, PROGRAM_END);
+        verify(taskRepository).findInWindow(MID, PROGRAM_START, PROGRAM_END);
+        verify(milestoneRepository).findInWindow(MID, PROGRAM_START, PROGRAM_END);
+    }
+
+    @Test
+    void getTimeline_explicitFromOverridesDefault() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+        OffsetDateTime customFrom = PROGRAM_START.plusDays(7);
+
+        service.getTimeline(MENTOR_ID, MID, customFrom, null);
+
+        verify(meetingRepository).findInWindow(MID, customFrom, PROGRAM_END);
+    }
+
+    @Test
+    void getTimeline_explicitToOverridesDefault() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+        OffsetDateTime customTo = PROGRAM_END.minusDays(7);
+
+        service.getTimeline(MENTOR_ID, MID, null, customTo);
+
+        verify(taskRepository).findInWindow(MID, PROGRAM_START, customTo);
+    }
+
+    // ── Window validation ──────────────────────────────────────────────────
+
+    @Test
+    void getTimeline_throwsWhenFromAfterTo() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime laterFrom = PROGRAM_START.plusDays(10);
+        OffsetDateTime earlierTo = PROGRAM_START.plusDays(5);
+
+        assertThatThrownBy(() -> service.getTimeline(MENTOR_ID, MID, laterFrom, earlierTo))
+                .isInstanceOf(InvalidTimelineWindowException.class)
+                .hasMessageContaining("'from' must be before");
+    }
+
+    @Test
+    void getTimeline_throwsWhenMentorshipHasNullProgramDates() {
+        // Defensive guard for legacy rows that bypass DDL or are constructed in-memory.
+        mentorship.setStartDate(null);
+        mentorship.setEndDate(null);
+        stubFound(MENTOR_ID);
+
+        assertThatThrownBy(() -> service.getTimeline(MENTOR_ID, MID, null, null))
+                .isInstanceOf(InvalidTimelineWindowException.class)
+                .hasMessageContaining("no program window");
+    }
+
+    /**
+     * Both arms of the short-circuit null check in validateWindow must throw. The other
+     * test exercises the {@code from == null} arm; this one pins the {@code to == null}
+     * arm to keep branch coverage at 100%.
+     */
+    @Test
+    void validateWindow_throwsOnNullToWithNonNullFrom() {
+        assertThatThrownBy(() ->
+                MentorshipTimelineService.validateWindow(PROGRAM_START, null))
+                .isInstanceOf(InvalidTimelineWindowException.class)
+                .hasMessageContaining("no program window");
+    }
+
+    @Test
+    void getTimeline_zeroWidthWindowIsValid() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+        OffsetDateTime instant = PROGRAM_START.plusDays(15);
+
+        assertThatCode(() -> service.getTimeline(MENTOR_ID, MID, instant, instant))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void getTimeline_exactly24MonthWindowIsValid() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+        OffsetDateTime from = PROGRAM_START;
+        OffsetDateTime to = PROGRAM_START.plusMonths(24);
+
+        assertThatCode(() -> service.getTimeline(MENTOR_ID, MID, from, to))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void getTimeline_throwsWhenWindowIsOneDayPast24Months() {
+        // Pins the cap. The earlier ChronoUnit-based check truncated; this one uses
+        // plusMonths so even +1 day past the boundary trips the cap.
+        stubFound(MENTOR_ID);
+        OffsetDateTime from = PROGRAM_START;
+        OffsetDateTime to = PROGRAM_START.plusMonths(24).plusDays(1);
+
+        assertThatThrownBy(() -> service.getTimeline(MENTOR_ID, MID, from, to))
+                .isInstanceOf(InvalidTimelineWindowException.class)
+                .hasMessageContaining("24 months");
+    }
+
+    // ── Item shape ──────────────────────────────────────────────────────────
+
+    @Test
+    void meetingItem_carriesCounters_hasNotesTrueWhenNotesPresent() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(newMeeting(55L, t, MeetingStatus.CONFIRMED, "agenda")));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(meetingActionItemRepository.countByMeetingIds(any()))
+                .thenReturn(List.of(new ActionItemCountTuple(55L, 3L, 1L)));
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+        TimelineItem item = r.items().get(0);
+
+        assertThat(item.type()).isEqualTo(TimelineItemType.MEETING);
+        assertThat(item.id()).isEqualTo(55L);
+        assertThat(item.occursAt()).isEqualTo(t);
+        assertThat(item.status()).isEqualTo("CONFIRMED");
+        assertThat(item.detailUrl()).isEqualTo("/api/meetings/55");
+        assertThat(item.actionItemTotal()).isEqualTo(3L);
+        assertThat(item.actionItemCompleted()).isEqualTo(1L);
+        assertThat(item.hasNotes()).isTrue();
+    }
+
+    @Test
+    void meetingItem_hasNotesFalseWhenNotesNullOrBlank() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(
+                        newMeeting(1L, t, MeetingStatus.CONFIRMED, null),
+                        newMeeting(2L, t.plusHours(1), MeetingStatus.CONFIRMED, "   ")));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.items()).extracting(TimelineItem::hasNotes).containsExactly(false, false);
+    }
+
+    @Test
+    void meetingItem_zeroCountersWhenNoActionItems() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(newMeeting(7L, t, MeetingStatus.CONFIRMED, null)));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+        TimelineItem item = r.items().get(0);
+
+        assertThat(item.actionItemTotal()).isEqualTo(0L);
+        assertThat(item.actionItemCompleted()).isEqualTo(0L);
+    }
+
+    @Test
+    void taskItem_typeConditionalFieldsAreNull() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(taskRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(newTask(11L, t, TaskStatus.PENDING)));
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+        TimelineItem item = r.items().get(0);
+
+        assertThat(item.type()).isEqualTo(TimelineItemType.TASK);
+        assertThat(item.detailUrl()).isEqualTo("/api/tasks/11");
+        assertThat(item.actionItemTotal()).isNull();
+        assertThat(item.actionItemCompleted()).isNull();
+        assertThat(item.hasNotes()).isNull();
+    }
+
+    @Test
+    void milestoneItem_carriesCounters_hasNotesAlwaysNull() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(newMilestone(20L, t, MilestoneStatus.IN_PROGRESS)));
+        when(milestoneActionItemRepository.countByMilestoneIds(any()))
+                .thenReturn(List.of(new ActionItemCountTuple(20L, 5L, 2L)));
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+        TimelineItem item = r.items().get(0);
+
+        assertThat(item.type()).isEqualTo(TimelineItemType.MILESTONE);
+        assertThat(item.detailUrl()).isEqualTo("/api/milestones/20");
+        assertThat(item.actionItemTotal()).isEqualTo(5L);
+        assertThat(item.actionItemCompleted()).isEqualTo(2L);
+        assertThat(item.hasNotes()).isNull();
+    }
+
+    // ── Sort & tiebreaker ───────────────────────────────────────────────────
+
+    @Test
+    void items_sortedByOccursAtAscending() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime base = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMeeting(1L, base.plusHours(2), MeetingStatus.CONFIRMED, null)));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newTask(2L, base, TaskStatus.PENDING)));
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMilestone(3L, base.plusHours(4), MilestoneStatus.PENDING)));
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+        when(milestoneActionItemRepository.countByMilestoneIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.items()).extracting(TimelineItem::id).containsExactly(2L, 1L, 3L);
+    }
+
+    @Test
+    void items_tiebreakerMilestoneBeforeMeetingBeforeTask() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime sameInstant = PROGRAM_START.plusDays(5);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMeeting(101L, sameInstant, MeetingStatus.CONFIRMED, null)));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newTask(102L, sameInstant, TaskStatus.PENDING)));
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMilestone(103L, sameInstant, MilestoneStatus.PENDING)));
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+        when(milestoneActionItemRepository.countByMilestoneIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.items()).extracting(TimelineItem::type).containsExactly(
+                TimelineItemType.MILESTONE, TimelineItemType.MEETING, TimelineItemType.TASK);
+    }
+
+    @Test
+    void items_tiebreakerByIdWithinSameType() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime sameInstant = PROGRAM_START.plusDays(5);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMeeting(20L, sameInstant, MeetingStatus.CONFIRMED, null),
+                newMeeting(10L, sameInstant, MeetingStatus.CONFIRMED, null)));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.items()).extracting(TimelineItem::id).containsExactly(10L, 20L);
+    }
+
+    // ── currentDate ─────────────────────────────────────────────────────────
+
+    @Test
+    void currentDate_isSourcedFromInjectedClock() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        // Use a different clock instant to prove we're reading from `clock`, not `OffsetDateTime.now()`.
+        OffsetDateTime otherInstant = OffsetDateTime.of(2999, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        Clock otherClock = Clock.fixed(Instant.parse("2999-01-01T00:00:00Z"), ZoneOffset.UTC);
+        MentorshipTimelineService otherService = new MentorshipTimelineService(
+                mentorshipService, meetingRepository, meetingActionItemRepository,
+                taskRepository, milestoneRepository, milestoneActionItemRepository, otherClock);
+        TimelineResponse other = otherService.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.currentDate()).isEqualTo(FIXED_NOW);
+        assertThat(other.currentDate()).isEqualTo(otherInstant);
+    }
+
+    // ── TimelineItem null-guard contract ────────────────────────────────────
+
+    @Test
+    void timelineItem_compactConstructorRejectsNullOnAlwaysPresentFields() {
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+
+        assertThatThrownBy(() -> new TimelineItem(null, 1L, "x", t, "OK", "/u", null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("type");
+        assertThatThrownBy(() -> new TimelineItem(TimelineItemType.TASK, 1L, null, t, "OK", "/u", null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("title");
+        assertThatThrownBy(() -> new TimelineItem(TimelineItemType.TASK, 1L, "x", null, "OK", "/u", null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("occursAt");
+        assertThatThrownBy(() -> new TimelineItem(TimelineItemType.TASK, 1L, "x", t, null, "/u", null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("status");
+        assertThatThrownBy(() -> new TimelineItem(TimelineItemType.TASK, 1L, "x", t, "OK", null, null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("detailUrl");
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MilestoneServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MilestoneServiceTest.java
@@ -5,6 +5,7 @@ import com.group7.backend.dto.request.MilestoneActionItemUpdateRequest;
 import com.group7.backend.dto.request.MilestoneCreateRequest;
 import com.group7.backend.dto.request.MilestoneUpdateRequest;
 import com.group7.backend.entity.*;
+import com.group7.backend.exception.GoalRequiredException;
 import com.group7.backend.exception.MilestoneConflictException;
 import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.exception.ResourceNotFoundException;
@@ -58,6 +59,7 @@ class MilestoneServiceTest {
         activeMentorship.setStatus(MentorshipStatus.ACTIVE);
         activeMentorship.setStartDate(OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
         activeMentorship.setEndDate(OffsetDateTime.of(2026, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC));
+        activeMentorship.setSharedGoal("Build a portfolio");
 
         pendingMilestone = new Milestone();
         pendingMilestone.setId(100L);
@@ -204,5 +206,57 @@ class MilestoneServiceTest {
         assertThatThrownBy(() -> milestoneService.updateActionItem(500L, 1L, req))
                 .isInstanceOf(MilestoneConflictException.class)
                 .hasMessageContaining("not active");
+    }
+
+    // ── Shared-goal gate ───────────────────────────────────────────────────
+
+    @Test
+    void createMilestone_NullGoal_GoalRequired() {
+        activeMentorship.setSharedGoal(null);
+        when(mentorshipRepository.findById(10L)).thenReturn(Optional.of(activeMentorship));
+        MilestoneCreateRequest req = new MilestoneCreateRequest();
+        req.setTitle("Anything");
+
+        assertThatThrownBy(() -> milestoneService.createMilestone(10L, 1L, req))
+                .isInstanceOf(GoalRequiredException.class)
+                .extracting(ex -> ((GoalRequiredException) ex).getMentorshipId())
+                .isEqualTo(10L);
+    }
+
+    @Test
+    void createMilestone_BlankGoal_GoalRequired() {
+        activeMentorship.setSharedGoal("   ");
+        when(mentorshipRepository.findById(10L)).thenReturn(Optional.of(activeMentorship));
+        MilestoneCreateRequest req = new MilestoneCreateRequest();
+        req.setTitle("Anything");
+
+        assertThatThrownBy(() -> milestoneService.createMilestone(10L, 1L, req))
+                .isInstanceOf(GoalRequiredException.class);
+    }
+
+    /** Inactive status surfaces before goal-required (deeper invariant wins). */
+    @Test
+    void createMilestone_InactiveAndNullGoal_StatusErrorWins() {
+        activeMentorship.setStatus(MentorshipStatus.COMPLETED);
+        activeMentorship.setSharedGoal(null);
+        when(mentorshipRepository.findById(10L)).thenReturn(Optional.of(activeMentorship));
+        MilestoneCreateRequest req = new MilestoneCreateRequest();
+        req.setTitle("Should Fail");
+
+        assertThatThrownBy(() -> milestoneService.createMilestone(10L, 1L, req))
+                .isInstanceOf(MilestoneConflictException.class)
+                .hasMessageContaining("not active");
+    }
+
+    /** Mentor-auth check surfaces before goal-required. */
+    @Test
+    void createMilestone_NonMentorAndNullGoal_ForbiddenWins() {
+        activeMentorship.setSharedGoal(null);
+        when(mentorshipRepository.findById(10L)).thenReturn(Optional.of(activeMentorship));
+        MilestoneCreateRequest req = new MilestoneCreateRequest();
+
+        assertThatThrownBy(() -> milestoneService.createMilestone(10L, 2L, req))
+                .isInstanceOf(ProfileNotVisibleException.class)
+                .hasMessageContaining("Only mentors can create");
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/TaskServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/TaskServiceTest.java
@@ -4,6 +4,7 @@ import com.group7.backend.dto.request.TaskCreateRequest;
 import com.group7.backend.dto.request.TaskReviewRequest;
 import com.group7.backend.dto.request.TaskSubmissionRequest;
 import com.group7.backend.entity.*;
+import com.group7.backend.exception.GoalRequiredException;
 import com.group7.backend.repository.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,12 +53,14 @@ class TaskServiceTest {
         activeMentorship.setMentor(mentor);
         activeMentorship.setMentee(mentee);
         activeMentorship.setStatus(MentorshipStatus.ACTIVE);
+        activeMentorship.setSharedGoal("Build a portfolio");
 
         endedMentorship = new Mentorship();
         endedMentorship.setId(20L);
         endedMentorship.setMentor(mentor);
         endedMentorship.setMentee(mentee);
         endedMentorship.setStatus(MentorshipStatus.COMPLETED);
+        endedMentorship.setSharedGoal("Build a portfolio");
 
         pendingTask = new Task();
         pendingTask.setId(100L);
@@ -118,6 +121,54 @@ class TaskServiceTest {
         assertThatThrownBy(() -> taskService.createTask(10L, 1L, req))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("Due date must be in the future");
+    }
+
+    @Test
+    void createTask_NullGoal_GoalRequired() {
+        activeMentorship.setSharedGoal(null);
+        when(mentorshipRepository.findById(10L)).thenReturn(Optional.of(activeMentorship));
+        TaskCreateRequest req = new TaskCreateRequest();
+        req.setTitle("Anything");
+
+        assertThatThrownBy(() -> taskService.createTask(10L, 1L, req))
+                .isInstanceOf(GoalRequiredException.class);
+    }
+
+    @Test
+    void createTask_BlankGoal_GoalRequired() {
+        activeMentorship.setSharedGoal("   ");
+        when(mentorshipRepository.findById(10L)).thenReturn(Optional.of(activeMentorship));
+        TaskCreateRequest req = new TaskCreateRequest();
+        req.setTitle("Anything");
+
+        assertThatThrownBy(() -> taskService.createTask(10L, 1L, req))
+                .isInstanceOf(GoalRequiredException.class)
+                .extracting(ex -> ((GoalRequiredException) ex).getMentorshipId())
+                .isEqualTo(10L);
+    }
+
+    /** Status-inactive must surface before goal-required so the deeper invariant wins. */
+    @Test
+    void createTask_InactiveAndNullGoal_StatusErrorWins() {
+        endedMentorship.setSharedGoal(null);
+        when(mentorshipRepository.findById(20L)).thenReturn(Optional.of(endedMentorship));
+        TaskCreateRequest req = new TaskCreateRequest();
+
+        assertThatThrownBy(() -> taskService.createTask(20L, 1L, req))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Mentorship is not active");
+    }
+
+    /** Auth (FORBIDDEN) must surface before goal-required. */
+    @Test
+    void createTask_NonMentorAndNullGoal_ForbiddenWins() {
+        activeMentorship.setSharedGoal(null);
+        when(mentorshipRepository.findById(10L)).thenReturn(Optional.of(activeMentorship));
+        TaskCreateRequest req = new TaskCreateRequest();
+
+        assertThatThrownBy(() -> taskService.createTask(10L, 2L, req))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Only the mentor can assign");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #335. Backend enforcement of spec **1.1.5.6** ("mentors and mentees must define a shared goal after matching and acceptance"). The web prompt (#277) was the only line of defence; this PR adds the read-side flag and the write-side gate so the requirement holds even if a non-web client is added.

- New `GET /api/mentorships/{id}` returning the mentorship (mentor + mentee only; 404 for non-participants — privacy stance matches the rest of the service).
- `MentorshipResponse` now exposes `goalDefined: boolean` (additive; the existing list endpoint emits it too).
- `SharedGoalRequest`: `@NotNull` → `@NotBlank`, `@Size(max=500)` retained.
- Gate `MentorshipPreconditions.requireSharedGoal(mentorship)` throws `GoalRequiredException(mentorshipId)`. Wired into `TaskService.createTask`, `MeetingService.createMeetings`, `MilestoneService.createMilestone` after the existing auth + active-status checks — deeper invariants surface first.
- `GlobalExceptionHandler` maps the new exception to HTTP 409 with a structured body so the frontend can branch deterministically:

  ```json
  { "error": "Conflict", "code": "GOAL_REQUIRED", "message": "...", "mentorshipId": 196 }
  ```

- `MentorshipService` cleanup: extracted private `findForParticipant(userId, mentorshipId)` helper used by both `getMentorship` and `setSharedGoal` (eliminates a duplicated participant filter).
- 409 `@ApiResponse` documented on the three gated POST endpoints; new GET fully OpenAPI-annotated.
- `pom.xml`: JaCoCo agent excludes for Hibernate / Mockito generated proxies to unblock coverage on this JDK; no impact on app behaviour.

## URL note

Keeps `PUT /api/mentorships/{id}/goal` as already shipped — the issue text says `/shared-goal`, but #277 already calls `/goal` and renaming would break the frontend. Documented for review.

## Stacking

Branch is off `feature/283-milestones` (PR #378). The milestone gate ships in this PR because the milestone service exists on that branch. When #378 merges to `dev`, GitHub will auto-retarget this PR's base to `dev`.

## Test plan

- [x] `mvn test`: **1331 tests, 0 failures, 0 errors**
- [x] **JaCoCo**: 100% line + branch on every file added by this change; the three new gate lines (`TaskService:60`, `MeetingService:72`, `MilestoneService:56`) are `class="fc"` (fully covered). Pre-existing baseline gaps in those services are not introduced by this PR.
- [x] **New unit tests**: `MentorshipPreconditionsTest` (7), `entity/MentorshipTest` (5), `exception/GoalRequiredHandlerTest` (3)
- [x] **Extended unit tests**: `MentorshipServiceTest` (`getMentorship` paths, `goalDefined` assertions on `setSharedGoal`), `MentorshipControllerTest` (GET 200/404 + PUT `@NotBlank` / `@Size` boundary cases), `TaskServiceTest` / `MeetingServiceTest` / `MilestoneServiceTest` (null-goal, blank-goal, ordering invariant: status-inactive surfaces before goal-required, non-mentor surfaces before goal-required)
- [x] **Integration**: `MentorshipIntegrationTest` extended with 11 end-to-end cases (PUT validation matrix, GET visibility matrix, 409 body shape on each of the three gated POSTs, success after goal set)
- [x] **Live HTTP smoke** against the running Docker stack: GET → 200 with `goalDefined: false`; POST tasks/meetings/milestones (no goal) → 409 with the documented body; `PUT /goal` whitespace → 400 (`Shared goal must not be blank`); `PUT /goal` 501 chars → 400 (`Shared goal must not exceed 500 characters`); `PUT /goal` valid → 200 with `goalDefined: true`; `POST /tasks` after goal → 201
- [x] **OpenAPI** (`/v3/api-docs`): new `GET /api/mentorships/{id}` documented (200/401/404), 409 advertised on all three gated POSTs, `MentorshipResponse.goalDefined` in schema, `SharedGoalRequest.sharedGoal.maxLength = 500`

## Out of scope

- Optimistic locking on `Mentorship` (concurrent PUT from mentor and mentee can race; no `@Version` exists today). Worth a separate small issue.
- Project-wide migration of error responses to RFC 7807 `ProblemDetail`. The `code`-bearing shape introduced here is a stepping stone, not the destination.
- Normalising `TaskService` to typed exceptions (it currently raises `ResponseStatusException` for its own checks). The new gate uses the typed `GoalRequiredException` — a deliberate, narrowly scoped inconsistency.