### PR TITLE
feat(#316): AT-02 mentorship+blog spec, AT-04/AT-05 scaffolds, admin fixture

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/TestSupportController.java
+++ b/backend/src/main/java/com/group7/backend/controller/TestSupportController.java
@@ -2,12 +2,15 @@ package com.group7.backend.controller;
 
 import com.group7.backend.dto.request.RegisterRequest;
 import com.group7.backend.dto.response.UserResponse;
+import com.group7.backend.entity.Admin;
 import com.group7.backend.entity.PasswordResetToken;
 import com.group7.backend.entity.User;
 import com.group7.backend.entity.VerificationToken;
 import com.group7.backend.repository.UserRepository;
 import com.group7.backend.repository.VerificationTokenRepository;
 import com.group7.backend.service.AuthService;
+import com.group7.backend.service.JwtService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.Comparator;
@@ -47,6 +50,8 @@ public class TestSupportController {
     private final UserRepository userRepository;
     private final VerificationTokenRepository verificationTokenRepository;
     private final AuthService authService;
+    private final JwtService jwtService;
+    private final PasswordEncoder passwordEncoder;
     private final Faker faker = new Faker(Locale.of("tr"));
 
     @PersistenceContext
@@ -54,10 +59,14 @@ public class TestSupportController {
 
     public TestSupportController(UserRepository userRepository,
                                  VerificationTokenRepository verificationTokenRepository,
-                                 AuthService authService) {
+                                 AuthService authService,
+                                 JwtService jwtService,
+                                 PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
         this.verificationTokenRepository = verificationTokenRepository;
         this.authService = authService;
+        this.jwtService = jwtService;
+        this.passwordEncoder = passwordEncoder;
         log.warn("TestSupportController is ENABLED — this MUST NOT happen in production");
     }
 
@@ -136,13 +145,55 @@ public class TestSupportController {
             userRepository.save(saved);
         }
 
+        // Pre-mint a session token so specs can skip the UI login when they
+        // just need an authenticated request context (used by AT-02 for the
+        // schedule/task/blog API legs).
+        String sessionToken = jwtService.generateToken(created.getId(), email, created.getRole());
+
         return ResponseEntity.ok(Map.of(
                 "id", created.getId(),
                 "email", email,
                 "password", password,
                 "role", created.getRole(),
                 "firstName", firstName,
-                "lastName", lastName
+                "lastName", lastName,
+                "sessionToken", sessionToken
+        ));
+    }
+
+    /**
+     * Seeds an Admin user (the production AuthService.register flow only
+     * builds Mentor/Mentee), bypasses verification, and returns a JWT so
+     * Playwright specs can persist it as a {@code storageState} fixture for
+     * AT-05 admin-review flows. Bean is still gated by
+     * {@code app.test-endpoints.enabled=true}.
+     */
+    @PostMapping("/admin")
+    @Transactional
+    public ResponseEntity<Map<String, Object>> seedAdmin() {
+        String firstName = faker.name().firstName();
+        String lastName = faker.name().lastName();
+        String email = "e2e-admin-" + faker.regexify("[a-z0-9]{8}") + "@example.com";
+        String password = "Admin!" + faker.number().digits(6);
+
+        Admin admin = new Admin();
+        admin.setFirstName(firstName);
+        admin.setLastName(lastName);
+        admin.setEmail(email);
+        admin.setPasswordHash(passwordEncoder.encode(password));
+        admin.setIsEmailVerified(true);
+        Admin saved = userRepository.save(admin);
+
+        String sessionToken = jwtService.generateToken(saved.getId(), email, "ADMIN");
+
+        return ResponseEntity.ok(Map.of(
+                "id", saved.getId(),
+                "email", email,
+                "password", password,
+                "role", "ADMIN",
+                "firstName", firstName,
+                "lastName", lastName,
+                "sessionToken", sessionToken
         ));
     }
 

--- a/frontend/e2e/fixtures/adminFixture.js
+++ b/frontend/e2e/fixtures/adminFixture.js
@@ -1,0 +1,46 @@
+/**
+ * Admin auth helpers for AT-05.
+ *
+ * Issue #316 calls for an admin role accessed via Playwright `storageState`,
+ * so the login step doesn't repeat in every test. Storage state in Playwright
+ * is a JSON snapshot of cookies + localStorage; the existing AuthContext
+ * keeps tokens in localStorage (auth_token / auth_role / auth_user_id), so
+ * the cleanest way to ship "logged-in admin" without per-test login is to
+ * inject those keys into a fresh browser context before any navigation.
+ *
+ * `applyAdminAuth(context, admin)` does exactly that and is intended to be
+ * called once per test (or once in a fixture/beforeAll) after seeding the
+ * admin via `seedAdmin(request)` from apiClient.js.
+ *
+ * AT-05 is currently `test.fixme`'d pending #135 (reporting/moderation merge)
+ * and the admin frontend pages, but the helper is in place so unfixming is a
+ * one-line change.
+ */
+export async function applyAdminAuth(context, admin) {
+  await context.addInitScript(({ token, role, userId }) => {
+    window.localStorage.setItem('auth_token', token);
+    window.localStorage.setItem('auth_role', role);
+    window.localStorage.setItem('auth_user_id', String(userId));
+  }, {
+    token: admin.sessionToken,
+    role: admin.role,
+    userId: admin.id,
+  });
+}
+
+/**
+ * Same shape, applied to an already-open page rather than a fresh context.
+ * Useful when a spec wants to swap roles mid-test (rare, but happens in
+ * AT-05 toxicity → admin review flows).
+ */
+export async function injectAdminAuthIntoPage(page, admin) {
+  await page.evaluate(({ token, role, userId }) => {
+    window.localStorage.setItem('auth_token', token);
+    window.localStorage.setItem('auth_role', role);
+    window.localStorage.setItem('auth_user_id', String(userId));
+  }, {
+    token: admin.sessionToken,
+    role: admin.role,
+    userId: admin.id,
+  });
+}

--- a/frontend/e2e/fixtures/apiClient.js
+++ b/frontend/e2e/fixtures/apiClient.js
@@ -45,5 +45,33 @@ export async function seedUser(request, { isMentor = false, preVerified = true }
     data: { isMentor, preVerified },
   });
   await expectOk(res, 'POST /api/test/users');
+  return res.json(); // { id, email, password, role, firstName, lastName, sessionToken }
+}
+
+/** Sugar for the two roles AT-02 cares about. */
+export const seedMentor = (request) => seedUser(request, { isMentor: true, preVerified: true });
+export const seedMentee = (request) => seedUser(request, { isMentor: false, preVerified: true });
+
+/**
+ * Seeds an Admin user via /api/test/admin and returns the same shape as
+ * seedUser plus a pre-minted sessionToken. AT-05 will persist this as a
+ * Playwright `storageState` so the admin login step doesn't repeat per test.
+ */
+export async function seedAdmin(request) {
+  const res = await request.post(`${apiBase}/api/test/admin`);
+  await expectOk(res, 'POST /api/test/admin');
+  return res.json();
+}
+
+/**
+ * POST /api/auth/login as a fallback for specs that already hold credentials
+ * (e.g., logging back in with a new password during AT-01). Returns the
+ * full AuthResponse: { sessionToken, role, userId }.
+ */
+export async function login(request, email, password) {
+  const res = await request.post(`${apiBase}/api/auth/login`, {
+    data: { email, password },
+  });
+  await expectOk(res, 'POST /api/auth/login');
   return res.json();
 }

--- a/frontend/e2e/fixtures/mentorshipApi.js
+++ b/frontend/e2e/fixtures/mentorshipApi.js
@@ -21,13 +21,49 @@ async function expectOk(res, label) {
   return res.json();
 }
 
-/** POST /api/mentorships/{id}/meetings — mentor only. */
+/**
+ * POST /api/mentorships/{id}/meetings — mentor only.
+ *
+ * Accepts the test-ergonomic shape `{ title, description?, date,
+ * durationMin?, meetingType?, meetingLink? }` and translates to the
+ * backend's `MeetingCreateRequest` (`title`, `startTime`, `endTime`,
+ * `meetingType`, `meetingLink`). `startTime`/`endTime` may also be passed
+ * directly. ONLINE meetings (the default) require a meetingLink, so we
+ * default to a placeholder URL — tests don't actually open the link.
+ *
+ * Backend returns `MeetingCreateResponse { meetings: [...], warnings: [...] }`;
+ * callers want a single meeting, so we unwrap `meetings[0]`.
+ */
 export async function createMeeting(request, token, mentorshipId, body) {
+  const {
+    title,
+    description,
+    date,
+    startTime,
+    endTime,
+    durationMin = 30,
+    meetingType = 'ONLINE',
+    meetingLink = 'https://meet.example.com/e2e',
+    ...rest
+  } = body;
+  const start = startTime ?? date;
+  const computedEnd =
+    endTime ?? new Date(new Date(start).getTime() + durationMin * 60_000).toISOString();
+  const payload = {
+    title,
+    description,
+    startTime: start,
+    endTime: computedEnd,
+    meetingType,
+    ...(meetingType === 'ONLINE' ? { meetingLink } : {}),
+    ...rest,
+  };
   const res = await request.post(`${apiBase()}/api/mentorships/${mentorshipId}/meetings`, {
     headers: authHeaders(token),
-    data: body,
+    data: payload,
   });
-  return expectOk(res, `POST /api/mentorships/${mentorshipId}/meetings`);
+  const responseBody = await expectOk(res, `POST /api/mentorships/${mentorshipId}/meetings`);
+  return responseBody?.meetings?.[0] ?? responseBody;
 }
 
 /** POST /api/meetings/{id}/confirm — mentee accepts the proposed slot. */

--- a/frontend/e2e/fixtures/mentorshipApi.js
+++ b/frontend/e2e/fixtures/mentorshipApi.js
@@ -66,6 +66,19 @@ export async function createMeeting(request, token, mentorshipId, body) {
   return responseBody?.meetings?.[0] ?? responseBody;
 }
 
+/**
+ * PUT /api/mentorships/{id}/goal — set shared goal. Required before any
+ * meeting / task / milestone write since #335 added the precondition gate.
+ * Either mentor or mentee can set it.
+ */
+export async function setSharedGoal(request, token, mentorshipId, sharedGoal) {
+  const res = await request.put(`${apiBase()}/api/mentorships/${mentorshipId}/goal`, {
+    headers: authHeaders(token),
+    data: { sharedGoal },
+  });
+  return expectOk(res, `PUT /api/mentorships/${mentorshipId}/goal`);
+}
+
 /** POST /api/meetings/{id}/confirm — mentee accepts the proposed slot. */
 export async function confirmMeeting(request, token, meetingId) {
   const res = await request.post(`${apiBase()}/api/meetings/${meetingId}/confirm`, {

--- a/frontend/e2e/fixtures/mentorshipApi.js
+++ b/frontend/e2e/fixtures/mentorshipApi.js
@@ -1,0 +1,112 @@
+/**
+ * Backend API helpers for AT-02 legs whose UI doesn't exist yet (#316 notes
+ * that SchedulePage/TasksPage are read-only mocks and there's no blog publish
+ * page). These call the real backend endpoints with a bearer token so the
+ * integration is genuine end-to-end — only the UI step is missing.
+ *
+ * Each helper accepts a Playwright `request` (APIRequestContext) and a JWT.
+ */
+
+const apiBase = () => process.env.E2E_BACKEND_URL ?? 'http://localhost:8080';
+
+function authHeaders(token) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function expectOk(res, label) {
+  if (!res.ok()) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`${label} -> ${res.status()} ${body}`);
+  }
+  return res.json();
+}
+
+/** POST /api/mentorships/{id}/meetings — mentor only. */
+export async function createMeeting(request, token, mentorshipId, body) {
+  const res = await request.post(`${apiBase()}/api/mentorships/${mentorshipId}/meetings`, {
+    headers: authHeaders(token),
+    data: body,
+  });
+  return expectOk(res, `POST /api/mentorships/${mentorshipId}/meetings`);
+}
+
+/** POST /api/meetings/{id}/confirm — mentee accepts the proposed slot. */
+export async function confirmMeeting(request, token, meetingId) {
+  const res = await request.post(`${apiBase()}/api/meetings/${meetingId}/confirm`, {
+    headers: authHeaders(token),
+  });
+  return expectOk(res, `POST /api/meetings/${meetingId}/confirm`);
+}
+
+/** POST /api/mentorships/{id}/tasks — mentor assigns. */
+export async function createTask(request, token, mentorshipId, body) {
+  const res = await request.post(`${apiBase()}/api/mentorships/${mentorshipId}/tasks`, {
+    headers: authHeaders(token),
+    data: body,
+  });
+  return expectOk(res, `POST /api/mentorships/${mentorshipId}/tasks`);
+}
+
+/** POST /api/tasks/{id}/submission — mentee submits. */
+export async function submitTask(request, token, taskId, body) {
+  const res = await request.post(`${apiBase()}/api/tasks/${taskId}/submission`, {
+    headers: authHeaders(token),
+    data: body,
+  });
+  return expectOk(res, `POST /api/tasks/${taskId}/submission`);
+}
+
+/** PATCH /api/tasks/{id}/feedback — mentor reviews. */
+export async function reviewTask(request, token, taskId, body) {
+  const res = await request.patch(`${apiBase()}/api/tasks/${taskId}/feedback`, {
+    headers: authHeaders(token),
+    data: body,
+  });
+  return expectOk(res, `PATCH /api/tasks/${taskId}/feedback`);
+}
+
+/**
+ * POST /api/feed/posts — used as the "blog publish" leg of AT-02. The product
+ * has no dedicated blog feature; the social feed post is the closest thing,
+ * and the issue's "blog publish" deliverable is satisfied by exercising this
+ * controller end-to-end.
+ */
+export async function publishBlogPost(request, token, body) {
+  const res = await request.post(`${apiBase()}/api/feed/posts`, {
+    headers: authHeaders(token),
+    data: body,
+  });
+  return expectOk(res, 'POST /api/feed/posts');
+}
+
+/** GET /api/feed/posts/{id} for verification. */
+export async function getBlogPost(request, token, postId) {
+  const res = await request.get(`${apiBase()}/api/feed/posts/${postId}`, {
+    headers: authHeaders(token),
+  });
+  return expectOk(res, `GET /api/feed/posts/${postId}`);
+}
+
+/**
+ * GET /api/mentorship-requests received by the authenticated mentor. AT-02
+ * uses this to look up the request id created by the mentee's UI submit, so
+ * the spec can later assert state transitions on it.
+ */
+export async function listIncomingRequests(request, token) {
+  const res = await request.get(`${apiBase()}/api/mentorship-requests/received`, {
+    headers: authHeaders(token),
+  });
+  return expectOk(res, 'GET /api/mentorship-requests/received');
+}
+
+/**
+ * GET /api/mentorships returns the authenticated user's active mentorships
+ * (mentor + mentee sides combined). Used after accept to discover the new
+ * mentorship id.
+ */
+export async function listActiveMentorships(request, token) {
+  const res = await request.get(`${apiBase()}/api/mentorships`, {
+    headers: authHeaders(token),
+  });
+  return expectOk(res, 'GET /api/mentorships');
+}

--- a/frontend/e2e/fixtures/mentorshipApi.js
+++ b/frontend/e2e/fixtures/mentorshipApi.js
@@ -91,12 +91,18 @@ export async function getBlogPost(request, token, postId) {
  * GET /api/mentorship-requests received by the authenticated mentor. AT-02
  * uses this to look up the request id created by the mentee's UI submit, so
  * the spec can later assert state transitions on it.
+ *
+ * The endpoint returns a Spring Data Page wrapper (`{ content: [...],
+ * totalElements, ... }`), so unwrap `.content` here. Treat a missing
+ * `content` field defensively as an empty list.
  */
 export async function listIncomingRequests(request, token) {
-  const res = await request.get(`${apiBase()}/api/mentorship-requests/received`, {
-    headers: authHeaders(token),
-  });
-  return expectOk(res, 'GET /api/mentorship-requests/received');
+  const res = await request.get(
+    `${apiBase()}/api/mentorship-requests/received?page=0&size=50`,
+    { headers: authHeaders(token) },
+  );
+  const body = await expectOk(res, 'GET /api/mentorship-requests/received');
+  return Array.isArray(body) ? body : (body?.content ?? []);
 }
 
 /**

--- a/frontend/e2e/pages/ExplorePage.js
+++ b/frontend/e2e/pages/ExplorePage.js
@@ -1,0 +1,27 @@
+export class ExplorePage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/explore');
+  }
+
+  mentorCard(mentorId) {
+    return this.page.getByTestId(`explore-mentor-card-${mentorId}`);
+  }
+
+  /** Open the Request Mentorship modal for a specific mentor by id. */
+  async openRequestForMentor(mentorId) {
+    await this.page.getByTestId(`explore-send-request-${mentorId}`).click();
+  }
+
+  /**
+   * Convenience for tests that don't pin a specific mentor id — useful when the
+   * spec just needs to discover *some* mentor and there's only one in the seed.
+   */
+  async openFirstAvailableRequest() {
+    await this.page.getByTestId('explore-mentor-grid').waitFor();
+    await this.page.locator('[data-testid^="explore-send-request-"]:not([disabled])').first().click();
+  }
+}

--- a/frontend/e2e/pages/MentorshipInbox.js
+++ b/frontend/e2e/pages/MentorshipInbox.js
@@ -1,0 +1,43 @@
+/**
+ * The mentor's "Incoming Requests" panel lives on /home, so this POM wraps
+ * just that section rather than introducing a dedicated /mentorship page.
+ * AT-02 uses it to accept the pending request from the mentee with a chosen
+ * mentorship duration.
+ */
+export class MentorshipInbox {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto() {
+    await this.page.goto('/home');
+  }
+
+  inbox() {
+    return this.page.getByTestId('mentor-inbox');
+  }
+
+  requestRow(requestId) {
+    return this.page.getByTestId(`mentor-inbox-request-${requestId}`);
+  }
+
+  /**
+   * Click "Accept" on the (only) pending request row, choose a duration, then
+   * confirm. The spec doesn't pin the request id ahead of time because the id
+   * comes from the backend after the mentee submits via UI.
+   */
+  async acceptFirstRequest({ months = 3 } = {}) {
+    await this.inbox().waitFor();
+    const row = this.page
+      .locator('[data-testid^="mentor-inbox-request-"]')
+      .first();
+    const requestId = await row.getAttribute('data-testid');
+    const id = requestId?.replace('mentor-inbox-request-', '');
+    if (!id) throw new Error('mentor-inbox: no pending request row found');
+
+    await this.page.getByTestId(`mentor-inbox-accept-${id}`).click();
+    await this.page.getByTestId(`mentor-inbox-duration-${months}`).click();
+    await this.page.getByTestId(`mentor-inbox-confirm-${id}`).click();
+    return id;
+  }
+}

--- a/frontend/e2e/pages/RequestMentorshipModal.js
+++ b/frontend/e2e/pages/RequestMentorshipModal.js
@@ -1,0 +1,20 @@
+export class RequestMentorshipModal {
+  constructor(page) {
+    this.page = page;
+  }
+
+  root() {
+    return this.page.getByTestId('mentorship-request-modal');
+  }
+
+  async fillAndSubmit(message = '') {
+    if (message) {
+      await this.page.getByTestId('mentorship-request-message').fill(message);
+    }
+    await this.page.getByTestId('mentorship-request-submit').click();
+  }
+
+  errorBanner() {
+    return this.page.getByTestId('mentorship-request-error');
+  }
+}

--- a/frontend/e2e/pages/SchedulePage.js
+++ b/frontend/e2e/pages/SchedulePage.js
@@ -1,0 +1,29 @@
+/**
+ * Read-only POM for /schedule. The current SchedulePage implementation reads
+ * mock data from `src/services/mentorshipMocks.js` rather than the real
+ * /api/mentorships/{id}/meetings endpoint, so AT-02's meeting-create leg goes
+ * through the API directly. This POM is kept for the smoke-level "page loads"
+ * assertion and to be filled out once the page is wired to the real backend.
+ */
+export class SchedulePage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto({ mentorshipId } = {}) {
+    const path = mentorshipId ? `/schedule?mentorshipId=${mentorshipId}` : '/schedule';
+    await this.page.goto(path);
+  }
+
+  list() {
+    return this.page.getByTestId('schedule-list');
+  }
+
+  emptyState() {
+    return this.page.getByTestId('schedule-empty');
+  }
+
+  meetingCard(meetingId) {
+    return this.page.getByTestId(`schedule-meeting-${meetingId}`);
+  }
+}

--- a/frontend/e2e/pages/TasksPage.js
+++ b/frontend/e2e/pages/TasksPage.js
@@ -1,0 +1,29 @@
+/**
+ * Read-only POM for /tasks. Same caveat as SchedulePage — the current
+ * TasksPage renders mock data, so AT-02's task assign/submit/feedback leg
+ * goes through /api/tasks directly. This POM exists so the spec can still
+ * smoke-check that /tasks renders and so it's already in place once the page
+ * is wired to the real backend.
+ */
+export class TasksPage {
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto({ mentorshipId } = {}) {
+    const path = mentorshipId ? `/tasks?mentorshipId=${mentorshipId}` : '/tasks';
+    await this.page.goto(path);
+  }
+
+  list() {
+    return this.page.getByTestId('tasks-list');
+  }
+
+  emptyState() {
+    return this.page.getByTestId('tasks-empty');
+  }
+
+  taskItem(taskId) {
+    return this.page.getByTestId(`tasks-item-${taskId}`);
+  }
+}

--- a/frontend/e2e/specs/at02-mentorship-blog.spec.js
+++ b/frontend/e2e/specs/at02-mentorship-blog.spec.js
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test';
+import {
+  resetDb,
+  seedMentor,
+  seedMentee,
+  login,
+} from '../fixtures/apiClient.js';
+import {
+  createMeeting,
+  confirmMeeting,
+  createTask,
+  submitTask,
+  reviewTask,
+  publishBlogPost,
+  getBlogPost,
+  listIncomingRequests,
+  listActiveMentorships,
+} from '../fixtures/mentorshipApi.js';
+import { LoginPage } from '../pages/LoginPage.js';
+import { ExplorePage } from '../pages/ExplorePage.js';
+import { RequestMentorshipModal } from '../pages/RequestMentorshipModal.js';
+import { MentorshipInbox } from '../pages/MentorshipInbox.js';
+import { SchedulePage } from '../pages/SchedulePage.js';
+import { TasksPage } from '../pages/TasksPage.js';
+
+/**
+ * AT-02: discover mentor → request → accept → schedule → meeting → task
+ * assign / submit / feedback → blog publish.
+ *
+ * Hybrid spec by necessity:
+ *   - Discover / request / accept run through the real UI (the only legs that
+ *     actually have interactive screens today).
+ *   - Schedule, task assign/submit/feedback, and blog publish go through the
+ *     backend HTTP API directly — the corresponding pages are either
+ *     mock-driven (SchedulePage, TasksPage source data from
+ *     `services/mentorshipMocks.js`) or unbuilt (no blog/feed publish UI).
+ *     The backend endpoints exist and are exercised end-to-end; only the UI
+ *     verb is missing.
+ *
+ * Two browser contexts are used so the mentor and mentee can be active
+ * simultaneously without juggling logout/login on a single context. Each
+ * spec resets the DB up front so the run is order-independent across the
+ * three browser projects.
+ */
+
+async function loginViaUi(page, { email, password }) {
+  const loginPage = new LoginPage(page);
+  await loginPage.goto();
+  await loginPage.signIn({ email, password });
+  await expect(page).toHaveURL(/\/home$/);
+}
+
+test('AT-02 mentorship lifecycle + blog publish', async ({ browser, request }) => {
+  await resetDb(request);
+
+  const mentor = await seedMentor(request);
+  const mentee = await seedMentee(request);
+
+  // Two isolated browser contexts so both sides stay logged in concurrently.
+  const mentorCtx = await browser.newContext();
+  const menteeCtx = await browser.newContext();
+  const mentorPage = await mentorCtx.newPage();
+  const menteePage = await menteeCtx.newPage();
+
+  try {
+    // 1. Mentee logs in via UI, opens /explore.
+    await loginViaUi(menteePage, mentee);
+    const explore = new ExplorePage(menteePage);
+    await explore.goto();
+
+    // 2. Send mentorship request through the modal.
+    await explore.openRequestForMentor(mentor.id);
+    const modal = new RequestMentorshipModal(menteePage);
+    await expect(modal.root()).toBeVisible();
+    await modal.fillAndSubmit('Hi, I would love your guidance on backend systems.');
+    // Modal closes on success; the "Request Sent" label appears on the card.
+    await expect(menteePage.getByTestId(`explore-send-request-${mentor.id}`)).toContainText(/sent/i);
+
+    // 3. Mentor logs in via UI and accepts the pending request.
+    await loginViaUi(mentorPage, mentor);
+    const inbox = new MentorshipInbox(mentorPage);
+    await inbox.goto();
+    await inbox.acceptFirstRequest({ months: 3 });
+
+    // After accept, the active mentorship exists. Pull tokens for direct API work.
+    const mentorAuth = await login(request, mentor.email, mentor.password);
+    const menteeAuth = await login(request, mentee.email, mentee.password);
+
+    // Sanity: both sides see the new ACTIVE mentorship.
+    const [mentorMentorships, menteeMentorships] = await Promise.all([
+      listActiveMentorships(request, mentorAuth.sessionToken),
+      listActiveMentorships(request, menteeAuth.sessionToken),
+    ]);
+    expect(mentorMentorships.length).toBe(1);
+    expect(menteeMentorships.length).toBe(1);
+    const mentorshipId = mentorMentorships[0].id;
+    expect(menteeMentorships[0].id).toBe(mentorshipId);
+
+    // (Side check: there are no longer any incoming pending requests for the mentor.)
+    const remainingRequests = await listIncomingRequests(request, mentorAuth.sessionToken);
+    expect(remainingRequests.filter(r => r.status === 'PENDING')).toHaveLength(0);
+
+    // 4. Mentor schedules a meeting (API leg — no create UI on /schedule yet).
+    const inOneWeek = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const meeting = await createMeeting(request, mentorAuth.sessionToken, mentorshipId, {
+      title: 'Kickoff: project goals',
+      date: inOneWeek,
+      durationMin: 45,
+    });
+    expect(meeting.id).toBeDefined();
+
+    // 5. Mentee confirms the meeting.
+    const confirmed = await confirmMeeting(request, menteeAuth.sessionToken, meeting.id);
+    expect(confirmed.status).toBe('CONFIRMED');
+
+    // /schedule is mock-driven today, so we only smoke-check it renders for the
+    // mentee. Once the page is wired to /api/mentorships/{id}/meetings, the
+    // assertion below should be promoted to `meetingCard(meeting.id).toBeVisible()`.
+    const schedulePage = new SchedulePage(menteePage);
+    await schedulePage.goto();
+    await expect(menteePage.locator('h1, .page-title').first()).toBeVisible();
+
+    // 6. Mentor assigns a task; mentee submits; mentor reviews.
+    const task = await createTask(request, mentorAuth.sessionToken, mentorshipId, {
+      title: 'Read the architecture doc',
+      description: 'Skim the high-level overview and note three questions.',
+      dueDate: inOneWeek,
+    });
+    expect(task.status).toBe('PENDING');
+
+    const submitted = await submitTask(request, menteeAuth.sessionToken, task.id, {
+      content: 'Done. Three questions noted in the comment thread.',
+    });
+    expect(submitted.status).toBe('SUBMITTED');
+
+    const reviewed = await reviewTask(request, mentorAuth.sessionToken, task.id, {
+      status: 'COMPLETED',
+      feedback: 'Solid questions, well-framed. Marking complete.',
+    });
+    expect(reviewed.status).toBe('COMPLETED');
+
+    // /tasks is also mock-driven; smoke-render only for now. Same upgrade
+    // path as /schedule once the page consumes the real backend.
+    const tasksPage = new TasksPage(menteePage);
+    await tasksPage.goto();
+    await expect(menteePage.locator('h1, .page-title').first()).toBeVisible();
+
+    // 7. Mentor publishes a blog post (POST /api/feed/posts is the closest
+    // surface to "blog publish" today; there's no dedicated blog UI yet).
+    const post = await publishBlogPost(request, mentorAuth.sessionToken, {
+      body: 'Reflections from a kickoff session — first mentee onboarded today.',
+      hashtags: ['mentorship', 'reflection'],
+    });
+    expect(post.id).toBeDefined();
+
+    const fetched = await getBlogPost(request, mentorAuth.sessionToken, post.id);
+    expect(fetched.body).toContain('Reflections from a kickoff session');
+    expect(fetched.hashtags).toEqual(expect.arrayContaining(['mentorship', 'reflection']));
+  } finally {
+    await mentorCtx.close();
+    await menteeCtx.close();
+  }
+});

--- a/frontend/e2e/specs/at02-mentorship-blog.spec.js
+++ b/frontend/e2e/specs/at02-mentorship-blog.spec.js
@@ -46,7 +46,19 @@ import { TasksPage } from '../pages/TasksPage.js';
 async function loginViaUi(page, { email, password }) {
   const loginPage = new LoginPage(page);
   await loginPage.goto();
+  // Surface the underlying /api/auth/login outcome — without this, a 401
+  // from the backend just leaves us stuck on /login and the test only
+  // reports "URL didn't change" with no signal as to why.
+  const loginResponsePromise = page.waitForResponse(
+    res => res.url().endsWith('/api/auth/login') && res.request().method() === 'POST',
+    { timeout: 10_000 },
+  );
   await loginPage.signIn({ email, password });
+  const loginResponse = await loginResponsePromise;
+  if (!loginResponse.ok()) {
+    const body = await loginResponse.text().catch(() => '');
+    throw new Error(`UI login for ${email} returned ${loginResponse.status()}: ${body}`);
+  }
   await expect(page).toHaveURL(/\/home$/);
 }
 

--- a/frontend/e2e/specs/at02-mentorship-blog.spec.js
+++ b/frontend/e2e/specs/at02-mentorship-blog.spec.js
@@ -15,6 +15,7 @@ import {
   getBlogPost,
   listIncomingRequests,
   listActiveMentorships,
+  setSharedGoal,
 } from '../fixtures/mentorshipApi.js';
 import { LoginPage } from '../pages/LoginPage.js';
 import { ExplorePage } from '../pages/ExplorePage.js';
@@ -111,6 +112,15 @@ test('AT-02 mentorship lifecycle + blog publish', async ({ browser, request }) =
     // (Side check: there are no longer any incoming pending requests for the mentor.)
     const remainingRequests = await listIncomingRequests(request, mentorAuth.sessionToken);
     expect(remainingRequests.filter(r => r.status === 'PENDING')).toHaveLength(0);
+
+    // Shared goal is the precondition for any meeting / task / milestone write
+    // since #335 added the gate; set it as the mentor before scheduling.
+    await setSharedGoal(
+      request,
+      mentorAuth.sessionToken,
+      mentorshipId,
+      'Build a portfolio project together end-to-end',
+    );
 
     // 4. Mentor schedules a meeting (API leg — no create UI on /schedule yet).
     const inOneWeek = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();

--- a/frontend/e2e/specs/at02-mentorship-blog.spec.js
+++ b/frontend/e2e/specs/at02-mentorship-blog.spec.js
@@ -141,7 +141,7 @@ test('AT-02 mentorship lifecycle + blog publish', async ({ browser, request }) =
     expect(task.status).toBe('PENDING');
 
     const submitted = await submitTask(request, menteeAuth.sessionToken, task.id, {
-      content: 'Done. Three questions noted in the comment thread.',
+      submissionText: 'Done. Three questions noted in the comment thread.',
     });
     expect(submitted.status).toBe('SUBMITTED');
 

--- a/frontend/e2e/specs/at04a-community-create.spec.js
+++ b/frontend/e2e/specs/at04a-community-create.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * AT-04a — community create + join + leave.
+ *
+ * BLOCKED. The community/group concept does not exist on dev: there is no
+ * `Community` (or `Group`) entity, no controller, no migration, and no
+ * frontend page. Issue #316's Notes pin this on the Blog & Content System
+ * issue (#281), which has not landed.
+ *
+ * When #281 ships:
+ *   1. Replace `test.fixme` below with a real test body.
+ *   2. Add a `CommunityPage` POM under `e2e/pages/`.
+ *   3. Extend `e2e/fixtures/apiClient.js` with `seedCommunities(request, n)`
+ *      so the create + join + leave flow has predictable starting state.
+ *
+ * Acceptance check from #316: "create, join/leave" all hit the UI and assert
+ * post-state via the same UI. Order-independence requires resetting via
+ * `/api/test/reset` at the top of each test.
+ */
+test.fixme('AT-04a community create + join + leave (blocked by #281)', async () => {
+  // Intentionally empty until the community feature lands.
+  expect.fail('Unblock by removing test.fixme once community endpoints exist.');
+});

--- a/frontend/e2e/specs/at04b-posts-voting.spec.js
+++ b/frontend/e2e/specs/at04b-posts-voting.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * AT-04b — posts + comments + upvote/downvote.
+ *
+ * BLOCKED on two fronts:
+ *   - Backend: feed interactions (#347 — likes, comments, bookmarks,
+ *     FeedInteractionController) is on `feature/347-feed-interactions` and
+ *     not merged to dev. The product's voting model is binary "like", not
+ *     reddit-style up/down — when this spec is unblocked, decide whether to
+ *     reinterpret AT-04b's "upvote/downvote" as like-toggle or to push back
+ *     on the issue text.
+ *   - Frontend: no feed UI exists; #316 will need a FeedPage + PostDetail +
+ *     comment thread before this spec can drive anything.
+ *
+ * Once unblocked, the spec should cover:
+ *   - Mentee creates a post (UI), assert it appears in the feed.
+ *   - Another user comments (UI), assert it appears under the post.
+ *   - Toggle like (or upvote, depending on resolution above) and assert
+ *     interaction state echoes back via FeedPostInteractionState.
+ */
+test.fixme('AT-04b post + comment + vote (blocked by #347 merge + feed UI)', async () => {
+  expect.fail('Unblock by removing test.fixme once feed interactions ship + UI exists.');
+});

--- a/frontend/e2e/specs/at04c-feed-ranking.spec.js
+++ b/frontend/e2e/specs/at04c-feed-ranking.spec.js
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * AT-04c — feed sort / filter / pagination / infinite scroll.
+ *
+ * BLOCKED. Feed surfaces (#350: For-You, Following, Search controllers and
+ * the Schwartzian-sorted ranker) live on `feature/350-feed-surfaces` and
+ * have not merged to dev. The frontend has no feed page either.
+ *
+ * Spec scope when unblocked (per #316 acceptance criteria):
+ *   - "For-You" tab returns ranked, paginated results; assert page boundary
+ *     behavior (size 20 default, last page truncates).
+ *   - "Following" tab returns chronological posts only from followed users.
+ *   - Infinite scroll appends a fresh page when the sentinel enters
+ *     viewport; existing items are not duplicated.
+ *   - Hashtag and keyword search filters narrow the set as expected.
+ *
+ * The seed data strategy for ranking assertions is NetworkX-distributed
+ * votes, called out explicitly in the issue. That helper will need to live
+ * under `e2e/fixtures/feedSeed.js` and call a yet-to-exist
+ * `/api/test/feed-seed` endpoint that posts N posts + simulated interactions
+ * matching a configurable graph.
+ */
+test.fixme('AT-04c feed ranking + pagination + infinite scroll (blocked by #350 merge + feed UI)', async () => {
+  expect.fail('Unblock by removing test.fixme once feed surfaces ship + UI exists.');
+});

--- a/frontend/e2e/specs/at04d-moderation.spec.js
+++ b/frontend/e2e/specs/at04d-moderation.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * AT-04d — moderator mute / remove / pin.
+ *
+ * BLOCKED. There is no community-moderator role, no mute endpoint, no pin
+ * endpoint, and no remove-by-moderator endpoint on dev. The closest existing
+ * surfaces are platform-admin actions (#135, also unmerged) which are
+ * different — moderator authority is community-scoped, admin is platform-
+ * wide. AT-04d depends on the community feature (#281) shipping a moderator
+ * role first, then dedicated moderation endpoints + UI.
+ *
+ * Once unblocked, three discrete tests:
+ *   - Moderator mutes a user; muted user's subsequent post in the same
+ *     community is hidden from the feed (or 403'd at write).
+ *   - Moderator removes a post; the post's `deletedAt` is set (or
+ *     equivalent), and it disappears from the feed for non-mods.
+ *   - Moderator pins a post; the post sorts to the top of the community
+ *     feed regardless of timestamp / score.
+ */
+test.fixme('AT-04d moderation: mute / remove / pin (blocked by #281 community + missing mod endpoints)', async () => {
+  expect.fail('Unblock when community moderator role + endpoints + UI exist.');
+});

--- a/frontend/e2e/specs/at05-abuse-mitigation.spec.js
+++ b/frontend/e2e/specs/at05-abuse-mitigation.spec.js
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * AT-05 — toxic post auto-flag → user report flow → admin escalation review
+ * (ban / dismiss).
+ *
+ * BLOCKED, but only partially:
+ *
+ * - **Toxicity auto-flagging** is *not built* anywhere in the codebase. There
+ *   is no Perspective/OpenAI/manual-corpus pipeline, no "flagged" column on
+ *   FeedPost, no moderation worker. Issue text says "auto-flag" but the
+ *   product has only manual user reports. Either narrow the spec to
+ *   manual-only, or block on a new feature issue for auto-flagging.
+ *
+ * - **User report flow** is built on `feature/135-reporting-moderation` but
+ *   not merged to dev. The endpoints (`POST /api/reports`,
+ *   `GET /api/admin/reports`, `PATCH /api/admin/reports/{id}`) and the
+ *   state machine OPEN → UNDER_REVIEW → RESOLVED/DISMISSED exist there.
+ *
+ * - **Admin frontend** does not exist — no AdminPage, no
+ *   /admin/reports route, no role-conditional rendering. Even after #135
+ *   merges, AT-05 needs a UI before it can run UI-driven assertions.
+ *
+ * Infrastructure that *is* ready (so unfixming is fast):
+ *   - `seedAdmin(request)` from apiClient.js returns an admin + JWT.
+ *   - `applyAdminAuth(context, admin)` from adminFixture.js injects the
+ *     admin tokens into a Playwright context's localStorage so the admin
+ *     login step doesn't repeat per test (the issue's storageState ask).
+ *   - The toxicity corpus mentioned in the issue is also TODO; once
+ *     auto-flag lands, seed under `e2e/fixtures/toxicCorpus.js`.
+ *
+ * Once unblocked, the spec should cover three independent tests:
+ *   1. Toxic content auto-flag: post a known-toxic body, assert it lands
+ *      under admin review without any user action.
+ *   2. User report → admin queue: a user reports a post via UI, an admin
+ *      sees it in the queue and transitions OPEN → UNDER_REVIEW.
+ *   3. Admin resolves: ban the offending user (#134) or dismiss the
+ *      report; assert state machine + downstream side effects.
+ */
+test.fixme('AT-05 abuse mitigation (blocked by auto-flag missing + #135 merge + admin UI)', async () => {
+  expect.fail('Unblock by removing test.fixme once reporting + admin UI exist.');
+});

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -7,7 +7,11 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 2 : undefined,
+  // CI is serialized to 1 worker because /api/test/reset TRUNCATEs the whole
+  // DB and parallel workers race-stomp on each other's seeded users — a
+  // mid-test reset wipes the other worker's session. True isolation needs
+  // schema-per-worker or per-test data namespacing; tracked as a follow-up.
+  workers: process.env.CI ? 1 : undefined,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
     baseURL,

--- a/frontend/src/components/RequestMentorshipModal.jsx
+++ b/frontend/src/components/RequestMentorshipModal.jsx
@@ -47,7 +47,7 @@ export default function RequestMentorshipModal({ visible, onClose, onSubmit, loa
   const charCount = message.trim().length
 
   return (
-    <div className="modal-overlay" ref={overlayRef} onMouseDown={handleOverlayClick}>
+    <div className="modal-overlay" ref={overlayRef} onMouseDown={handleOverlayClick} data-testid="mentorship-request-modal">
       <div className="modal-card" role="dialog" aria-modal="true" aria-labelledby="requestMentorshipTitle">
         <div className="modal-header">
           <div>
@@ -68,6 +68,7 @@ export default function RequestMentorshipModal({ visible, onClose, onSubmit, loa
             onChange={(e) => setMessage(e.target.value)}
             placeholder="Tell the mentor why you'd like to work with them..."
             rows={8}
+            data-testid="mentorship-request-message"
           />
           <div className="modal-footer-row">
             <span className="char-count" style={{ color: charCount > maxChars ? '#b91c1c' : '#64748b' }}>
@@ -75,11 +76,11 @@ export default function RequestMentorshipModal({ visible, onClose, onSubmit, loa
             </span>
           </div>
 
-          {error && <div className="modal-api-error">{error}</div>}
+          {error && <div className="modal-api-error" data-testid="mentorship-request-error">{error}</div>}
 
           <div className="modal-actions">
             <button type="button" className="modal-btn-secondary" onClick={onClose}>Cancel</button>
-            <button type="submit" className="modal-btn-primary" disabled={loading || !isValid}>
+            <button type="submit" className="modal-btn-primary" disabled={loading || !isValid} data-testid="mentorship-request-submit">
               {loading ? 'Sending...' : 'Send Request'}
             </button>
           </div>

--- a/frontend/src/pages/ExplorePage.jsx
+++ b/frontend/src/pages/ExplorePage.jsx
@@ -380,14 +380,14 @@ export default function ExplorePage() {
           {isMentee ? 'No mentors found. Try a different search or filter.' : 'No candidate mentees found.'}
         </div>
       ) : isMentee ? (
-        <div className="mentors-grid">
+        <div className="mentors-grid" data-testid="explore-mentor-grid">
           {filtered.map(m => {
             const tags = (m.interests || []).slice(0, 3)
             const alreadySent = requestSentIds.has(m.id)
             const full = m.maxMenteeCapacity != null && m.currentMenteeCount >= m.maxMenteeCapacity
             const btnDisabled = alreadySent || hasActiveMentor || full
             return (
-              <div className="mentor-card" key={m.id}>
+              <div className="mentor-card" key={m.id} data-testid={`explore-mentor-card-${m.id}`}>
                 <div className="mc-header">
                   <div className="mc-info">
                     <Avatar src={m.profilePhoto} initials={m.firstName?.[0]?.toUpperCase() ?? '?'} size="md" />
@@ -411,6 +411,7 @@ export default function ExplorePage() {
                       disabled={btnDisabled}
                       onClick={() => !btnDisabled && openRequestModal(m)}
                       title={hasActiveMentor && !alreadySent ? 'You already have an active mentor' : undefined}
+                      data-testid={`explore-send-request-${m.id}`}
                     >
                       {alreadySent ? 'Request Sent' : full ? 'At Capacity' : hasActiveMentor ? 'Already Mentored' : 'Send Request'}
                     </button>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -263,15 +263,15 @@ export default function HomePage() {
           ) : (
             <div className="home-grid">
               {/* Incoming Requests */}
-              <div>
+              <div data-testid="mentor-inbox">
                 <div className="section-label">Incoming Requests</div>
                 {pendingRequests.length === 0 ? (
-                  <div className="empty-state" style={{ padding: '24px', fontSize: '14px' }}>
+                  <div className="empty-state" style={{ padding: '24px', fontSize: '14px' }} data-testid="mentor-inbox-empty">
                     No pending requests
                   </div>
                 ) : (
                   pendingRequests.map(req => (
-                    <div className="request-card" key={req.id}>
+                    <div className="request-card" key={req.id} data-testid={`mentor-inbox-request-${req.id}`}>
                       <div className="req-header">
                         <div className="req-avatar">
                           {req.menteeFirstName?.[0] ?? '?'}
@@ -286,7 +286,7 @@ export default function HomePage() {
 
                       {/* Duration picker shown when accepting this request */}
                       {acceptingId === req.id ? (
-                        <div className="duration-picker">
+                        <div className="duration-picker" data-testid={`mentor-inbox-duration-${req.id}`}>
                           <p className="duration-label">Select mentorship duration:</p>
                           <div className="duration-options">
                             {[1, 3, 6].map(d => (
@@ -294,6 +294,7 @@ export default function HomePage() {
                                 key={d}
                                 className={`duration-btn${selectedDuration === d ? ' duration-btn--active' : ''}`}
                                 onClick={() => setSelectedDuration(d)}
+                                data-testid={`mentor-inbox-duration-${d}`}
                               >
                                 {d} {d === 1 ? 'month' : 'months'}
                               </button>
@@ -304,6 +305,7 @@ export default function HomePage() {
                               className="btn-accept"
                               onClick={handleAcceptConfirm}
                               disabled={actionLoading}
+                              data-testid={`mentor-inbox-confirm-${req.id}`}
                             >
                               {actionLoading ? 'Confirming…' : 'Confirm'}
                             </button>
@@ -322,6 +324,7 @@ export default function HomePage() {
                             className="btn-accept"
                             onClick={() => { setAcceptingId(req.id); setSelectedDuration(3) }}
                             disabled={actionLoading}
+                            data-testid={`mentor-inbox-accept-${req.id}`}
                           >
                             Accept
                           </button>
@@ -329,6 +332,7 @@ export default function HomePage() {
                             className="btn-decline"
                             onClick={() => handleReject(req.id)}
                             disabled={actionLoading}
+                            data-testid={`mentor-inbox-decline-${req.id}`}
                           >
                             Decline
                           </button>

--- a/frontend/src/pages/SchedulePage.jsx
+++ b/frontend/src/pages/SchedulePage.jsx
@@ -61,7 +61,7 @@ export default function SchedulePage() {
             const date = new Date(m.date)
             const mentLabel = !scopedId ? labelFor(m.mentorship, role) : null
             return (
-              <div key={m.id} className="md-meeting-card">
+              <div key={m.id} className="md-meeting-card" data-testid={`schedule-meeting-${m.id}`}>
                 <div className="md-meeting-day">
                   <div className="md-meeting-day-num">{date.getDate()}</div>
                   <div className="md-meeting-day-mo">{date.toLocaleDateString('en-GB', { month: 'short' })}</div>
@@ -112,12 +112,12 @@ export default function SchedulePage() {
       {loading ? (
         <div className="md-loading">Loading meetings…</div>
       ) : sorted.length === 0 ? (
-        <div className="empty-state">No meetings scheduled.</div>
+        <div className="empty-state" data-testid="schedule-empty">No meetings scheduled.</div>
       ) : (
-        <>
+        <div data-testid="schedule-list">
           <Section title="Upcoming" items={upcoming} />
           <Section title="Past" items={past} />
-        </>
+        </div>
       )}
     </MainLayout>
   )

--- a/frontend/src/pages/TasksPage.jsx
+++ b/frontend/src/pages/TasksPage.jsx
@@ -84,14 +84,14 @@ export default function TasksPage() {
       {loading ? (
         <div className="md-loading">Loading tasks…</div>
       ) : tasks.length === 0 ? (
-        <div className="empty-state">No tasks yet.</div>
+        <div className="empty-state" data-testid="tasks-empty">No tasks yet.</div>
       ) : (
-        <div className="md-task-list">
+        <div className="md-task-list" data-testid="tasks-list">
           {tasks.map(t => {
             const done = t.status === 'DONE'
             const mentLabel = !scopedId ? labelFor(t.mentorship, role) : null
             return (
-              <label key={t.id} className={`md-task-item${done ? ' md-task-done' : ''}`}>
+              <label key={t.id} className={`md-task-item${done ? ' md-task-done' : ''}`} data-testid={`tasks-item-${t.id}`}>
                 <input
                   type="checkbox"
                   checked={done}


### PR DESCRIPTION
Closes #316.

> ⚠️ **Stacked on #315.** Until that PR merges, the diff here will also show the #315 changes (Playwright config, AT-01, AT-03, backend test-support infra). Once #315 lands in `dev`, this PR's diff will narrow to the #316-specific changes automatically. Review #315 first; this PR depends on its POM conventions, `TestSupportController`, and `data-testid` strategy.

## Scope reality check

The issue's "six green spec files" goal can't be met today because three product surfaces it depends on aren't in `dev` yet. Rather than waiting weeks, this PR ships everything that's *actually deliverable now*, with the rest scaffolded as `test.fixme` so they're one-line unblocks when their upstream lands.

| Deliverable | Status | Why |
|---|---|---|
| AT-02 mentorship + blog | ✅ **Done** (hybrid UI + API) | Backend ready (#237 lifecycle merged); UI exists for discover/request/accept; meeting/task pages still mock-driven so those legs go through API |
| AT-04a community create | 🟡 `test.fixme` | No `Community` entity, controller, or page on `dev` (depends on #281) |
| AT-04b posts + voting | 🟡 `test.fixme` | #347 (feed interactions) unmerged + no feed UI; "upvote/downvote" terminology mismatches built "like" toggle |
| AT-04c feed ranking | 🟡 `test.fixme` | #350 (feed surfaces — for-you/following/search ranker) unmerged + no feed UI |
| AT-04d moderation | 🟡 `test.fixme` | No moderator role, no mute/pin/remove endpoints anywhere |
| AT-05 abuse mitigation | 🟡 `test.fixme` | Auto-toxicity pipeline doesn't exist; #135 (manual reports) unmerged; no admin frontend |

Each fixme spec carries a multi-line block comment naming the exact upstream blocker(s) and what to write once unblocked, so picking these up later doesn't require re-discovery.

## What's in this PR

### Backend — TestSupportController extensions
- `POST /api/test/users` response now includes a pre-minted `sessionToken` (JWT). Specs that need an authenticated `request` context can skip the UI login and go straight to API calls — used heavily by AT-02's schedule/task/blog API legs.
- New `POST /api/test/admin`. `AuthService.register` only constructs `Mentor` / `Mentee`, so this seeds the `Admin` entity through `userRepository.save` directly, bypasses email verification, and returns a JWT for AT-05's `storageState` fixture. Same `@ConditionalOnProperty(app.test-endpoints.enabled)` gating + SecurityConfig 404 guard from #315 — production posture unchanged.

### Frontend — POMs and fixtures
- POMs: `ExplorePage`, `RequestMentorshipModal`, `MentorshipInbox` (the mentor's incoming-requests panel on `/home`), `SchedulePage` (read-only), `TasksPage` (read-only). The two read-only POMs are intentional — `SchedulePage.jsx` and `TasksPage.jsx` currently render mock data from `services/mentorshipMocks.js`, so the POMs only smoke-check that the page renders. The contract for promoting them to real assertions is documented in each POM's header comment.
- Fixtures:
  - `e2e/fixtures/mentorshipApi.js` — typed helpers for the legs whose UI doesn't exist yet: `createMeeting`, `confirmMeeting`, `createTask`, `submitTask`, `reviewTask`, `publishBlogPost`, `getBlogPost`, `listIncomingRequests`, `listActiveMentorships`. All use bearer-token auth against the real backend.
  - `e2e/fixtures/adminFixture.js` — `applyAdminAuth(context, admin)` injects `auth_token`/`auth_role`/`auth_user_id` into a fresh context's `localStorage` via `addInitScript`, satisfying #316's "admin via storageState; login does not repeat" requirement without needing a serialized state file. AT-05 will call this once unfixme'd.
  - `e2e/fixtures/apiClient.js` — added `seedMentor`, `seedMentee`, `seedAdmin`, `login` sugar.

### data-testid hooks (auth/profile-only convention from #315 extended)
- `ExplorePage`: `explore-mentor-grid`, `explore-mentor-card-{id}`, `explore-send-request-{id}`
- `RequestMentorshipModal`: `mentorship-request-modal`, `mentorship-request-message`, `mentorship-request-submit`, `mentorship-request-error`
- `HomePage` (mentor inbox): `mentor-inbox`, `mentor-inbox-empty`, `mentor-inbox-request-{id}`, `mentor-inbox-accept-{id}`, `mentor-inbox-decline-{id}`, `mentor-inbox-duration-{months}`, `mentor-inbox-confirm-{id}`
- `SchedulePage`: `schedule-list`, `schedule-empty`, `schedule-meeting-{id}` (for future use once page consumes real backend)
- `TasksPage`: `tasks-list`, `tasks-empty`, `tasks-item-{id}` (same future-use note)

### AT-02 spec — hybrid by necessity
`at02-mentorship-blog.spec.js` runs as a single sequential test across all three browsers (chromium/firefox/webkit) using the standard `projects` mechanism — no per-browser describe duplication.

Two `browser.newContext()` instances keep mentor and mentee logged in concurrently:
1. Mentee logs in via UI, opens `/explore`, clicks Send Request on the seeded mentor's card, fills + submits the modal, asserts the "Request Sent" badge.
2. Mentor logs in via UI, navigates to `/home`, accepts the pending request via the duration picker (3 months).
3. Both sides' `GET /api/mentorships` confirm the new `ACTIVE` mentorship; mentor's incoming queue shows zero pending.
4. Mentor schedules a meeting (`POST /api/mentorships/{id}/meetings`); mentee confirms (`POST /api/meetings/{id}/confirm`); status transitions to `CONFIRMED`. `/schedule` smoke-renders for the mentee.
5. Mentor assigns a task; mentee submits (status → `SUBMITTED`); mentor reviews with `COMPLETED` + feedback (status → `COMPLETED`). `/tasks` smoke-renders for the mentee.
6. Mentor publishes a blog-equivalent post via `POST /api/feed/posts`; `GET /api/feed/posts/{id}` confirms the body + hashtags round-tripped. (`#316`'s "blog publish" deliverable maps to the social feed since there's no dedicated blog feature.)

Each leg is justified inline in the spec — when the missing UI ships, promoting an API leg to UI is a localized change.

### AT-04 / AT-05 scaffolds
Five `test.fixme` files, each with a multi-paragraph header explaining:
- which dependency blocks it (PR / branch numbers),
- what the spec body should cover when unblocked,
- which fixtures or helpers will need to exist by then.

Listed as `Total: 33 tests in 8 files` by `npx playwright test --list` — the fixme'd tests appear as `skipped` at run time, not failed.

## Acceptance criteria check

- [x] Six spec files exist (AT-02 + AT-04a/b/c/d + AT-05) and Playwright discovers them across all three browser projects
- [x] AT-02 runs green (cross-browser, single sequential test)
- [x] Each AT-02 leg is order-independent — `resetDb` at the start, no shared state
- [x] Admin role accessed via `applyAdminAuth(context, admin)` rather than per-test login (used in AT-05 once unfixme'd)
- [x] Faker-driven user data (`seedMentor` / `seedMentee` / `seedAdmin`)
- [ ] AT-04 covers pagination + infinite scroll — *deferred*, scaffold only (see "Scope reality check")
- [ ] NetworkX-distributed votes — *deferred*, ditto. The seed-fixture helper (`feedSeed.js`) is mentioned in `at04c` so the future contributor knows where to put it.

## Test plan

- [ ] CI's `e2e-ci` job is green for `at01`, `at02`, `at03`. AT-04/AT-05 should appear as **skipped**, not failed.
- [ ] On a deliberately broken AT-02 assertion, failed-job artifacts surface `playwright-report/`, `test-results/` (with traces / videos / screenshots), and the backend / frontend logs.
- [ ] `cd frontend && npm run test:e2e -- --grep "AT-02"` passes locally once the backend is started with `APP_TEST_ENDPOINTS_ENABLED=true APP_EMAIL_ENABLED=false`.
- [ ] `npx playwright test --grep @smoke` still finishes under 30 seconds.
- [ ] `curl -i http://localhost:8080/api/test/admin -X POST` returns 404 in default config; 200 only when test endpoints are enabled.

## Out of scope (follow-ups)

- All AT-04 and AT-05 spec bodies — each is `test.fixme`'d with a clear unblock plan.
- Wiring `SchedulePage` and `TasksPage` to the real backend (currently mock-driven). When that lands, promote the smoke renders in AT-02 to `meetingCard(id).toBeVisible()` and `taskItem(id).toBeVisible()` — one-line changes per leg.
- Toxicity auto-flagging pipeline. The product currently has no moderation pipeline; AT-05's "toxic content auto-flag" leg needs a separate feature issue before its spec can be written.
- Mobile Detox/Maestro — #318.
- Umbrella docs (test data strategy, ownership, contribution guide) — #314.