### PR TITLE
fix(e2e): bump per-test timeout to 60s to absorb AT-02 slow-runner flakes

### DIFF
--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -12,6 +12,14 @@ export default defineConfig({
   // mid-test reset wipes the other worker's session. True isolation needs
   // schema-per-worker or per-test data namespacing; tracked as a follow-up.
   workers: process.env.CI ? 1 : undefined,
+  // AT-02 has ~15 sequential UI+API steps including two UI logins that each
+  // wait up to 20s for /home navigation (`expect(page).toHaveURL(/\/home$/,
+  // { timeout: 20_000 })`). The spec's own per-action timeouts already
+  // permit ~40s of login budget alone, exceeding Playwright's default 30s
+  // testTimeout. 60s aligns the framework ceiling with the spec's
+  // arithmetic. Doesn't mask real regressions — passing tests exit on
+  // assertions, not on the ceiling.
+  timeout: 60_000,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
     baseURL,


### PR DESCRIPTION
## Summary

Dev's e2e CI on the post-#397 merge (3dc85e2) failed: AT-02 timed out across all browsers with `Test timeout of 30000ms exceeded`. Same flake pattern existed before the recent merges — it's not a new regression, just finally noticed.

## Root cause (the arithmetic mismatch)

`at02-mentorship-blog.spec.js` runs ~15 sequential UI+API steps. The two `loginViaUi(...)` calls each contain:

```js
await expect(page).toHaveURL(/\/home$/, { timeout: 20_000 });
```

That's a 20-second internal wait per UI login. With two logins, the spec's own per-action timeouts already permit up to **40 seconds of login budget alone**, before any of the other 13 steps. Playwright's default per-test timeout is **30 seconds**. The test's own internal timeouts mathematically exceed the framework's default budget.

In practice the logins usually complete in 1–4s and the whole test fits in 10–25s, but on slower CI runners the wall-clock pushes past 30s. The retry-#2-passes-in-3.8s pattern observed on dev is consistent with warm caches/JIT (real wall-clock variance), not a deterministic break.

## Change

One field in `frontend/playwright.config.js`:

```js
timeout: 60_000,
```

Aligns the framework ceiling with the spec's internal arithmetic. Doesn't mask real regressions — passing tests exit on assertions, not on the ceiling. AT-01 (~4s), AT-03 (sub-1s), AT-06 (10s waits), AT-07 (5–10s) all stay well below 60s, so the bump doesn't slow anything down.

## Verification

Local against `vite preview` + native backend with the env vars from `.github/workflows/e2e-ci.yml`:

- Backend `mvn test`: 1377 tests pass.
- Frontend `npm test` + `npm run build`: clean.
- `CI=true npx playwright test`: 20 passed, 26 skipped (AT-04*/AT-05 fixme'd), 2 flaky (firefox AT-02 + AT-07 needed retry due to a separate, pre-existing login-nav flake — both passed on retry, overall run exits 0). The original `Test timeout of 30000ms exceeded` error mode is gone.

## Test plan

- [ ] CI's `e2e` job goes green.
- [ ] CI's `test` and `web-test-and-build` jobs stay green.
- [ ] Post-merge, dev's e2e on the merge commit goes green.

## Open follow-up (not in this PR)

Replace one of the two UI logins in AT-02 with API-token + `applyAdminAuth`-style injection from `frontend/e2e/fixtures/adminFixture.js`. Cuts ~5–10s wall-clock and is the proper long-term fix; this PR is the surgical one-liner that gets dev green today.