### PR TITLE
Add mobile critical flow tests

### DIFF
--- a/mobile-app/__tests__/notifications.test.tsx
+++ b/mobile-app/__tests__/notifications.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { router } from 'expo-router';
+
+import NotificationsScreen from '../app/notifications';
+import apiClient from '../api/client';
+
+jest.mock('../api/client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    patch: jest.fn(),
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+  },
+}));
+
+const notificationsFixture = [
+  {
+    id: 1,
+    type: 'NEW_MESSAGE',
+    title: 'New message',
+    body: 'You received a new chat message.',
+    isRead: false,
+    createdAt: '2026-05-09T10:00:00Z',
+  },
+  {
+    id: 2,
+    type: 'MATCH_FOUND',
+    title: 'Match found',
+    body: 'A mentorship connection is ready.',
+    isRead: true,
+    createdAt: '2026-05-08T09:00:00Z',
+  },
+];
+
+describe('NotificationsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads notifications and marks all unread items as read on first open', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({ data: notificationsFixture });
+    (apiClient.patch as jest.Mock).mockResolvedValue({});
+
+    const { findByText } = render(<NotificationsScreen />);
+
+    expect(await findByText('New message')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith('/notifications');
+    });
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalledWith('/notifications/read-all');
+    });
+  });
+
+  it('routes to messages when a message notification is opened', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          ...notificationsFixture[0],
+          isRead: true,
+        },
+      ],
+    });
+    (apiClient.patch as jest.Mock).mockResolvedValue({});
+
+    const { findByText } = render(<NotificationsScreen />);
+
+    const card = await findByText('New message');
+    fireEvent.press(card);
+
+    expect(router.push).toHaveBeenCalledWith('/(tabs)/messages');
+  });
+
+  it('shows the empty state when there are no notifications', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({ data: [] });
+
+    const { findByText } = render(<NotificationsScreen />);
+
+    expect(await findByText('No notifications yet.')).toBeTruthy();
+  });
+});

--- a/mobile-app/__tests__/reset-password.test.tsx
+++ b/mobile-app/__tests__/reset-password.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+
+import ResetPasswordScreen from '../app/reset-password';
+import apiClient from '../api/client';
+
+jest.mock('../api/client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+  },
+  useLocalSearchParams: jest.fn(),
+}));
+
+describe('ResetPasswordScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ token: 'valid-token' });
+  });
+
+  it('validates the incoming token on mount and resets the password successfully', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({});
+    (apiClient.post as jest.Mock).mockResolvedValue({
+      data: {
+        message: 'Password reset successfully.',
+      },
+    });
+
+    const { getByPlaceholderText, getByText, findByText } = render(<ResetPasswordScreen />);
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith('/auth/validate-reset-token?token=valid-token');
+    });
+
+    fireEvent.changeText(getByPlaceholderText('••••••••'), 'StrongPass1');
+    fireEvent.press(getByText('Reset Password'));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith('/auth/reset-password', {
+        token: 'valid-token',
+        newPassword: 'StrongPass1',
+      });
+    });
+
+    expect(await findByText('Password reset successfully.')).toBeTruthy();
+    fireEvent.press(getByText('Go to Sign In'));
+    expect(router.replace).toHaveBeenCalledWith('/login');
+  });
+
+  it('shows the invalid-link state and can route to request a new link', async () => {
+    (apiClient.get as jest.Mock).mockRejectedValue({
+      response: {
+        data: {
+          message: 'Token expired.',
+        },
+      },
+    });
+
+    const { findByText, getByText } = render(<ResetPasswordScreen />);
+
+    expect(await findByText('Token expired.')).toBeTruthy();
+    fireEvent.press(getByText('Request a New Link'));
+    expect(router.replace).toHaveBeenCalledWith('/forgot-password');
+  });
+
+  it('keeps the form disabled for weak passwords', async () => {
+    (apiClient.get as jest.Mock).mockResolvedValue({});
+
+    const { getByPlaceholderText, getByText } = render(<ResetPasswordScreen />);
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalled();
+    });
+
+    fireEvent.changeText(getByPlaceholderText('••••••••'), 'weak');
+    fireEvent.press(getByText('Reset Password'));
+
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Extends the mobile automated test suite with additional critical user flows.

## What Changed
- added reset-password screen tests covering token validation, successful reset, and invalid-link fallback
- added notifications screen tests covering fetch, read-state handling, navigation, and empty state
- kept the existing login and forgot-password tests intact as the base auth suite

## Verification
- `cd mobile-app && npm test -- --runInBand`
- `cd mobile-app && npx tsc --noEmit`

## Related Issue
Closes #318
