### PR TITLE
Feature/315 playwright e2e(#315)

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -1,0 +1,147 @@
+name: E2E CI (Playwright)
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - ".github/workflows/e2e-ci.yml"
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "backend/**"
+      - "frontend/**"
+      - ".github/workflows/e2e-ci.yml"
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: group7db
+          POSTGRES_USER: group7
+          POSTGRES_PASSWORD: group7pass
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U group7 -d group7db"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          cache-dependency-path: backend/pom.xml
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build backend jar
+        working-directory: backend
+        run: mvn -B package -DskipTests
+
+      - name: Start backend (test endpoints + email disabled)
+        working-directory: backend
+        env:
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5433/group7db
+          SPRING_DATASOURCE_USERNAME: group7
+          SPRING_DATASOURCE_PASSWORD: group7pass
+          APP_TEST_ENDPOINTS_ENABLED: "true"
+          APP_EMAIL_ENABLED: "false"
+          APP_RATELIMIT_ENABLED: "false"
+          APP_BASE_URL: http://localhost:8080
+          APP_FRONTEND_URL: http://localhost:8000
+          APP_CORS_ALLOWED_ORIGINS: http://localhost:8000,http://localhost:5173
+          JWT_SECRET: bXlTdXBlclNlY3JldEtleUZvckdyb3VwN0JhY2tlbmRBcHBsaWNhdGlvbjIwMjY=
+          RESEND_API_KEY: re_noop_disabled
+        run: |
+          nohup java -jar target/*.jar > backend.log 2>&1 &
+          echo $! > backend.pid
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build and start frontend preview
+        working-directory: frontend
+        env:
+          VITE_BACKEND_URL: http://localhost:8080
+        run: |
+          npm run build
+          nohup npx vite preview --port 8000 --host 0.0.0.0 > frontend.log 2>&1 &
+          echo $! > frontend.pid
+
+      - name: Wait for backend and frontend to be ready
+        run: |
+          npx --yes wait-on -t 120000 http://localhost:8080/actuator/health http://localhost:8000
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright suite
+        working-directory: frontend
+        env:
+          CI: "true"
+          E2E_BASE_URL: http://localhost:8000
+          E2E_BACKEND_URL: http://localhost:8080
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: frontend/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload backend log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-log
+          path: backend/backend.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload frontend log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-log
+          path: frontend/frontend.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Stop background processes
+        if: always()
+        run: |
+          [ -f backend/backend.pid ] && kill "$(cat backend/backend.pid)" || true
+          [ -f frontend/frontend.pid ] && kill "$(cat frontend/frontend.pid)" || true

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -71,9 +71,30 @@ jobs:
           APP_CORS_ALLOWED_ORIGINS: http://localhost:8000,http://localhost:5173
           JWT_SECRET: bXlTdXBlclNlY3JldEtleUZvckdyb3VwN0JhY2tlbmRBcHBsaWNhdGlvbjIwMjY=
           RESEND_API_KEY: re_noop_disabled
+          # Default upload paths point at /app/uploads/{photos,attachments} —
+          # those don't exist on a bare GitHub runner. Redirect to /tmp like
+          # application-test.properties does, so any startup-time directory
+          # check passes.
+          UPLOAD_DIR: /tmp/group7-e2e/photos
+          UPLOAD_ATTACHMENTS_DIR: /tmp/group7-e2e/attachments
         run: |
-          nohup java -jar target/*.jar > backend.log 2>&1 &
+          mkdir -p /tmp/group7-e2e/photos /tmp/group7-e2e/attachments
+          ls -la target/*.jar
+          # Pin to the executable Spring Boot fat jar; the .original sibling
+          # (un-repackaged) shouldn't be matched but be explicit anyway.
+          JAR=$(ls target/*.jar | grep -v '\.original$' | head -1)
+          echo "Launching: $JAR"
+          nohup java -jar "$JAR" > backend.log 2>&1 &
           echo $! > backend.pid
+          # Give the JVM a chance to exit immediately on a fatal config error
+          # so we surface it here instead of after a 4-minute wait-on timeout.
+          sleep 5
+          if ! kill -0 "$(cat backend.pid)" 2>/dev/null; then
+            echo "::error::Backend process died within 5s of launch. backend.log:"
+            sed 's/^/[backend] /' backend.log || true
+            exit 1
+          fi
+          echo "Backend PID $(cat backend.pid) is alive after 5s; proceeding."
 
       - name: Install frontend deps
         working-directory: frontend
@@ -82,10 +103,21 @@ jobs:
       - name: Wait for backend to be ready
         run: |
           set +e
+          # Tail backend.log to stdout in the background so progress is
+          # visible during startup instead of only on failure.
+          ( tail -F -n +1 backend/backend.log 2>/dev/null | sed 's/^/[backend] /' ) &
+          TAIL_PID=$!
           npx --yes wait-on -t 240000 -i 2000 http://localhost:8080/actuator/health
           rc=$?
+          # Stop the tailer regardless of outcome.
+          kill "$TAIL_PID" 2>/dev/null || true
           if [ "$rc" -ne 0 ]; then
-            echo "::error::Backend never became healthy. Dumping backend.log:"
+            echo "::error::Backend never became healthy. Diagnostic context follows."
+            echo "---- ps (java) ----"
+            ps -ef | grep -E '[j]ava' || echo "no java process found"
+            echo "---- listening ports ----"
+            ss -tlnp 2>/dev/null || netstat -tlnp 2>/dev/null || true
+            echo "---- backend.log (full) ----"
             sed 's/^/[backend] /' backend/backend.log || true
             exit "$rc"
           fi

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -79,18 +79,36 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: Wait for backend to be ready
+        run: |
+          set +e
+          npx --yes wait-on -t 240000 -i 2000 http://localhost:8080/actuator/health
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Backend never became healthy. Dumping backend.log:"
+            sed 's/^/[backend] /' backend/backend.log || true
+            exit "$rc"
+          fi
+
       - name: Build and start frontend preview
         working-directory: frontend
         env:
           VITE_BACKEND_URL: http://localhost:8080
         run: |
           npm run build
-          nohup npx vite preview --port 8000 --host 0.0.0.0 > frontend.log 2>&1 &
+          nohup npx vite preview --port 8000 --host 0.0.0.0 --strictPort > frontend.log 2>&1 &
           echo $! > frontend.pid
 
-      - name: Wait for backend and frontend to be ready
+      - name: Wait for frontend to be ready
         run: |
-          npx --yes wait-on -t 120000 http://localhost:8080/actuator/health http://localhost:8000
+          set +e
+          npx --yes wait-on -t 120000 -i 2000 http://localhost:8000
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::Frontend preview never came up. Dumping frontend.log:"
+            sed 's/^/[frontend] /' frontend/frontend.log || true
+            exit "$rc"
+          fi
 
       - name: Install Playwright browsers
         working-directory: frontend

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -126,6 +126,15 @@
             <artifactId>firebase-admin</artifactId>
             <version>9.4.1</version>
         </dependency>
+        <!-- Faker generator for the profile-gated TestSupportController (#315).
+             Used to seed users in CI E2E runs; the controller bean is loaded
+             only when app.test-endpoints.enabled=true, so this dependency is
+             never exercised in production. -->
+        <dependency>
+            <groupId>net.datafaker</groupId>
+            <artifactId>datafaker</artifactId>
+            <version>2.4.2</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/backend/src/main/java/com/group7/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/group7/backend/config/SecurityConfig.java
@@ -32,6 +32,16 @@ public class SecurityConfig {
     private String[] allowedOrigins;
 
     /**
+     * Defence-in-depth for the {@code /api/test/**} endpoints (#315). The
+     * {@link com.group7.backend.controller.TestSupportController} bean is itself
+     * gated by {@code app.test-endpoints.enabled}; when this flag is off we also
+     * 404 the path here so the surface area cannot leak even if a misconfigured
+     * deployment somehow registers the controller.
+     */
+    @Value("${app.test-endpoints.enabled:false}")
+    private boolean testEndpointsEnabled;
+
+    /**
      * {@code rateLimitFilter} is wrapped in {@link Optional} so {@code @WebMvcTest}
      * controller slices that import {@link SecurityConfig} without the rate-limit
      * beans still wire a filter chain.
@@ -44,9 +54,18 @@ public class SecurityConfig {
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers(
-            "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs", "/v3/api-docs/**"
-        );
+        return web -> {
+            web.ignoring().requestMatchers(
+                "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs", "/v3/api-docs/**"
+            );
+            // When test endpoints are disabled, ignore the path entirely so the
+            // dispatcher answers with a genuine 404 (the conditional controller
+            // bean isn't registered). With this, prod responses don't leak that
+            // /api/test exists at all.
+            if (!testEndpointsEnabled) {
+                web.ignoring().requestMatchers("/api/test/**");
+            }
+        };
     }
 
     @Bean
@@ -60,7 +79,13 @@ public class SecurityConfig {
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(auth -> auth
+            .authorizeHttpRequests(auth -> {
+                if (testEndpointsEnabled) {
+                    auth.requestMatchers("/api/test/**").permitAll();
+                } else {
+                    auth.requestMatchers("/api/test/**").denyAll();
+                }
+                auth
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
@@ -82,8 +107,8 @@ public class SecurityConfig {
                 // enumeration is rate-limited by IP via the
                 // {@code availability-ical} rule in application.properties.
                 .requestMatchers(HttpMethod.GET, "/api/availability/*/ical").permitAll()
-                .anyRequest().authenticated()
-            )
+                .anyRequest().authenticated();
+            })
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         rateLimitFilter.ifPresent(filter ->

--- a/backend/src/main/java/com/group7/backend/controller/TestSupportController.java
+++ b/backend/src/main/java/com/group7/backend/controller/TestSupportController.java
@@ -1,0 +1,150 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.dto.response.UserResponse;
+import com.group7.backend.entity.PasswordResetToken;
+import com.group7.backend.entity.User;
+import com.group7.backend.entity.VerificationToken;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.AuthService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import net.datafaker.Faker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Test-only support endpoints for the Playwright E2E suite (#315).
+ *
+ * <p>Bean is registered only when {@code app.test-endpoints.enabled=true}; in
+ * production the property is unset/false so this controller never enters the
+ * application context. {@link com.group7.backend.config.SecurityConfig} also
+ * 404s {@code /api/test/**} when the flag is off as defence-in-depth.
+ */
+@RestController
+@RequestMapping("/api/test")
+@ConditionalOnProperty(name = "app.test-endpoints.enabled", havingValue = "true")
+public class TestSupportController {
+
+    private static final Logger log = LoggerFactory.getLogger(TestSupportController.class);
+
+    private final UserRepository userRepository;
+    private final VerificationTokenRepository verificationTokenRepository;
+    private final AuthService authService;
+    private final Faker faker = new Faker(Locale.of("tr"));
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public TestSupportController(UserRepository userRepository,
+                                 VerificationTokenRepository verificationTokenRepository,
+                                 AuthService authService) {
+        this.userRepository = userRepository;
+        this.verificationTokenRepository = verificationTokenRepository;
+        this.authService = authService;
+        log.warn("TestSupportController is ENABLED — this MUST NOT happen in production");
+    }
+
+    /**
+     * Wipes all user-derived test state. TRUNCATE CASCADE on {@code users}
+     * propagates to mentors/mentees and every FK dependent (mentorships,
+     * tokens, notifications, conversations, ...) so subsequent runs start
+     * from a clean slate.
+     */
+    @PostMapping("/reset")
+    @Transactional
+    public ResponseEntity<Void> reset() {
+        entityManager.createNativeQuery("TRUNCATE TABLE users RESTART IDENTITY CASCADE").executeUpdate();
+        log.info("TestSupportController.reset truncated users + cascaded dependents");
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/verification-token")
+    public ResponseEntity<Map<String, String>> verificationToken(@RequestParam String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "user not found"));
+        List<VerificationToken> tokens = verificationTokenRepository.findByUserIdAndUsedFalse(user.getId());
+        VerificationToken latest = tokens.stream()
+                .max(Comparator.comparing(VerificationToken::getCreatedAt))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "no unused verification token"));
+        return ResponseEntity.ok(Map.of("token", latest.getToken()));
+    }
+
+    @GetMapping("/password-reset-token")
+    public ResponseEntity<Map<String, String>> passwordResetToken(@RequestParam String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "user not found"));
+        List<PasswordResetToken> tokens = entityManager.createQuery(
+                        "select t from PasswordResetToken t "
+                                + "where t.user.id = :uid and t.used = false "
+                                + "order by t.createdAt desc",
+                        PasswordResetToken.class)
+                .setParameter("uid", user.getId())
+                .setMaxResults(1)
+                .getResultList();
+        if (tokens.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "no unused password reset token");
+        }
+        return ResponseEntity.ok(Map.of("token", tokens.get(0).getToken()));
+    }
+
+    /**
+     * Seeds a Faker-generated user via the production register flow, then
+     * (optionally) flips {@code is_email_verified=true} so non-AT-01 specs can
+     * skip the verify step. NoOpEmailService suppresses the outbound HTTP call.
+     */
+    @PostMapping("/users")
+    @Transactional
+    public ResponseEntity<Map<String, Object>> seedUser(@RequestBody SeedUserRequest body) {
+        boolean isMentor = Boolean.TRUE.equals(body.isMentor());
+        boolean preVerified = body.preVerified() == null || Boolean.TRUE.equals(body.preVerified());
+
+        String firstName = faker.name().firstName();
+        String lastName = faker.name().lastName();
+        String email = faker.internet().emailAddress();
+        String password = "Pass!" + faker.number().digits(6);
+
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName(firstName);
+        req.setLastName(lastName);
+        req.setEmail(email);
+        req.setPassword(password);
+        req.setIsMentor(isMentor);
+
+        UserResponse created = authService.register(req);
+
+        if (preVerified) {
+            User saved = userRepository.findByEmail(email)
+                    .orElseThrow(() -> new IllegalStateException("seeded user vanished"));
+            saved.setIsEmailVerified(true);
+            userRepository.save(saved);
+        }
+
+        return ResponseEntity.ok(Map.of(
+                "id", created.getId(),
+                "email", email,
+                "password", password,
+                "role", created.getRole(),
+                "firstName", firstName,
+                "lastName", lastName
+        ));
+    }
+
+    public record SeedUserRequest(Boolean isMentor, Boolean preVerified) {}
+}

--- a/backend/src/main/java/com/group7/backend/service/EmailService.java
+++ b/backend/src/main/java/com/group7/backend/service/EmailService.java
@@ -6,9 +6,17 @@ import com.resend.Resend;
 import com.resend.core.exception.ResendException;
 import com.resend.services.emails.model.CreateEmailOptions;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
+/**
+ * Production EmailService. Bean is registered only when {@code app.email.enabled}
+ * is true (default). When disabled (e.g. in CI E2E runs), {@link NoOpEmailService}
+ * is registered instead so the verification/reset token rows still get persisted
+ * and the test-support controller can hand them to Playwright.
+ */
 @Service
+@ConditionalOnProperty(name = "app.email.enabled", havingValue = "true", matchIfMissing = true)
 public class EmailService {
 
     private final Resend resend;

--- a/backend/src/main/java/com/group7/backend/service/NoOpEmailService.java
+++ b/backend/src/main/java/com/group7/backend/service/NoOpEmailService.java
@@ -1,0 +1,34 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+/**
+ * Drop-in EmailService replacement for E2E runs where the Resend HTTP call must
+ * be skipped. The verification / password-reset token rows are still written by
+ * AuthService before this is invoked, so {@code TestSupportController} can fetch
+ * them and hand them to Playwright. Activated by {@code app.email.enabled=false}.
+ */
+@Service
+@ConditionalOnProperty(name = "app.email.enabled", havingValue = "false")
+public class NoOpEmailService extends EmailService {
+
+    private static final Logger log = LoggerFactory.getLogger(NoOpEmailService.class);
+
+    public NoOpEmailService() {
+        super("re_noop_disabled");
+    }
+
+    @Override
+    public void sendVerificationEmail(User user, String token) {
+        log.info("[NoOpEmailService] suppressed verification email for userId={}", user.getId());
+    }
+
+    @Override
+    public void sendPasswordResetEmail(User user, String token) {
+        log.info("[NoOpEmailService] suppressed password reset email for userId={}", user.getId());
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -46,6 +46,18 @@ management.endpoint.health.probes.enabled=true
 
 resend.api-key=${RESEND_API_KEY:re_test_placeholder}
 
+# Outbound email switch. Set to false in CI/E2E so the verification and
+# password-reset rows are still persisted but the Resend HTTP call is skipped
+# (NoOpEmailService takes over). Production must keep this true.
+app.email.enabled=${APP_EMAIL_ENABLED:true}
+
+# Profile-gated test-support controller (#315). When true, /api/test/{reset,
+# verification-token,password-reset-token,users} are wired so Playwright can
+# fetch tokens and reset state without touching real email. MUST be false in
+# any production-shaped deployment; defence-in-depth in SecurityConfig 404s
+# the path when this is off.
+app.test-endpoints.enabled=${APP_TEST_ENDPOINTS_ENABLED:false}
+
 # Admin bootstrap (disabled by default; enable in deploy env only)
 app.admin-bootstrap.enabled=${APP_ADMIN_BOOTSTRAP_ENABLED:false}
 app.admin-bootstrap.email=${APP_ADMIN_BOOTSTRAP_EMAIL:}

--- a/backend/src/test/java/com/group7/backend/integration/TestSupportControllerSecurityTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/TestSupportControllerSecurityTest.java
@@ -1,0 +1,46 @@
+package com.group7.backend.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies that with the default config (test profile inherits
+ * {@code app.test-endpoints.enabled=false}), the /api/test/** surface from
+ * {@link com.group7.backend.controller.TestSupportController} is invisible
+ * — the conditional bean is not registered and SecurityConfig ignores the
+ * path so DispatcherServlet returns 404.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class TestSupportControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void resetEndpointReturns404WhenTestEndpointsDisabled() throws Exception {
+        mockMvc.perform(post("/api/test/reset"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void verificationTokenEndpointReturns404WhenTestEndpointsDisabled() throws Exception {
+        mockMvc.perform(get("/api/test/verification-token").param("email", "anyone@example.com"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void seedUserEndpointReturns404WhenTestEndpointsDisabled() throws Exception {
+        mockMvc.perform(post("/api/test/users").contentType("application/json").content("{}"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,11 @@ services:
       VERIFICATION_RESEND_MAX_PER_HOUR: ${VERIFICATION_RESEND_MAX_PER_HOUR:-3}
       PASSWORD_RESET_TOKEN_EXPIRY_HOURS: ${PASSWORD_RESET_TOKEN_EXPIRY_HOURS:-1}
       PASSWORD_RESET_MAX_REQUESTS_PER_HOUR: ${PASSWORD_RESET_MAX_REQUESTS_PER_HOUR:-5}
+      # Hard-pin to false in prod regardless of host env: the conditional
+      # bean and SecurityConfig guard for /api/test/** (#315) must never
+      # activate against a production database.
+      APP_TEST_ENDPOINTS_ENABLED: "false"
+      APP_EMAIL_ENABLED: "true"
     volumes:
       - uploads_data:/app/uploads
     healthcheck:

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright (#315)
+/playwright-report
+/test-results
+/playwright/.cache

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,3 +14,53 @@ The React Compiler is not enabled on this template because of its impact on dev 
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Running E2E (Playwright)
+
+End-to-end specs live in `e2e/` and run against a real backend + Vite preview.
+The auth flows pull verification / password-reset tokens from the profile-gated
+`/api/test/**` endpoints (#315), so the backend must be started with the test
+flags on:
+
+```sh
+APP_TEST_ENDPOINTS_ENABLED=true APP_EMAIL_ENABLED=false \
+  ./mvnw -pl backend spring-boot:run
+```
+
+In production these flags default to `false`; the controller bean is not
+registered and `SecurityConfig` 404s the path.
+
+First-time setup (downloads browser binaries):
+
+```sh
+npm run test:e2e:install
+```
+
+Run the full suite (chromium + firefox + webkit):
+
+```sh
+npm run test:e2e
+```
+
+Smoke only (chromium, <30s, for fast PR feedback):
+
+```sh
+npx playwright test --grep @smoke
+```
+
+Single browser:
+
+```sh
+npx playwright test --project=chromium
+```
+
+Interactive UI mode for local debugging:
+
+```sh
+npm run test:e2e:ui
+```
+
+`E2E_BASE_URL` (frontend) and `E2E_BACKEND_URL` (backend) override the defaults
+of `http://localhost:8000` and `http://localhost:8080`. CI sets `CI=true`,
+which enables 2 retries and disables Playwright's auto-spawned vite dev server
+so the workflow can manage backend/frontend lifecycle itself.

--- a/frontend/e2e/fixtures/apiClient.js
+++ b/frontend/e2e/fixtures/apiClient.js
@@ -1,0 +1,49 @@
+/**
+ * Thin client over the profile-gated TestSupportController endpoints. Only used
+ * by E2E specs to fetch verification/reset tokens without going through real
+ * email, and to wipe user state between runs.
+ *
+ * The backend must be started with APP_TEST_ENDPOINTS_ENABLED=true and
+ * APP_EMAIL_ENABLED=false; otherwise these calls will 404.
+ */
+
+const apiBase = process.env.E2E_BACKEND_URL ?? 'http://localhost:8080';
+
+async function expectOk(res, label) {
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`${label} failed: ${res.status} ${body}`);
+  }
+  return res;
+}
+
+export async function resetDb(request) {
+  const res = await request.post(`${apiBase}/api/test/reset`);
+  await expectOk(res, 'POST /api/test/reset');
+}
+
+export async function getVerificationToken(request, email) {
+  const res = await request.get(`${apiBase}/api/test/verification-token`, {
+    params: { email },
+  });
+  await expectOk(res, 'GET /api/test/verification-token');
+  const body = await res.json();
+  return body.token;
+}
+
+export async function getResetToken(request, email) {
+  const res = await request.get(`${apiBase}/api/test/password-reset-token`, {
+    params: { email },
+  });
+  await expectOk(res, 'GET /api/test/password-reset-token');
+  const body = await res.json();
+  return body.token;
+}
+
+export async function seedUser(request, { isMentor = false, preVerified = true } = {}) {
+  const res = await request.post(`${apiBase}/api/test/users`, {
+    data: { isMentor, preVerified },
+  });
+  await expectOk(res, 'POST /api/test/users');
+  return res.json();
+}

--- a/frontend/e2e/fixtures/users.js
+++ b/frontend/e2e/fixtures/users.js
@@ -1,0 +1,18 @@
+import { faker } from '@faker-js/faker/locale/tr';
+
+/**
+ * Faker-driven user factory for the AT-01 register flow. The password matches
+ * AuthService's @ValidPassword rule (>=8 chars, upper+lower+digit) so the
+ * register POST does not 400 on validation alone.
+ */
+export function makeUser({ isMentor = false } = {}) {
+  const firstName = faker.person.firstName();
+  const lastName = faker.person.lastName();
+  const email = `e2e-${Date.now()}-${faker.string.alphanumeric(6).toLowerCase()}@example.com`;
+  const password = `P@ss${faker.number.int({ min: 100000, max: 999999 })}`;
+  return { firstName, lastName, email, password, isMentor };
+}
+
+export function newPassword() {
+  return `Reset${faker.number.int({ min: 100000, max: 999999 })}!`;
+}

--- a/frontend/e2e/pages/ForgotPasswordPage.js
+++ b/frontend/e2e/pages/ForgotPasswordPage.js
@@ -1,0 +1,18 @@
+export class ForgotPasswordPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/forgot-password');
+  }
+
+  async submitEmail(email) {
+    await this.page.getByTestId('forgot-password-email').fill(email);
+    await this.page.getByTestId('forgot-password-submit').click();
+  }
+
+  successBanner() {
+    return this.page.getByTestId('forgot-password-success');
+  }
+}

--- a/frontend/e2e/pages/LoginPage.js
+++ b/frontend/e2e/pages/LoginPage.js
@@ -1,0 +1,23 @@
+export class LoginPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+  }
+
+  async signIn({ email, password }) {
+    await this.page.getByTestId('login-email').fill(email);
+    await this.page.getByTestId('login-password').fill(password);
+    await this.page.getByTestId('login-submit').click();
+  }
+
+  forgotPasswordLink() {
+    return this.page.getByTestId('login-forgot-link');
+  }
+
+  errorBanner() {
+    return this.page.getByTestId('login-error');
+  }
+}

--- a/frontend/e2e/pages/ProfilePage.js
+++ b/frontend/e2e/pages/ProfilePage.js
@@ -1,0 +1,27 @@
+export class ProfilePage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/profile');
+  }
+
+  async editAndSave({ name, interests }) {
+    if (name !== undefined) {
+      const nameField = this.page.getByTestId('profile-name');
+      await nameField.fill('');
+      await nameField.fill(name);
+    }
+    if (interests !== undefined) {
+      const interestsField = this.page.getByTestId('profile-interests');
+      await interestsField.fill('');
+      await interestsField.fill(interests);
+    }
+    await this.page.getByTestId('profile-save').click();
+  }
+
+  successBanner() {
+    return this.page.getByTestId('profile-save-success');
+  }
+}

--- a/frontend/e2e/pages/RegisterPage.js
+++ b/frontend/e2e/pages/RegisterPage.js
@@ -1,0 +1,22 @@
+export class RegisterPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/register');
+  }
+
+  async fillAndSubmit({ firstName, lastName, email, password, isMentor }) {
+    await this.page.getByTestId('register-first-name').fill(firstName);
+    await this.page.getByTestId('register-last-name').fill(lastName);
+    await this.page.getByTestId('register-email').fill(email);
+    await this.page.getByTestId('register-password').fill(password);
+    if (isMentor) {
+      await this.page.getByTestId('register-role-mentor').click();
+    } else {
+      await this.page.getByTestId('register-role-mentee').click();
+    }
+    await this.page.getByTestId('register-submit').click();
+  }
+}

--- a/frontend/e2e/pages/ResetPasswordPage.js
+++ b/frontend/e2e/pages/ResetPasswordPage.js
@@ -1,0 +1,14 @@
+export class ResetPasswordPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async gotoWithToken(token) {
+    await this.page.goto(`/reset-password?token=${encodeURIComponent(token)}`);
+  }
+
+  async submitNewPassword(password) {
+    await this.page.getByTestId('reset-password-new-password').fill(password);
+    await this.page.getByTestId('reset-password-submit').click();
+  }
+}

--- a/frontend/e2e/pages/VerifyEmailPage.js
+++ b/frontend/e2e/pages/VerifyEmailPage.js
@@ -1,0 +1,17 @@
+export class VerifyEmailPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async gotoWithToken(token) {
+    await this.page.goto(`/verify-email?token=${encodeURIComponent(token)}`);
+  }
+
+  successBanner() {
+    return this.page.getByTestId('verify-email-success');
+  }
+
+  errorBanner() {
+    return this.page.getByTestId('verify-email-error');
+  }
+}

--- a/frontend/e2e/specs/at01-auth-profile.spec.js
+++ b/frontend/e2e/specs/at01-auth-profile.spec.js
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { makeUser, newPassword } from '../fixtures/users.js';
+import {
+  resetDb,
+  getVerificationToken,
+  getResetToken,
+} from '../fixtures/apiClient.js';
+import { RegisterPage } from '../pages/RegisterPage.js';
+import { LoginPage } from '../pages/LoginPage.js';
+import { VerifyEmailPage } from '../pages/VerifyEmailPage.js';
+import { ForgotPasswordPage } from '../pages/ForgotPasswordPage.js';
+import { ResetPasswordPage } from '../pages/ResetPasswordPage.js';
+import { ProfilePage } from '../pages/ProfilePage.js';
+
+// AT-01: register → verify email → login → profile completion → password reset.
+// One sequential test; Playwright `projects` runs the whole spec on chromium,
+// firefox, and webkit so per-browser duplication is unnecessary.
+test('AT-01 full auth + profile + reset flow', async ({ page, request }) => {
+  await resetDb(request);
+
+  const user = makeUser({ isMentor: false });
+
+  // 1. Register via UI; backend writes a verification_tokens row but
+  //    NoOpEmailService suppresses the Resend call.
+  const registerPage = new RegisterPage(page);
+  await registerPage.goto();
+  await registerPage.fillAndSubmit(user);
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByTestId('login-registered-banner')).toBeVisible();
+
+  // 2. Pull the token through /api/test/* and submit it via the UI URL.
+  const verificationToken = await getVerificationToken(request, user.email);
+  const verifyEmailPage = new VerifyEmailPage(page);
+  await verifyEmailPage.gotoWithToken(verificationToken);
+  await expect(verifyEmailPage.successBanner()).toBeVisible();
+
+  // 3. Login with the original credentials.
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.signIn({ email: user.email, password: user.password });
+  await expect(page).toHaveURL(/\/home$/);
+
+  // 4. Profile completion: edit a couple of fields and confirm save.
+  const profilePage = new ProfilePage(page);
+  await profilePage.goto();
+  await profilePage.editAndSave({
+    name: `${user.firstName} ${user.lastName}`,
+    interests: 'Mobile Development, AI/ML',
+  });
+  await expect(profilePage.successBanner()).toBeVisible();
+
+  // 5. Logout via clearing the auth token (no dedicated logout button on the
+  //    profile screen; AuthContext reads token from localStorage on mount).
+  await page.evaluate(() => {
+    window.localStorage.removeItem('auth_token');
+    window.localStorage.removeItem('auth_role');
+    window.localStorage.removeItem('auth_user_id');
+  });
+
+  // 6. Forgot-password flow.
+  const forgotPasswordPage = new ForgotPasswordPage(page);
+  await forgotPasswordPage.goto();
+  await forgotPasswordPage.submitEmail(user.email);
+  await expect(forgotPasswordPage.successBanner()).toBeVisible();
+
+  // 7. Pull the reset token, submit new password through the UI.
+  const resetToken = await getResetToken(request, user.email);
+  const resetPasswordPage = new ResetPasswordPage(page);
+  await resetPasswordPage.gotoWithToken(resetToken);
+  const replacementPassword = newPassword();
+  await resetPasswordPage.submitNewPassword(replacementPassword);
+  await expect(page).toHaveURL(/\/login$/);
+
+  // 8. Login with the new password to confirm the reset took effect.
+  await loginPage.signIn({ email: user.email, password: replacementPassword });
+  await expect(page).toHaveURL(/\/home$/);
+});

--- a/frontend/e2e/specs/at01-auth-profile.spec.js
+++ b/frontend/e2e/specs/at01-auth-profile.spec.js
@@ -43,10 +43,27 @@ test('AT-01 full auth + profile + reset flow', async ({ page, request }) => {
   // 4. Profile completion: edit a couple of fields and confirm save.
   const profilePage = new ProfilePage(page);
   await profilePage.goto();
+  // Wait for the form to render — getOwnProfile is async and ProfilePage
+  // shows a "Loading profile..." pane until the response lands.
+  await page.getByTestId('profile-name').waitFor({ state: 'visible' });
+
+  // Capture the save API response so we can surface a useful diagnostic
+  // when the backend rejects the payload — the on-screen success banner
+  // alone gives no signal about why save didn't succeed.
+  const savePromise = page.waitForResponse(
+    res => /\/api\/users\/me\/(mentor|mentee)\b/.test(res.url())
+      && res.request().method() === 'PATCH',
+    { timeout: 15_000 },
+  );
   await profilePage.editAndSave({
     name: `${user.firstName} ${user.lastName}`,
     interests: 'Mobile Development, AI/ML',
   });
+  const saveResponse = await savePromise;
+  if (!saveResponse.ok()) {
+    const body = await saveResponse.text().catch(() => '');
+    throw new Error(`Profile save returned ${saveResponse.status()}: ${body}`);
+  }
   await expect(profilePage.successBanner()).toBeVisible();
 
   // 5. Logout via clearing the auth token (no dedicated logout button on the

--- a/frontend/e2e/specs/at03-smoke.spec.js
+++ b/frontend/e2e/specs/at03-smoke.spec.js
@@ -1,0 +1,44 @@
+import { test, expect, request as pwRequest } from '@playwright/test';
+
+const backendUrl = process.env.E2E_BACKEND_URL ?? 'http://localhost:8080';
+
+// AT-03 smoke: side-effect-free "system answers the door" checks. Chromium-only
+// because cross-browser coverage is AT-01's job and smoke is for fast PR
+// feedback. The describe stays serial so a single worker handles all four
+// tests inside the 30-second budget without spin-up overhead.
+test.describe.configure({ mode: 'serial' });
+
+test.beforeEach(async ({ browserName }) => {
+  test.skip(browserName !== 'chromium', '@smoke is chromium-only by design');
+});
+
+test('home loads @smoke', { tag: '@smoke' }, async ({ page }) => {
+  const response = await page.goto('/');
+  expect(response?.status(), 'GET / should be 2xx').toBeLessThan(400);
+  await expect(page.locator('body')).toBeVisible();
+});
+
+test('login form renders @smoke', { tag: '@smoke' }, async ({ page }) => {
+  await page.goto('/login');
+  await expect(page.getByTestId('login-email')).toBeVisible();
+  await expect(page.getByTestId('login-password')).toBeVisible();
+  await expect(page.getByTestId('login-submit')).toBeVisible();
+});
+
+test('register form renders @smoke', { tag: '@smoke' }, async ({ page }) => {
+  await page.goto('/register');
+  await expect(page.getByTestId('register-email')).toBeVisible();
+  await expect(page.getByTestId('register-submit')).toBeVisible();
+});
+
+test('backend health is up @smoke', { tag: '@smoke' }, async () => {
+  const ctx = await pwRequest.newContext();
+  try {
+    const res = await ctx.get(`${backendUrl}/actuator/health`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('UP');
+  } finally {
+    await ctx.dispose();
+  }
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@faker-js/faker": "^9.5.0",
+        "@playwright/test": "^1.49.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -29,7 +31,8 @@
         "globals": "^17.4.0",
         "jsdom": "^29.0.1",
         "vite": "^8.0.1",
-        "vitest": "^4.1.2"
+        "vitest": "^4.1.2",
+        "wait-on": "^8.0.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -712,6 +715,77 @@
         }
       }
     },
+    "node_modules/@faker-js/faker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      }
+    },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -839,6 +913,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -1519,6 +1609,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1592,6 +1701,20 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1671,6 +1794,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1775,6 +1911,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1803,6 +1949,21 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.321",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz",
@@ -1823,12 +1984,61 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2147,6 +2357,44 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/framer-motion": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
@@ -2189,6 +2437,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2197,6 +2455,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2225,6 +2522,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2233,6 +2543,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -2348,6 +2700,25 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/joi": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2768,6 +3139,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2815,12 +3193,45 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -2843,6 +3254,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/motion-dom": {
@@ -3034,6 +3455,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -3101,6 +3569,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {
@@ -3248,6 +3726,16 @@
       "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -3709,6 +4197,26 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
+      "integrity": "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.12.1",
+        "joi": "^18.0.1",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.2"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,10 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest --passWithNoTests --run"
+    "test": "vitest --passWithNoTests --run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:install": "playwright install --with-deps"
   },
   "dependencies": {
     "@stomp/stompjs": "^7.3.0",
@@ -20,6 +23,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@faker-js/faker": "^9.5.0",
+    "@playwright/test": "^1.49.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -32,6 +37,7 @@
     "globals": "^17.4.0",
     "jsdom": "^29.0.1",
     "vite": "^8.0.1",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "wait-on": "^8.0.1"
   }
 }

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:8000';
+
+export default defineConfig({
+  testDir: './e2e/specs',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox',  use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit',   use: { ...devices['Desktop Safari'] } },
+  ],
+  // CI brings up backend + frontend out-of-band so we don't double-start. For
+  // local runs Playwright spins up `vite dev` itself unless one is already up.
+  webServer: process.env.CI ? undefined : {
+    command: 'npm run dev',
+    url: baseURL,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+});

--- a/frontend/src/pages/ForgotPasswordPage.jsx
+++ b/frontend/src/pages/ForgotPasswordPage.jsx
@@ -43,15 +43,15 @@ export default function ForgotPasswordPage() {
         <div className="auth-title">Forgot<br /><em>password?</em></div>
         <div className="auth-sub">Enter your email to receive a reset link</div>
 
-        {serverError && <div className="auth-error">{serverError}</div>}
+        {serverError && <div className="auth-error" data-testid="forgot-password-error">{serverError}</div>}
         {success && (
-          <div className="auth-success">
+          <div className="auth-success" data-testid="forgot-password-success">
             Reset link sent! Check your inbox.
           </div>
         )}
 
         {!success && (
-          <form onSubmit={handleSubmit} noValidate>
+          <form onSubmit={handleSubmit} noValidate data-testid="forgot-password-form">
             <label className="field-label">Email</label>
             <input
               type="email"
@@ -60,10 +60,11 @@ export default function ForgotPasswordPage() {
               onChange={e => handleChange(e.target.value)}
               placeholder="you@example.com"
               aria-invalid={!!emailError}
+              data-testid="forgot-password-email"
             />
             {emailError && <div className="field-error-msg">{emailError}</div>}
 
-            <button type="submit" className="auth-btn" disabled={isLoading}>
+            <button type="submit" className="auth-btn" disabled={isLoading} data-testid="forgot-password-submit">
               {isLoading ? 'Sending...' : 'Send Reset Link'}
             </button>
           </form>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -83,13 +83,13 @@ export default function LoginPage() {
         <div className="auth-sub">Sign in to continue your journey</div>
 
         {registered && !serverError && (
-          <div className="auth-success">Account created! Please sign in.</div>
+          <div className="auth-success" data-testid="login-registered-banner">Account created! Please sign in.</div>
         )}
         {serverError && (
-          <div className="auth-error">{serverError}</div>
+          <div className="auth-error" data-testid="login-error">{serverError}</div>
         )}
 
-        <form onSubmit={handleSubmit} noValidate>
+        <form onSubmit={handleSubmit} noValidate data-testid="login-form">
           <label className="field-label">Email</label>
           <input
             type="email"
@@ -98,6 +98,7 @@ export default function LoginPage() {
             onChange={e => handleChange('email', e.target.value)}
             placeholder="you@example.com"
             aria-invalid={!!errors.email}
+            data-testid="login-email"
           />
           {errors.email && <div className="field-error-msg">{errors.email}</div>}
 
@@ -109,12 +110,13 @@ export default function LoginPage() {
             onChange={e => handleChange('password', e.target.value)}
             placeholder="••••••••"
             aria-invalid={!!errors.password}
+            data-testid="login-password"
           />
           {errors.password && <div className="field-error-msg">{errors.password}</div>}
 
-          <Link to="/forgot-password" className="forgot-link">Forgot password?</Link>
+          <Link to="/forgot-password" className="forgot-link" data-testid="login-forgot-link">Forgot password?</Link>
 
-          <button type="submit" className="auth-btn" disabled={isLoading}>
+          <button type="submit" className="auth-btn" disabled={isLoading} data-testid="login-submit">
             {isLoading ? 'Signing in...' : 'Sign In'}
           </button>
         </form>

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -317,7 +317,7 @@ export default function ProfilePage() {
         <div className="card">
           <div className="section-label">Edit Information</div>
 
-          <form onSubmit={handleSave} noValidate>
+          <form onSubmit={handleSave} noValidate data-testid="profile-form">
             <div className="form-field">
               <label className="form-label">Full Name</label>
               <input
@@ -326,6 +326,7 @@ export default function ProfilePage() {
                 maxLength={100}
                 value={form.name}
                 onChange={e => handleChange('name', e.target.value)}
+                data-testid="profile-name"
               />
               {errors.name && <div style={{ color: 'var(--red-text)', fontSize: '13px', marginTop: '4px' }}>{errors.name}</div>}
             </div>
@@ -338,6 +339,7 @@ export default function ProfilePage() {
                 value={form.interests}
                 onChange={e => handleChange('interests', e.target.value)}
                 placeholder="e.g. Mobile Development, AI/ML"
+                data-testid="profile-interests"
               />
             </div>
 
@@ -533,17 +535,17 @@ export default function ProfilePage() {
             )}
 
             {saveSuccess && (
-              <div style={{ color: 'var(--green-dark)', fontSize: '13px', marginBottom: '8px' }}>
+              <div data-testid="profile-save-success" style={{ color: 'var(--green-dark)', fontSize: '13px', marginBottom: '8px' }}>
                 Profile saved successfully.
               </div>
             )}
             {saveError && (
-              <div style={{ color: 'var(--red-text)', fontSize: '13px', marginBottom: '8px' }}>
+              <div data-testid="profile-save-error" style={{ color: 'var(--red-text)', fontSize: '13px', marginBottom: '8px' }}>
                 {saveError}
               </div>
             )}
 
-            <button type="submit" className="save-btn" style={{ marginTop: '16px' }} disabled={saving}>
+            <button type="submit" className="save-btn" style={{ marginTop: '16px' }} disabled={saving} data-testid="profile-save">
               {saving ? 'Saving...' : 'Save Changes'}
             </button>
           </form>

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -92,9 +92,9 @@ export default function RegisterPage() {
         <div className="auth-title">Create Account</div>
         <div className="auth-sub">Join the mentorship community</div>
 
-        {serverError && <div className="auth-error">{serverError}</div>}
+        {serverError && <div className="auth-error" data-testid="register-error">{serverError}</div>}
 
-        <form onSubmit={handleSubmit} noValidate>
+        <form onSubmit={handleSubmit} noValidate data-testid="register-form">
           <label className="field-label">First Name</label>
           <input
             type="text"
@@ -103,6 +103,7 @@ export default function RegisterPage() {
             onChange={e => handleChange('firstName', e.target.value)}
             placeholder="First name"
             aria-invalid={!!errors.firstName}
+            data-testid="register-first-name"
           />
           {errors.firstName && <div className="field-error-msg">{errors.firstName}</div>}
 
@@ -114,6 +115,7 @@ export default function RegisterPage() {
             onChange={e => handleChange('lastName', e.target.value)}
             placeholder="Last name"
             aria-invalid={!!errors.lastName}
+            data-testid="register-last-name"
           />
           {errors.lastName && <div className="field-error-msg">{errors.lastName}</div>}
 
@@ -125,6 +127,7 @@ export default function RegisterPage() {
             onChange={e => handleChange('email', e.target.value)}
             placeholder="you@example.com"
             aria-invalid={!!errors.email}
+            data-testid="register-email"
           />
           {errors.email && <div className="field-error-msg">{errors.email}</div>}
 
@@ -136,6 +139,7 @@ export default function RegisterPage() {
             onChange={e => handleChange('password', e.target.value)}
             placeholder="••••••••"
             aria-invalid={!!errors.password}
+            data-testid="register-password"
           />
           {errors.password && <div className="field-error-msg">{errors.password}</div>}
 
@@ -145,6 +149,7 @@ export default function RegisterPage() {
               type="button"
               className={`role-btn${!fields.isMentor ? ' active' : ''}`}
               onClick={() => handleChange('isMentor', false)}
+              data-testid="register-role-mentee"
             >
               Mentee
             </button>
@@ -152,12 +157,13 @@ export default function RegisterPage() {
               type="button"
               className={`role-btn${fields.isMentor ? ' active' : ''}`}
               onClick={() => handleChange('isMentor', true)}
+              data-testid="register-role-mentor"
             >
               Mentor
             </button>
           </div>
 
-          <button type="submit" className="auth-btn" disabled={isLoading}>
+          <button type="submit" className="auth-btn" disabled={isLoading} data-testid="register-submit">
             {isLoading ? 'Creating account...' : 'Create Account'}
           </button>
         </form>

--- a/frontend/src/pages/ResetPasswordPage.jsx
+++ b/frontend/src/pages/ResetPasswordPage.jsx
@@ -81,9 +81,9 @@ export default function ResetPasswordPage() {
         <div className="auth-title">Reset<br /><em>password.</em></div>
         <div className="auth-sub">Enter your new password below</div>
 
-        {serverError && <div className="auth-error">{serverError}</div>}
+        {serverError && <div className="auth-error" data-testid="reset-password-error">{serverError}</div>}
 
-        <form onSubmit={handleSubmit} noValidate>
+        <form onSubmit={handleSubmit} noValidate data-testid="reset-password-form">
           <label className="field-label">New Password</label>
           <input
             type="password"
@@ -92,10 +92,11 @@ export default function ResetPasswordPage() {
             onChange={e => handleChange(e.target.value)}
             placeholder="••••••••"
             aria-invalid={!!passwordError}
+            data-testid="reset-password-new-password"
           />
           {passwordError && <div className="field-error-msg">{passwordError}</div>}
 
-          <button type="submit" className="auth-btn" disabled={isLoading}>
+          <button type="submit" className="auth-btn" disabled={isLoading} data-testid="reset-password-submit">
             {isLoading ? 'Resetting...' : 'Reset Password'}
           </button>
         </form>

--- a/frontend/src/pages/VerifyEmailPage.jsx
+++ b/frontend/src/pages/VerifyEmailPage.jsx
@@ -22,7 +22,7 @@ export default function VerifyEmailPage() {
   if (status === 'loading') {
     return (
       <div className="auth-screen">
-        <div className="auth-card">
+        <div className="auth-card" data-testid="verify-email-loading">
           <div className="auth-sub">Verifying your email...</div>
         </div>
       </div>
@@ -32,7 +32,7 @@ export default function VerifyEmailPage() {
   if (status === 'error') {
     return (
       <div className="auth-screen">
-        <div className="auth-card">
+        <div className="auth-card" data-testid="verify-email-error">
           <div className="auth-title">Verification<br /><em>failed.</em></div>
           <div className="auth-error">This verification link is invalid or has expired.</div>
           <div className="auth-footer">
@@ -45,7 +45,7 @@ export default function VerifyEmailPage() {
 
   return (
     <div className="auth-screen">
-      <div className="auth-card">
+      <div className="auth-card" data-testid="verify-email-success">
         <div className="auth-title">Email<br /><em>verified!</em></div>
         <div className="auth-success">Your email has been verified. You can now sign in.</div>
         <div className="auth-footer">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -141,7 +141,13 @@ export async function deleteProfilePhoto() {
 
 export async function updateOwnProfile(data, role) {
   const token = localStorage.getItem('auth_token')
-  const res = await fetch(`${BASE_URL}/users/me`, {
+  // Backend exposes role-specific PATCH endpoints (`/users/me/mentor` and
+  // `/users/me/mentee`); the generic `/users/me` PATCH does not exist.
+  // Pick the path from the explicit role argument, falling back to the
+  // role stored on login.
+  const effectiveRole = role || localStorage.getItem('auth_role')
+  const path = effectiveRole === 'MENTOR' ? '/users/me/mentor' : '/users/me/mentee'
+  const res = await fetch(`${BASE_URL}${path}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(data),

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,6 +8,11 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/test/setup.js',
+    // Vitest's default include matches `**/*.spec.{js,ts,jsx,tsx}`, which would
+    // pick up the Playwright suite under `e2e/` and crash with
+    // "test.describe.configure() not expected here" because those specs use
+    // the @playwright/test runner. Keep the two test stacks separate.
+    exclude: ['node_modules', 'dist', 'e2e/**'],
   },
   server: {
     port: 8000,


### PR DESCRIPTION
Closes #315.

Establishes the Playwright E2E foundation that #316 and #317 are blocked on, plus the AT-01 (auth + profile + password reset) and AT-03 (smoke) specs from the issue's deliverables.

## What's in this PR

### Backend — profile-gated test support
- New `TestSupportController` (`@ConditionalOnProperty("app.test-endpoints.enabled")`) exposing `/api/test/{reset, verification-token, password-reset-token, users}`. Endpoints let Playwright fetch verification + reset tokens directly from the DB and seed Faker-generated users without going through real email.
- New `NoOpEmailService` — bound when `app.email.enabled=false`. Verification / reset token rows are still persisted by `AuthService`; only the outbound Resend HTTP call is suppressed. Existing `EmailService` is now `@ConditionalOnProperty(matchIfMissing=true)` so production behavior is unchanged.
- `SecurityConfig` ignores `/api/test/**` from the filter chain when `app.test-endpoints.enabled=false`. Combined with the conditional bean, the dispatcher returns a genuine 404 — the path doesn't merely deny, it doesn't exist.
- Defaults are off (`app.test-endpoints.enabled=false`, `app.email.enabled=true`). `docker-compose.prod.yml` hard-pins both env vars regardless of host config.
- `TestSupportControllerSecurityTest` asserts that default config 404s the endpoints.
- `datafaker` (tr_TR locale) added for the `/api/test/users` seed payload.

### Frontend — Playwright suite
- `@playwright/test`, `@faker-js/faker`, `wait-on` added as devDependencies; new scripts `test:e2e`, `test:e2e:ui`, `test:e2e:install`.
- `playwright.config.js`: chromium / firefox / webkit projects, env-driven `baseURL` (`E2E_BASE_URL`), `retries: process.env.CI ? 2 : 0`, `trace: 'on-first-retry'`, `video: 'retain-on-failure'`, `screenshot: 'only-on-failure'`. Local runs auto-spawn `vite dev` with `reuseExistingServer`; CI manages backend/frontend lifecycle out of band.
- `frontend/e2e/`:
  - `fixtures/users.js` — Faker (tr_TR) factory, every run generates a unique email
  - `fixtures/apiClient.js` — thin client over `/api/test/**`
  - `pages/` — POMs for Login, Register, VerifyEmail, ForgotPassword, ResetPassword, Profile (all backed by `data-testid`)
  - `specs/at01-auth-profile.spec.js` — register → fetch verification token → verify → login → edit profile + save → logout → forgot-password → fetch reset token → reset → re-login with new password. Single sequential test; cross-browser coverage comes from `projects` rather than describe duplication.
  - `specs/at03-smoke.spec.js` — `@smoke`-tagged, chromium-only via runtime skip, side-effect-free: home loads, login / register forms render, `/actuator/health` is `UP`. Designed to fit inside the 30-second budget.
- Auth + profile components gained `data-testid` hooks (`login-email`, `register-submit`, `profile-save`, etc.) — only on elements POMs actually touch, no codebase-wide sprinkling.
- `frontend/README.md` documents local invocation; `.gitignore` excludes `playwright-report/`, `test-results/`, `playwright/.cache/`.

### CI — `.github/workflows/e2e-ci.yml`
- Triggers on PR + push to `main`/`dev` when `backend/**`, `frontend/**`, or the workflow itself changes.
- Postgres 16 service container (mirrors `backend-ci.yml`), Java 21, Node 20 with cached deps.
- Builds the backend jar, starts it with `APP_TEST_ENDPOINTS_ENABLED=true APP_EMAIL_ENABLED=false APP_RATELIMIT_ENABLED=false`, builds the frontend, serves `vite preview` on port 8000, waits on health, runs `npx playwright test`.
- On failure uploads `playwright-report/`, `test-results/`, and both backend/frontend stdout logs (`if-no-files-found: ignore`, 7-day retention).
- Existing `web_ci.yml` (vitest + build) is left in place for fast feedback on frontend-only changes.

## Acceptance criteria check

- [x] `@playwright/test` devDependency, `playwright.config.js` with three browser projects, env-driven `baseURL`, CI retries=2
- [x] `frontend/e2e/{fixtures,pages,specs}/` structure
- [x] Scripts: `test:e2e`, `test:e2e:ui`
- [x] GitHub Actions workflow: brings up backend + frontend, runs tests, uploads reports on failure
- [x] Backend seed/reset endpoint (Faker tr_TR locale)
- [x] AT-01: register → email verification → login → profile completion → password reset
- [x] AT-03: smoke tagged `@smoke`, Chromium-only, sub-30 seconds
- [x] Page Objects: Login, Register, VerifyEmail, ForgotPassword, ResetPassword, Profile
- [x] README "Running E2E" section
- [x] Test users dynamically generated per run via Faker; no persistent fixtures

## Security notes

The test endpoints are guarded by three independent locks:
1. `@ConditionalOnProperty(name="app.test-endpoints.enabled", havingValue="true")` — the bean isn't registered when the flag is off (default).
2. `SecurityConfig.webSecurityCustomizer` ignores `/api/test/**` only when the flag is off, so the dispatcher returns a genuine 404 (path appears not to exist) instead of a 401/403 that leaks existence.
3. `docker-compose.prod.yml` explicitly sets `APP_TEST_ENDPOINTS_ENABLED=false` and `APP_EMAIL_ENABLED=true` regardless of the surrounding env, so a misconfigured host can't accidentally enable them in prod.

`TestSupportControllerSecurityTest` covers (1) and (2) by asserting 404 with default config.

## Test plan

- [ ] CI's `e2e-ci` job is green (Postgres service container + backend + Vite preview + Playwright across three browsers).
- [ ] On a deliberately broken assertion, the failed-job artifacts surface `playwright-report/`, `test-results/` (with traces/videos/screenshots), and the backend/frontend logs.
- [ ] Locally: `cd frontend && npm run test:e2e:install && npm run test:e2e` passes once the backend is started with `APP_TEST_ENDPOINTS_ENABLED=true APP_EMAIL_ENABLED=false`.
- [ ] Locally: `npx playwright test --grep @smoke` finishes under 30 seconds.
- [ ] Default-config curl: `curl -i http://localhost:8080/api/test/reset` returns 404 (no flags set).

## Out of scope (follow-ups)

- AT-02 (mentorship), AT-04 (community), AT-05 (abuse) → #316
- AT-06 (messaging/notifications) and AT-07 (NFR) → #317
- Mobile Detox/Maestro → #318
- The umbrella docs (test data strategy, ownership, contribution guide) → #314, will be drafted as those sub-issues land

🤖 Generated with [Claude Code](https://claude.com/claude-code)
