### PR TITLE
feat(backend): mentorship cancellation, cleanup, audit trail

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
@@ -1,6 +1,8 @@
 package com.group7.backend.controller;
 
+import com.group7.backend.dto.request.CancelMentorshipRequest;
 import com.group7.backend.dto.request.SharedGoalRequest;
+import com.group7.backend.dto.response.MentorshipAuditLogResponse;
 import com.group7.backend.dto.response.MentorshipProgressResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
 import com.group7.backend.dto.response.TimelineResponse;
@@ -139,5 +141,51 @@ public class MentorshipController {
             Authentication authentication) {
         Long userId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(mentorshipService.setSharedGoal(userId, id, request));
+    }
+
+    @PostMapping("/{id}/cancel")
+    @Operation(
+            summary = "Cancel an active mentorship (#133)",
+            description = "Either participant may cancel an active mentorship by supplying a reason. " +
+                    "Children (meetings, tasks, milestones, conversation/messages) are deleted; " +
+                    "the mentorship row itself is retained with status=CANCELLED for audit and " +
+                    "cool-down lookups. The other participant is notified."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Mentorship cancelled",
+                    content = @Content(schema = @Schema(implementation = MentorshipResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content),
+            @ApiResponse(responseCode = "409", description = "Mentorship is not active", content = @Content)
+    })
+    public ResponseEntity<MentorshipResponse> cancelMentorship(
+            @PathVariable Long id,
+            @Valid @RequestBody CancelMentorshipRequest request,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorshipService.cancelMentorship(userId, id, request));
+    }
+
+    @GetMapping("/{id}/audit")
+    @Operation(
+            summary = "Get mentorship audit trail (#133)",
+            description = "Returns every recorded state transition for the mentorship in chronological " +
+                    "order. The first row is the implicit creation transition (NULL → ACTIVE); " +
+                    "user-driven transitions include the actor and reason. Only the mentor and " +
+                    "mentee may read."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Audit trail",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = MentorshipAuditLogResponse.class)))),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content)
+    })
+    public ResponseEntity<List<MentorshipAuditLogResponse>> getAuditTrail(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorshipService.getAuditTrail(userId, id));
     }
 }

--- a/backend/src/main/java/com/group7/backend/dto/request/CancelMentorshipRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/CancelMentorshipRequest.java
@@ -1,0 +1,22 @@
+package com.group7.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Payload for cancelling an active mentorship (#133)")
+public class CancelMentorshipRequest {
+
+    @NotBlank(message = "Cancellation reason must not be blank")
+    @Size(max = 500, message = "Cancellation reason must not exceed 500 characters")
+    @Schema(description = "Reason the mentorship is being cancelled. Stored on the mentorship "
+                        + "row and in the audit trail.",
+            example = "Schedules no longer line up; pausing mentorship for the semester.")
+    private String reason;
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorshipAuditLogResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorshipAuditLogResponse.java
@@ -1,0 +1,52 @@
+package com.group7.backend.dto.response;
+
+import com.group7.backend.entity.MentorshipAuditLog;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "One row of a mentorship's state-transition audit trail (#133)")
+public class MentorshipAuditLogResponse {
+
+    @Schema(description = "Audit row id", example = "42")
+    private Long id;
+
+    @Schema(description = "Mentorship id this row belongs to", example = "100")
+    private Long mentorshipId;
+
+    @Schema(description = "Status the mentorship was in before the transition. Null on the "
+                        + "initial creation row (NULL → ACTIVE).", example = "ACTIVE")
+    private String fromStatus;
+
+    @Schema(description = "Status the mentorship moved to.", example = "CANCELLED")
+    private String toStatus;
+
+    @Schema(description = "User id that triggered the transition. May be null for "
+                        + "system-driven transitions.", example = "7")
+    private Long actorUserId;
+
+    @Schema(description = "Reason supplied by the actor (cancellations only).",
+            example = "Schedules no longer line up.")
+    private String reason;
+
+    @Schema(description = "When the transition was recorded.")
+    private OffsetDateTime createdAt;
+
+    public static MentorshipAuditLogResponse from(MentorshipAuditLog row) {
+        MentorshipAuditLogResponse r = new MentorshipAuditLogResponse();
+        r.setId(row.getId());
+        r.setMentorshipId(row.getMentorshipId());
+        r.setFromStatus(row.getFromStatus() == null ? null : row.getFromStatus().name());
+        r.setToStatus(row.getToStatus().name());
+        r.setActorUserId(row.getActorUserId());
+        r.setReason(row.getReason());
+        r.setCreatedAt(row.getCreatedAt());
+        return r;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorshipResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorshipResponse.java
@@ -48,6 +48,13 @@ public class MentorshipResponse {
             example = "true")
     private boolean goalDefined;
 
+    @Schema(description = "When the mentorship was terminated, or null if still active. (#133)")
+    private OffsetDateTime terminatedAt;
+
+    @Schema(description = "Reason captured at cancellation time, or null if still active. (#133)",
+            example = "Schedules no longer line up.")
+    private String cancellationReason;
+
     public static MentorshipResponse from(Mentorship mentorship) {
         MentorshipResponse r = new MentorshipResponse();
         r.setId(mentorship.getId());
@@ -61,6 +68,8 @@ public class MentorshipResponse {
         r.setStatus(mentorship.getStatus().name());
         r.setSharedGoal(mentorship.getSharedGoal());
         r.setGoalDefined(mentorship.hasSharedGoal());
+        r.setTerminatedAt(mentorship.getTerminatedAt());
+        r.setCancellationReason(mentorship.getCancellationReason());
         return r;
     }
 }

--- a/backend/src/main/java/com/group7/backend/entity/Mentorship.java
+++ b/backend/src/main/java/com/group7/backend/entity/Mentorship.java
@@ -50,9 +50,28 @@ public class Mentorship {
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @Column(name = "terminated_at")
+    private OffsetDateTime terminatedAt;
+
+    @Column(name = "terminated_by_user_id")
+    private Long terminatedByUserId;
+
+    @Column(name = "cancellation_reason", length = 500)
+    private String cancellationReason;
+
     @PrePersist
     protected void onCreate() {
-        this.createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public boolean hasSharedGoal() {

--- a/backend/src/main/java/com/group7/backend/entity/MentorshipAuditLog.java
+++ b/backend/src/main/java/com/group7/backend/entity/MentorshipAuditLog.java
@@ -1,0 +1,70 @@
+package com.group7.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * Append-only audit row for a mentorship state transition (#133).
+ *
+ * <p>One row per transition. The first row of a mentorship has
+ * {@code fromStatus = null} (NULL → ACTIVE on creation); subsequent rows
+ * record {@code from -> to} pairs. {@code reason} is set by user-driven
+ * cancellation flows; system-driven transitions leave it null.
+ */
+@Entity
+@Table(name = "mentorship_audit_log")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MentorshipAuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mentorship_id", nullable = false)
+    private Long mentorshipId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "from_status", length = 20)
+    private MentorshipStatus fromStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "to_status", length = 20, nullable = false)
+    private MentorshipStatus toStatus;
+
+    @Column(name = "actor_user_id")
+    private Long actorUserId;
+
+    @Column(name = "reason", length = 500)
+    private String reason;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
+    }
+
+    public static MentorshipAuditLog of(Long mentorshipId,
+                                        MentorshipStatus fromStatus,
+                                        MentorshipStatus toStatus,
+                                        Long actorUserId,
+                                        String reason) {
+        MentorshipAuditLog entry = new MentorshipAuditLog();
+        entry.setMentorshipId(mentorshipId);
+        entry.setFromStatus(fromStatus);
+        entry.setToStatus(toStatus);
+        entry.setActorUserId(actorUserId);
+        entry.setReason(reason);
+        return entry;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/entity/NotificationType.java
+++ b/backend/src/main/java/com/group7/backend/entity/NotificationType.java
@@ -31,5 +31,8 @@ public enum NotificationType {
     // overrides; BAN_EXPIRED fires once when the timer runs out.
     USER_BANNED,
     BAN_LIFTED,
-    BAN_EXPIRED
+    BAN_EXPIRED,
+    // Mentorship cancellation (#133). Sent to the OTHER participant when
+    // either side cancels an active mentorship; body includes the reason.
+    MENTORSHIP_CANCELLED
 }

--- a/backend/src/main/java/com/group7/backend/entity/UserNotificationPreferences.java
+++ b/backend/src/main/java/com/group7/backend/entity/UserNotificationPreferences.java
@@ -91,6 +91,10 @@ public class UserNotificationPreferences {
             // Auto-ban system (#134) — system-mandated communications, always
             // enabled. Users cannot opt out of "you have been banned" notices.
             case USER_BANNED, BAN_LIFTED, BAN_EXPIRED -> true;
+            // Mentorship cancellation (#133) — losing an active mentorship is a
+            // consequential lifecycle event that affects ongoing tasks/meetings,
+            // so it bypasses category opt-outs the same way ban notices do.
+            case MENTORSHIP_CANCELLED -> true;
         };
     }
 }

--- a/backend/src/main/java/com/group7/backend/repository/MentorshipAuditLogRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorshipAuditLogRepository.java
@@ -1,0 +1,13 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.MentorshipAuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MentorshipAuditLogRepository extends JpaRepository<MentorshipAuditLog, Long> {
+
+    List<MentorshipAuditLog> findByMentorshipIdOrderByCreatedAtAsc(Long mentorshipId);
+}

--- a/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,6 +24,19 @@ public interface MentorshipRepository extends JpaRepository<Mentorship, Long> {
     @Query("SELECT m FROM Mentorship m WHERE m.id = :id "
             + "AND (m.mentor.id = :userId OR m.mentee.id = :userId)")
     Optional<Mentorship> findByIdAndParticipant(@Param("id") Long id, @Param("userId") Long userId);
+
+    /**
+     * Most recent {@code terminatedAt} for the given (mentor, mentee) pair across any
+     * past mentorship. Used by {@code MentorshipCooldownPolicy} (#133) to block immediate
+     * re-matching after a cancellation. Returns the wrapper, not Optional, because JPQL
+     * MAX(...) over zero rows yields null which Spring Data hands back as
+     * Optional.empty(); callers treat that as "no past termination".
+     */
+    @Query("SELECT MAX(m.terminatedAt) FROM Mentorship m "
+            + "WHERE m.mentor.id = :mentorId AND m.mentee.id = :menteeId "
+            + "AND m.terminatedAt IS NOT NULL")
+    Optional<OffsetDateTime> findLastTerminatedAtForPair(@Param("mentorId") Long mentorId,
+                                                        @Param("menteeId") Long menteeId);
 
     @Query(value = "SELECT pg_advisory_xact_lock(:lockId)", nativeQuery = true)
     void acquireAdvisoryLock(@Param("lockId") Long lockId);

--- a/backend/src/main/java/com/group7/backend/repository/SentMilestoneReminderRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/SentMilestoneReminderRepository.java
@@ -2,9 +2,21 @@ package com.group7.backend.repository;
 
 import com.group7.backend.entity.SentMilestoneReminder;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
 
 @Repository
 public interface SentMilestoneReminderRepository extends JpaRepository<SentMilestoneReminder, Long> {
     boolean existsByUserIdAndMilestoneId(Long userId, Long milestoneId);
+
+    /**
+     * Bulk-delete reminders for a set of milestones. Needed by mentorship cancellation
+     * cleanup (#133) because {@code sent_milestone_reminders.milestone_id} is a column
+     * without an FK constraint, so the parent {@code milestones} delete cascade does
+     * not propagate.
+     */
+    @Modifying
+    void deleteByMilestoneIdIn(Collection<Long> milestoneIds);
 }

--- a/backend/src/main/java/com/group7/backend/repository/SentTaskReminderRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/SentTaskReminderRepository.java
@@ -2,9 +2,20 @@ package com.group7.backend.repository;
 
 import com.group7.backend.entity.SentTaskReminder;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
 
 @Repository
 public interface SentTaskReminderRepository extends JpaRepository<SentTaskReminder, Long> {
     boolean existsByUserIdAndTaskId(Long userId, Long taskId);
+
+    /**
+     * Bulk-delete reminders for a set of tasks. Needed by mentorship cancellation
+     * cleanup (#133) because {@code sent_task_reminders.task_id} is a column without
+     * an FK constraint, so the parent {@code tasks} delete cascade does not propagate.
+     */
+    @Modifying
+    void deleteByTaskIdIn(Collection<Long> taskIds);
 }

--- a/backend/src/main/java/com/group7/backend/service/MentorshipCleanupService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipCleanupService.java
@@ -1,0 +1,99 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.Meeting;
+import com.group7.backend.entity.Milestone;
+import com.group7.backend.entity.Task;
+import com.group7.backend.repository.ConversationRepository;
+import com.group7.backend.repository.MeetingRepository;
+import com.group7.backend.repository.MilestoneRepository;
+import com.group7.backend.repository.SentMilestoneReminderRepository;
+import com.group7.backend.repository.SentTaskReminderRepository;
+import com.group7.backend.repository.TaskRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Removes data hanging off a mentorship when it is cancelled or otherwise
+ * terminated (#133). Meeting / Task / Milestone / Conversation children all
+ * have ON DELETE CASCADE on their parent FKs, so deleting them by id is
+ * enough — their grandchildren (action items, submissions, attachments,
+ * messages, participants) follow.
+ *
+ * <p>The two {@code sent_*_reminders} tables are reminder dedup rows tracked
+ * by a plain {@code task_id} / {@code milestone_id} column without an FK
+ * constraint, so they need explicit cleanup before the parent rows go away.
+ *
+ * <p>Operates within the caller's transaction (Propagation.REQUIRED) so the
+ * status flip + cleanup either both commit or both roll back.
+ */
+@Service
+public class MentorshipCleanupService {
+
+    private static final Logger log = LoggerFactory.getLogger(MentorshipCleanupService.class);
+
+    private final TaskRepository taskRepository;
+    private final SentTaskReminderRepository sentTaskReminderRepository;
+    private final MilestoneRepository milestoneRepository;
+    private final SentMilestoneReminderRepository sentMilestoneReminderRepository;
+    private final MeetingRepository meetingRepository;
+    private final ConversationRepository conversationRepository;
+
+    public MentorshipCleanupService(TaskRepository taskRepository,
+                                    SentTaskReminderRepository sentTaskReminderRepository,
+                                    MilestoneRepository milestoneRepository,
+                                    SentMilestoneReminderRepository sentMilestoneReminderRepository,
+                                    MeetingRepository meetingRepository,
+                                    ConversationRepository conversationRepository) {
+        this.taskRepository = taskRepository;
+        this.sentTaskReminderRepository = sentTaskReminderRepository;
+        this.milestoneRepository = milestoneRepository;
+        this.sentMilestoneReminderRepository = sentMilestoneReminderRepository;
+        this.meetingRepository = meetingRepository;
+        this.conversationRepository = conversationRepository;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void cleanupChildren(Long mentorshipId) {
+        // Tasks (cascade: TaskSubmission + attachments). Reminders need a
+        // manual sweep first because they have no FK to tasks.
+        List<Task> tasks = taskRepository.findByMentorshipIdOrderByCreatedAtDesc(mentorshipId);
+        if (!tasks.isEmpty()) {
+            List<Long> taskIds = tasks.stream().map(Task::getId).toList();
+            sentTaskReminderRepository.deleteByTaskIdIn(taskIds);
+            taskRepository.deleteAllInBatch(tasks);
+        }
+
+        // Milestones (cascade: MilestoneActionItem). Same reminder caveat.
+        List<Milestone> milestones = milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(mentorshipId);
+        if (!milestones.isEmpty()) {
+            List<Long> milestoneIds = milestones.stream().map(Milestone::getId).toList();
+            sentMilestoneReminderRepository.deleteByMilestoneIdIn(milestoneIds);
+            milestoneRepository.deleteAllInBatch(milestones);
+        }
+
+        // Meetings (cascade: action items, reschedule requests, reminder state).
+        List<Meeting> meetings = meetingRepository.findByMentorshipIdOrderByStartTimeAsc(mentorshipId);
+        if (!meetings.isEmpty()) {
+            meetingRepository.deleteAllInBatch(meetings);
+        }
+
+        // Conversation (cascade: ConversationParticipant, Message). Mentorship-scoped
+        // conversations are 0..1 per mentorship; mentor-pair (user↔user) chats live
+        // outside the mentorship and are not touched.
+        Conversation conversation = conversationRepository.findByMentorshipId(mentorshipId).orElse(null);
+        if (conversation != null) {
+            conversationRepository.delete(conversation);
+        }
+
+        log.info("Mentorship cleanup complete: mentorshipId={}, tasks={}, milestones={}, "
+                        + "meetings={}, conversation={}",
+                mentorshipId, tasks.size(), milestones.size(), meetings.size(),
+                conversation != null);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MentorshipCooldownPolicy.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipCooldownPolicy.java
@@ -1,0 +1,66 @@
+package com.group7.backend.service;
+
+import com.group7.backend.exception.MentorshipRequestException;
+import com.group7.backend.repository.MentorshipRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+/**
+ * Enforces a cool-down window before the same mentor–mentee pair can
+ * re-match after a previous mentorship terminates (#133).
+ *
+ * <p>Active mentorships are still gated by {@code mentee.activeMentorId};
+ * this policy adds a second gate for pairs whose mentorship has ALREADY
+ * terminated, blocking immediate re-requests / re-acceptances. The window
+ * is configured by {@code app.mentorship.cooldown.duration} (ISO-8601
+ * Duration, default 7 days).
+ */
+@Service
+public class MentorshipCooldownPolicy {
+
+    private static final Logger log = LoggerFactory.getLogger(MentorshipCooldownPolicy.class);
+
+    private final MentorshipRepository mentorshipRepository;
+    private final Clock clock;
+    private final Duration cooldown;
+
+    public MentorshipCooldownPolicy(MentorshipRepository mentorshipRepository,
+                                    Clock clock,
+                                    @Value("${app.mentorship.cooldown.duration:PT168H}") Duration cooldown) {
+        this.mentorshipRepository = mentorshipRepository;
+        this.clock = clock;
+        this.cooldown = cooldown;
+    }
+
+    /**
+     * @throws MentorshipRequestException if the pair terminated a prior mentorship
+     *         less than {@link #cooldown} ago. The message names the date the
+     *         pair becomes eligible again so callers can surface it directly.
+     */
+    @Transactional(readOnly = true)
+    public void assertNotInCooldown(Long mentorId, Long menteeId) {
+        OffsetDateTime lastTerminated = mentorshipRepository
+                .findLastTerminatedAtForPair(mentorId, menteeId)
+                .orElse(null);
+        if (lastTerminated == null) {
+            return;
+        }
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        OffsetDateTime eligibleAt = lastTerminated.plus(cooldown);
+        if (eligibleAt.isAfter(now)) {
+            log.warn("Mentorship cool-down blocked: mentorId={}, menteeId={}, "
+                            + "lastTerminated={}, eligibleAt={}",
+                    mentorId, menteeId, lastTerminated, eligibleAt);
+            throw new MentorshipRequestException(
+                    "This mentor and mentee can re-match after " + eligibleAt
+                            + " (cool-down after the previous mentorship ended).");
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MentorshipRequestService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipRequestService.java
@@ -30,17 +30,20 @@ public class MentorshipRequestService {
     private final MentorRepository mentorRepository;
     private final NotificationEventPublisher notificationEventPublisher;
     private final BanService banService;
+    private final MentorshipCooldownPolicy mentorshipCooldownPolicy;
 
     public MentorshipRequestService(MentorshipRequestRepository mentorshipRequestRepository,
                                     MenteeRepository menteeRepository,
                                     MentorRepository mentorRepository,
                                     NotificationEventPublisher notificationEventPublisher,
-                                    BanService banService) {
+                                    BanService banService,
+                                    MentorshipCooldownPolicy mentorshipCooldownPolicy) {
         this.mentorshipRequestRepository = mentorshipRequestRepository;
         this.menteeRepository = menteeRepository;
         this.mentorRepository = mentorRepository;
         this.notificationEventPublisher = notificationEventPublisher;
         this.banService = banService;
+        this.mentorshipCooldownPolicy = mentorshipCooldownPolicy;
     }
 
     @Transactional
@@ -69,6 +72,9 @@ public class MentorshipRequestService {
             log.warn("Mentorship request rejected: mentorId={} is at capacity", dto.getMentorId());
             throw new MentorshipRequestException("Mentor has reached maximum mentee capacity");
         }
+
+        // Cool-down (#133): block re-requests if this pair just terminated a mentorship.
+        mentorshipCooldownPolicy.assertNotInCooldown(dto.getMentorId(), menteeId);
 
         if (mentorshipRequestRepository.existsByMentee_IdAndMentor_IdAndStatus(
                 menteeId, dto.getMentorId(), MentorshipRequestStatus.PENDING)) {

--- a/backend/src/main/java/com/group7/backend/service/MentorshipService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipService.java
@@ -1,11 +1,14 @@
 package com.group7.backend.service;
 
 import com.group7.backend.dto.request.AcceptRequestRequest;
+import com.group7.backend.dto.request.CancelMentorshipRequest;
 import com.group7.backend.dto.request.SharedGoalRequest;
+import com.group7.backend.dto.response.MentorshipAuditLogResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
 import com.group7.backend.entity.*;
 import com.group7.backend.exception.MentorshipRequestException;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MentorshipAuditLogRepository;
 import com.group7.backend.repository.MentorshipRepository;
 import com.group7.backend.repository.MentorshipRequestRepository;
 import org.slf4j.Logger;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @Service
@@ -26,15 +30,24 @@ public class MentorshipService {
 
     private final MentorshipRepository mentorshipRepository;
     private final MentorshipRequestRepository mentorshipRequestRepository;
+    private final MentorshipAuditLogRepository mentorshipAuditLogRepository;
+    private final MentorshipCleanupService mentorshipCleanupService;
+    private final MentorshipCooldownPolicy mentorshipCooldownPolicy;
     private final NotificationEventPublisher notificationEventPublisher;
     private final Clock clock;
 
     public MentorshipService(MentorshipRepository mentorshipRepository,
                              MentorshipRequestRepository mentorshipRequestRepository,
+                             MentorshipAuditLogRepository mentorshipAuditLogRepository,
+                             MentorshipCleanupService mentorshipCleanupService,
+                             MentorshipCooldownPolicy mentorshipCooldownPolicy,
                              NotificationEventPublisher notificationEventPublisher,
                              Clock clock) {
         this.mentorshipRepository = mentorshipRepository;
         this.mentorshipRequestRepository = mentorshipRequestRepository;
+        this.mentorshipAuditLogRepository = mentorshipAuditLogRepository;
+        this.mentorshipCleanupService = mentorshipCleanupService;
+        this.mentorshipCooldownPolicy = mentorshipCooldownPolicy;
         this.notificationEventPublisher = notificationEventPublisher;
         this.clock = clock;
     }
@@ -68,6 +81,10 @@ public class MentorshipService {
             throw new MentorshipRequestException("Duration must be 1, 3, or 6 months");
         }
 
+        // Cool-down (#133): block re-acceptance if this pair just terminated.
+        // Throws MentorshipRequestException; caller surfaces 409.
+        mentorshipCooldownPolicy.assertNotInCooldown(mentor.getId(), mentee.getId());
+
         request.setStatus(MentorshipRequestStatus.ACCEPTED);
 
         OffsetDateTime now = OffsetDateTime.now(clock);
@@ -85,6 +102,8 @@ public class MentorshipService {
         mentorshipRequestRepository.cancelOtherPendingRequests(mentee.getId(), requestId);
 
         Mentorship saved = mentorshipRepository.save(mentorship);
+        mentorshipAuditLogRepository.save(MentorshipAuditLog.of(
+                saved.getId(), null, MentorshipStatus.ACTIVE, mentorId, null));
         log.info("Mentorship accepted: mentorshipId={}, mentorId={}, menteeId={}, requestId={}",
             saved.getId(), mentor.getId(), mentee.getId(), requestId);
         notificationEventPublisher.publishRequestAccepted(mentee.getId(), mentor.getFirstName());
@@ -133,6 +152,76 @@ public class MentorshipService {
         Mentorship saved = mentorshipRepository.save(mentorship);
         log.info("Shared goal updated: mentorshipId={}, updatedByUserId={}", mentorshipId, userId);
         return MentorshipResponse.from(saved);
+    }
+
+    /**
+     * Cancels an active mentorship (#133). Either participant may cancel; the
+     * other side gets a notification. Children (meetings, tasks, milestones,
+     * conversation/messages) are deleted by {@link MentorshipCleanupService};
+     * the mentorship row itself is kept with {@code status = CANCELLED} so
+     * cool-down lookups can find the termination.
+     *
+     * @throws ResourceNotFoundException if the user is not a participant
+     * @throws MentorshipRequestException if the mentorship is not currently ACTIVE
+     */
+    @Transactional
+    public MentorshipResponse cancelMentorship(Long actorUserId,
+                                               Long mentorshipId,
+                                               CancelMentorshipRequest dto) {
+        Mentorship mentorship = findForParticipant(actorUserId, mentorshipId);
+
+        if (mentorship.getStatus() != MentorshipStatus.ACTIVE) {
+            log.warn("Cancel rejected: mentorshipId={} is in status {}", mentorshipId, mentorship.getStatus());
+            throw new MentorshipRequestException("Mentorship is not active");
+        }
+
+        Mentor mentor = mentorship.getMentor();
+        Mentee mentee = mentorship.getMentee();
+        boolean actorIsMentor = mentor.getId().equals(actorUserId);
+        Long otherUserId = actorIsMentor ? mentee.getId() : mentor.getId();
+        String actorFirstName = actorIsMentor ? mentor.getFirstName() : mentee.getFirstName();
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        mentorship.setStatus(MentorshipStatus.CANCELLED);
+        mentorship.setTerminatedAt(now);
+        mentorship.setTerminatedByUserId(actorUserId);
+        mentorship.setCancellationReason(dto.getReason());
+
+        // Free the mentee's slot only if this mentorship is the active one.
+        // Guards against a stale activeMentorId that points elsewhere.
+        if (Objects.equals(mentee.getActiveMentorId(), mentor.getId())) {
+            mentee.setActiveMentorId(null);
+        }
+        if (mentor.getCurrentMenteeCount() > 0) {
+            mentor.setCurrentMenteeCount(mentor.getCurrentMenteeCount() - 1);
+        }
+
+        // Cleanup children (meetings, tasks, milestones, conversation). Same
+        // transaction — if anything fails, the status flip rolls back too.
+        mentorshipCleanupService.cleanupChildren(mentorshipId);
+
+        Mentorship saved = mentorshipRepository.save(mentorship);
+
+        mentorshipAuditLogRepository.save(MentorshipAuditLog.of(
+                saved.getId(), MentorshipStatus.ACTIVE, MentorshipStatus.CANCELLED,
+                actorUserId, dto.getReason()));
+
+        notificationEventPublisher.publishMentorshipCancelled(otherUserId, actorFirstName, dto.getReason());
+
+        log.info("Mentorship cancelled: mentorshipId={}, actorUserId={}, otherUserId={}, "
+                        + "actorIsMentor={}",
+                mentorshipId, actorUserId, otherUserId, actorIsMentor);
+        return MentorshipResponse.from(saved);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MentorshipAuditLogResponse> getAuditTrail(Long userId, Long mentorshipId) {
+        // Participant gate: throws 404 if userId is not the mentor or mentee.
+        findForParticipant(userId, mentorshipId);
+        return mentorshipAuditLogRepository
+                .findByMentorshipIdOrderByCreatedAtAsc(mentorshipId).stream()
+                .map(MentorshipAuditLogResponse::from)
+                .toList();
     }
 
     /**

--- a/backend/src/main/java/com/group7/backend/service/NotificationEventPublisher.java
+++ b/backend/src/main/java/com/group7/backend/service/NotificationEventPublisher.java
@@ -237,6 +237,15 @@ public class NotificationEventPublisher {
         );
     }
 
+    public void publishMentorshipCancelled(Long recipientId, String otherFirstName, String reason) {
+        publish(
+                recipientId,
+                NotificationType.MENTORSHIP_CANCELLED,
+                "Mentorship cancelled",
+                otherFirstName + " cancelled your mentorship. Reason: " + reason
+        );
+    }
+
     public void publish(Long recipientId, NotificationType type, String title, String body) {
         applicationEventPublisher.publishEvent(new NotificationCreatedEvent(recipientId, type, title, body));
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -270,3 +270,9 @@ app.bans.max-ban-hours=${BAN_MAX_HOURS:720}
 app.bans.expiry-notification-enabled=${BAN_EXPIRY_NOTIFY_ENABLED:true}
 app.bans.expiry-notification.cron=${BAN_EXPIRY_NOTIFY_CRON:0 0 * * * *}
 app.bans.expiry-notification.zone=${BAN_EXPIRY_NOTIFY_ZONE:UTC}
+
+# Mentorship cancellation cool-down (#133). After a mentorship terminates,
+# the same (mentor, mentee) pair cannot re-request or re-accept until this
+# window has elapsed. ISO-8601 Duration; default = 168h = 7 days. Override
+# in deploy via MENTORSHIP_COOLDOWN_DURATION (e.g. PT24H, P30D).
+app.mentorship.cooldown.duration=${MENTORSHIP_COOLDOWN_DURATION:PT168H}

--- a/backend/src/main/resources/db/migration/V32__mentorship_cancellation.sql
+++ b/backend/src/main/resources/db/migration/V32__mentorship_cancellation.sql
@@ -1,0 +1,44 @@
+-- Mentorship cancellation & relationship archiving (#133).
+--
+-- Adds termination columns to `mentorships` and a separate
+-- `mentorship_audit_log` table that records every state transition
+-- (including the implicit creation transition NULL -> ACTIVE).
+--
+-- Schema choices, deliberate:
+--   * Mentorship rows are NEVER deleted on cancellation. Status flips to
+--     CANCELLED, terminated_at is stamped, and child rows (meetings,
+--     tasks, milestones, conversations) are deleted by the service. The
+--     row stays so cool-down lookups against (mentor_id, mentee_id) can
+--     find the most recent termination without joining a separate table.
+--   * `terminated_by_user_id` references users(id); ON DELETE SET NULL so
+--     deleting a user account does not orphan the audit history.
+--   * `updated_at` exists so JPA @PreUpdate hooks have somewhere to write.
+--     Default NOW() seeds existing rows.
+--   * mentorship_audit_log is append-only (no UPDATE path); from_status is
+--     NULL on the initial creation row, and to_status is always set.
+--   * Index `idx_mentorships_pair_terminated` is partial — only rows that
+--     have actually terminated; cool-down lookup is a sorted point query
+--     against this index.
+
+ALTER TABLE mentorships
+    ADD COLUMN terminated_at        TIMESTAMP NULL,
+    ADD COLUMN terminated_by_user_id BIGINT NULL REFERENCES users(id) ON DELETE SET NULL,
+    ADD COLUMN cancellation_reason  VARCHAR(500) NULL,
+    ADD COLUMN updated_at           TIMESTAMP NOT NULL DEFAULT NOW();
+
+CREATE INDEX idx_mentorships_pair_terminated
+    ON mentorships (mentor_id, mentee_id, terminated_at DESC)
+    WHERE terminated_at IS NOT NULL;
+
+CREATE TABLE mentorship_audit_log (
+    id              BIGSERIAL PRIMARY KEY,
+    mentorship_id   BIGINT NOT NULL REFERENCES mentorships(id) ON DELETE CASCADE,
+    from_status     VARCHAR(20) NULL,
+    to_status       VARCHAR(20) NOT NULL,
+    actor_user_id   BIGINT NULL REFERENCES users(id) ON DELETE SET NULL,
+    reason          VARCHAR(500) NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_mentorship_audit_log_mentorship_created
+    ON mentorship_audit_log (mentorship_id, created_at DESC);

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipCancellationIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipCancellationIntegrationTest.java
@@ -1,0 +1,319 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.config.ratelimit.MutableClock;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.Milestone;
+import com.group7.backend.entity.MilestoneStatus;
+import com.group7.backend.entity.Task;
+import com.group7.backend.entity.TaskStatus;
+import com.group7.backend.repository.*;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * End-to-end coverage for #133 — mentorship cancellation, related-data
+ * cleanup, audit trail, and re-match cool-down.
+ *
+ * <p>The cool-down property is shrunk to 1 hour for fast tests and the
+ * production {@link Clock} is overridden with a {@link MutableClock} so
+ * the cool-down boundary can be crossed deterministically.
+ */
+@SpringBootTest(properties = {
+        "app.mentorship.cooldown.duration=PT1H"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MentorshipCancellationIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired private MentorshipRequestRepository mentorshipRequestRepository;
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private MentorshipRepository mentorshipRepository;
+    @Autowired private MentorshipAuditLogRepository mentorshipAuditLogRepository;
+    @Autowired private TaskRepository taskRepository;
+    @Autowired private MilestoneRepository milestoneRepository;
+    @Autowired private MutableClock mutableClock;
+
+    @MockitoBean private EmailService emailService;
+
+    @TestConfiguration
+    static class ClockOverrideConfig {
+        @Bean
+        public MutableClock mutableClock() {
+            return new MutableClock(Instant.parse("2026-05-10T10:00:00Z"));
+        }
+
+        @Bean
+        @Primary
+        public Clock testClock(MutableClock mutableClock) {
+            return mutableClock;
+        }
+    }
+
+    @BeforeEach
+    void cleanDb() {
+        mentorshipAuditLogRepository.deleteAll();
+        taskRepository.deleteAll();
+        milestoneRepository.deleteAll();
+        mentorshipRepository.deleteAll();
+        mentorshipRequestRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+        doNothing().when(emailService).sendPasswordResetEmail(any(), anyString());
+        // Reset clock between tests so cool-down assertions are independent.
+        mutableClock.setNow(Instant.parse("2026-05-10T10:00:00Z"));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Test");
+        req.setLastName("User");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private record CanceledFixture(Long mentorshipId, Long mentorId, Long menteeId,
+                                   String mentorToken, String menteeToken) {}
+
+    private CanceledFixture acceptMentorship(String mentorEmail, String menteeEmail) throws Exception {
+        String mentorToken = registerAndLogin(mentorEmail, true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals(mentorEmail)).findFirst().orElseThrow();
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        String menteeToken = registerAndLogin(menteeEmail, false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals(menteeEmail)).findFirst().orElseThrow();
+
+        MvcResult requestResult = mockMvc.perform(post("/api/mentorship-requests")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("mentorId", mentor.getId()))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Long requestId = objectMapper.readTree(requestResult.getResponse().getContentAsString()).get("id").asLong();
+
+        MvcResult acceptResult = mockMvc.perform(put("/api/mentorship-requests/" + requestId + "/accept")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("duration", 3))))
+                .andExpect(status().isOk())
+                .andReturn();
+        Long mentorshipId = objectMapper.readTree(acceptResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        return new CanceledFixture(mentorshipId, mentor.getId(), mentee.getId(), mentorToken, menteeToken);
+    }
+
+    private void seedTaskAndMilestone(Long mentorshipId) {
+        Mentorship mentorship = mentorshipRepository.findById(mentorshipId).orElseThrow();
+
+        Task task = new Task();
+        task.setMentorship(mentorship);
+        task.setTitle("Cleanup probe task");
+        task.setStatus(TaskStatus.PENDING);
+        taskRepository.save(task);
+
+        Milestone milestone = new Milestone();
+        milestone.setMentorship(mentorship);
+        milestone.setTitle("Cleanup probe milestone");
+        milestone.setStatus(MilestoneStatus.PENDING);
+        milestone.setOrderIndex(0);
+        milestoneRepository.save(milestone);
+    }
+
+    // ── Tests ───────────────────────────────────────────────────────────────
+
+    @Test
+    void cancelMentorshipFlipsStatusAndDeletesChildren() throws Exception {
+        CanceledFixture f = acceptMentorship("c_mentor1@test.com", "c_mentee1@test.com");
+        seedTaskAndMilestone(f.mentorshipId());
+        assertThat(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(f.mentorshipId())).hasSize(1);
+        assertThat(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(f.mentorshipId())).hasSize(1);
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "Schedules diverged"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"))
+                .andExpect(jsonPath("$.cancellationReason").value("Schedules diverged"))
+                .andExpect(jsonPath("$.terminatedAt").exists());
+
+        Mentorship after = mentorshipRepository.findById(f.mentorshipId()).orElseThrow();
+        assertThat(after.getTerminatedAt()).isNotNull();
+        assertThat(after.getTerminatedByUserId()).isEqualTo(f.menteeId());
+        assertThat(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(f.mentorshipId())).isEmpty();
+        assertThat(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(f.mentorshipId())).isEmpty();
+
+        Mentee mentee = menteeRepository.findById(f.menteeId()).orElseThrow();
+        assertThat(mentee.getActiveMentorId()).isNull();
+        Mentor mentor = mentorRepository.findById(f.mentorId()).orElseThrow();
+        assertThat(mentor.getCurrentMenteeCount()).isZero();
+    }
+
+    @Test
+    void cancelWritesAuditTrail() throws Exception {
+        CanceledFixture f = acceptMentorship("c_mentor2@test.com", "c_mentee2@test.com");
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "Capacity needed elsewhere"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/audit")
+                        .header("Authorization", "Bearer " + f.menteeToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].fromStatus").doesNotExist())
+                .andExpect(jsonPath("$[0].toStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$[1].fromStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$[1].toStatus").value("CANCELLED"))
+                .andExpect(jsonPath("$[1].reason").value("Capacity needed elsewhere"))
+                .andExpect(jsonPath("$[1].actorUserId").value(f.mentorId()));
+    }
+
+    @Test
+    void cancelRejectsNonParticipant() throws Exception {
+        CanceledFixture f = acceptMentorship("c_mentor3@test.com", "c_mentee3@test.com");
+        String intruderToken = registerAndLogin("c_intruder3@test.com", false);
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + intruderToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "n/a"))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void cancelRejectsBlankReason() throws Exception {
+        CanceledFixture f = acceptMentorship("c_mentor4@test.com", "c_mentee4@test.com");
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"   \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void cancelRejectsAlreadyCancelled() throws Exception {
+        CanceledFixture f = acceptMentorship("c_mentor5@test.com", "c_mentee5@test.com");
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "first cancel"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "second cancel"))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void auditEndpointRejectsNonParticipant() throws Exception {
+        CanceledFixture f = acceptMentorship("c_mentor6@test.com", "c_mentee6@test.com");
+        String intruderToken = registerAndLogin("c_intruder6@test.com", false);
+
+        mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/audit")
+                        .header("Authorization", "Bearer " + intruderToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void cooldownBlocksImmediateRerequestAndExpiresWithTime() throws Exception {
+        CanceledFixture f = acceptMentorship("c_mentor7@test.com", "c_mentee7@test.com");
+        // Stamp the mentorship's terminated_at via service path — uses MutableClock = T0.
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "pause"))))
+                .andExpect(status().isOk());
+
+        Mentorship cancelled = mentorshipRepository.findById(f.mentorshipId()).orElseThrow();
+        assertThat(cancelled.getTerminatedAt()).isNotNull();
+
+        // Immediate re-request inside the 1-hour cool-down → 409.
+        mockMvc.perform(post("/api/mentorship-requests")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("mentorId", f.mentorId()))))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("cool-down")));
+
+        // Advance past the 1-hour window; the same pair becomes eligible again.
+        mutableClock.advance(Duration.ofHours(1).plusMinutes(1));
+
+        mockMvc.perform(post("/api/mentorship-requests")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("mentorId", f.mentorId()))))
+                .andExpect(status().isCreated());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorshipCleanupServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipCleanupServiceTest.java
@@ -1,0 +1,158 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.Meeting;
+import com.group7.backend.entity.Milestone;
+import com.group7.backend.entity.Task;
+import com.group7.backend.repository.ConversationRepository;
+import com.group7.backend.repository.MeetingRepository;
+import com.group7.backend.repository.MilestoneRepository;
+import com.group7.backend.repository.SentMilestoneReminderRepository;
+import com.group7.backend.repository.SentTaskReminderRepository;
+import com.group7.backend.repository.TaskRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MentorshipCleanupServiceTest {
+
+    @Mock private TaskRepository taskRepository;
+    @Mock private SentTaskReminderRepository sentTaskReminderRepository;
+    @Mock private MilestoneRepository milestoneRepository;
+    @Mock private SentMilestoneReminderRepository sentMilestoneReminderRepository;
+    @Mock private MeetingRepository meetingRepository;
+    @Mock private ConversationRepository conversationRepository;
+
+    @InjectMocks private MentorshipCleanupService mentorshipCleanupService;
+
+    private static Task task(Long id) {
+        Task t = new Task();
+        t.setId(id);
+        return t;
+    }
+
+    private static Milestone milestone(Long id) {
+        Milestone m = new Milestone();
+        m.setId(id);
+        return m;
+    }
+
+    private static Meeting meeting(Long id) {
+        Meeting m = new Meeting();
+        m.setId(id);
+        return m;
+    }
+
+    @Test
+    void deletesTasksAndTheirReminders() {
+        when(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(100L))
+                .thenReturn(List.of(task(11L), task(12L)));
+        when(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(100L)).thenReturn(List.of());
+        when(meetingRepository.findByMentorshipIdOrderByStartTimeAsc(100L)).thenReturn(List.of());
+        when(conversationRepository.findByMentorshipId(100L)).thenReturn(Optional.empty());
+
+        mentorshipCleanupService.cleanupChildren(100L);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<Long>> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(sentTaskReminderRepository).deleteByTaskIdIn(captor.capture());
+        assertThat(captor.getValue()).containsExactly(11L, 12L);
+        verify(taskRepository).deleteAllInBatch(any());
+    }
+
+    @Test
+    void deletesMilestonesAndTheirReminders() {
+        when(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(100L)).thenReturn(List.of());
+        when(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(100L))
+                .thenReturn(List.of(milestone(21L), milestone(22L)));
+        when(meetingRepository.findByMentorshipIdOrderByStartTimeAsc(100L)).thenReturn(List.of());
+        when(conversationRepository.findByMentorshipId(100L)).thenReturn(Optional.empty());
+
+        mentorshipCleanupService.cleanupChildren(100L);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<Long>> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(sentMilestoneReminderRepository).deleteByMilestoneIdIn(captor.capture());
+        assertThat(captor.getValue()).containsExactly(21L, 22L);
+        verify(milestoneRepository).deleteAllInBatch(any());
+    }
+
+    @Test
+    void deletesMeetingsInBatch() {
+        when(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(100L)).thenReturn(List.of());
+        when(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(100L)).thenReturn(List.of());
+        when(meetingRepository.findByMentorshipIdOrderByStartTimeAsc(100L))
+                .thenReturn(List.of(meeting(31L), meeting(32L)));
+        when(conversationRepository.findByMentorshipId(100L)).thenReturn(Optional.empty());
+
+        mentorshipCleanupService.cleanupChildren(100L);
+
+        verify(meetingRepository).deleteAllInBatch(any());
+    }
+
+    @Test
+    void deletesConversationWhenPresent() {
+        Conversation conversation = new Conversation();
+        conversation.setId(500L);
+
+        when(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(100L)).thenReturn(List.of());
+        when(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(100L)).thenReturn(List.of());
+        when(meetingRepository.findByMentorshipIdOrderByStartTimeAsc(100L)).thenReturn(List.of());
+        when(conversationRepository.findByMentorshipId(100L)).thenReturn(Optional.of(conversation));
+
+        mentorshipCleanupService.cleanupChildren(100L);
+
+        verify(conversationRepository).delete(conversation);
+    }
+
+    @Test
+    void skipsReminderDeleteWhenNoChildren() {
+        when(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(100L)).thenReturn(List.of());
+        when(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(100L)).thenReturn(List.of());
+        when(meetingRepository.findByMentorshipIdOrderByStartTimeAsc(100L)).thenReturn(List.of());
+        when(conversationRepository.findByMentorshipId(100L)).thenReturn(Optional.empty());
+
+        mentorshipCleanupService.cleanupChildren(100L);
+
+        verify(sentTaskReminderRepository, never()).deleteByTaskIdIn(any());
+        verify(sentMilestoneReminderRepository, never()).deleteByMilestoneIdIn(any());
+        verify(taskRepository, never()).deleteAllInBatch(any());
+        verify(milestoneRepository, never()).deleteAllInBatch(any());
+        verify(meetingRepository, never()).deleteAllInBatch(any());
+        verify(conversationRepository, never()).delete(any(Conversation.class));
+    }
+
+    @Test
+    void cleansUpAllChildTypesInOneCall() {
+        when(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(100L)).thenReturn(List.of(task(11L)));
+        when(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(100L)).thenReturn(List.of(milestone(21L)));
+        when(meetingRepository.findByMentorshipIdOrderByStartTimeAsc(100L)).thenReturn(List.of(meeting(31L)));
+        Conversation conversation = new Conversation();
+        conversation.setId(500L);
+        when(conversationRepository.findByMentorshipId(100L)).thenReturn(Optional.of(conversation));
+
+        mentorshipCleanupService.cleanupChildren(100L);
+
+        verify(sentTaskReminderRepository).deleteByTaskIdIn(eq(List.of(11L)));
+        verify(taskRepository).deleteAllInBatch(any());
+        verify(sentMilestoneReminderRepository).deleteByMilestoneIdIn(eq(List.of(21L)));
+        verify(milestoneRepository).deleteAllInBatch(any());
+        verify(meetingRepository).deleteAllInBatch(any());
+        verify(conversationRepository).delete(conversation);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorshipCooldownPolicyTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipCooldownPolicyTest.java
@@ -1,0 +1,91 @@
+package com.group7.backend.service;
+
+import com.group7.backend.config.ratelimit.MutableClock;
+import com.group7.backend.exception.MentorshipRequestException;
+import com.group7.backend.repository.MentorshipRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MentorshipCooldownPolicyTest {
+
+    private static final Duration COOLDOWN = Duration.ofDays(7);
+    private static final Instant T0 = Instant.parse("2026-05-10T10:00:00Z");
+
+    @Mock private MentorshipRepository mentorshipRepository;
+
+    private MutableClock clock;
+    private MentorshipCooldownPolicy policy;
+
+    @BeforeEach
+    void setUp() {
+        clock = new MutableClock(T0);
+        policy = new MentorshipCooldownPolicy(mentorshipRepository, clock, COOLDOWN);
+    }
+
+    @Test
+    void allowsWhenPairHasNoPriorTermination() {
+        when(mentorshipRepository.findLastTerminatedAtForPair(1L, 2L)).thenReturn(Optional.empty());
+
+        assertThatCode(() -> policy.assertNotInCooldown(1L, 2L)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void blocksWhenLastTerminationIsInsideCooldown() {
+        OffsetDateTime terminatedAt = OffsetDateTime.ofInstant(T0.minus(Duration.ofDays(1)), ZoneOffset.UTC);
+        when(mentorshipRepository.findLastTerminatedAtForPair(1L, 2L))
+                .thenReturn(Optional.of(terminatedAt));
+
+        assertThatThrownBy(() -> policy.assertNotInCooldown(1L, 2L))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("cool-down");
+    }
+
+    @Test
+    void allowsWhenCooldownHasJustElapsed() {
+        // Termination exactly COOLDOWN ago: eligibleAt == now, NOT after, so not blocked.
+        OffsetDateTime terminatedAt = OffsetDateTime.ofInstant(T0.minus(COOLDOWN), ZoneOffset.UTC);
+        when(mentorshipRepository.findLastTerminatedAtForPair(1L, 2L))
+                .thenReturn(Optional.of(terminatedAt));
+
+        assertThatCode(() -> policy.assertNotInCooldown(1L, 2L)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void blocksAtBoundaryMinusOneSecond() {
+        OffsetDateTime terminatedAt = OffsetDateTime.ofInstant(
+                T0.minus(COOLDOWN).plusSeconds(1), ZoneOffset.UTC);
+        when(mentorshipRepository.findLastTerminatedAtForPair(1L, 2L))
+                .thenReturn(Optional.of(terminatedAt));
+
+        assertThatThrownBy(() -> policy.assertNotInCooldown(1L, 2L))
+                .isInstanceOf(MentorshipRequestException.class);
+    }
+
+    @Test
+    void allowsAfterClockAdvancesPastCooldown() {
+        OffsetDateTime terminatedAt = OffsetDateTime.ofInstant(T0.minus(Duration.ofDays(1)), ZoneOffset.UTC);
+        when(mentorshipRepository.findLastTerminatedAtForPair(1L, 2L))
+                .thenReturn(Optional.of(terminatedAt));
+
+        assertThatThrownBy(() -> policy.assertNotInCooldown(1L, 2L))
+                .isInstanceOf(MentorshipRequestException.class);
+
+        clock.advance(Duration.ofDays(7));
+
+        assertThatCode(() -> policy.assertNotInCooldown(1L, 2L)).doesNotThrowAnyException();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorshipRequestServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipRequestServiceTest.java
@@ -56,6 +56,9 @@ class MentorshipRequestServiceTest {
     @Mock
     private BanService banService;
 
+    @Mock
+    private MentorshipCooldownPolicy mentorshipCooldownPolicy;
+
     @InjectMocks
     private MentorshipRequestService mentorshipRequestService;
 

--- a/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
@@ -1,16 +1,20 @@
 package com.group7.backend.service;
 
 import com.group7.backend.dto.request.AcceptRequestRequest;
+import com.group7.backend.dto.request.CancelMentorshipRequest;
 import com.group7.backend.dto.request.SharedGoalRequest;
+import com.group7.backend.dto.response.MentorshipAuditLogResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
 import com.group7.backend.entity.*;
 import com.group7.backend.exception.MentorshipRequestException;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MentorshipAuditLogRepository;
 import com.group7.backend.repository.MentorshipRepository;
 import com.group7.backend.repository.MentorshipRequestRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -25,6 +29,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,6 +41,15 @@ class MentorshipServiceTest {
 
     @Mock
     private MentorshipRequestRepository mentorshipRequestRepository;
+
+    @Mock
+    private MentorshipAuditLogRepository mentorshipAuditLogRepository;
+
+    @Mock
+    private MentorshipCleanupService mentorshipCleanupService;
+
+    @Mock
+    private MentorshipCooldownPolicy mentorshipCooldownPolicy;
 
     @Mock
     private NotificationEventPublisher notificationEventPublisher;
@@ -405,5 +419,166 @@ class MentorshipServiceTest {
 
         assertThat(response.isGoalDefined()).isFalse();
         assertThat(response.getSharedGoal()).isEqualTo("   ");
+    }
+
+    // ── Cancel mentorship (#133) ────────────────────────────────────────────
+
+    private Mentorship activeMentorship() {
+        Mentorship m = new Mentorship();
+        m.setId(100L);
+        m.setMentor(mentor);
+        m.setMentee(mentee);
+        m.setStatus(MentorshipStatus.ACTIVE);
+        m.setStartDate(OffsetDateTime.now(ZoneOffset.UTC));
+        m.setEndDate(OffsetDateTime.now(ZoneOffset.UTC).plusMonths(3));
+        m.setDuration(3);
+        return m;
+    }
+
+    private CancelMentorshipRequest cancelDto(String reason) {
+        CancelMentorshipRequest dto = new CancelMentorshipRequest();
+        dto.setReason(reason);
+        return dto;
+    }
+
+    @Test
+    void cancelMentorshipByMentorMarksCancelledAndCleansUp() {
+        Mentorship mentorship = activeMentorship();
+        mentee.setActiveMentorId(mentor.getId());
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.save(any(Mentorship.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        MentorshipResponse response = mentorshipService.cancelMentorship(1L, 100L, cancelDto("Schedule clash"));
+
+        assertThat(response.getStatus()).isEqualTo("CANCELLED");
+        assertThat(response.getCancellationReason()).isEqualTo("Schedule clash");
+        assertThat(response.getTerminatedAt()).isNotNull();
+        assertThat(mentorship.getTerminatedByUserId()).isEqualTo(1L);
+        assertThat(mentee.getActiveMentorId()).isNull();
+        assertThat(mentor.getCurrentMenteeCount()).isEqualTo(0);
+        verify(mentorshipCleanupService).cleanupChildren(100L);
+        verify(notificationEventPublisher).publishMentorshipCancelled(2L, "Ahmet", "Schedule clash");
+
+        ArgumentCaptor<MentorshipAuditLog> captor = ArgumentCaptor.forClass(MentorshipAuditLog.class);
+        verify(mentorshipAuditLogRepository).save(captor.capture());
+        MentorshipAuditLog logged = captor.getValue();
+        assertThat(logged.getMentorshipId()).isEqualTo(100L);
+        assertThat(logged.getFromStatus()).isEqualTo(MentorshipStatus.ACTIVE);
+        assertThat(logged.getToStatus()).isEqualTo(MentorshipStatus.CANCELLED);
+        assertThat(logged.getActorUserId()).isEqualTo(1L);
+        assertThat(logged.getReason()).isEqualTo("Schedule clash");
+    }
+
+    @Test
+    void cancelMentorshipByMenteeNotifiesMentor() {
+        Mentorship mentorship = activeMentorship();
+        mentee.setActiveMentorId(mentor.getId());
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.save(any(Mentorship.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        mentorshipService.cancelMentorship(2L, 100L, cancelDto("Lost interest"));
+
+        verify(notificationEventPublisher).publishMentorshipCancelled(1L, "Elif", "Lost interest");
+        assertThat(mentorship.getTerminatedByUserId()).isEqualTo(2L);
+    }
+
+    @Test
+    void cancelMentorshipRejectsNonParticipant() {
+        when(mentorshipRepository.findByIdAndParticipant(100L, 999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> mentorshipService.cancelMentorship(999L, 100L, cancelDto("nope")))
+                .isInstanceOf(ResourceNotFoundException.class);
+        verify(mentorshipCleanupService, never()).cleanupChildren(any());
+    }
+
+    @Test
+    void cancelMentorshipRejectsAlreadyCancelled() {
+        Mentorship mentorship = activeMentorship();
+        mentorship.setStatus(MentorshipStatus.CANCELLED);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorshipService.cancelMentorship(1L, 100L, cancelDto("again")))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("not active");
+        verify(mentorshipCleanupService, never()).cleanupChildren(any());
+        verify(mentorshipAuditLogRepository, never()).save(any());
+    }
+
+    @Test
+    void cancelMentorshipPreservesActiveMentorIdWhenItPointsElsewhere() {
+        // A stale activeMentorId pointing at a different mentor should not be cleared,
+        // because that other mentorship is still the active one for the mentee.
+        Mentorship mentorship = activeMentorship();
+        mentee.setActiveMentorId(999L);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.save(any(Mentorship.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        mentorshipService.cancelMentorship(1L, 100L, cancelDto("done"));
+
+        assertThat(mentee.getActiveMentorId()).isEqualTo(999L);
+    }
+
+    // ── Accept request: cool-down + initial audit row (#133) ────────────────
+
+    @Test
+    void acceptRequestWritesInitialAuditRow() {
+        when(mentorshipRequestRepository.findById(10L)).thenReturn(Optional.of(request));
+        when(mentorshipRepository.save(any(Mentorship.class))).thenAnswer(inv -> {
+            Mentorship m = inv.getArgument(0);
+            m.setId(100L);
+            return m;
+        });
+
+        mentorshipService.acceptRequest(1L, 10L, acceptDto);
+
+        ArgumentCaptor<MentorshipAuditLog> captor = ArgumentCaptor.forClass(MentorshipAuditLog.class);
+        verify(mentorshipAuditLogRepository).save(captor.capture());
+        MentorshipAuditLog logged = captor.getValue();
+        assertThat(logged.getMentorshipId()).isEqualTo(100L);
+        assertThat(logged.getFromStatus()).isNull();
+        assertThat(logged.getToStatus()).isEqualTo(MentorshipStatus.ACTIVE);
+        assertThat(logged.getActorUserId()).isEqualTo(1L);
+        assertThat(logged.getReason()).isNull();
+    }
+
+    @Test
+    void acceptRequestBlockedDuringCooldown() {
+        when(mentorshipRequestRepository.findById(10L)).thenReturn(Optional.of(request));
+        org.mockito.Mockito.doThrow(new MentorshipRequestException("cool-down active"))
+                .when(mentorshipCooldownPolicy).assertNotInCooldown(1L, 2L);
+
+        assertThatThrownBy(() -> mentorshipService.acceptRequest(1L, 10L, acceptDto))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("cool-down");
+        verify(mentorshipRepository, never()).save(any());
+        verify(mentorshipAuditLogRepository, never()).save(any());
+    }
+
+    // ── Audit trail endpoint (#133) ─────────────────────────────────────────
+
+    @Test
+    void getAuditTrailReturnsParticipantView() {
+        Mentorship mentorship = activeMentorship();
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+
+        MentorshipAuditLog row = MentorshipAuditLog.of(100L, null, MentorshipStatus.ACTIVE, 1L, null);
+        row.setId(1L);
+        row.setCreatedAt(OffsetDateTime.now(ZoneOffset.UTC));
+        when(mentorshipAuditLogRepository.findByMentorshipIdOrderByCreatedAtAsc(100L))
+                .thenReturn(List.of(row));
+
+        List<MentorshipAuditLogResponse> trail = mentorshipService.getAuditTrail(1L, 100L);
+
+        assertThat(trail).hasSize(1);
+        assertThat(trail.get(0).getToStatus()).isEqualTo("ACTIVE");
+        assertThat(trail.get(0).getFromStatus()).isNull();
+    }
+
+    @Test
+    void getAuditTrailRejectsNonParticipant() {
+        when(mentorshipRepository.findByIdAndParticipant(100L, 999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> mentorshipService.getAuditTrail(999L, 100L))
+                .isInstanceOf(ResourceNotFoundException.class);
     }
 }


### PR DESCRIPTION
## Summary

Closes #133. Wires up the mentorship lifecycle so an active relationship can actually be ended — with a captured reason, full child-data cleanup, an append-only audit trail of every state transition, and a configurable cool-down that prevents the same pair from immediately re-matching.

Either participant (mentor or mentee) can cancel. The mentorship row itself is retained with `status=CANCELLED` (not hard-deleted), so cool-down lookups against `(mentor_id, mentee_id)` find the most recent termination without joining a separate table. Children — meetings, tasks, milestones, conversation/messages, and the two FK-less `sent_*_reminders` tables — are removed in the same transaction.

## Acceptance criteria

- [x] **Cancellation reason** — required (`@NotBlank`, ≤ 500 chars), stored on the mentorship row and in the audit log.
- [x] **Related-data cleanup** — Meeting / Task / Milestone / Conversation children deleted via DB cascade; `sent_task_reminders` and `sent_milestone_reminders` swept manually since they have no FK to their parents.
- [x] **Audit trail** — new `mentorship_audit_log` table; one row on creation (`NULL → ACTIVE`) and one per subsequent transition (`ACTIVE → CANCELLED`), with actor + reason + timestamp.
- [x] **Cool-down** — `app.mentorship.cooldown.duration` (ISO-8601 Duration, default `PT168H` = 7 days, `MENTORSHIP_COOLDOWN_DURATION` env override). Enforced both on `POST /api/mentorship-requests` and on `PUT /api/mentorship-requests/{id}/accept`.
- [x] **Tests** — 14 new unit tests + 7 new integration tests; full suite (1403 tests) green.

## Schema

`V32__mentorship_cancellation.sql`:

```sql
ALTER TABLE mentorships
    ADD COLUMN terminated_at        TIMESTAMP NULL,
    ADD COLUMN terminated_by_user_id BIGINT NULL REFERENCES users(id) ON DELETE SET NULL,
    ADD COLUMN cancellation_reason  VARCHAR(500) NULL,
    ADD COLUMN updated_at           TIMESTAMP NOT NULL DEFAULT NOW();

CREATE INDEX idx_mentorships_pair_terminated
    ON mentorships (mentor_id, mentee_id, terminated_at DESC)
    WHERE terminated_at IS NOT NULL;

CREATE TABLE mentorship_audit_log (
    id              BIGSERIAL PRIMARY KEY,
    mentorship_id   BIGINT NOT NULL REFERENCES mentorships(id) ON DELETE CASCADE,
    from_status     VARCHAR(20) NULL,
    to_status       VARCHAR(20) NOT NULL,
    actor_user_id   BIGINT NULL REFERENCES users(id) ON DELETE SET NULL,
    reason          VARCHAR(500) NULL,
    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
);
```

The cool-down index is partial (only rows that have terminated), so it stays small as the table grows.

## API

| Method | Path | Auth | Notes |
|--------|------|------|-------|
| `POST` | `/api/mentorships/{id}/cancel` | Participant | Body: `{ "reason": "..." }`. Returns updated `MentorshipResponse` (now also exposes `terminatedAt` and `cancellationReason`). 409 if not ACTIVE; 404 for non-participants; 400 on blank/oversized reason. |
| `GET`  | `/api/mentorships/{id}/audit`  | Participant | Returns the chronological audit trail. 404 for non-participants. |

The other side of the pair receives a `MENTORSHIP_CANCELLED` notification (new `NotificationType` value). This category bypasses user opt-out — losing an active mentorship affects ongoing tasks/meetings, so it's treated as a system-mandated event the same way ban notices are.

## Design decisions

- **Mentorship row kept, not deleted.** Cool-down needs a "most recent terminated_at" lookup per pair; keeping the row makes that a single indexed query rather than a parallel history table to maintain. Children are still removed.
- **Cool-down is a separate `MentorshipCooldownPolicy` service.** Reused from both `MentorshipRequestService.createRequest` and `MentorshipService.acceptRequest` so a banned-and-back mentee can't slip through by going straight to acceptance.
- **`MentorshipCleanupService` runs in `Propagation.REQUIRED`.** The status flip + cleanup either both commit or both roll back.
- **Time injection via `Clock` bean.** Mirrors `BanService` / `RateLimitFilter`; integration test overrides with the existing `MutableClock` so cool-down boundary crossings are deterministic.

## Files

**New (10)** — V32 migration, `MentorshipAuditLog` entity + repository, `CancelMentorshipRequest` + `MentorshipAuditLogResponse` DTOs, `MentorshipCleanupService`, `MentorshipCooldownPolicy`, three new test classes (`MentorshipCleanupServiceTest`, `MentorshipCooldownPolicyTest`, `MentorshipCancellationIntegrationTest`).

**Edited (14)** — `Mentorship` entity, `MentorshipResponse`, `MentorshipRepository` (new `findLastTerminatedAtForPair`), the two `Sent*ReminderRepository` interfaces (`deleteByXxxIdIn`), `MentorshipService` (cancel + audit + cool-down call + initial audit row), `MentorshipRequestService` (cool-down in `createRequest`), `MentorshipController` (two new endpoints), `NotificationType` + `NotificationEventPublisher` + `UserNotificationPreferences` (new `MENTORSHIP_CANCELLED`), `application.properties` (cool-down config), and the two existing service tests for the new constructor deps + cancel/audit cases.

## Test plan

- [ ] CI green on backend module
- [ ] Manual smoke against a dev DB:
  - [ ] Accept a request → confirm `mentorship_audit_log` has one row (`NULL → ACTIVE`)
  - [ ] `POST /api/mentorships/{id}/cancel` with reason → 200, response shows `status=CANCELLED`, `terminatedAt` set, `cancellationReason` echoed
  - [ ] Confirm related meetings/tasks/milestones/conversation rows are gone for that mentorship
  - [ ] `GET /api/mentorships/{id}/audit` → two rows in chronological order
  - [ ] Re-request the same mentor immediately → 409 with cool-down message
  - [ ] Wait past cool-down (or shrink `MENTORSHIP_COOLDOWN_DURATION` for the smoke run) → request accepted

## Out of scope

- Auto-completion of mentorships when `end_date` passes (separate cron job; follow-up issue).
- Admin-driven `TERMINATED` flow (the enum value stays defined but is not yet wired).
- Frontend / mobile UI for the new endpoints.
- Adding a custom-reason parameter to the existing pending-request cancellation path (`MentorshipRequestService.cancelOwnPendingRequest`); that flow is separate from active-mentorship cancellation and out of scope for this issue.
