### PR TITLE
feat: add mentee profile visibility controls

### DIFF
--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -158,7 +158,7 @@ export default function ProfilePage() {
         }),
       }
 
-      const updated = await updateOwnProfile(payload)
+      const updated = await updateOwnProfile(payload, isMentor ? 'MENTOR' : 'MENTEE')
       setProfileData(updated.firstName, updated.lastName, updated.profilePhoto)
       setSaveSuccess(true)
       setTimeout(() => setSaveSuccess(false), 3000)
@@ -515,19 +515,31 @@ export default function ProfilePage() {
                 <div className="divider" />
 
                 <div className="section-label">Privacy Settings</div>
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 0' }}>
+                <div className="visibility-row">
                   <div>
                     <div style={{ fontSize: '14px', fontWeight: 500 }}>Profile Visibility</div>
                     <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '2px' }}>
-                      {form.profileVisible ? 'Your profile is visible to matched users' : 'Your profile is hidden'}
+                      {form.profileVisible ? 'Public — visible to other users' : 'Private — hidden from other users'}
                     </div>
                   </div>
-                  <button
-                    type="button"
-                    className={`toggle${form.profileVisible ? '' : ' off'}`}
-                    onClick={() => handleChange('profileVisible', !form.profileVisible)}
-                    aria-label="Toggle profile visibility"
-                  />
+                  <div className="visibility-toggle" role="group" aria-label="Profile visibility">
+                    <button
+                      type="button"
+                      className={`visibility-option${form.profileVisible ? ' active' : ''}`}
+                      onClick={() => handleChange('profileVisible', true)}
+                      aria-pressed={form.profileVisible}
+                    >
+                      Public
+                    </button>
+                    <button
+                      type="button"
+                      className={`visibility-option${form.profileVisible ? '' : ' active'}`}
+                      onClick={() => handleChange('profileVisible', false)}
+                      aria-pressed={!form.profileVisible}
+                    >
+                      Private
+                    </button>
+                  </div>
                 </div>
               </>
             )}

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -34,7 +34,7 @@ function ProfileField({ label, value, chips = false }) {
 export default function UserProfilePage() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const { role } = useAuth()
+  const { role, userId } = useAuth()
   const isMentee = role === 'MENTEE'
 
   const [profile, setProfile] = useState(null)
@@ -127,6 +127,8 @@ export default function UserProfilePage() {
   }
 
   const isMentorProfile = profile.role === 'MENTOR'
+  const isOwner = userId && String(profile.id) === String(userId)
+  const isPrivateMentee = !isMentorProfile && profile.profileVisibility === false && !isOwner
   const initials = [profile.firstName, isMentorProfile ? profile.lastName : null]
     .filter(Boolean).map(w => w[0]).join('').toUpperCase() || '?'
 
@@ -244,10 +246,23 @@ export default function UserProfilePage() {
           ) : (
             <>
               {/* Per req 1.1.2.6: hide lastName and profilePhoto for unmatched mentees */}
-              <ProfileField label="Background" value={profile.backgroundInfo} />
-              <ProfileField label="Goals" value={profile.goals} />
-              <ProfileField label="Interests" value={profile.interests} chips />
-              <ProfileField label="Skills" value={profile.skills} chips />
+              {isPrivateMentee ? (
+                <div style={{ textAlign: 'center', padding: '28px 12px', color: 'var(--text-muted)' }}>
+                  <div style={{ fontSize: '16px', fontWeight: 600, color: 'var(--text-main)', marginBottom: '8px' }}>
+                    This profile is private
+                  </div>
+                  <div style={{ fontSize: '13px' }}>
+                    Only the profile owner can view these details.
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <ProfileField label="Background" value={profile.backgroundInfo} />
+                  <ProfileField label="Goals" value={profile.goals} />
+                  <ProfileField label="Interests" value={profile.interests} chips />
+                  <ProfileField label="Skills" value={profile.skills} chips />
+                </>
+              )}
             </>
           )}
         </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -141,7 +141,8 @@ export async function deleteProfilePhoto() {
 
 export async function updateOwnProfile(data, role) {
   const token = localStorage.getItem('auth_token')
-  const res = await fetch(`${BASE_URL}/users/me`, {
+  const endpoint = role === 'MENTOR' ? 'mentor' : 'mentee'
+  const res = await fetch(`${BASE_URL}/users/me/${endpoint}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(data),

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -141,8 +141,9 @@ export async function deleteProfilePhoto() {
 
 export async function updateOwnProfile(data, role) {
   const token = localStorage.getItem('auth_token')
-  const endpoint = role === 'MENTOR' ? 'mentor' : 'mentee'
-  const res = await fetch(`${BASE_URL}/users/me/${endpoint}`, {
+  const effectiveRole = role || localStorage.getItem('auth_role')
+  const path = effectiveRole === 'MENTOR' ? '/users/me/mentor' : '/users/me/mentee'
+  const res = await fetch(`${BASE_URL}${path}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(data),

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1186,6 +1186,42 @@
 .toggle.off { background: #d0d5d0; }
 .toggle.off::after { right: auto; left: 3px; }
 
+.visibility-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 0;
+}
+
+.visibility-toggle {
+  display: inline-flex;
+  padding: 4px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: #f6f8f6;
+  gap: 4px;
+}
+
+.visibility-option {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+  font-family: 'DM Sans', sans-serif;
+}
+
+.visibility-option.active {
+  background: #fff;
+  color: var(--green-dark);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+}
+
 .duration-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
 .dur-btn {
   padding: 14px 12px; border-radius: 10px;


### PR DESCRIPTION
## Summary
- Add explicit `Public/Private` visibility control for mentee profiles.
- Route profile updates to role-specific endpoints (`/users/me/mentee` / `/users/me/mentor`).
- Show “This profile is private” placeholder when a mentee profile is hidden from non-owners.

## Changes
- Updated profile edit UI to use a segmented visibility selector.
- Wired profile save to role-based PATCH endpoints.
- Added client-side visibility gate on public mentee profile view.
- Added styles for the visibility selector.

Related to #359 