### PR TITLE
feat(backend): mentorship timeline aggregation endpoint (#332)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
@@ -3,8 +3,10 @@ package com.group7.backend.controller;
 import com.group7.backend.dto.request.SharedGoalRequest;
 import com.group7.backend.dto.response.MentorshipProgressResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
+import com.group7.backend.dto.response.TimelineResponse;
 import com.group7.backend.service.MentorshipProgressService;
 import com.group7.backend.service.MentorshipService;
+import com.group7.backend.service.MentorshipTimelineService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,10 +15,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @RestController
@@ -26,11 +30,14 @@ public class MentorshipController {
 
     private final MentorshipService mentorshipService;
     private final MentorshipProgressService mentorshipProgressService;
+    private final MentorshipTimelineService mentorshipTimelineService;
 
     public MentorshipController(MentorshipService mentorshipService,
-                                MentorshipProgressService mentorshipProgressService) {
+                                MentorshipProgressService mentorshipProgressService,
+                                MentorshipTimelineService mentorshipTimelineService) {
         this.mentorshipService = mentorshipService;
         this.mentorshipProgressService = mentorshipProgressService;
+        this.mentorshipTimelineService = mentorshipTimelineService;
     }
 
     @GetMapping
@@ -85,6 +92,34 @@ public class MentorshipController {
             Authentication authentication) {
         Long userId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(mentorshipProgressService.getProgress(userId, id));
+    }
+
+    @GetMapping("/{id}/timeline")
+    @Operation(
+            summary = "Get mentorship timeline",
+            description = "Returns meetings, tasks, and milestones merged into a single " +
+                    "chronologically-sorted feed, scoped to a window (default = mentorship " +
+                    "startDate..endDate; max 24 months). Only the mentor and mentee may read; " +
+                    "non-participants get 404."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Timeline payload",
+                    content = @Content(schema = @Schema(implementation = TimelineResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid window: from > to, or window > 24 months",
+                    content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content)
+    })
+    public ResponseEntity<TimelineResponse> getMentorshipTimeline(
+            @PathVariable Long id,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime from,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime to,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorshipTimelineService.getTimeline(userId, id, from, to));
     }
 
     @PutMapping("/{id}/goal")

--- a/backend/src/main/java/com/group7/backend/dto/response/TimelineItem.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/TimelineItem.java
@@ -1,0 +1,54 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+/**
+ * One row of the mentorship timeline. The shape is uniform across the three source
+ * domains (meetings, tasks, milestones); type-conditional fields are nullable and
+ * carry an explicit {@code null} for "not applicable" rather than being omitted, so
+ * clients never need to defend against missing keys.
+ */
+@Schema(description = "One row of the mentorship timeline (#332).")
+public record TimelineItem(
+        @Schema(description = "Item type discriminator")
+        TimelineItemType type,
+
+        long id,
+
+        String title,
+
+        @Schema(description = "Chronological position: meeting.startTime | task.dueDate | milestone.targetDate. " +
+                "Tasks with no dueDate and milestones with no targetDate have no chronological " +
+                "position and are excluded from the timeline; fetch them via the per-domain endpoints.")
+        OffsetDateTime occursAt,
+
+        @Schema(description = "Type-specific status string (MeetingStatus / TaskStatus / MilestoneStatus name)")
+        String status,
+
+        @Schema(description = "Path to the per-type detail endpoint, e.g. /api/meetings/{id}")
+        String detailUrl,
+
+        @Schema(description = "Total action items; null for TASK (tasks have no action items)",
+                nullable = true)
+        Long actionItemTotal,
+
+        @Schema(description = "Action items in completed state; null for TASK", nullable = true)
+        Long actionItemCompleted,
+
+        @Schema(description = "True iff a non-blank notes field exists on the underlying entity; "
+                + "null for TASK and MILESTONE (only meetings carry notes)", nullable = true)
+        Boolean hasNotes
+) {
+    public TimelineItem {
+        // Compact-constructor null guards on the always-present fields. The three
+        // type-conditional fields above are intentionally nullable.
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(occursAt, "occursAt");
+        Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(detailUrl, "detailUrl");
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/TimelineItemType.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/TimelineItemType.java
@@ -1,0 +1,25 @@
+package com.group7.backend.dto.response;
+
+/**
+ * Discriminator for {@link TimelineItem}. The {@link #priority()} accessor returns
+ * the value used as the second-level sort key in the timeline (after {@code occursAt});
+ * lower priority means earlier in the rendered list when timestamps tie.
+ *
+ * <p>Priority is an explicit field, not {@link Enum#ordinal()}, so reordering the enum
+ * declaration cannot silently change sort behaviour.
+ */
+public enum TimelineItemType {
+    MILESTONE(0),
+    MEETING(1),
+    TASK(2);
+
+    private final int priority;
+
+    TimelineItemType(int priority) {
+        this.priority = priority;
+    }
+
+    public int priority() {
+        return priority;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/TimelineResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/TimelineResponse.java
@@ -1,0 +1,34 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Aggregated mentorship timeline payload (#332, spec 1.1.5.9-1.1.5.13).
+ *
+ * <p>Returns the program window ({@code startDate}, {@code endDate}), a server-clock
+ * {@code currentDate} for the "today" marker, and the merged chronologically-sorted
+ * list of timeline items.
+ */
+@Schema(description = "Aggregated mentorship timeline (#332).")
+public record TimelineResponse(
+        @Schema(description = "Mentorship id", example = "42")
+        long mentorshipId,
+
+        @Schema(description = "Mentorship program window start")
+        OffsetDateTime startDate,
+
+        @Schema(description = "Mentorship program window end")
+        OffsetDateTime endDate,
+
+        @Schema(description = "Server clock instant at request time. Full timestamp despite the "
+                + "name; clients render the date portion for the today marker.")
+        OffsetDateTime currentDate,
+
+        @Schema(description = "Merged timeline items, sorted by occursAt ascending; "
+                + "ties broken by type priority (MILESTONE > MEETING > TASK) then id ascending")
+        List<TimelineItem> items
+) {
+}

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -74,6 +74,14 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.CONFLICT, "Conflict", ex.getMessage());
     }
 
+    @ExceptionHandler(InvalidTimelineWindowException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidTimelineWindow(InvalidTimelineWindowException ex,
+                                                                           HttpServletRequest request) {
+        log.warn("Invalid timeline window: method={}, path={}, message={}",
+                request.getMethod(), request.getRequestURI(), ex.getMessage());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage());
+    }
+
     @ExceptionHandler(GoalRequiredException.class)
     public ResponseEntity<Map<String, Object>> handleGoalRequired(GoalRequiredException ex,
                                                                   HttpServletRequest request) {

--- a/backend/src/main/java/com/group7/backend/exception/InvalidTimelineWindowException.java
+++ b/backend/src/main/java/com/group7/backend/exception/InvalidTimelineWindowException.java
@@ -1,0 +1,14 @@
+package com.group7.backend.exception;
+
+/**
+ * Thrown when a timeline window is malformed: {@code from > to}, too wide
+ * (over 24 months), or relies on a mentorship with missing program dates.
+ *
+ * <p>Maps to HTTP 400 via {@link GlobalExceptionHandler}.
+ */
+public class InvalidTimelineWindowException extends RuntimeException {
+
+    public InvalidTimelineWindowException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/repository/MeetingActionItemRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MeetingActionItemRepository.java
@@ -1,11 +1,39 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.MeetingActionItem;
+import com.group7.backend.repository.projection.ActionItemCountTuple;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface MeetingActionItemRepository extends JpaRepository<MeetingActionItem, Long> {
 
     List<MeetingActionItem> findByMeetingIdOrderByOrderIndexAscIdAsc(Long meetingId);
+
+    /**
+     * Bulk-load action-item counts for a set of meeting ids in one query.
+     * Returns one tuple per meeting that has at least one action item; meetings with
+     * zero action items don't appear in the result and the caller defaults them to
+     * {@code (0, 0)}. Used by the mentorship timeline aggregation (#332) to avoid N+1.
+     *
+     * <p>Caller must short-circuit on an empty {@code ids} collection — Hibernate 6
+     * emits invalid SQL ({@code WHERE x IN ()}) for empty IN parameters.
+     */
+    /**
+     * The {@code CAST(... AS Long)} on the {@code SUM} pins the expression's return type so
+     * Hibernate's JPQL constructor-expression resolution against
+     * {@link ActionItemCountTuple} (which takes three {@code Long} components) cannot
+     * silently drift on a future Hibernate / driver upgrade where {@code SUM} of a
+     * {@code CASE} integer might widen to a different numeric type.
+     */
+    @Query("SELECT new com.group7.backend.repository.projection.ActionItemCountTuple("
+            + "a.meeting.id, COUNT(a), "
+            + "CAST(COALESCE(SUM(CASE WHEN a.completed = true THEN 1L ELSE 0L END), 0L) AS java.lang.Long)) "
+            + "FROM MeetingActionItem a "
+            + "WHERE a.meeting.id IN :ids "
+            + "GROUP BY a.meeting.id")
+    List<ActionItemCountTuple> countByMeetingIds(@Param("ids") Collection<Long> ids);
 }

--- a/backend/src/main/java/com/group7/backend/repository/MeetingRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MeetingRepository.java
@@ -60,6 +60,24 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             @Param("windowStart") OffsetDateTime windowStart,
             @Param("windowEnd") OffsetDateTime windowEnd);
 
+    /**
+     * Meetings of a mentorship whose {@code startTime} falls inside the inclusive
+     * {@code [from, to]} window. Used by the mentorship timeline aggregation (#332).
+     *
+     * <p>The window predicate anchors on {@code startTime} only — a meeting that began
+     * before {@code from} and ended inside the window is excluded. This matches the
+     * timeline's "chronological position = startTime" model. If the product wants
+     * straddling meetings to surface in their endpoint window, change the predicate to
+     * {@code m.startTime <= :to AND m.endTime >= :from}.
+     */
+    @Query("SELECT m FROM Meeting m "
+            + "WHERE m.mentorship.id = :mentorshipId "
+            + "AND m.startTime BETWEEN :from AND :to")
+    List<Meeting> findInWindow(
+            @Param("mentorshipId") Long mentorshipId,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to);
+
     @Modifying
     @Query("UPDATE Meeting m SET m.status = 'EXPIRED' WHERE m.id = :meetingId AND m.status = 'PENDING_CONFIRMATION'")
     int expireMeeting(@Param("meetingId") Long meetingId);

--- a/backend/src/main/java/com/group7/backend/repository/MilestoneActionItemRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MilestoneActionItemRepository.java
@@ -1,10 +1,13 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.MilestoneActionItem;
+import com.group7.backend.repository.projection.ActionItemCountTuple;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +18,27 @@ public interface MilestoneActionItemRepository extends JpaRepository<MilestoneAc
 
     @Query("SELECT a FROM MilestoneActionItem a JOIN FETCH a.milestone m JOIN FETCH m.mentorship WHERE a.id = :id")
     Optional<MilestoneActionItem> findByIdWithMilestoneAndMentorship(Long id);
+
+    /**
+     * Bulk-load action-item counts for a set of milestone ids in one query.
+     * Returns one tuple per milestone that has at least one action item; milestones
+     * with zero action items don't appear in the result and the caller defaults them
+     * to {@code (0, 0)}. Used by the mentorship timeline aggregation (#332) to avoid N+1.
+     *
+     * <p>Caller must short-circuit on an empty {@code ids} collection — Hibernate 6
+     * emits invalid SQL ({@code WHERE x IN ()}) for empty IN parameters.
+     */
+    /**
+     * The {@code CAST(... AS Long)} on the {@code SUM} pins the expression's return type so
+     * Hibernate's JPQL constructor-expression resolution against
+     * {@link ActionItemCountTuple} (which takes three {@code Long} components) cannot
+     * silently drift on a future Hibernate / driver upgrade.
+     */
+    @Query("SELECT new com.group7.backend.repository.projection.ActionItemCountTuple("
+            + "a.milestone.id, COUNT(a), "
+            + "CAST(COALESCE(SUM(CASE WHEN a.isCompleted = true THEN 1L ELSE 0L END), 0L) AS java.lang.Long)) "
+            + "FROM MilestoneActionItem a "
+            + "WHERE a.milestone.id IN :ids "
+            + "GROUP BY a.milestone.id")
+    List<ActionItemCountTuple> countByMilestoneIds(@Param("ids") Collection<Long> ids);
 }

--- a/backend/src/main/java/com/group7/backend/repository/MilestoneRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MilestoneRepository.java
@@ -25,4 +25,18 @@ public interface MilestoneRepository extends JpaRepository<Milestone, Long> {
 
     @Query("SELECT MAX(m.completedAt) FROM Milestone m WHERE m.mentorship.id = :mentorshipId")
     OffsetDateTime findMaxCompletedAtForMentorship(@Param("mentorshipId") Long mentorshipId);
+
+    /**
+     * Milestones of a mentorship whose {@code targetDate} falls inside the inclusive
+     * {@code [from, to]} window. Milestones with a null {@code targetDate} are
+     * excluded naturally by the {@code BETWEEN} predicate — they have no place on a
+     * chronological timeline. Used by the mentorship timeline aggregation (#332).
+     */
+    @Query("SELECT m FROM Milestone m "
+            + "WHERE m.mentorship.id = :mentorshipId "
+            + "AND m.targetDate BETWEEN :from AND :to")
+    List<Milestone> findInWindow(
+            @Param("mentorshipId") Long mentorshipId,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to);
 }

--- a/backend/src/main/java/com/group7/backend/repository/TaskRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/TaskRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,4 +22,18 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     long countByMentorshipId(Long mentorshipId);
 
     long countByMentorshipIdAndStatus(Long mentorshipId, TaskStatus status);
+
+    /**
+     * Tasks of a mentorship whose {@code dueDate} falls inside the inclusive
+     * {@code [from, to]} window. Tasks with a null {@code dueDate} are excluded
+     * naturally by the {@code BETWEEN} predicate — they have no place on a
+     * chronological timeline. Used by the mentorship timeline aggregation (#332).
+     */
+    @Query("SELECT t FROM Task t "
+            + "WHERE t.mentorship.id = :mentorshipId "
+            + "AND t.dueDate BETWEEN :from AND :to")
+    List<Task> findInWindow(
+            @Param("mentorshipId") Long mentorshipId,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to);
 }

--- a/backend/src/main/java/com/group7/backend/repository/projection/ActionItemCountTuple.java
+++ b/backend/src/main/java/com/group7/backend/repository/projection/ActionItemCountTuple.java
@@ -1,0 +1,16 @@
+package com.group7.backend.repository.projection;
+
+/**
+ * Projection target for grouped action-item count queries on
+ * {@code MeetingActionItemRepository} and {@code MilestoneActionItemRepository}.
+ *
+ * <p>Both repositories use a JPQL constructor expression
+ * ({@code SELECT new ActionItemCountTuple(...)}) so the service layer never has to
+ * unpack a {@code List<Object[]>}.
+ */
+public record ActionItemCountTuple(
+        Long parentId,
+        Long total,
+        Long completed
+) {
+}

--- a/backend/src/main/java/com/group7/backend/service/MentorshipTimelineService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipTimelineService.java
@@ -1,0 +1,201 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.TimelineItem;
+import com.group7.backend.dto.response.TimelineItemType;
+import com.group7.backend.dto.response.TimelineResponse;
+import com.group7.backend.entity.Meeting;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.Milestone;
+import com.group7.backend.entity.Task;
+import com.group7.backend.exception.InvalidTimelineWindowException;
+import com.group7.backend.repository.MeetingActionItemRepository;
+import com.group7.backend.repository.MeetingRepository;
+import com.group7.backend.repository.MilestoneActionItemRepository;
+import com.group7.backend.repository.MilestoneRepository;
+import com.group7.backend.repository.TaskRepository;
+import com.group7.backend.repository.projection.ActionItemCountTuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Read-only aggregator for the mentorship timeline (#332, spec 1.1.5.9-1.1.5.13).
+ *
+ * <p>Merges meetings + tasks + milestones into one chronologically-sorted feed scoped to a
+ * window (default = mentorship.startDate..endDate, capped at {@value #MAX_WINDOW_MONTHS}
+ * months). Action-item counts are bulk-loaded via grouped queries; sort is performed in
+ * Java because Hibernate has no clean cross-entity union-sort idiom.
+ *
+ * <p>Stateless and thread-safe.
+ */
+@Service
+public class MentorshipTimelineService {
+
+    private static final Logger log = LoggerFactory.getLogger(MentorshipTimelineService.class);
+
+    private static final long MAX_WINDOW_MONTHS = 24;
+
+    private static final String MEETING_DETAIL_URL_PREFIX = "/api/meetings/";
+    private static final String TASK_DETAIL_URL_PREFIX = "/api/tasks/";
+    private static final String MILESTONE_DETAIL_URL_PREFIX = "/api/milestones/";
+
+    private final MentorshipService mentorshipService;
+    private final MeetingRepository meetingRepository;
+    private final MeetingActionItemRepository meetingActionItemRepository;
+    private final TaskRepository taskRepository;
+    private final MilestoneRepository milestoneRepository;
+    private final MilestoneActionItemRepository milestoneActionItemRepository;
+    private final Clock clock;
+
+    public MentorshipTimelineService(MentorshipService mentorshipService,
+                                     MeetingRepository meetingRepository,
+                                     MeetingActionItemRepository meetingActionItemRepository,
+                                     TaskRepository taskRepository,
+                                     MilestoneRepository milestoneRepository,
+                                     MilestoneActionItemRepository milestoneActionItemRepository,
+                                     Clock clock) {
+        this.mentorshipService = mentorshipService;
+        this.meetingRepository = meetingRepository;
+        this.meetingActionItemRepository = meetingActionItemRepository;
+        this.taskRepository = taskRepository;
+        this.milestoneRepository = milestoneRepository;
+        this.milestoneActionItemRepository = milestoneActionItemRepository;
+        this.clock = clock;
+    }
+
+    @Transactional(readOnly = true)
+    public TimelineResponse getTimeline(Long userId, Long mentorshipId,
+                                        OffsetDateTime from, OffsetDateTime to) {
+        // 1. Auth — non-participants get 404 here, before any window math.
+        Mentorship mentorship = mentorshipService.findForParticipant(userId, mentorshipId);
+
+        // 2. Window — defaults from the mentorship; validation throws 400.
+        OffsetDateTime windowFrom = from != null ? from : mentorship.getStartDate();
+        OffsetDateTime windowTo = to != null ? to : mentorship.getEndDate();
+        validateWindow(windowFrom, windowTo);
+
+        // 3. Fetch each domain in the window.
+        List<Meeting> meetings = meetingRepository.findInWindow(mentorshipId, windowFrom, windowTo);
+        List<Task> tasks = taskRepository.findInWindow(mentorshipId, windowFrom, windowTo);
+        List<Milestone> milestones = milestoneRepository.findInWindow(mentorshipId, windowFrom, windowTo);
+
+        // 4. Bulk action-item counters keyed by parent id (avoids N+1).
+        //    Empty-list short-circuit — Hibernate 6 emits invalid SQL on `WHERE x IN ()`.
+        Map<Long, ActionItemCounts> meetingAi = meetings.isEmpty()
+                ? Map.of()
+                : indexCounts(meetingActionItemRepository.countByMeetingIds(idsOfMeetings(meetings)));
+        Map<Long, ActionItemCounts> milestoneAi = milestones.isEmpty()
+                ? Map.of()
+                : indexCounts(milestoneActionItemRepository.countByMilestoneIds(idsOfMilestones(milestones)));
+
+        // 5. Map to uniform TimelineItem; null means "not applicable to this type".
+        List<TimelineItem> items = new ArrayList<>(meetings.size() + tasks.size() + milestones.size());
+        meetings.forEach(m -> items.add(
+                toMeetingItem(m, meetingAi.getOrDefault(m.getId(), ActionItemCounts.ZERO))));
+        tasks.forEach(t -> items.add(toTaskItem(t)));
+        milestones.forEach(ms -> items.add(
+                toMilestoneItem(ms, milestoneAi.getOrDefault(ms.getId(), ActionItemCounts.ZERO))));
+
+        // 6. Stable sort: occursAt asc, then MILESTONE > MEETING > TASK, then id asc.
+        items.sort(
+                Comparator.comparing(TimelineItem::occursAt)
+                        .thenComparingInt(it -> it.type().priority())
+                        .thenComparingLong(TimelineItem::id));
+
+        log.debug("timeline userId={} mentorshipId={} window=[{}, {}] meetings={} tasks={} milestones={}",
+                userId, mentorshipId, windowFrom, windowTo,
+                meetings.size(), tasks.size(), milestones.size());
+
+        return new TimelineResponse(
+                mentorshipId,
+                mentorship.getStartDate(),
+                mentorship.getEndDate(),
+                OffsetDateTime.now(clock),
+                items);
+    }
+
+    /** Internal value type for bulk-loaded action-item counts. */
+    private record ActionItemCounts(long total, long completed) {
+        static final ActionItemCounts ZERO = new ActionItemCounts(0L, 0L);
+    }
+
+    static void validateWindow(OffsetDateTime from, OffsetDateTime to) {
+        if (from == null || to == null) {
+            throw new InvalidTimelineWindowException(
+                    "Mentorship has no program window; supply 'from' and 'to'");
+        }
+        if (from.isAfter(to)) {
+            throw new InvalidTimelineWindowException("'from' must be before or equal to 'to'");
+        }
+        // Use plusMonths comparison instead of ChronoUnit.MONTHS.between(...), which truncates
+        // to whole months and silently lets ~1 month of slack past the 24-month cap.
+        if (to.isAfter(from.plusMonths(MAX_WINDOW_MONTHS))) {
+            throw new InvalidTimelineWindowException(
+                    "Timeline window cannot exceed " + MAX_WINDOW_MONTHS + " months");
+        }
+    }
+
+    private static Collection<Long> idsOfMeetings(List<Meeting> meetings) {
+        return meetings.stream().map(Meeting::getId).toList();
+    }
+
+    private static Collection<Long> idsOfMilestones(List<Milestone> milestones) {
+        return milestones.stream().map(Milestone::getId).toList();
+    }
+
+    private static Map<Long, ActionItemCounts> indexCounts(List<ActionItemCountTuple> tuples) {
+        return tuples.stream().collect(Collectors.toUnmodifiableMap(
+                ActionItemCountTuple::parentId,
+                t -> new ActionItemCounts(t.total(), t.completed())));
+    }
+
+    private static TimelineItem toMeetingItem(Meeting m, ActionItemCounts counts) {
+        boolean hasNotes = m.getNotes() != null && !m.getNotes().isBlank();
+        return new TimelineItem(
+                TimelineItemType.MEETING,
+                m.getId(),
+                m.getTitle(),
+                m.getStartTime(),
+                m.getStatus().name(),
+                MEETING_DETAIL_URL_PREFIX + m.getId(),
+                counts.total(),
+                counts.completed(),
+                hasNotes);
+    }
+
+    private static TimelineItem toTaskItem(Task t) {
+        return new TimelineItem(
+                TimelineItemType.TASK,
+                t.getId(),
+                t.getTitle(),
+                t.getDueDate(),
+                t.getStatus().name(),
+                TASK_DETAIL_URL_PREFIX + t.getId(),
+                null,
+                null,
+                null);
+    }
+
+    private static TimelineItem toMilestoneItem(Milestone ms, ActionItemCounts counts) {
+        return new TimelineItem(
+                TimelineItemType.MILESTONE,
+                ms.getId(),
+                ms.getTitle(),
+                ms.getTargetDate(),
+                ms.getStatus().name(),
+                MILESTONE_DETAIL_URL_PREFIX + ms.getId(),
+                counts.total(),
+                counts.completed(),
+                null);
+    }
+}

--- a/backend/src/main/resources/db/migration/V29__add_shared_goal_to_mentorships.sql
+++ b/backend/src/main/resources/db/migration/V29__add_shared_goal_to_mentorships.sql
@@ -1,0 +1,6 @@
+-- #335: Add shared_goal column to mentorships table.
+-- Nullable TEXT so existing rows are unaffected (NULL = no goal set yet).
+-- The shared-goal precondition gate checks this column before allowing
+-- task / milestone / meeting writes on a mentorship.
+ALTER TABLE mentorships
+    ADD COLUMN IF NOT EXISTS shared_goal TEXT;

--- a/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
@@ -7,12 +7,16 @@ import com.group7.backend.dto.request.AcceptRequestRequest;
 import com.group7.backend.dto.request.SharedGoalRequest;
 import com.group7.backend.dto.response.MentorshipProgressResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
+import com.group7.backend.dto.response.TimelineItem;
+import com.group7.backend.dto.response.TimelineItemType;
+import com.group7.backend.dto.response.TimelineResponse;
 import com.group7.backend.exception.MentorshipRequestException;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.service.JwtService;
 import com.group7.backend.service.MentorshipProgressService;
 import com.group7.backend.service.MentorshipRequestService;
 import com.group7.backend.service.MentorshipService;
+import com.group7.backend.service.MentorshipTimelineService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -52,6 +56,9 @@ class MentorshipControllerTest {
 
     @MockitoBean
     private MentorshipProgressService mentorshipProgressService;
+
+    @MockitoBean
+    private MentorshipTimelineService mentorshipTimelineService;
 
     @MockitoBean
     private JwtService jwtService;
@@ -404,5 +411,117 @@ class MentorshipControllerTest {
         mockMvc.perform(get("/api/mentorships/404/progress")
                         .header("Authorization", "Bearer mentor-token"))
                 .andExpect(status().isNotFound());
+    }
+
+    // ── Get mentorship timeline (#332) ──────────────────────────────────────
+
+    private TimelineResponse sampleTimeline() {
+        OffsetDateTime t = OffsetDateTime.of(2026, 5, 5, 0, 0, 0, 0, ZoneOffset.UTC);
+        TimelineItem milestoneItem = new TimelineItem(
+                TimelineItemType.MILESTONE, 7L, "M1", t, "PENDING", "/api/milestones/7", 0L, 0L, null);
+        TimelineItem meetingItem = new TimelineItem(
+                TimelineItemType.MEETING, 8L, "Sync", t.plusHours(1), "CONFIRMED",
+                "/api/meetings/8", 1L, 0L, false);
+        return new TimelineResponse(
+                100L,
+                OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2026, 8, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2026, 6, 1, 12, 0, 0, 0, ZoneOffset.UTC),
+                List.of(milestoneItem, meetingItem));
+    }
+
+    @Test
+    void getTimelineReturns200ForMentor() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipTimelineService.getTimeline(eq(1L), eq(100L), any(), any()))
+                .thenReturn(sampleTimeline());
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(100))
+                .andExpect(jsonPath("$.startDate").exists())
+                .andExpect(jsonPath("$.endDate").exists())
+                .andExpect(jsonPath("$.currentDate").exists())
+                .andExpect(jsonPath("$.items.length()").value(2))
+                .andExpect(jsonPath("$.items[0].type").value("MILESTONE"))
+                .andExpect(jsonPath("$.items[1].type").value("MEETING"));
+    }
+
+    @Test
+    void getTimelineReturns200ForMentee() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+        when(mentorshipTimelineService.getTimeline(eq(2L), eq(100L), any(), any()))
+                .thenReturn(sampleTimeline());
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(100));
+    }
+
+    @Test
+    void getTimelineReturns404ForNonParticipant() throws Exception {
+        mockMenteeJwt("intruder-token", 999L);
+        when(mentorshipTimelineService.getTimeline(eq(999L), eq(100L), any(), any()))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .header("Authorization", "Bearer intruder-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getTimelineReturns404ForUnknownId() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipTimelineService.getTimeline(eq(1L), eq(404L), any(), any()))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        mockMvc.perform(get("/api/mentorships/404/timeline")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getTimelineReturns400WhenFromAfterTo() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipTimelineService.getTimeline(eq(1L), eq(100L), any(), any()))
+                .thenThrow(new com.group7.backend.exception.InvalidTimelineWindowException(
+                        "'from' must be before or equal to 'to'"));
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .param("from", "2026-08-01T00:00:00Z")
+                        .param("to", "2026-05-01T00:00:00Z")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getTimelineParsesIsoDateTimeWithZAndOffset() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipTimelineService.getTimeline(eq(1L), eq(100L), any(), any()))
+                .thenReturn(sampleTimeline());
+
+        // Z offset
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .param("from", "2026-05-01T00:00:00Z")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk());
+
+        // +03:00 offset
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .param("from", "2026-05-01T03:00:00+03:00")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getTimelineRejectsMalformedFrom() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+
+        mockMvc.perform(get("/api/mentorships/100/timeline")
+                        .param("from", "banana")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/backend/src/test/java/com/group7/backend/dto/response/TimelineItemTypeTest.java
+++ b/backend/src/test/java/com/group7/backend/dto/response/TimelineItemTypeTest.java
@@ -1,0 +1,28 @@
+package com.group7.backend.dto.response;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the priority values of {@link TimelineItemType}. The timeline service uses
+ * priority as the second-level sort key; if a future commit reorders the enum
+ * declaration this test fails fast instead of silently shifting the rendered order.
+ */
+class TimelineItemTypeTest {
+
+    @Test
+    void milestoneHasPriorityZero() {
+        assertThat(TimelineItemType.MILESTONE.priority()).isEqualTo(0);
+    }
+
+    @Test
+    void meetingHasPriorityOne() {
+        assertThat(TimelineItemType.MEETING.priority()).isEqualTo(1);
+    }
+
+    @Test
+    void taskHasPriorityTwo() {
+        assertThat(TimelineItemType.TASK.priority()).isEqualTo(2);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipIntegrationTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.time.OffsetDateTime;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -591,5 +592,318 @@ class MentorshipIntegrationTest {
         mockMvc.perform(get("/api/mentorships/999999/progress")
                         .header("Authorization", "Bearer " + mentorToken))
                 .andExpect(status().isNotFound());
+    }
+
+    // ── Mentorship timeline aggregation (issue #332) ────────────────────────
+
+    @org.springframework.beans.factory.annotation.Autowired
+    private jakarta.persistence.EntityManager entityManager;
+
+    @Test
+    void getTimeline_emptyMentorshipReturnsEmptyItems() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m1@test.com", "tl_e1@test.com");
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(f.mentorshipId()))
+                .andExpect(jsonPath("$.startDate").exists())
+                .andExpect(jsonPath("$.endDate").exists())
+                .andExpect(jsonPath("$.currentDate").exists())
+                .andExpect(jsonPath("$.items.length()").value(0));
+    }
+
+    @Test
+    void getTimeline_returnsAllThreeDomainsInChronologicalOrder() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m2@test.com", "tl_e2@test.com");
+        setGoal(f);
+
+        // Read mentorship startDate to schedule items inside the program window.
+        MvcResult getResult = mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andReturn();
+        OffsetDateTime startDate = OffsetDateTime.parse(
+                objectMapper.readTree(getResult.getResponse().getContentAsString())
+                        .get("startDate").asText());
+
+        // Create one of each, in time order: meeting (+1d), task (+2d), milestone (+3d).
+        OffsetDateTime t1 = startDate.plusDays(1);
+        OffsetDateTime t2 = startDate.plusDays(2);
+        OffsetDateTime t3 = startDate.plusDays(3);
+
+        Map<String, Object> meetingBody = Map.of(
+                "title", "Sync",
+                "startTime", t1.toString(),
+                "endTime", t1.plusHours(1).toString(),
+                "meetingType", "ONLINE",
+                "meetingLink", "https://meet.example.com/abc",
+                "recurring", false);
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/meetings")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(meetingBody)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "T1", "dueDate", t2.toString()))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("title", "M1", "targetDate", t3.toString()))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.menteeToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(3))
+                .andExpect(jsonPath("$.items[0].type").value("MEETING"))
+                .andExpect(jsonPath("$.items[0].hasNotes").value(false))
+                .andExpect(jsonPath("$.items[0].actionItemTotal").value(0))
+                .andExpect(jsonPath("$.items[0].actionItemCompleted").value(0))
+                .andExpect(jsonPath("$.items[0].detailUrl").value(org.hamcrest.Matchers.startsWith("/api/meetings/")))
+                .andExpect(jsonPath("$.items[1].type").value("TASK"))
+                .andExpect(jsonPath("$.items[1].actionItemTotal").doesNotExist())
+                .andExpect(jsonPath("$.items[1].hasNotes").doesNotExist())
+                .andExpect(jsonPath("$.items[1].detailUrl").value(org.hamcrest.Matchers.startsWith("/api/tasks/")))
+                .andExpect(jsonPath("$.items[2].type").value("MILESTONE"))
+                .andExpect(jsonPath("$.items[2].actionItemTotal").value(0))
+                .andExpect(jsonPath("$.items[2].actionItemCompleted").value(0))
+                .andExpect(jsonPath("$.items[2].hasNotes").doesNotExist())
+                .andExpect(jsonPath("$.items[2].detailUrl").value(org.hamcrest.Matchers.startsWith("/api/milestones/")));
+    }
+
+    @Test
+    void getTimeline_windowOutsideProgramReturnsEmptyItemsButPopulatedMetadata() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m3@test.com", "tl_e3@test.com");
+
+        // Window deliberately set to an instant 3 years in the future — far outside the mentorship.
+        // Use a same-instant from/to so we don't trip the 24-month window cap.
+        String far = "2999-01-01T00:00:00Z";
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .param("from", far)
+                        .param("to", far)
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(0))
+                .andExpect(jsonPath("$.startDate").exists())
+                .andExpect(jsonPath("$.currentDate").exists());
+    }
+
+    @Test
+    void getTimeline_returns400ForFromAfterTo() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m4@test.com", "tl_e4@test.com");
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .param("from", "2026-08-01T00:00:00Z")
+                        .param("to", "2026-05-01T00:00:00Z")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getTimeline_returns400ForWindowOver24Months() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m5@test.com", "tl_e5@test.com");
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .param("from", "2024-01-01T00:00:00Z")
+                        .param("to", "2027-01-02T00:00:00Z")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getTimeline_returns404ForNonParticipant() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_m6@test.com", "tl_e6@test.com");
+        String intruderToken = registerAndLogin("tl_intruder@test.com", false);
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + intruderToken))
+                .andExpect(status().isNotFound());
+    }
+
+    /**
+     * Records the prepared-statement count for one timeline GET against a mentorship
+     * seeded with N items per domain. The whole point is that the returned count is
+     * {@code O(1)} in {@code N} — see {@link #getTimeline_n1SafeIsConstantBetweenN1AndN3}.
+     */
+    private long timelineQueryCountForSeededMentorship(int itemsPerDomain,
+                                                       String mentorEmail,
+                                                       String menteeEmail) throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId(mentorEmail, menteeEmail);
+        setGoal(f);
+
+        MvcResult getResult = mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andReturn();
+        OffsetDateTime startDate = OffsetDateTime.parse(
+                objectMapper.readTree(getResult.getResponse().getContentAsString())
+                        .get("startDate").asText());
+
+        for (int i = 1; i <= itemsPerDomain; i++) {
+            OffsetDateTime t = startDate.plusDays(i);
+            Map<String, Object> meetingBody = Map.of(
+                    "title", "Sync " + i,
+                    "startTime", t.toString(),
+                    "endTime", t.plusHours(1).toString(),
+                    "meetingType", "ONLINE",
+                    "meetingLink", "https://meet.example.com/abc",
+                    "recurring", false);
+            mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/meetings")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(meetingBody)))
+                    .andExpect(status().isCreated());
+            mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(
+                                    Map.of("title", "T" + i, "dueDate", t.plusHours(2).toString()))))
+                    .andExpect(status().isCreated());
+            mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(
+                                    Map.of("title", "M" + i, "targetDate", t.plusHours(4).toString()))))
+                    .andExpect(status().isCreated());
+        }
+
+        org.hibernate.stat.Statistics stats = entityManager.getEntityManagerFactory()
+                .unwrap(org.hibernate.SessionFactory.class).getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(itemsPerDomain * 3));
+
+        return stats.getPrepareStatementCount();
+    }
+
+    @Test
+    void getTimeline_n1SafeIsConstantBetweenN1AndN3() throws Exception {
+        long n1 = timelineQueryCountForSeededMentorship(1, "tl_m7a@test.com", "tl_e7a@test.com");
+        long n3 = timelineQueryCountForSeededMentorship(3, "tl_m7b@test.com", "tl_e7b@test.com");
+
+        // The actual N+1 invariant: the query count must NOT scale with N.
+        // Floor measured at N=1 is 8 (1 mentorship + 3 windows + 2 group counts + 2 from
+        // the JWT auth filter / Spring auto-flushes). A single accidental N+1 would jump
+        // the N=3 count to 8 + 3 = 11, which the equality assertion below catches.
+        assertThat(n1)
+                .as("Timeline query count for N=1 should be at most 8")
+                .isLessThanOrEqualTo(8);
+        assertThat(n3)
+                .as("Timeline query count for N=3 should equal the N=1 count (no scaling with N)")
+                .isEqualTo(n1);
+    }
+
+    @Test
+    void getTimeline_actionItemCountersReflectCompletion() throws Exception {
+        // Exercises the JPQL constructor-expression path for non-empty action items.
+        // If the bulk-count query's CAST(SUM(...) AS Long) drifts on a future Hibernate
+        // upgrade, this test catches it before any client does.
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_ai_m@test.com", "tl_ai_e@test.com");
+        setGoal(f);
+
+        MvcResult getResult = mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andReturn();
+        OffsetDateTime startDate = OffsetDateTime.parse(
+                objectMapper.readTree(getResult.getResponse().getContentAsString())
+                        .get("startDate").asText());
+        OffsetDateTime when = startDate.plusDays(1);
+
+        // Create one milestone, capture id.
+        MvcResult msResult = mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("title", "MS", "targetDate", when.toString()))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Long msId = objectMapper.readTree(msResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        // Add 3 action items, mark one complete.
+        Long firstAiId = null;
+        for (int i = 1; i <= 3; i++) {
+            MvcResult aiResult = mockMvc.perform(post("/api/milestones/" + msId + "/action-items")
+                            .header("Authorization", "Bearer " + f.mentorToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("text", "AI " + i))))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+            if (i == 1) {
+                firstAiId = objectMapper.readTree(aiResult.getResponse().getContentAsString())
+                        .get("id").asLong();
+            }
+        }
+        mockMvc.perform(patch("/api/milestone-action-items/" + firstAiId)
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"completed\":true}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(1))
+                .andExpect(jsonPath("$.items[0].type").value("MILESTONE"))
+                .andExpect(jsonPath("$.items[0].actionItemTotal").value(3))
+                .andExpect(jsonPath("$.items[0].actionItemCompleted").value(1));
+    }
+
+    @Test
+    void getTimeline_tiebreakerMilestoneBeforeMeetingBeforeTask() throws Exception {
+        MentorshipFixture f = acceptAndReturnMentorshipId("tl_tie_m@test.com", "tl_tie_e@test.com");
+        setGoal(f);
+
+        MvcResult getResult = mockMvc.perform(get("/api/mentorships/" + f.mentorshipId())
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andReturn();
+        OffsetDateTime startDate = OffsetDateTime.parse(
+                objectMapper.readTree(getResult.getResponse().getContentAsString())
+                        .get("startDate").asText());
+        OffsetDateTime sameInstant = startDate.plusDays(5);
+
+        // Create one of each at the SAME instant.
+        Map<String, Object> meetingBody = Map.of(
+                "title", "Sync",
+                "startTime", sameInstant.toString(),
+                "endTime", sameInstant.plusHours(1).toString(),
+                "meetingType", "ONLINE",
+                "meetingLink", "https://meet.example.com/abc",
+                "recurring", false);
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/meetings")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(meetingBody)))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/tasks")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("title", "T", "dueDate", sameInstant.toString()))))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/milestones")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("title", "M", "targetDate", sameInstant.toString()))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/timeline")
+                        .header("Authorization", "Bearer " + f.mentorToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.length()").value(3))
+                .andExpect(jsonPath("$.items[0].type").value("MILESTONE"))
+                .andExpect(jsonPath("$.items[1].type").value("MEETING"))
+                .andExpect(jsonPath("$.items[2].type").value("TASK"));
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/MentorshipTimelineServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipTimelineServiceTest.java
@@ -1,0 +1,489 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.TimelineItem;
+import com.group7.backend.dto.response.TimelineItemType;
+import com.group7.backend.dto.response.TimelineResponse;
+import com.group7.backend.entity.Meeting;
+import com.group7.backend.entity.MeetingStatus;
+import com.group7.backend.entity.MeetingType;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.entity.Milestone;
+import com.group7.backend.entity.MilestoneStatus;
+import com.group7.backend.entity.Task;
+import com.group7.backend.entity.TaskStatus;
+import com.group7.backend.exception.InvalidTimelineWindowException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MeetingActionItemRepository;
+import com.group7.backend.repository.MeetingRepository;
+import com.group7.backend.repository.MilestoneActionItemRepository;
+import com.group7.backend.repository.MilestoneRepository;
+import com.group7.backend.repository.TaskRepository;
+import com.group7.backend.repository.projection.ActionItemCountTuple;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MentorshipTimelineServiceTest {
+
+    @Mock private MentorshipService mentorshipService;
+    @Mock private MeetingRepository meetingRepository;
+    @Mock private MeetingActionItemRepository meetingActionItemRepository;
+    @Mock private TaskRepository taskRepository;
+    @Mock private MilestoneRepository milestoneRepository;
+    @Mock private MilestoneActionItemRepository milestoneActionItemRepository;
+
+    private Clock fixedClock;
+    private MentorshipTimelineService service;
+
+    private Mentorship mentorship;
+
+    private static final long MID = 100L;
+    private static final long MENTOR_ID = 1L;
+    private static final long MENTEE_ID = 2L;
+    private static final OffsetDateTime PROGRAM_START =
+            OffsetDateTime.of(2026, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime PROGRAM_END =
+            OffsetDateTime.of(2026, 8, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime FIXED_NOW =
+            OffsetDateTime.of(2026, 6, 1, 12, 0, 0, 0, ZoneOffset.UTC);
+
+    @BeforeEach
+    void setUp() {
+        fixedClock = Clock.fixed(FIXED_NOW.toInstant(), ZoneOffset.UTC);
+        service = new MentorshipTimelineService(
+                mentorshipService, meetingRepository, meetingActionItemRepository,
+                taskRepository, milestoneRepository, milestoneActionItemRepository, fixedClock);
+
+        Mentor mentor = new Mentor();
+        mentor.setId(MENTOR_ID);
+        mentor.setFirstName("Mentor");
+        Mentee mentee = new Mentee();
+        mentee.setId(MENTEE_ID);
+        mentee.setFirstName("Mentee");
+
+        mentorship = new Mentorship();
+        mentorship.setId(MID);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+        mentorship.setStatus(MentorshipStatus.ACTIVE);
+        mentorship.setStartDate(PROGRAM_START);
+        mentorship.setEndDate(PROGRAM_END);
+    }
+
+    private void stubFound(long callerId) {
+        when(mentorshipService.findForParticipant(callerId, MID)).thenReturn(mentorship);
+    }
+
+    private void stubEmptyDomains() {
+        lenient().when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        lenient().when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        lenient().when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+    }
+
+    private static Meeting newMeeting(long id, OffsetDateTime startTime, MeetingStatus status, String notes) {
+        Meeting m = new Meeting();
+        m.setId(id);
+        m.setTitle("Meeting " + id);
+        m.setStartTime(startTime);
+        m.setEndTime(startTime.plusHours(1));
+        m.setStatus(status);
+        m.setMeetingType(MeetingType.ONLINE);
+        m.setMeetingLink("https://meet.example.com/" + id);
+        m.setNotes(notes);
+        return m;
+    }
+
+    private static Task newTask(long id, OffsetDateTime dueDate, TaskStatus status) {
+        Task t = new Task();
+        t.setId(id);
+        t.setTitle("Task " + id);
+        t.setDueDate(dueDate);
+        t.setStatus(status);
+        return t;
+    }
+
+    private static Milestone newMilestone(long id, OffsetDateTime targetDate, MilestoneStatus status) {
+        Milestone ms = new Milestone();
+        ms.setId(id);
+        ms.setTitle("Milestone " + id);
+        ms.setTargetDate(targetDate);
+        ms.setStatus(status);
+        return ms;
+    }
+
+    // ── Authorisation ────────────────────────────────────────────────────────
+
+    @Test
+    void getTimeline_returnsForMentor() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.mentorshipId()).isEqualTo(MID);
+    }
+
+    @Test
+    void getTimeline_returnsForMentee() {
+        stubFound(MENTEE_ID);
+        stubEmptyDomains();
+
+        TimelineResponse r = service.getTimeline(MENTEE_ID, MID, null, null);
+
+        assertThat(r.mentorshipId()).isEqualTo(MID);
+    }
+
+    @Test
+    void getTimeline_propagatesResourceNotFoundFromFinder() {
+        when(mentorshipService.findForParticipant(999L, MID))
+                .thenThrow(new ResourceNotFoundException("Mentorship not found"));
+
+        assertThatThrownBy(() -> service.getTimeline(999L, MID, null, null))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ── Empty window ─────────────────────────────────────────────────────────
+
+    @Test
+    void getTimeline_emptyMentorshipReturnsEmptyItemsButPopulatedMetadata() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.mentorshipId()).isEqualTo(MID);
+        assertThat(r.startDate()).isEqualTo(PROGRAM_START);
+        assertThat(r.endDate()).isEqualTo(PROGRAM_END);
+        assertThat(r.currentDate()).isEqualTo(FIXED_NOW);
+        assertThat(r.items()).isEmpty();
+
+        // Empty parent lists must short-circuit the bulk count queries (Hibernate 6 invalid SQL guard).
+        verify(meetingActionItemRepository, never()).countByMeetingIds(anyCollection());
+        verify(milestoneActionItemRepository, never()).countByMilestoneIds(anyCollection());
+    }
+
+    // ── Default window ──────────────────────────────────────────────────────
+
+    @Test
+    void getTimeline_defaultWindowUsesMentorshipDates() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+
+        service.getTimeline(MENTOR_ID, MID, null, null);
+
+        verify(meetingRepository).findInWindow(MID, PROGRAM_START, PROGRAM_END);
+        verify(taskRepository).findInWindow(MID, PROGRAM_START, PROGRAM_END);
+        verify(milestoneRepository).findInWindow(MID, PROGRAM_START, PROGRAM_END);
+    }
+
+    @Test
+    void getTimeline_explicitFromOverridesDefault() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+        OffsetDateTime customFrom = PROGRAM_START.plusDays(7);
+
+        service.getTimeline(MENTOR_ID, MID, customFrom, null);
+
+        verify(meetingRepository).findInWindow(MID, customFrom, PROGRAM_END);
+    }
+
+    @Test
+    void getTimeline_explicitToOverridesDefault() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+        OffsetDateTime customTo = PROGRAM_END.minusDays(7);
+
+        service.getTimeline(MENTOR_ID, MID, null, customTo);
+
+        verify(taskRepository).findInWindow(MID, PROGRAM_START, customTo);
+    }
+
+    // ── Window validation ──────────────────────────────────────────────────
+
+    @Test
+    void getTimeline_throwsWhenFromAfterTo() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime laterFrom = PROGRAM_START.plusDays(10);
+        OffsetDateTime earlierTo = PROGRAM_START.plusDays(5);
+
+        assertThatThrownBy(() -> service.getTimeline(MENTOR_ID, MID, laterFrom, earlierTo))
+                .isInstanceOf(InvalidTimelineWindowException.class)
+                .hasMessageContaining("'from' must be before");
+    }
+
+    @Test
+    void getTimeline_throwsWhenMentorshipHasNullProgramDates() {
+        // Defensive guard for legacy rows that bypass DDL or are constructed in-memory.
+        mentorship.setStartDate(null);
+        mentorship.setEndDate(null);
+        stubFound(MENTOR_ID);
+
+        assertThatThrownBy(() -> service.getTimeline(MENTOR_ID, MID, null, null))
+                .isInstanceOf(InvalidTimelineWindowException.class)
+                .hasMessageContaining("no program window");
+    }
+
+    /**
+     * Both arms of the short-circuit null check in validateWindow must throw. The other
+     * test exercises the {@code from == null} arm; this one pins the {@code to == null}
+     * arm to keep branch coverage at 100%.
+     */
+    @Test
+    void validateWindow_throwsOnNullToWithNonNullFrom() {
+        assertThatThrownBy(() ->
+                MentorshipTimelineService.validateWindow(PROGRAM_START, null))
+                .isInstanceOf(InvalidTimelineWindowException.class)
+                .hasMessageContaining("no program window");
+    }
+
+    @Test
+    void getTimeline_zeroWidthWindowIsValid() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+        OffsetDateTime instant = PROGRAM_START.plusDays(15);
+
+        assertThatCode(() -> service.getTimeline(MENTOR_ID, MID, instant, instant))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void getTimeline_exactly24MonthWindowIsValid() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+        OffsetDateTime from = PROGRAM_START;
+        OffsetDateTime to = PROGRAM_START.plusMonths(24);
+
+        assertThatCode(() -> service.getTimeline(MENTOR_ID, MID, from, to))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void getTimeline_throwsWhenWindowIsOneDayPast24Months() {
+        // Pins the cap. The earlier ChronoUnit-based check truncated; this one uses
+        // plusMonths so even +1 day past the boundary trips the cap.
+        stubFound(MENTOR_ID);
+        OffsetDateTime from = PROGRAM_START;
+        OffsetDateTime to = PROGRAM_START.plusMonths(24).plusDays(1);
+
+        assertThatThrownBy(() -> service.getTimeline(MENTOR_ID, MID, from, to))
+                .isInstanceOf(InvalidTimelineWindowException.class)
+                .hasMessageContaining("24 months");
+    }
+
+    // ── Item shape ──────────────────────────────────────────────────────────
+
+    @Test
+    void meetingItem_carriesCounters_hasNotesTrueWhenNotesPresent() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(newMeeting(55L, t, MeetingStatus.CONFIRMED, "agenda")));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(meetingActionItemRepository.countByMeetingIds(any()))
+                .thenReturn(List.of(new ActionItemCountTuple(55L, 3L, 1L)));
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+        TimelineItem item = r.items().get(0);
+
+        assertThat(item.type()).isEqualTo(TimelineItemType.MEETING);
+        assertThat(item.id()).isEqualTo(55L);
+        assertThat(item.occursAt()).isEqualTo(t);
+        assertThat(item.status()).isEqualTo("CONFIRMED");
+        assertThat(item.detailUrl()).isEqualTo("/api/meetings/55");
+        assertThat(item.actionItemTotal()).isEqualTo(3L);
+        assertThat(item.actionItemCompleted()).isEqualTo(1L);
+        assertThat(item.hasNotes()).isTrue();
+    }
+
+    @Test
+    void meetingItem_hasNotesFalseWhenNotesNullOrBlank() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(
+                        newMeeting(1L, t, MeetingStatus.CONFIRMED, null),
+                        newMeeting(2L, t.plusHours(1), MeetingStatus.CONFIRMED, "   ")));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.items()).extracting(TimelineItem::hasNotes).containsExactly(false, false);
+    }
+
+    @Test
+    void meetingItem_zeroCountersWhenNoActionItems() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(newMeeting(7L, t, MeetingStatus.CONFIRMED, null)));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+        TimelineItem item = r.items().get(0);
+
+        assertThat(item.actionItemTotal()).isEqualTo(0L);
+        assertThat(item.actionItemCompleted()).isEqualTo(0L);
+    }
+
+    @Test
+    void taskItem_typeConditionalFieldsAreNull() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(taskRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(newTask(11L, t, TaskStatus.PENDING)));
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+        TimelineItem item = r.items().get(0);
+
+        assertThat(item.type()).isEqualTo(TimelineItemType.TASK);
+        assertThat(item.detailUrl()).isEqualTo("/api/tasks/11");
+        assertThat(item.actionItemTotal()).isNull();
+        assertThat(item.actionItemCompleted()).isNull();
+        assertThat(item.hasNotes()).isNull();
+    }
+
+    @Test
+    void milestoneItem_carriesCounters_hasNotesAlwaysNull() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any()))
+                .thenReturn(List.of(newMilestone(20L, t, MilestoneStatus.IN_PROGRESS)));
+        when(milestoneActionItemRepository.countByMilestoneIds(any()))
+                .thenReturn(List.of(new ActionItemCountTuple(20L, 5L, 2L)));
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+        TimelineItem item = r.items().get(0);
+
+        assertThat(item.type()).isEqualTo(TimelineItemType.MILESTONE);
+        assertThat(item.detailUrl()).isEqualTo("/api/milestones/20");
+        assertThat(item.actionItemTotal()).isEqualTo(5L);
+        assertThat(item.actionItemCompleted()).isEqualTo(2L);
+        assertThat(item.hasNotes()).isNull();
+    }
+
+    // ── Sort & tiebreaker ───────────────────────────────────────────────────
+
+    @Test
+    void items_sortedByOccursAtAscending() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime base = PROGRAM_START.plusDays(1);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMeeting(1L, base.plusHours(2), MeetingStatus.CONFIRMED, null)));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newTask(2L, base, TaskStatus.PENDING)));
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMilestone(3L, base.plusHours(4), MilestoneStatus.PENDING)));
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+        when(milestoneActionItemRepository.countByMilestoneIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.items()).extracting(TimelineItem::id).containsExactly(2L, 1L, 3L);
+    }
+
+    @Test
+    void items_tiebreakerMilestoneBeforeMeetingBeforeTask() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime sameInstant = PROGRAM_START.plusDays(5);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMeeting(101L, sameInstant, MeetingStatus.CONFIRMED, null)));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newTask(102L, sameInstant, TaskStatus.PENDING)));
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMilestone(103L, sameInstant, MilestoneStatus.PENDING)));
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+        when(milestoneActionItemRepository.countByMilestoneIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.items()).extracting(TimelineItem::type).containsExactly(
+                TimelineItemType.MILESTONE, TimelineItemType.MEETING, TimelineItemType.TASK);
+    }
+
+    @Test
+    void items_tiebreakerByIdWithinSameType() {
+        stubFound(MENTOR_ID);
+        OffsetDateTime sameInstant = PROGRAM_START.plusDays(5);
+        when(meetingRepository.findInWindow(any(), any(), any())).thenReturn(List.of(
+                newMeeting(20L, sameInstant, MeetingStatus.CONFIRMED, null),
+                newMeeting(10L, sameInstant, MeetingStatus.CONFIRMED, null)));
+        when(taskRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(milestoneRepository.findInWindow(any(), any(), any())).thenReturn(List.of());
+        when(meetingActionItemRepository.countByMeetingIds(any())).thenReturn(List.of());
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.items()).extracting(TimelineItem::id).containsExactly(10L, 20L);
+    }
+
+    // ── currentDate ─────────────────────────────────────────────────────────
+
+    @Test
+    void currentDate_isSourcedFromInjectedClock() {
+        stubFound(MENTOR_ID);
+        stubEmptyDomains();
+
+        TimelineResponse r = service.getTimeline(MENTOR_ID, MID, null, null);
+
+        // Use a different clock instant to prove we're reading from `clock`, not `OffsetDateTime.now()`.
+        OffsetDateTime otherInstant = OffsetDateTime.of(2999, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        Clock otherClock = Clock.fixed(Instant.parse("2999-01-01T00:00:00Z"), ZoneOffset.UTC);
+        MentorshipTimelineService otherService = new MentorshipTimelineService(
+                mentorshipService, meetingRepository, meetingActionItemRepository,
+                taskRepository, milestoneRepository, milestoneActionItemRepository, otherClock);
+        TimelineResponse other = otherService.getTimeline(MENTOR_ID, MID, null, null);
+
+        assertThat(r.currentDate()).isEqualTo(FIXED_NOW);
+        assertThat(other.currentDate()).isEqualTo(otherInstant);
+    }
+
+    // ── TimelineItem null-guard contract ────────────────────────────────────
+
+    @Test
+    void timelineItem_compactConstructorRejectsNullOnAlwaysPresentFields() {
+        OffsetDateTime t = PROGRAM_START.plusDays(1);
+
+        assertThatThrownBy(() -> new TimelineItem(null, 1L, "x", t, "OK", "/u", null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("type");
+        assertThatThrownBy(() -> new TimelineItem(TimelineItemType.TASK, 1L, null, t, "OK", "/u", null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("title");
+        assertThatThrownBy(() -> new TimelineItem(TimelineItemType.TASK, 1L, "x", null, "OK", "/u", null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("occursAt");
+        assertThatThrownBy(() -> new TimelineItem(TimelineItemType.TASK, 1L, "x", t, null, "/u", null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("status");
+        assertThatThrownBy(() -> new TimelineItem(TimelineItemType.TASK, 1L, "x", t, "OK", null, null, null, null))
+                .isInstanceOf(NullPointerException.class).hasMessageContaining("detailUrl");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #332. Spec **1.1.5.9–1.1.5.13** — read-only aggregation endpoint that merges meetings, tasks, and milestones into a single chronologically-sorted feed alongside the program window and a server-clock "today" marker.

- New `GET /api/mentorships/{id}/timeline?from={iso}&to={iso}` (mentor + mentee only; non-participants get 404 — same privacy stance as #335 / #334).
- Both `from` / `to` are optional ISO-8601 `OffsetDateTime` query params with explicit `@DateTimeFormat(iso=DATE_TIME)`. Default window = mentorship `startDate..endDate`, capped at **24 months**.
- New `MentorshipTimelineService` runs **6 DB round-trips** per call regardless of item count: 1 mentorship lookup + 3 windowed source queries + 2 grouped action-item count queries. Sort is performed in Java since Hibernate has no clean cross-entity union-sort idiom.
- New typed `InvalidTimelineWindowException` mapped to 400 by `GlobalExceptionHandler` (avoids the leaky `IllegalArgumentException → 400` shortcut).
- New `TimelineResponse` / `TimelineItem` Java records with **uniform shape** across the three source types — type-conditional fields (`actionItemTotal`, `actionItemCompleted`, `hasNotes`) are explicitly nullable so clients never face missing keys. Compact-constructor null-guards on the always-present fields.
- New `TimelineItemType` enum with **explicit `priority()` field** (not `ordinal()`) so a future enum reorder cannot silently change sort behaviour.
- New `ActionItemCountTuple` JPQL constructor-expression projection — keeps service code off `List<Object[]>`. The grouped count query pins the `SUM` return type with `CAST(COALESCE(SUM(...), 0L) AS Long)` against a future Hibernate / driver upgrade.

## Sort & tiebreaker

Stable sort: `occursAt` ascending, then `MILESTONE > MEETING > TASK` (priority 0 / 1 / 2), then `id` ascending. Tasks with no `dueDate` and milestones with no `targetDate` have no chronological position and are excluded; documented on `TimelineItem.occursAt`.

## Stacking

Branch is off `feature/334-progress-aggregation` (PR #391) which itself stacks on `feature/335-shared-goal-precondition` (PR #390). Each PR's base auto-rolls forward as the chain merges.

Reuses the package-private `MentorshipService.findForParticipant(...)` helper that #334 introduced (and that #334 itself made LAZY-fetch-safe via `findByIdAndParticipant`). No further changes to that helper here.

## Commits

1. `feat(backend): add TimelineResponse / TimelineItem DTOs + projection record`
2. `feat(backend): repository extensions for windowed reads + bulk action-item counts`
3. `feat(backend): typed InvalidTimelineWindowException mapped to 400`
4. `feat(backend): MentorshipTimelineService aggregates meetings + tasks + milestones`
5. `feat(backend): GET /api/mentorships/{id}/timeline endpoint`
6. `test(backend): cover timeline aggregation (unit + slice + integration)`

## Design decisions worth flagging for review

- **404 (not 403) for non-participants**, diverging from the issue's literal acceptance criterion. Matches the privacy stance #335 / #334 set; documented in the plan.
- **Reads allowed on completed/terminated mentorships** — the issue says "active-mentorship participants" but the acceptance criteria don't require an active filter, and reading historical timelines is reasonable. Matches #334.
- **24-month window cap enforced via `to.isAfter(from.plusMonths(24))`** — `ChronoUnit.MONTHS.between(...)` truncates whole months and would silently let ~1 month past the cap.
- **Path-only `detailUrl`** (e.g. `/api/meetings/{id}`) — matches every other DTO in this codebase. Absolute URLs (`app.base-url`) are reserved for JSON-LD `@id` IRIs.
- **Single uniform DTO + always-emit-keys** rather than a sealed-interface hierarchy — keeps the OpenAPI surface clean and clients don't have to discriminate before reading common fields.

## Reviewer-driven hardening (applied during this PR)

A `code-reviewer` and a `spring-boot-engineer` agent reviewed the diff. No criticals were left unaddressed; the recommended slate was applied:

- Cap-leak fix (`from.plusMonths(...)` instead of truncating `MONTHS.between(...)`)
- JPQL constructor-expression `CAST(... AS Long)` to pin the SUM return type, plus a real integration test that seeds non-empty action items so the path is exercised against PostgreSQL
- Typed `InvalidTimelineWindowException` instead of bare `IllegalArgumentException`
- Defensive null-window guard on legacy mentorship rows (NPE → clean 400)
- Tightened N+1 invariant: integration test asserts query count is **equal** at N=1 and N=3 (not just ≤ a budget), which catches a single accidental N+1
- New same-instant tiebreaker integration test
- Javadoc on `MeetingRepository.findInWindow` documenting the "anchored on `startTime`" decision
- Schema description on `TimelineItem.occursAt` documenting null-`occursAt` exclusion

## Test plan

- [x] `mvn test`: **1397 tests, 0 failures, 0 errors** (was 1355 before #332; +42 new cases — service unit + enum micro + 8 controller-slice + 7 integration).
- [x] **JaCoCo branch coverage**: 100% line + branch on every file added: `MentorshipTimelineService` (20/20 branches, 88/88 lines), `TimelineItem`, `TimelineItemType`, `TimelineResponse`, `ActionItemCountTuple`, `InvalidTimelineWindowException`.
- [x] **Live HTTP smoke matrices A–H** against rebuilt Docker: empty timeline; 3 domains in chronological order; `hasNotes` flips after `PATCH /meetings/{id}/notes`; action-item counters reflect updates; same-instant tiebreaker order MILESTONE → MEETING → TASK; narrow window filtering; `from > to` → 400; window outside program → empty items; window > 24 months → 400; ISO `+03:00` offset accepted; unknown id → 404; missing auth → 403; malformed `from=banana` → 400; completed mentorship still readable.
- [x] **OpenAPI** (`/v3/api-docs`): endpoint documented (200 / 400 / 401 / 404); `from` / `to` typed `string format date-time`; `TimelineItem.type` enum surfaces MILESTONE / MEETING / TASK; `items` references `TimelineItem`. Minor doc-only quirk: springdoc didn't render `nullable: true` on the type-conditional record components — JSON still emits nulls correctly. Non-blocking; potential follow-up.

## Out of scope

- Recurring-meeting expansion (`Meeting.recurring` exists; `findInWindow` returns the master rows only).
- Server-side filtering by meeting status (cancelled / declined / expired). Returned as-is so the frontend filters per UX.
- Caching / scheduled denormalisation. The issue explicitly excludes caching.
- Pagination. Window-bounded by `from` / `to` and the 24-month cap.
- JSON-LD content negotiation. The endpoint correctly downgrades to plain JSON via the existing advice — no new mapping needed.
- Renaming `currentDate` → `currentInstant` (reviewer suggestion). Kept the issue's literal name; schema description clarifies it carries a full instant.