### PR TITLE
Feature/237 mentorship lifecycle

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
@@ -1,11 +1,16 @@
 package com.group7.backend.controller;
 
 import com.group7.backend.dto.request.CancelMentorshipRequest;
+import com.group7.backend.dto.request.CreateMentorRatingRequest;
+import com.group7.backend.dto.request.EndMentorshipRequest;
+import com.group7.backend.dto.request.ExtendMentorshipRequest;
 import com.group7.backend.dto.request.SharedGoalRequest;
+import com.group7.backend.dto.response.MentorRatingResponse;
 import com.group7.backend.dto.response.MentorshipAuditLogResponse;
 import com.group7.backend.dto.response.MentorshipProgressResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
 import com.group7.backend.dto.response.TimelineResponse;
+import com.group7.backend.service.MentorRatingService;
 import com.group7.backend.service.MentorshipProgressService;
 import com.group7.backend.service.MentorshipService;
 import com.group7.backend.service.MentorshipTimelineService;
@@ -33,13 +38,16 @@ public class MentorshipController {
     private final MentorshipService mentorshipService;
     private final MentorshipProgressService mentorshipProgressService;
     private final MentorshipTimelineService mentorshipTimelineService;
+    private final MentorRatingService mentorRatingService;
 
     public MentorshipController(MentorshipService mentorshipService,
                                 MentorshipProgressService mentorshipProgressService,
-                                MentorshipTimelineService mentorshipTimelineService) {
+                                MentorshipTimelineService mentorshipTimelineService,
+                                MentorRatingService mentorRatingService) {
         this.mentorshipService = mentorshipService;
         this.mentorshipProgressService = mentorshipProgressService;
         this.mentorshipTimelineService = mentorshipTimelineService;
+        this.mentorRatingService = mentorRatingService;
     }
 
     @GetMapping
@@ -145,16 +153,20 @@ public class MentorshipController {
 
     @PostMapping("/{id}/cancel")
     @Operation(
-            summary = "Cancel an active mentorship (#133)",
-            description = "Either participant may cancel an active mentorship by supplying a reason. " +
-                    "Children (meetings, tasks, milestones, conversation/messages) are deleted; " +
-                    "the mentorship row itself is retained with status=CANCELLED for audit and " +
-                    "cool-down lookups. The other participant is notified."
+            summary = "Cancel an active mentorship (mentee-only, #133/#237)",
+            description = "Mentee cancels an active mentorship with a reason. Children " +
+                    "(meetings, tasks, milestones, conversation/messages) are deleted; the " +
+                    "mentorship row itself is retained with status=CANCELLED for audit and " +
+                    "cool-down lookups. The mentor is notified. The cancellation is recorded " +
+                    "against the auto-ban system (#134) and may impose a temporary ban once " +
+                    "the threshold is crossed. Mentors must use PATCH /end instead."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Mentorship cancelled",
                     content = @Content(schema = @Schema(implementation = MentorshipResponse.class))),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Mentor attempted to cancel; use /end instead",
+                    content = @Content),
             @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
                     content = @Content),
             @ApiResponse(responseCode = "409", description = "Mentorship is not active", content = @Content)
@@ -165,6 +177,87 @@ public class MentorshipController {
             Authentication authentication) {
         Long userId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(mentorshipService.cancelMentorship(userId, id, request));
+    }
+
+    @PatchMapping("/{id}/end")
+    @Operation(
+            summary = "End an active mentorship gracefully (mentor-only, #237)",
+            description = "Mentor closes an active mentorship — sets status=COMPLETED, stamps " +
+                    "endDate=now, deletes children, audits the transition, and notifies the " +
+                    "mentee. Reason is optional (mentor's wrap-up note, not a violation). " +
+                    "Mentees must use POST /cancel instead."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Mentorship ended",
+                    content = @Content(schema = @Schema(implementation = MentorshipResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Mentee attempted to end; use /cancel instead",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content),
+            @ApiResponse(responseCode = "409", description = "Mentorship is not active", content = @Content)
+    })
+    public ResponseEntity<MentorshipResponse> endMentorship(
+            @PathVariable Long id,
+            @Valid @RequestBody EndMentorshipRequest request,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorshipService.endMentorship(userId, id, request));
+    }
+
+    @PatchMapping("/{id}/extend")
+    @Operation(
+            summary = "Extend duration of an active mentorship (mentor-only, #237)",
+            description = "Pushes endDate forward by 1, 3, or 6 months and adds the same to " +
+                    "duration. Records the extension in the audit trail and notifies the mentee."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Mentorship extended",
+                    content = @Content(schema = @Schema(implementation = MentorshipResponse.class))),
+            @ApiResponse(responseCode = "400", description = "additionalMonths is not 1, 3, or 6",
+                    content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Mentee attempted to extend",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content),
+            @ApiResponse(responseCode = "409", description = "Mentorship is not active", content = @Content)
+    })
+    public ResponseEntity<MentorshipResponse> extendMentorship(
+            @PathVariable Long id,
+            @Valid @RequestBody ExtendMentorshipRequest request,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorshipService.extendMentorship(userId, id, request));
+    }
+
+    @PostMapping("/{id}/rating")
+    @Operation(
+            summary = "Submit a mentor rating (mentee-only, #237)",
+            description = "Mentee submits a 1–5 score with an optional comment after the " +
+                    "mentorship has terminated (status=COMPLETED or CANCELLED). One rating per " +
+                    "mentorship — a second POST returns 409. The rating contributes to the " +
+                    "mentor's averageRating / ratingCount on their profile."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Rating created",
+                    content = @Content(schema = @Schema(implementation = MentorRatingResponse.class))),
+            @ApiResponse(responseCode = "400", description = "score outside 1–5 or comment too long",
+                    content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Mentor attempted to rate", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content),
+            @ApiResponse(responseCode = "409", description = "Mentorship not yet terminated, or already rated",
+                    content = @Content)
+    })
+    public ResponseEntity<MentorRatingResponse> rateMentor(
+            @PathVariable Long id,
+            @Valid @RequestBody CreateMentorRatingRequest request,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        MentorRatingResponse response = mentorRatingService.createRating(userId, id, request);
+        return ResponseEntity.status(org.springframework.http.HttpStatus.CREATED).body(response);
     }
 
     @GetMapping("/{id}/audit")

--- a/backend/src/main/java/com/group7/backend/dto/request/CreateMentorRatingRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/CreateMentorRatingRequest.java
@@ -1,0 +1,28 @@
+package com.group7.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Mentee-submitted rating for a mentor after the mentorship "
+                    + "has terminated (#237).")
+public class CreateMentorRatingRequest {
+
+    @NotNull(message = "score is required")
+    @Min(value = 1, message = "score must be between 1 and 5")
+    @Max(value = 5, message = "score must be between 1 and 5")
+    @Schema(description = "Score from 1 to 5 inclusive.", example = "5")
+    private Integer score;
+
+    @Size(max = 1000, message = "Comment must not exceed 1000 characters")
+    @Schema(description = "Optional free-text comment.", example = "Great mentor!")
+    private String comment;
+}

--- a/backend/src/main/java/com/group7/backend/dto/request/EndMentorshipRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/EndMentorshipRequest.java
@@ -1,0 +1,21 @@
+package com.group7.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Payload for the mentor ending an active mentorship (#237). "
+                    + "Reason is optional — this is a graceful close, not a violation.")
+public class EndMentorshipRequest {
+
+    @Size(max = 500, message = "Reason must not exceed 500 characters")
+    @Schema(description = "Optional wrap-up note from the mentor; surfaced in the audit trail "
+                        + "and the notification body.",
+            example = "Goal achieved — congrats!")
+    private String reason;
+}

--- a/backend/src/main/java/com/group7/backend/dto/request/ExtendMentorshipRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/ExtendMentorshipRequest.java
@@ -1,0 +1,32 @@
+package com.group7.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Set;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Payload for extending an active mentorship's duration (#237). "
+                    + "Mentor-only. Adds the requested months to end_date.")
+public class ExtendMentorshipRequest {
+
+    private static final Set<Integer> ALLOWED = Set.of(1, 3, 6);
+
+    @NotNull(message = "additionalMonths is required")
+    @Schema(description = "Months to add to the current end_date. Must be 1, 3, or 6 — "
+                        + "matching the durations allowed at acceptance time.",
+            example = "3")
+    private Integer additionalMonths;
+
+    @jakarta.validation.constraints.AssertTrue(message = "additionalMonths must be 1, 3, or 6")
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    @io.swagger.v3.oas.annotations.media.Schema(hidden = true)
+    public boolean isAdditionalMonthsAllowed() {
+        return additionalMonths != null && ALLOWED.contains(additionalMonths);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorRatingResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorRatingResponse.java
@@ -1,0 +1,49 @@
+package com.group7.backend.dto.response;
+
+import com.group7.backend.entity.MentorRating;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Mentor rating submitted by a mentee (#237).")
+public class MentorRatingResponse {
+
+    @Schema(description = "Rating id", example = "42")
+    private Long id;
+
+    @Schema(description = "Mentorship id this rating belongs to", example = "100")
+    private Long mentorshipId;
+
+    @Schema(description = "Rated mentor user id", example = "1")
+    private Long mentorId;
+
+    @Schema(description = "Submitting mentee user id", example = "2")
+    private Long menteeId;
+
+    @Schema(description = "Score from 1 to 5", example = "5")
+    private Integer score;
+
+    @Schema(description = "Optional comment", example = "Great mentor!")
+    private String comment;
+
+    @Schema(description = "When the rating was submitted")
+    private OffsetDateTime createdAt;
+
+    public static MentorRatingResponse from(MentorRating rating) {
+        MentorRatingResponse r = new MentorRatingResponse();
+        r.setId(rating.getId());
+        r.setMentorshipId(rating.getMentorshipId());
+        r.setMentorId(rating.getMentorId());
+        r.setMenteeId(rating.getMenteeId());
+        r.setScore(rating.getScore());
+        r.setComment(rating.getComment());
+        r.setCreatedAt(rating.getCreatedAt());
+        return r;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/UserRatingSummary.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/UserRatingSummary.java
@@ -1,0 +1,17 @@
+package com.group7.backend.dto.response;
+
+/**
+ * Aggregate rating summary surfaced on a mentor's profile (#237). Built by
+ * {@code MentorRatingRepository.aggregateForMentor} via a JPQL constructor
+ * expression so a single query returns both fields.
+ *
+ * @param averageRating mean of all rating scores for this mentor, or {@code null}
+ *                      when {@code ratingCount == 0}
+ * @param ratingCount   number of ratings submitted for this mentor
+ */
+public record UserRatingSummary(Double averageRating, long ratingCount) {
+
+    public static UserRatingSummary empty() {
+        return new UserRatingSummary(null, 0L);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/UserResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/UserResponse.java
@@ -27,4 +27,11 @@ public class UserResponse {
     private OffsetDateTime createdAt;
     @Schema(description = "Role", example = "MENTEE")
     private String role;
+    @Schema(description = "Average mentor rating (1.0–5.0). Populated only on profile-detail "
+                        + "endpoints (#237); null on list / search responses and for non-mentor "
+                        + "users.", example = "4.6")
+    private Double averageRating;
+    @Schema(description = "Number of ratings the mentor has received (#237). 0 when "
+                        + "averageRating is null.", example = "12")
+    private Long ratingCount;
 }

--- a/backend/src/main/java/com/group7/backend/entity/MentorRating.java
+++ b/backend/src/main/java/com/group7/backend/entity/MentorRating.java
@@ -1,0 +1,65 @@
+package com.group7.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * Mentee-submitted rating for a mentor after a mentorship has terminated
+ * (#237). One row per mentorship — enforced both by the service-level
+ * existsBy check and by the {@code UNIQUE(mentorship_id)} DB constraint.
+ *
+ * <p>Scope is intentionally mentee → mentor only for #237; mentor → mentee
+ * ratings are out of scope.
+ */
+@Entity
+@Table(name = "mentor_ratings")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MentorRating {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mentorship_id", nullable = false, unique = true)
+    private Long mentorshipId;
+
+    @Column(name = "mentor_id", nullable = false)
+    private Long mentorId;
+
+    @Column(name = "mentee_id", nullable = false)
+    private Long menteeId;
+
+    @Column(nullable = false)
+    private Integer score;
+
+    @Column(length = 1000)
+    private String comment;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
+    }
+
+    public static MentorRating of(Long mentorshipId, Long mentorId, Long menteeId,
+                                  Integer score, String comment) {
+        MentorRating r = new MentorRating();
+        r.setMentorshipId(mentorshipId);
+        r.setMentorId(mentorId);
+        r.setMenteeId(menteeId);
+        r.setScore(score);
+        r.setComment(comment);
+        return r;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/entity/NotificationType.java
+++ b/backend/src/main/java/com/group7/backend/entity/NotificationType.java
@@ -34,5 +34,13 @@ public enum NotificationType {
     BAN_EXPIRED,
     // Mentorship cancellation (#133). Sent to the OTHER participant when
     // either side cancels an active mentorship; body includes the reason.
-    MENTORSHIP_CANCELLED
+    MENTORSHIP_CANCELLED,
+    // Mentorship lifecycle (#237). MENTORSHIP_ENDED is sent to the mentee
+    // when the mentor closes a mentorship gracefully (status -> COMPLETED).
+    // MENTORSHIP_EXTENDED is sent to the mentee when the mentor pushes
+    // end_date forward. MENTORSHIP_AUTO_COMPLETED fires from the scheduler
+    // when end_date passes; both participants receive it.
+    MENTORSHIP_ENDED,
+    MENTORSHIP_EXTENDED,
+    MENTORSHIP_AUTO_COMPLETED
 }

--- a/backend/src/main/java/com/group7/backend/entity/UserNotificationPreferences.java
+++ b/backend/src/main/java/com/group7/backend/entity/UserNotificationPreferences.java
@@ -95,6 +95,10 @@ public class UserNotificationPreferences {
             // consequential lifecycle event that affects ongoing tasks/meetings,
             // so it bypasses category opt-outs the same way ban notices do.
             case MENTORSHIP_CANCELLED -> true;
+            // Mentorship lifecycle (#237) — same reasoning: end / extend /
+            // auto-completion all change the user's relationship status and
+            // their pending tasks/meetings, so always-on.
+            case MENTORSHIP_ENDED, MENTORSHIP_EXTENDED, MENTORSHIP_AUTO_COMPLETED -> true;
         };
     }
 }

--- a/backend/src/main/java/com/group7/backend/repository/MentorRatingRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorRatingRepository.java
@@ -1,0 +1,29 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.dto.response.UserRatingSummary;
+import com.group7.backend.entity.MentorRating;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MentorRatingRepository extends JpaRepository<MentorRating, Long> {
+
+    Optional<MentorRating> findByMentorshipId(Long mentorshipId);
+
+    boolean existsByMentorshipId(Long mentorshipId);
+
+    /**
+     * Aggregate average + count for a mentor in one query (#237). Returns
+     * {@code (null, 0)} when the mentor has no ratings — JPQL {@code AVG}
+     * over the empty set is {@code null}, which the constructor expression
+     * passes straight through.
+     */
+    @Query("SELECT new com.group7.backend.dto.response.UserRatingSummary("
+            + "AVG(CAST(r.score AS double)), COUNT(r)) "
+            + "FROM MentorRating r WHERE r.mentorId = :mentorId")
+    UserRatingSummary aggregateForMentor(@Param("mentorId") Long mentorId);
+}

--- a/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
@@ -38,6 +38,17 @@ public interface MentorshipRepository extends JpaRepository<Mentorship, Long> {
     Optional<OffsetDateTime> findLastTerminatedAtForPair(@Param("mentorId") Long mentorId,
                                                         @Param("menteeId") Long menteeId);
 
+    /**
+     * Active mentorships whose {@code endDate} has passed (#237). Used by the
+     * auto-termination scheduler to flip them to COMPLETED. JOIN FETCHes mentor
+     * and mentee so the per-row processing can read counters and ids without
+     * triggering LAZY loads.
+     */
+    @Query("SELECT m FROM Mentorship m JOIN FETCH m.mentor JOIN FETCH m.mentee "
+            + "WHERE m.status = :status AND m.endDate < :now")
+    List<Mentorship> findActiveExpiredAt(@Param("status") MentorshipStatus status,
+                                         @Param("now") OffsetDateTime now);
+
     @Query(value = "SELECT pg_advisory_xact_lock(:lockId)", nativeQuery = true)
     void acquireAdvisoryLock(@Param("lockId") Long lockId);
 }

--- a/backend/src/main/java/com/group7/backend/scheduler/MentorshipAutoCompletionScheduler.java
+++ b/backend/src/main/java/com/group7/backend/scheduler/MentorshipAutoCompletionScheduler.java
@@ -1,0 +1,41 @@
+package com.group7.backend.scheduler;
+
+import com.group7.backend.service.MentorshipAutoCompletionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Cron sweep that auto-completes ACTIVE mentorships whose {@code endDate}
+ * has passed (#237). Hourly UTC default; tunable via
+ * {@code app.mentorships.auto-completion.cron} and
+ * {@code app.mentorships.auto-completion.zone}.
+ *
+ * <p>{@code @ConditionalOnProperty} gates the bean so the test profile
+ * (which sets {@code app.mentorships.auto-completion.enabled=false}) skips
+ * scheduler creation entirely.
+ */
+@Component
+@ConditionalOnProperty(name = "app.mentorships.auto-completion.enabled",
+        havingValue = "true", matchIfMissing = true)
+public class MentorshipAutoCompletionScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(MentorshipAutoCompletionScheduler.class);
+
+    private final MentorshipAutoCompletionService service;
+
+    public MentorshipAutoCompletionScheduler(MentorshipAutoCompletionService service) {
+        this.service = service;
+    }
+
+    @Scheduled(cron = "${app.mentorships.auto-completion.cron:0 0 * * * *}",
+            zone = "${app.mentorships.auto-completion.zone:UTC}")
+    public void sweep() {
+        int n = service.autoCompleteExpired();
+        if (n > 0) {
+            log.info("MentorshipAutoCompletion: completed {} expired mentorships", n);
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MentorRatingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorRatingService.java
@@ -1,0 +1,89 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.request.CreateMentorRatingRequest;
+import com.group7.backend.dto.response.MentorRatingResponse;
+import com.group7.backend.dto.response.UserRatingSummary;
+import com.group7.backend.entity.MentorRating;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.exception.MentorshipRequestException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MentorRatingRepository;
+import com.group7.backend.repository.MentorshipRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Mentee → mentor rating after a mentorship has terminated (#237).
+ *
+ * <p>Validation order: 404 (not a participant) → 403 (not the mentee) →
+ * 409 (mentorship still active) → 409 (already rated). Persistence catches
+ * {@link DataIntegrityViolationException} as the race-loss path because the
+ * {@code UNIQUE(mentorship_id)} constraint can fire even when the existsBy
+ * check above passed (two concurrent POSTs).
+ */
+@Service
+public class MentorRatingService {
+
+    private static final Logger log = LoggerFactory.getLogger(MentorRatingService.class);
+
+    private final MentorRatingRepository mentorRatingRepository;
+    private final MentorshipRepository mentorshipRepository;
+
+    public MentorRatingService(MentorRatingRepository mentorRatingRepository,
+                               MentorshipRepository mentorshipRepository) {
+        this.mentorRatingRepository = mentorRatingRepository;
+        this.mentorshipRepository = mentorshipRepository;
+    }
+
+    @Transactional
+    public MentorRatingResponse createRating(Long menteeUserId,
+                                             Long mentorshipId,
+                                             CreateMentorRatingRequest dto) {
+        Mentorship mentorship = mentorshipRepository
+                .findByIdAndParticipant(mentorshipId, menteeUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mentorship not found"));
+
+        if (!mentorship.getMentee().getId().equals(menteeUserId)) {
+            throw new AccessDeniedException("Only the mentee can rate the mentor");
+        }
+
+        MentorshipStatus status = mentorship.getStatus();
+        if (status != MentorshipStatus.COMPLETED && status != MentorshipStatus.CANCELLED) {
+            log.warn("Rating rejected: mentorshipId={} is in status {}", mentorshipId, status);
+            throw new MentorshipRequestException("Mentorship has not ended yet");
+        }
+
+        if (mentorRatingRepository.existsByMentorshipId(mentorshipId)) {
+            throw new MentorshipRequestException("This mentorship has already been rated");
+        }
+
+        MentorRating rating = MentorRating.of(
+                mentorshipId,
+                mentorship.getMentor().getId(),
+                menteeUserId,
+                dto.getScore(),
+                dto.getComment());
+
+        try {
+            MentorRating saved = mentorRatingRepository.save(rating);
+            log.info("Mentor rating created: ratingId={}, mentorshipId={}, mentorId={}, score={}",
+                    saved.getId(), mentorshipId, saved.getMentorId(), saved.getScore());
+            return MentorRatingResponse.from(saved);
+        } catch (DataIntegrityViolationException e) {
+            // UNIQUE(mentorship_id) lost the race against a concurrent POST.
+            log.warn("Mentor rating race-lost on UNIQUE(mentorship_id): mentorshipId={}", mentorshipId);
+            throw new MentorshipRequestException("This mentorship has already been rated");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public UserRatingSummary aggregateForMentor(Long mentorId) {
+        UserRatingSummary summary = mentorRatingRepository.aggregateForMentor(mentorId);
+        return summary != null ? summary : UserRatingSummary.empty();
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MentorshipAutoCompletionService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipAutoCompletionService.java
@@ -1,0 +1,133 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipAuditLog;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.repository.MentorshipAuditLogRepository;
+import com.group7.backend.repository.MentorshipRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Auto-terminates ACTIVE mentorships whose {@code endDate} has passed
+ * (#237). Each row goes through the same cleanup + audit + notification
+ * machinery as a mentor /end, but with {@code terminatedByUserId = null}
+ * to denote a system-initiated transition.
+ *
+ * <p>Invoked by {@link com.group7.backend.scheduler.MentorshipAutoCompletionScheduler}
+ * (and directly from tests). Each row is processed in its own
+ * transaction (REQUIRES_NEW) so a single failure can't poison the rest of
+ * the sweep — mirrors the {@code BanExpiryScheduler} resilience pattern.
+ */
+@Service
+public class MentorshipAutoCompletionService {
+
+    private static final Logger log = LoggerFactory.getLogger(MentorshipAutoCompletionService.class);
+
+    private final MentorshipRepository mentorshipRepository;
+    private final MentorshipAuditLogRepository mentorshipAuditLogRepository;
+    private final MentorshipCleanupService mentorshipCleanupService;
+    private final NotificationEventPublisher notificationEventPublisher;
+    private final Clock clock;
+    private final TransactionTemplate perRowTx;
+
+    public MentorshipAutoCompletionService(MentorshipRepository mentorshipRepository,
+                                           MentorshipAuditLogRepository mentorshipAuditLogRepository,
+                                           MentorshipCleanupService mentorshipCleanupService,
+                                           NotificationEventPublisher notificationEventPublisher,
+                                           Clock clock,
+                                           PlatformTransactionManager transactionManager) {
+        this.mentorshipRepository = mentorshipRepository;
+        this.mentorshipAuditLogRepository = mentorshipAuditLogRepository;
+        this.mentorshipCleanupService = mentorshipCleanupService;
+        this.notificationEventPublisher = notificationEventPublisher;
+        this.clock = clock;
+        // Per-row REQUIRES_NEW transaction. Keeps the sweep resilient — one
+        // row's failure rolls back only its own work; subsequent rows still
+        // process. Goes through TransactionTemplate so we don't depend on
+        // Spring AOP proxying a self-call (which silently bypasses
+        // @Transactional and was the cause of the original integration-test
+        // regression).
+        this.perRowTx = new TransactionTemplate(transactionManager);
+        this.perRowTx.setPropagationBehavior(
+                org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
+
+    /**
+     * Sweep: load expired ACTIVE mentorships and complete each one. Returns
+     * the number of rows successfully processed (failures are logged and
+     * skipped). The query runs once outside any transaction so each row's
+     * processing can commit independently.
+     */
+    public int autoCompleteExpired() {
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        List<Mentorship> expired = mentorshipRepository.findActiveExpiredAt(MentorshipStatus.ACTIVE, now);
+        if (expired.isEmpty()) {
+            return 0;
+        }
+        int processed = 0;
+        for (Mentorship m : expired) {
+            try {
+                perRowTx.executeWithoutResult(status -> completeOne(m.getId(), now));
+                processed++;
+            } catch (RuntimeException ex) {
+                log.warn("Auto-completion failed for mentorshipId={}: {}",
+                        m.getId(), ex.getMessage());
+            }
+        }
+        return processed;
+    }
+
+    /**
+     * Per-row processing. Invoked inside a {@code REQUIRES_NEW} transaction
+     * by {@link #autoCompleteExpired()} via {@link #perRowTx} so a failure
+     * rolls back only this row.
+     */
+    public void completeOne(Long mentorshipId, OffsetDateTime now) {
+        Mentorship mentorship = mentorshipRepository.findById(mentorshipId)
+                .orElse(null);
+        if (mentorship == null || mentorship.getStatus() != MentorshipStatus.ACTIVE) {
+            // Race: someone else terminated it between the sweep query and now.
+            return;
+        }
+
+        Mentor mentor = mentorship.getMentor();
+        Mentee mentee = mentorship.getMentee();
+
+        mentorship.setStatus(MentorshipStatus.COMPLETED);
+        mentorship.setTerminatedAt(now);
+        mentorship.setTerminatedByUserId(null);
+
+        if (Objects.equals(mentee.getActiveMentorId(), mentor.getId())) {
+            mentee.setActiveMentorId(null);
+        }
+        if (mentor.getCurrentMenteeCount() > 0) {
+            mentor.setCurrentMenteeCount(mentor.getCurrentMenteeCount() - 1);
+        }
+
+        mentorshipCleanupService.cleanupChildren(mentorshipId);
+        mentorshipRepository.save(mentorship);
+
+        mentorshipAuditLogRepository.save(MentorshipAuditLog.of(
+                mentorshipId, MentorshipStatus.ACTIVE, MentorshipStatus.COMPLETED,
+                null, "Auto-completed at end_date"));
+
+        notificationEventPublisher.publishMentorshipAutoCompleted(
+                mentor.getId(), mentee.getFirstName());
+        notificationEventPublisher.publishMentorshipAutoCompleted(
+                mentee.getId(), mentor.getFirstName());
+
+        log.info("Mentorship auto-completed: mentorshipId={}, mentorId={}, menteeId={}",
+                mentorshipId, mentor.getId(), mentee.getId());
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/MentorshipService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipService.java
@@ -2,6 +2,8 @@ package com.group7.backend.service;
 
 import com.group7.backend.dto.request.AcceptRequestRequest;
 import com.group7.backend.dto.request.CancelMentorshipRequest;
+import com.group7.backend.dto.request.EndMentorshipRequest;
+import com.group7.backend.dto.request.ExtendMentorshipRequest;
 import com.group7.backend.dto.request.SharedGoalRequest;
 import com.group7.backend.dto.response.MentorshipAuditLogResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
@@ -13,6 +15,7 @@ import com.group7.backend.repository.MentorshipRepository;
 import com.group7.backend.repository.MentorshipRequestRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +37,7 @@ public class MentorshipService {
     private final MentorshipCleanupService mentorshipCleanupService;
     private final MentorshipCooldownPolicy mentorshipCooldownPolicy;
     private final NotificationEventPublisher notificationEventPublisher;
+    private final BanService banService;
     private final Clock clock;
 
     public MentorshipService(MentorshipRepository mentorshipRepository,
@@ -42,6 +46,7 @@ public class MentorshipService {
                              MentorshipCleanupService mentorshipCleanupService,
                              MentorshipCooldownPolicy mentorshipCooldownPolicy,
                              NotificationEventPublisher notificationEventPublisher,
+                             BanService banService,
                              Clock clock) {
         this.mentorshipRepository = mentorshipRepository;
         this.mentorshipRequestRepository = mentorshipRequestRepository;
@@ -49,6 +54,7 @@ public class MentorshipService {
         this.mentorshipCleanupService = mentorshipCleanupService;
         this.mentorshipCooldownPolicy = mentorshipCooldownPolicy;
         this.notificationEventPublisher = notificationEventPublisher;
+        this.banService = banService;
         this.clock = clock;
     }
 
@@ -155,14 +161,18 @@ public class MentorshipService {
     }
 
     /**
-     * Cancels an active mentorship (#133). Either participant may cancel; the
-     * other side gets a notification. Children (meetings, tasks, milestones,
-     * conversation/messages) are deleted by {@link MentorshipCleanupService};
-     * the mentorship row itself is kept with {@code status = CANCELLED} so
-     * cool-down lookups can find the termination.
+     * Mentee cancels an active mentorship (#133, scoped down by #237). Mentor
+     * uses {@link #endMentorship} for graceful termination instead. Children
+     * (meetings, tasks, milestones, conversation/messages) are deleted by
+     * {@link MentorshipCleanupService}; the mentorship row itself is kept
+     * with {@code status = CANCELLED} so cool-down lookups can find the
+     * termination. The cancellation is recorded against {@link BanService}
+     * so the existing auto-ban escalation (#134) ramps up for repeat
+     * offenders.
      *
      * @throws ResourceNotFoundException if the user is not a participant
-     * @throws MentorshipRequestException if the mentorship is not currently ACTIVE
+     * @throws AccessDeniedException     if the user is the mentor (403)
+     * @throws MentorshipRequestException if the mentorship is not currently ACTIVE (409)
      */
     @Transactional
     public MentorshipResponse cancelMentorship(Long actorUserId,
@@ -170,16 +180,18 @@ public class MentorshipService {
                                                CancelMentorshipRequest dto) {
         Mentorship mentorship = findForParticipant(actorUserId, mentorshipId);
 
+        Mentor mentor = mentorship.getMentor();
+        Mentee mentee = mentorship.getMentee();
+        if (!mentee.getId().equals(actorUserId)) {
+            log.warn("Cancel rejected: mentorshipId={} attempted by non-mentee userId={}",
+                    mentorshipId, actorUserId);
+            throw new AccessDeniedException("Only the mentee can cancel a mentorship; mentors should use /end");
+        }
+
         if (mentorship.getStatus() != MentorshipStatus.ACTIVE) {
             log.warn("Cancel rejected: mentorshipId={} is in status {}", mentorshipId, mentorship.getStatus());
             throw new MentorshipRequestException("Mentorship is not active");
         }
-
-        Mentor mentor = mentorship.getMentor();
-        Mentee mentee = mentorship.getMentee();
-        boolean actorIsMentor = mentor.getId().equals(actorUserId);
-        Long otherUserId = actorIsMentor ? mentee.getId() : mentor.getId();
-        String actorFirstName = actorIsMentor ? mentor.getFirstName() : mentee.getFirstName();
 
         OffsetDateTime now = OffsetDateTime.now(clock);
         mentorship.setStatus(MentorshipStatus.CANCELLED);
@@ -196,8 +208,6 @@ public class MentorshipService {
             mentor.setCurrentMenteeCount(mentor.getCurrentMenteeCount() - 1);
         }
 
-        // Cleanup children (meetings, tasks, milestones, conversation). Same
-        // transaction — if anything fails, the status flip rolls back too.
         mentorshipCleanupService.cleanupChildren(mentorshipId);
 
         Mentorship saved = mentorshipRepository.save(mentorship);
@@ -206,11 +216,122 @@ public class MentorshipService {
                 saved.getId(), MentorshipStatus.ACTIVE, MentorshipStatus.CANCELLED,
                 actorUserId, dto.getReason()));
 
-        notificationEventPublisher.publishMentorshipCancelled(otherUserId, actorFirstName, dto.getReason());
+        // Hook into the auto-ban system (#134). Mentee-driven cancellation of
+        // an active mentorship counts as a violation, the same as cancelling
+        // a pending request, and feeds the same escalating-ban policy.
+        banService.recordCancellation(actorUserId, "Cancelled active mentorship: " + dto.getReason());
 
-        log.info("Mentorship cancelled: mentorshipId={}, actorUserId={}, otherUserId={}, "
-                        + "actorIsMentor={}",
-                mentorshipId, actorUserId, otherUserId, actorIsMentor);
+        notificationEventPublisher.publishMentorshipCancelled(
+                mentor.getId(), mentee.getFirstName(), dto.getReason());
+
+        log.info("Mentorship cancelled by mentee: mentorshipId={}, menteeId={}, mentorId={}",
+                mentorshipId, actorUserId, mentor.getId());
+        return MentorshipResponse.from(saved);
+    }
+
+    /**
+     * Mentor ends an active mentorship gracefully (#237). Sets
+     * {@code status = COMPLETED}, stamps {@code endDate = now}, cleans up
+     * children, audits the transition, and notifies the mentee. Reason is
+     * optional (mentor wrap-up note, not a violation — the mentor is not
+     * subject to ban escalation).
+     */
+    @Transactional
+    public MentorshipResponse endMentorship(Long mentorUserId,
+                                            Long mentorshipId,
+                                            EndMentorshipRequest dto) {
+        Mentorship mentorship = findForParticipant(mentorUserId, mentorshipId);
+
+        Mentor mentor = mentorship.getMentor();
+        Mentee mentee = mentorship.getMentee();
+        if (!mentor.getId().equals(mentorUserId)) {
+            log.warn("End rejected: mentorshipId={} attempted by non-mentor userId={}",
+                    mentorshipId, mentorUserId);
+            throw new AccessDeniedException("Only the mentor can end a mentorship; mentees should use /cancel");
+        }
+
+        if (mentorship.getStatus() != MentorshipStatus.ACTIVE) {
+            log.warn("End rejected: mentorshipId={} is in status {}", mentorshipId, mentorship.getStatus());
+            throw new MentorshipRequestException("Mentorship is not active");
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(clock);
+        mentorship.setStatus(MentorshipStatus.COMPLETED);
+        mentorship.setEndDate(now);
+        mentorship.setTerminatedAt(now);
+        mentorship.setTerminatedByUserId(mentorUserId);
+        mentorship.setCancellationReason(dto.getReason());
+
+        if (Objects.equals(mentee.getActiveMentorId(), mentor.getId())) {
+            mentee.setActiveMentorId(null);
+        }
+        if (mentor.getCurrentMenteeCount() > 0) {
+            mentor.setCurrentMenteeCount(mentor.getCurrentMenteeCount() - 1);
+        }
+
+        mentorshipCleanupService.cleanupChildren(mentorshipId);
+
+        Mentorship saved = mentorshipRepository.save(mentorship);
+
+        mentorshipAuditLogRepository.save(MentorshipAuditLog.of(
+                saved.getId(), MentorshipStatus.ACTIVE, MentorshipStatus.COMPLETED,
+                mentorUserId, dto.getReason()));
+
+        notificationEventPublisher.publishMentorshipEnded(
+                mentee.getId(), mentor.getFirstName(), dto.getReason());
+
+        log.info("Mentorship ended by mentor: mentorshipId={}, mentorId={}, menteeId={}",
+                mentorshipId, mentorUserId, mentee.getId());
+        return MentorshipResponse.from(saved);
+    }
+
+    /**
+     * Mentor extends the duration of an active mentorship (#237). Pushes
+     * {@code endDate} forward by 1, 3, or 6 months and increments
+     * {@code duration} accordingly. Records the lifecycle event in the audit
+     * log even though the status doesn't change.
+     */
+    @Transactional
+    public MentorshipResponse extendMentorship(Long mentorUserId,
+                                               Long mentorshipId,
+                                               ExtendMentorshipRequest dto) {
+        Mentorship mentorship = findForParticipant(mentorUserId, mentorshipId);
+
+        Mentor mentor = mentorship.getMentor();
+        Mentee mentee = mentorship.getMentee();
+        if (!mentor.getId().equals(mentorUserId)) {
+            log.warn("Extend rejected: mentorshipId={} attempted by non-mentor userId={}",
+                    mentorshipId, mentorUserId);
+            throw new AccessDeniedException("Only the mentor can extend a mentorship");
+        }
+
+        if (mentorship.getStatus() != MentorshipStatus.ACTIVE) {
+            log.warn("Extend rejected: mentorshipId={} is in status {}", mentorshipId, mentorship.getStatus());
+            throw new MentorshipRequestException("Mentorship is not active");
+        }
+
+        int additional = dto.getAdditionalMonths();
+        if (!ALLOWED_DURATIONS.contains(additional)) {
+            // DTO @AssertTrue covers this at the controller boundary, but
+            // service-side defence-in-depth catches non-validated callers.
+            throw new MentorshipRequestException("additionalMonths must be 1, 3, or 6");
+        }
+
+        OffsetDateTime newEndDate = mentorship.getEndDate().plusMonths(additional);
+        mentorship.setEndDate(newEndDate);
+        mentorship.setDuration(mentorship.getDuration() + additional);
+
+        Mentorship saved = mentorshipRepository.save(mentorship);
+
+        mentorshipAuditLogRepository.save(MentorshipAuditLog.of(
+                saved.getId(), MentorshipStatus.ACTIVE, MentorshipStatus.ACTIVE,
+                mentorUserId, "Extended by " + additional + " month(s); new end date " + newEndDate));
+
+        notificationEventPublisher.publishMentorshipExtended(
+                mentee.getId(), mentor.getFirstName(), additional, newEndDate);
+
+        log.info("Mentorship extended: mentorshipId={}, mentorId={}, additionalMonths={}, newEndDate={}",
+                mentorshipId, mentorUserId, additional, newEndDate);
         return MentorshipResponse.from(saved);
     }
 

--- a/backend/src/main/java/com/group7/backend/service/NotificationEventPublisher.java
+++ b/backend/src/main/java/com/group7/backend/service/NotificationEventPublisher.java
@@ -246,6 +246,37 @@ public class NotificationEventPublisher {
         );
     }
 
+    public void publishMentorshipEnded(Long recipientId, String mentorFirstName, String reason) {
+        String suffix = (reason == null || reason.isBlank()) ? "." : ". Note: " + reason;
+        publish(
+                recipientId,
+                NotificationType.MENTORSHIP_ENDED,
+                "Mentorship ended",
+                mentorFirstName + " ended your mentorship" + suffix
+        );
+    }
+
+    public void publishMentorshipExtended(Long recipientId, String mentorFirstName,
+                                          int additionalMonths, OffsetDateTime newEndDate) {
+        publish(
+                recipientId,
+                NotificationType.MENTORSHIP_EXTENDED,
+                "Mentorship extended",
+                mentorFirstName + " extended your mentorship by " + additionalMonths
+                        + " month(s); new end date " + newEndDate + "."
+        );
+    }
+
+    public void publishMentorshipAutoCompleted(Long recipientId, String counterpartFirstName) {
+        publish(
+                recipientId,
+                NotificationType.MENTORSHIP_AUTO_COMPLETED,
+                "Mentorship completed",
+                "Your mentorship with " + counterpartFirstName
+                        + " has reached its end date and is now complete."
+        );
+    }
+
     public void publish(Long recipientId, NotificationType type, String title, String body) {
         applicationEventPublisher.publishEvent(new NotificationCreatedEvent(recipientId, type, title, body));
     }

--- a/backend/src/main/java/com/group7/backend/service/UserService.java
+++ b/backend/src/main/java/com/group7/backend/service/UserService.java
@@ -8,6 +8,8 @@ import com.group7.backend.dto.response.MenteeResponse;
 import com.group7.backend.dto.response.MentorResponse;
 import com.group7.backend.dto.response.ProfileResponse;
 import com.group7.backend.dto.response.UserProfileResponse;
+import com.group7.backend.dto.response.UserRatingSummary;
+import com.group7.backend.dto.response.UserResponse;
 import com.group7.backend.entity.Admin;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
@@ -42,13 +44,15 @@ public class UserService {
     private final MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
     private final FollowRepository followRepository;
     private final FileStorageService fileStorageService;
+    private final MentorRatingService mentorRatingService;
 
     public UserService(UserRepository userRepository, MentorRepository mentorRepository,
                        MenteeRepository menteeRepository,
                        AvailabilitySlotRepository availabilitySlotRepository,
                        MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository,
                        FollowRepository followRepository,
-                       FileStorageService fileStorageService) {
+                       FileStorageService fileStorageService,
+                       MentorRatingService mentorRatingService) {
         this.userRepository = userRepository;
         this.mentorRepository = mentorRepository;
         this.menteeRepository = menteeRepository;
@@ -56,6 +60,7 @@ public class UserService {
         this.menteeAvailabilitySlotRepository = menteeAvailabilitySlotRepository;
         this.followRepository = followRepository;
         this.fileStorageService = fileStorageService;
+        this.mentorRatingService = mentorRatingService;
     }
 
     // ── Existing methods ────────────────────────────────────
@@ -230,6 +235,14 @@ public class UserService {
     private UserProfileResponse wrapWithCounts(ProfileResponse profile, Long userId) {
         long followers = followRepository.countByIdFolloweeId(userId);
         long following = followRepository.countByIdFollowerId(userId);
+        // Mentor rating summary (#237). Mentees never accumulate rows in
+        // mentor_ratings, so the aggregate returns (null, 0) for them; we
+        // still set the fields uniformly so the response shape is stable.
+        UserRatingSummary rating = mentorRatingService.aggregateForMentor(userId);
+        if (profile instanceof UserResponse base) {
+            base.setAverageRating(rating.averageRating());
+            base.setRatingCount(rating.ratingCount());
+        }
         return new UserProfileResponse(profile, followers, following);
     }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -276,3 +276,11 @@ app.bans.expiry-notification.zone=${BAN_EXPIRY_NOTIFY_ZONE:UTC}
 # window has elapsed. ISO-8601 Duration; default = 168h = 7 days. Override
 # in deploy via MENTORSHIP_COOLDOWN_DURATION (e.g. PT24H, P30D).
 app.mentorship.cooldown.duration=${MENTORSHIP_COOLDOWN_DURATION:PT168H}
+
+# Mentorship auto-completion sweep (#237). Hourly UTC cron flips ACTIVE
+# mentorships whose end_date has passed to COMPLETED, deletes their child
+# data (meetings, tasks, milestones, conversations), audits the transition,
+# and notifies both participants. enabled=false skips the bean entirely.
+app.mentorships.auto-completion.enabled=${MENTORSHIP_AUTO_COMPLETE_ENABLED:true}
+app.mentorships.auto-completion.cron=${MENTORSHIP_AUTO_COMPLETE_CRON:0 0 * * * *}
+app.mentorships.auto-completion.zone=${MENTORSHIP_AUTO_COMPLETE_ZONE:UTC}

--- a/backend/src/main/resources/db/migration/V33__mentorship_ratings.sql
+++ b/backend/src/main/resources/db/migration/V33__mentorship_ratings.sql
@@ -1,0 +1,27 @@
+-- Mentor ratings (#237).
+--
+-- One row per (mentorship, score, comment). Scope is intentionally
+-- mentee → mentor only; mentor-rating-mentee is out of scope for #237.
+--
+-- Schema choices, deliberate:
+--   * UNIQUE(mentorship_id) enforces "one rating per mentorship" at the DB
+--     level so concurrent POSTs can't both succeed; the service still does
+--     an existsBy check up front for a clean 409 on the common path.
+--   * mentor_id and mentee_id reference users(id) directly (mentors and
+--     mentees both inherit the users PK), with ON DELETE CASCADE so the
+--     rating disappears with the rated participant.
+--   * idx_mentor_ratings_mentor backs the GET /api/users/{id} aggregate
+--     (AVG(score), COUNT(*)) so it stays a single index scan as the table
+--     grows.
+
+CREATE TABLE mentor_ratings (
+    id              BIGSERIAL PRIMARY KEY,
+    mentorship_id   BIGINT NOT NULL UNIQUE REFERENCES mentorships(id) ON DELETE CASCADE,
+    mentor_id       BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    mentee_id       BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    score           INTEGER NOT NULL CHECK (score BETWEEN 1 AND 5),
+    comment         VARCHAR(1000) NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_mentor_ratings_mentor ON mentor_ratings (mentor_id);

--- a/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
@@ -13,6 +13,7 @@ import com.group7.backend.dto.response.TimelineResponse;
 import com.group7.backend.exception.MentorshipRequestException;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.service.JwtService;
+import com.group7.backend.service.MentorRatingService;
 import com.group7.backend.service.MentorshipProgressService;
 import com.group7.backend.service.MentorshipRequestService;
 import com.group7.backend.service.MentorshipService;
@@ -59,6 +60,9 @@ class MentorshipControllerTest {
 
     @MockitoBean
     private MentorshipTimelineService mentorshipTimelineService;
+
+    @MockitoBean
+    private MentorRatingService mentorRatingService;
 
     @MockitoBean
     private JwtService jwtService;

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipCancellationIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipCancellationIntegrationTest.java
@@ -220,13 +220,13 @@ class MentorshipCancellationIntegrationTest {
         CanceledFixture f = acceptMentorship("c_mentor2@test.com", "c_mentee2@test.com");
 
         mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
-                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .header("Authorization", "Bearer " + f.menteeToken())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of("reason", "Capacity needed elsewhere"))))
                 .andExpect(status().isOk());
 
         mockMvc.perform(get("/api/mentorships/" + f.mentorshipId() + "/audit")
-                        .header("Authorization", "Bearer " + f.menteeToken()))
+                        .header("Authorization", "Bearer " + f.mentorToken()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2))
                 .andExpect(jsonPath("$[0].fromStatus").doesNotExist())
@@ -234,7 +234,7 @@ class MentorshipCancellationIntegrationTest {
                 .andExpect(jsonPath("$[1].fromStatus").value("ACTIVE"))
                 .andExpect(jsonPath("$[1].toStatus").value("CANCELLED"))
                 .andExpect(jsonPath("$[1].reason").value("Capacity needed elsewhere"))
-                .andExpect(jsonPath("$[1].actorUserId").value(f.mentorId()));
+                .andExpect(jsonPath("$[1].actorUserId").value(f.menteeId()));
     }
 
     @Test
@@ -254,7 +254,7 @@ class MentorshipCancellationIntegrationTest {
         CanceledFixture f = acceptMentorship("c_mentor4@test.com", "c_mentee4@test.com");
 
         mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
-                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .header("Authorization", "Bearer " + f.menteeToken())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"reason\":\"   \"}"))
                 .andExpect(status().isBadRequest());
@@ -264,13 +264,13 @@ class MentorshipCancellationIntegrationTest {
     void cancelRejectsAlreadyCancelled() throws Exception {
         CanceledFixture f = acceptMentorship("c_mentor5@test.com", "c_mentee5@test.com");
         mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
-                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .header("Authorization", "Bearer " + f.menteeToken())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of("reason", "first cancel"))))
                 .andExpect(status().isOk());
 
         mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
-                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .header("Authorization", "Bearer " + f.menteeToken())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Map.of("reason", "second cancel"))))
                 .andExpect(status().isConflict());

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipLifecycleIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipLifecycleIntegrationTest.java
@@ -1,0 +1,371 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.repository.*;
+import com.group7.backend.service.EmailService;
+import com.group7.backend.service.MentorshipAutoCompletionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * End-to-end coverage for #237 — mentorship lifecycle: extend, end (mentor),
+ * mentee cancel + ban accounting, auto-termination, rating, and the
+ * averageRating / ratingCount fields surfacing on the user profile.
+ *
+ * <p>Cancellation cool-down is shrunk to 1 hour so mentee re-request flows
+ * stay deterministic, but the bulk of #237 doesn't depend on time travel.
+ * Auto-termination is invoked directly via the service to avoid waiting
+ * for the cron.
+ */
+@SpringBootTest(properties = {
+        "app.mentorship.cooldown.duration=PT1H"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MentorshipLifecycleIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired private MentorshipRequestRepository mentorshipRequestRepository;
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private MentorshipRepository mentorshipRepository;
+    @Autowired private MentorshipAuditLogRepository mentorshipAuditLogRepository;
+    @Autowired private MentorRatingRepository mentorRatingRepository;
+    @Autowired private BanRepository banRepository;
+    @Autowired private MentorshipAutoCompletionService autoCompletionService;
+
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        mentorRatingRepository.deleteAll();
+        mentorshipAuditLogRepository.deleteAll();
+        mentorshipRepository.deleteAll();
+        mentorshipRequestRepository.deleteAll();
+        banRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+        doNothing().when(emailService).sendPasswordResetEmail(any(), anyString());
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Test");
+        req.setLastName("User");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private record Fixture(Long mentorshipId, Long mentorId, Long menteeId,
+                           String mentorToken, String menteeToken) {}
+
+    private Fixture acceptMentorship(String mentorEmail, String menteeEmail) throws Exception {
+        String mentorToken = registerAndLogin(mentorEmail, true);
+        Mentor mentor = mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals(mentorEmail)).findFirst().orElseThrow();
+        mentor.setMaxMenteeCapacity(3);
+        mentorRepository.save(mentor);
+
+        String menteeToken = registerAndLogin(menteeEmail, false);
+        Mentee mentee = menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals(menteeEmail)).findFirst().orElseThrow();
+
+        MvcResult requestResult = mockMvc.perform(post("/api/mentorship-requests")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("mentorId", mentor.getId()))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        Long requestId = objectMapper.readTree(requestResult.getResponse().getContentAsString()).get("id").asLong();
+
+        MvcResult acceptResult = mockMvc.perform(put("/api/mentorship-requests/" + requestId + "/accept")
+                        .header("Authorization", "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("duration", 3))))
+                .andExpect(status().isOk())
+                .andReturn();
+        Long mentorshipId = objectMapper.readTree(acceptResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        return new Fixture(mentorshipId, mentor.getId(), mentee.getId(), mentorToken, menteeToken);
+    }
+
+    // ── /end (mentor) ───────────────────────────────────────────────────────
+
+    @Test
+    void endMentorshipByMentorSetsCompletedAndNotifiesMentee() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor1@test.com", "lc_mentee1@test.com");
+
+        mockMvc.perform(patch("/api/mentorships/" + f.mentorshipId() + "/end")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "Goal achieved"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("COMPLETED"))
+                .andExpect(jsonPath("$.cancellationReason").value("Goal achieved"))
+                .andExpect(jsonPath("$.terminatedAt").exists());
+
+        Mentorship after = mentorshipRepository.findById(f.mentorshipId()).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(MentorshipStatus.COMPLETED);
+        assertThat(after.getTerminatedByUserId()).isEqualTo(f.mentorId());
+        assertThat(menteeRepository.findById(f.menteeId()).orElseThrow().getActiveMentorId()).isNull();
+        assertThat(mentorRepository.findById(f.mentorId()).orElseThrow().getCurrentMenteeCount()).isZero();
+    }
+
+    @Test
+    void endMentorshipByMenteeReturns403() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor2@test.com", "lc_mentee2@test.com");
+
+        mockMvc.perform(patch("/api/mentorships/" + f.mentorshipId() + "/end")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── /extend (mentor) ────────────────────────────────────────────────────
+
+    @Test
+    void extendMentorshipByMentorPushesEndDate() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor3@test.com", "lc_mentee3@test.com");
+        OffsetDateTime originalEnd = mentorshipRepository.findById(f.mentorshipId()).orElseThrow().getEndDate();
+
+        mockMvc.perform(patch("/api/mentorships/" + f.mentorshipId() + "/extend")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("additionalMonths", 3))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.duration").value(6));
+
+        Mentorship after = mentorshipRepository.findById(f.mentorshipId()).orElseThrow();
+        assertThat(after.getEndDate()).isEqualTo(originalEnd.plusMonths(3));
+    }
+
+    @Test
+    void extendMentorshipRejectsInvalidMonths() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor4@test.com", "lc_mentee4@test.com");
+
+        mockMvc.perform(patch("/api/mentorships/" + f.mentorshipId() + "/extend")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("additionalMonths", 2))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void extendMentorshipByMenteeReturns403() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor5@test.com", "lc_mentee5@test.com");
+
+        mockMvc.perform(patch("/api/mentorships/" + f.mentorshipId() + "/extend")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("additionalMonths", 3))))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── /cancel (mentee) wired to BanService ────────────────────────────────
+
+    @Test
+    void cancelByMentorReturns403() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor6@test.com", "lc_mentee6@test.com");
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "no"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void cancelByMenteeIncrementsCancelCount() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor7@test.com", "lc_mentee7@test.com");
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "Schedule conflict"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+
+        Mentee mentee = menteeRepository.findById(f.menteeId()).orElseThrow();
+        assertThat(mentee.getCancelCount()).isEqualTo(1);
+    }
+
+    // ── Auto-termination ────────────────────────────────────────────────────
+
+    @Test
+    void autoCompleteFlipsExpiredMentorshipToCompleted() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor8@test.com", "lc_mentee8@test.com");
+        // Force end_date into the past so the sweep picks it up.
+        Mentorship m = mentorshipRepository.findById(f.mentorshipId()).orElseThrow();
+        m.setEndDate(OffsetDateTime.now(ZoneOffset.UTC).minusHours(1));
+        Mentorship savedExpired = mentorshipRepository.saveAndFlush(m);
+        assertThat(savedExpired.getEndDate()).isBefore(OffsetDateTime.now(ZoneOffset.UTC));
+        assertThat(savedExpired.getStatus()).isEqualTo(MentorshipStatus.ACTIVE);
+
+        // Sanity-check the repository query directly — isolates whether the
+        // failure is in the query or in the service flow.
+        java.util.List<Mentorship> directQuery = mentorshipRepository.findActiveExpiredAt(
+                MentorshipStatus.ACTIVE, OffsetDateTime.now(ZoneOffset.UTC));
+        assertThat(directQuery).as("repository query should find the expired ACTIVE row")
+                .extracting(Mentorship::getId).contains(f.mentorshipId());
+
+        int processed = autoCompletionService.autoCompleteExpired();
+        assertThat(processed).isEqualTo(1);
+
+        Mentorship after = mentorshipRepository.findById(f.mentorshipId()).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(MentorshipStatus.COMPLETED);
+        assertThat(after.getTerminatedByUserId()).isNull();
+        assertThat(menteeRepository.findById(f.menteeId()).orElseThrow().getActiveMentorId()).isNull();
+    }
+
+    // ── Rating + profile aggregation ────────────────────────────────────────
+
+    @Test
+    void rateMentorAfterCompletionAndProfileShowsAggregate() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor9@test.com", "lc_mentee9@test.com");
+
+        // Mentor ends the mentorship gracefully.
+        mockMvc.perform(patch("/api/mentorships/" + f.mentorshipId() + "/end")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk());
+
+        // Mentee submits a 5-star rating.
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/rating")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("score", 5, "comment", "Excellent"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.score").value(5))
+                .andExpect(jsonPath("$.mentorId").value(f.mentorId()))
+                .andExpect(jsonPath("$.menteeId").value(f.menteeId()));
+
+        // Second rating attempt is rejected.
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/rating")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("score", 3))))
+                .andExpect(status().isConflict());
+
+        // Mentor profile now exposes averageRating + ratingCount.
+        mockMvc.perform(get("/api/users/" + f.mentorId())
+                        .header("Authorization", "Bearer " + f.menteeToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.averageRating").value(5.0))
+                .andExpect(jsonPath("$.ratingCount").value(1));
+    }
+
+    @Test
+    void rateMentorWhileActiveReturns409() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor10@test.com", "lc_mentee10@test.com");
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/rating")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("score", 5))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void rateMentorByMentorReturns403() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor11@test.com", "lc_mentee11@test.com");
+        mockMvc.perform(patch("/api/mentorships/" + f.mentorshipId() + "/end")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/rating")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("score", 5))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void ratingScoreMustBeWithinOneToFive() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor12@test.com", "lc_mentee12@test.com");
+        mockMvc.perform(patch("/api/mentorships/" + f.mentorshipId() + "/end")
+                        .header("Authorization", "Bearer " + f.mentorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/rating")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("score", 6))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void profileWithoutRatingsShowsNullAndZero() throws Exception {
+        Fixture f = acceptMentorship("lc_mentor13@test.com", "lc_mentee13@test.com");
+
+        mockMvc.perform(get("/api/users/" + f.mentorId())
+                        .header("Authorization", "Bearer " + f.menteeToken()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.averageRating").isEmpty())
+                .andExpect(jsonPath("$.ratingCount").value(0));
+    }
+}

--- a/backend/src/test/java/com/group7/backend/scheduler/MentorshipAutoCompletionSchedulerTest.java
+++ b/backend/src/test/java/com/group7/backend/scheduler/MentorshipAutoCompletionSchedulerTest.java
@@ -1,0 +1,42 @@
+package com.group7.backend.scheduler;
+
+import com.group7.backend.service.MentorshipAutoCompletionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MentorshipAutoCompletionSchedulerTest {
+
+    @Mock private MentorshipAutoCompletionService service;
+
+    private MentorshipAutoCompletionScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new MentorshipAutoCompletionScheduler(service);
+    }
+
+    @Test
+    void sweepDelegatesToService() {
+        when(service.autoCompleteExpired()).thenReturn(0);
+
+        scheduler.sweep();
+
+        verify(service).autoCompleteExpired();
+    }
+
+    @Test
+    void sweepLogsWhenRowsProcessed() {
+        when(service.autoCompleteExpired()).thenReturn(3);
+
+        scheduler.sweep();
+
+        verify(service).autoCompleteExpired();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorRatingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorRatingServiceTest.java
@@ -1,0 +1,187 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.request.CreateMentorRatingRequest;
+import com.group7.backend.dto.response.MentorRatingResponse;
+import com.group7.backend.dto.response.UserRatingSummary;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.MentorRating;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.exception.MentorshipRequestException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MentorRatingRepository;
+import com.group7.backend.repository.MentorshipRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MentorRatingServiceTest {
+
+    @Mock private MentorRatingRepository mentorRatingRepository;
+    @Mock private MentorshipRepository mentorshipRepository;
+
+    @InjectMocks private MentorRatingService mentorRatingService;
+
+    private Mentor mentor;
+    private Mentee mentee;
+    private Mentorship mentorship;
+
+    @BeforeEach
+    void setUp() {
+        mentor = new Mentor();
+        mentor.setId(1L);
+        mentor.setFirstName("Ahmet");
+
+        mentee = new Mentee();
+        mentee.setId(2L);
+        mentee.setFirstName("Elif");
+
+        mentorship = new Mentorship();
+        mentorship.setId(100L);
+        mentorship.setMentor(mentor);
+        mentorship.setMentee(mentee);
+        mentorship.setStatus(MentorshipStatus.COMPLETED);
+    }
+
+    private CreateMentorRatingRequest dto(int score, String comment) {
+        CreateMentorRatingRequest d = new CreateMentorRatingRequest();
+        d.setScore(score);
+        d.setComment(comment);
+        return d;
+    }
+
+    @Test
+    void createRating_persistsAndReturns() {
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
+        when(mentorRatingRepository.existsByMentorshipId(100L)).thenReturn(false);
+        when(mentorRatingRepository.save(any(MentorRating.class))).thenAnswer(inv -> {
+            MentorRating r = inv.getArgument(0);
+            r.setId(42L);
+            return r;
+        });
+
+        MentorRatingResponse response = mentorRatingService.createRating(2L, 100L, dto(5, "Great!"));
+
+        assertThat(response.getId()).isEqualTo(42L);
+        assertThat(response.getMentorId()).isEqualTo(1L);
+        assertThat(response.getMenteeId()).isEqualTo(2L);
+        assertThat(response.getScore()).isEqualTo(5);
+        assertThat(response.getComment()).isEqualTo("Great!");
+
+        ArgumentCaptor<MentorRating> captor = ArgumentCaptor.forClass(MentorRating.class);
+        verify(mentorRatingRepository).save(captor.capture());
+        assertThat(captor.getValue().getMentorshipId()).isEqualTo(100L);
+    }
+
+    @Test
+    void createRating_alsoAllowedAfterCancelled() {
+        mentorship.setStatus(MentorshipStatus.CANCELLED);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
+        when(mentorRatingRepository.existsByMentorshipId(100L)).thenReturn(false);
+        when(mentorRatingRepository.save(any(MentorRating.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        mentorRatingService.createRating(2L, 100L, dto(3, null));
+
+        verify(mentorRatingRepository).save(any());
+    }
+
+    @Test
+    void createRating_rejectsActiveMentorship() {
+        mentorship.setStatus(MentorshipStatus.ACTIVE);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorRatingService.createRating(2L, 100L, dto(5, null)))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("not ended");
+        verify(mentorRatingRepository, never()).save(any());
+    }
+
+    @Test
+    void createRating_rejectsMentorActor() {
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorRatingService.createRating(1L, 100L, dto(5, null)))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void createRating_rejectsNonParticipant() {
+        when(mentorshipRepository.findByIdAndParticipant(100L, 999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> mentorRatingService.createRating(999L, 100L, dto(5, null)))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void createRating_rejectsDuplicate_existsByCheck() {
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
+        when(mentorRatingRepository.existsByMentorshipId(100L)).thenReturn(true);
+
+        assertThatThrownBy(() -> mentorRatingService.createRating(2L, 100L, dto(5, null)))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("already been rated");
+        verify(mentorRatingRepository, never()).save(any());
+    }
+
+    @Test
+    void createRating_rejectsDuplicate_raceLost() {
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
+        when(mentorRatingRepository.existsByMentorshipId(100L)).thenReturn(false);
+        when(mentorRatingRepository.save(any(MentorRating.class)))
+                .thenThrow(new DataIntegrityViolationException("UNIQUE(mentorship_id)"));
+
+        assertThatThrownBy(() -> mentorRatingService.createRating(2L, 100L, dto(5, null)))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("already been rated");
+    }
+
+    @Test
+    void aggregateForMentor_returnsZerosWhenNone() {
+        when(mentorRatingRepository.aggregateForMentor(1L)).thenReturn(UserRatingSummary.empty());
+
+        UserRatingSummary summary = mentorRatingService.aggregateForMentor(1L);
+
+        assertThat(summary.averageRating()).isNull();
+        assertThat(summary.ratingCount()).isZero();
+    }
+
+    @Test
+    void aggregateForMentor_returnsAggregate() {
+        when(mentorRatingRepository.aggregateForMentor(1L))
+                .thenReturn(new UserRatingSummary(4.5, 12L));
+
+        UserRatingSummary summary = mentorRatingService.aggregateForMentor(1L);
+
+        assertThat(summary.averageRating()).isEqualTo(4.5);
+        assertThat(summary.ratingCount()).isEqualTo(12L);
+    }
+
+    @Test
+    void aggregateForMentor_handlesNullFromRepository() {
+        // Some repo configurations return null for an empty aggregate; service
+        // must coalesce to UserRatingSummary.empty() to keep callers safe.
+        when(mentorRatingRepository.aggregateForMentor(1L)).thenReturn(null);
+
+        UserRatingSummary summary = mentorRatingService.aggregateForMentor(1L);
+
+        assertThat(summary.averageRating()).isNull();
+        assertThat(summary.ratingCount()).isZero();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorshipAutoCompletionServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipAutoCompletionServiceTest.java
@@ -1,0 +1,188 @@
+package com.group7.backend.service;
+
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipAuditLog;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.repository.MentorshipAuditLogRepository;
+import com.group7.backend.repository.MentorshipRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MentorshipAutoCompletionServiceTest {
+
+    private static final Instant NOW = Instant.parse("2026-05-10T12:00:00Z");
+
+    @Mock private MentorshipRepository mentorshipRepository;
+    @Mock private MentorshipAuditLogRepository mentorshipAuditLogRepository;
+    @Mock private MentorshipCleanupService mentorshipCleanupService;
+    @Mock private NotificationEventPublisher notificationEventPublisher;
+    @Mock private PlatformTransactionManager transactionManager;
+
+    private final Clock clock = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    private MentorshipAutoCompletionService service;
+
+    @BeforeEach
+    void setUp() {
+        // Lenient: only some tests run a per-row callback (others return on
+        // the empty-list short-circuit before TransactionTemplate is touched).
+        lenient().when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+        service = new MentorshipAutoCompletionService(mentorshipRepository,
+                mentorshipAuditLogRepository, mentorshipCleanupService,
+                notificationEventPublisher, clock, transactionManager);
+    }
+
+    private Mentorship activeExpired(Long id, Long mentorId, Long menteeId) {
+        Mentor mentor = new Mentor();
+        mentor.setId(mentorId);
+        mentor.setFirstName("Mentor" + mentorId);
+        mentor.setCurrentMenteeCount(1);
+
+        Mentee mentee = new Mentee();
+        mentee.setId(menteeId);
+        mentee.setFirstName("Mentee" + menteeId);
+        mentee.setActiveMentorId(mentorId);
+
+        Mentorship m = new Mentorship();
+        m.setId(id);
+        m.setMentor(mentor);
+        m.setMentee(mentee);
+        m.setStatus(MentorshipStatus.ACTIVE);
+        m.setStartDate(OffsetDateTime.ofInstant(NOW, ZoneOffset.UTC).minusMonths(3));
+        m.setEndDate(OffsetDateTime.ofInstant(NOW, ZoneOffset.UTC).minusHours(1));
+        m.setDuration(3);
+        return m;
+    }
+
+    @Test
+    void autoCompleteExpired_returnsZeroWhenNothingExpired() {
+        when(mentorshipRepository.findActiveExpiredAt(eq(MentorshipStatus.ACTIVE), any(OffsetDateTime.class)))
+                .thenReturn(List.of());
+
+        assertThat(service.autoCompleteExpired()).isZero();
+        verify(mentorshipAuditLogRepository, never()).save(any());
+    }
+
+    @Test
+    void autoCompleteExpired_processesAllExpiredRows() {
+        Mentorship m1 = activeExpired(100L, 1L, 2L);
+        Mentorship m2 = activeExpired(101L, 3L, 4L);
+        when(mentorshipRepository.findActiveExpiredAt(eq(MentorshipStatus.ACTIVE), any(OffsetDateTime.class)))
+                .thenReturn(List.of(m1, m2));
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(m1));
+        when(mentorshipRepository.findById(101L)).thenReturn(Optional.of(m2));
+
+        int processed = service.autoCompleteExpired();
+
+        assertThat(processed).isEqualTo(2);
+        assertThat(m1.getStatus()).isEqualTo(MentorshipStatus.COMPLETED);
+        assertThat(m2.getStatus()).isEqualTo(MentorshipStatus.COMPLETED);
+        verify(mentorshipCleanupService).cleanupChildren(100L);
+        verify(mentorshipCleanupService).cleanupChildren(101L);
+        // Both participants of each mentorship receive a notification:
+        // m1 -> recipients 1L (mentor) and 2L (mentee); m2 -> 3L and 4L.
+        verify(notificationEventPublisher).publishMentorshipAutoCompleted(eq(1L), anyString());
+        verify(notificationEventPublisher).publishMentorshipAutoCompleted(eq(2L), anyString());
+        verify(notificationEventPublisher).publishMentorshipAutoCompleted(eq(3L), anyString());
+        verify(notificationEventPublisher).publishMentorshipAutoCompleted(eq(4L), anyString());
+    }
+
+    @Test
+    void autoCompleteExpired_writesAuditRowAndNotifiesBoth() {
+        Mentorship m = activeExpired(100L, 1L, 2L);
+        when(mentorshipRepository.findActiveExpiredAt(eq(MentorshipStatus.ACTIVE), any(OffsetDateTime.class)))
+                .thenReturn(List.of(m));
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(m));
+
+        service.autoCompleteExpired();
+
+        ArgumentCaptor<MentorshipAuditLog> captor = ArgumentCaptor.forClass(MentorshipAuditLog.class);
+        verify(mentorshipAuditLogRepository).save(captor.capture());
+        MentorshipAuditLog logged = captor.getValue();
+        assertThat(logged.getFromStatus()).isEqualTo(MentorshipStatus.ACTIVE);
+        assertThat(logged.getToStatus()).isEqualTo(MentorshipStatus.COMPLETED);
+        assertThat(logged.getActorUserId()).isNull();
+        assertThat(logged.getReason()).contains("Auto-completed");
+
+        verify(notificationEventPublisher).publishMentorshipAutoCompleted(1L, "Mentee2");
+        verify(notificationEventPublisher).publishMentorshipAutoCompleted(2L, "Mentor1");
+    }
+
+    @Test
+    void autoCompleteExpired_clearsActiveMentorIdAndDecrementsCount() {
+        Mentorship m = activeExpired(100L, 1L, 2L);
+        Mentor mentor = m.getMentor();
+        Mentee mentee = m.getMentee();
+        when(mentorshipRepository.findActiveExpiredAt(eq(MentorshipStatus.ACTIVE), any(OffsetDateTime.class)))
+                .thenReturn(List.of(m));
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(m));
+
+        service.autoCompleteExpired();
+
+        assertThat(mentee.getActiveMentorId()).isNull();
+        assertThat(mentor.getCurrentMenteeCount()).isZero();
+    }
+
+    @Test
+    void autoCompleteExpired_skipsRowFlippedByConcurrentActor() {
+        // Sweep query loaded m as ACTIVE, but by the time completeOne runs the
+        // row was cancelled by someone else. Service must no-op silently.
+        Mentorship m = activeExpired(100L, 1L, 2L);
+        when(mentorshipRepository.findActiveExpiredAt(eq(MentorshipStatus.ACTIVE), any(OffsetDateTime.class)))
+                .thenReturn(List.of(m));
+        Mentorship raceFlipped = activeExpired(100L, 1L, 2L);
+        raceFlipped.setStatus(MentorshipStatus.CANCELLED);
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(raceFlipped));
+
+        int processed = service.autoCompleteExpired();
+
+        assertThat(processed).isEqualTo(1);
+        verify(mentorshipCleanupService, never()).cleanupChildren(anyLong());
+        verify(mentorshipAuditLogRepository, never()).save(any());
+    }
+
+    @Test
+    void autoCompleteExpired_oneFailureDoesNotBlockOthers() {
+        Mentorship m1 = activeExpired(100L, 1L, 2L);
+        Mentorship m2 = activeExpired(101L, 3L, 4L);
+        when(mentorshipRepository.findActiveExpiredAt(eq(MentorshipStatus.ACTIVE), any(OffsetDateTime.class)))
+                .thenReturn(List.of(m1, m2));
+        when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(m1));
+        when(mentorshipRepository.findById(101L)).thenReturn(Optional.of(m2));
+        doThrow(new RuntimeException("cleanup boom"))
+                .when(mentorshipCleanupService).cleanupChildren(100L);
+
+        int processed = service.autoCompleteExpired();
+
+        assertThat(processed).isEqualTo(1);
+        assertThat(m2.getStatus()).isEqualTo(MentorshipStatus.COMPLETED);
+        verify(mentorshipCleanupService).cleanupChildren(101L);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
@@ -2,6 +2,8 @@ package com.group7.backend.service;
 
 import com.group7.backend.dto.request.AcceptRequestRequest;
 import com.group7.backend.dto.request.CancelMentorshipRequest;
+import com.group7.backend.dto.request.EndMentorshipRequest;
+import com.group7.backend.dto.request.ExtendMentorshipRequest;
 import com.group7.backend.dto.request.SharedGoalRequest;
 import com.group7.backend.dto.response.MentorshipAuditLogResponse;
 import com.group7.backend.dto.response.MentorshipResponse;
@@ -11,6 +13,7 @@ import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.MentorshipAuditLogRepository;
 import com.group7.backend.repository.MentorshipRepository;
 import com.group7.backend.repository.MentorshipRequestRepository;
+import org.springframework.security.access.AccessDeniedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,6 +56,9 @@ class MentorshipServiceTest {
 
     @Mock
     private NotificationEventPublisher notificationEventPublisher;
+
+    @Mock
+    private BanService banService;
 
     @Spy
     private Clock clock = Clock.systemUTC();
@@ -442,22 +448,23 @@ class MentorshipServiceTest {
     }
 
     @Test
-    void cancelMentorshipByMentorMarksCancelledAndCleansUp() {
+    void cancelMentorshipByMenteeMarksCancelledAndCleansUp() {
         Mentorship mentorship = activeMentorship();
         mentee.setActiveMentorId(mentor.getId());
-        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
         when(mentorshipRepository.save(any(Mentorship.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        MentorshipResponse response = mentorshipService.cancelMentorship(1L, 100L, cancelDto("Schedule clash"));
+        MentorshipResponse response = mentorshipService.cancelMentorship(2L, 100L, cancelDto("Schedule clash"));
 
         assertThat(response.getStatus()).isEqualTo("CANCELLED");
         assertThat(response.getCancellationReason()).isEqualTo("Schedule clash");
         assertThat(response.getTerminatedAt()).isNotNull();
-        assertThat(mentorship.getTerminatedByUserId()).isEqualTo(1L);
+        assertThat(mentorship.getTerminatedByUserId()).isEqualTo(2L);
         assertThat(mentee.getActiveMentorId()).isNull();
         assertThat(mentor.getCurrentMenteeCount()).isEqualTo(0);
         verify(mentorshipCleanupService).cleanupChildren(100L);
-        verify(notificationEventPublisher).publishMentorshipCancelled(2L, "Ahmet", "Schedule clash");
+        verify(notificationEventPublisher).publishMentorshipCancelled(1L, "Elif", "Schedule clash");
+        verify(banService).recordCancellation(2L, "Cancelled active mentorship: Schedule clash");
 
         ArgumentCaptor<MentorshipAuditLog> captor = ArgumentCaptor.forClass(MentorshipAuditLog.class);
         verify(mentorshipAuditLogRepository).save(captor.capture());
@@ -465,21 +472,21 @@ class MentorshipServiceTest {
         assertThat(logged.getMentorshipId()).isEqualTo(100L);
         assertThat(logged.getFromStatus()).isEqualTo(MentorshipStatus.ACTIVE);
         assertThat(logged.getToStatus()).isEqualTo(MentorshipStatus.CANCELLED);
-        assertThat(logged.getActorUserId()).isEqualTo(1L);
+        assertThat(logged.getActorUserId()).isEqualTo(2L);
         assertThat(logged.getReason()).isEqualTo("Schedule clash");
     }
 
     @Test
-    void cancelMentorshipByMenteeNotifiesMentor() {
+    void cancelMentorshipRejectsMentorActor() {
+        // Mentor must use /end instead; /cancel is mentee-only after #237.
         Mentorship mentorship = activeMentorship();
-        mentee.setActiveMentorId(mentor.getId());
-        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
-        when(mentorshipRepository.save(any(Mentorship.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
 
-        mentorshipService.cancelMentorship(2L, 100L, cancelDto("Lost interest"));
-
-        verify(notificationEventPublisher).publishMentorshipCancelled(1L, "Elif", "Lost interest");
-        assertThat(mentorship.getTerminatedByUserId()).isEqualTo(2L);
+        assertThatThrownBy(() -> mentorshipService.cancelMentorship(1L, 100L, cancelDto("nope")))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("/end");
+        verify(mentorshipCleanupService, never()).cleanupChildren(any());
+        verify(banService, never()).recordCancellation(any(), any());
     }
 
     @Test
@@ -495,27 +502,144 @@ class MentorshipServiceTest {
     void cancelMentorshipRejectsAlreadyCancelled() {
         Mentorship mentorship = activeMentorship();
         mentorship.setStatus(MentorshipStatus.CANCELLED);
-        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
 
-        assertThatThrownBy(() -> mentorshipService.cancelMentorship(1L, 100L, cancelDto("again")))
+        assertThatThrownBy(() -> mentorshipService.cancelMentorship(2L, 100L, cancelDto("again")))
                 .isInstanceOf(MentorshipRequestException.class)
                 .hasMessageContaining("not active");
         verify(mentorshipCleanupService, never()).cleanupChildren(any());
         verify(mentorshipAuditLogRepository, never()).save(any());
+        verify(banService, never()).recordCancellation(any(), any());
     }
 
     @Test
     void cancelMentorshipPreservesActiveMentorIdWhenItPointsElsewhere() {
-        // A stale activeMentorId pointing at a different mentor should not be cleared,
-        // because that other mentorship is still the active one for the mentee.
+        // A stale activeMentorId pointing at a different mentor should not be cleared.
         Mentorship mentorship = activeMentorship();
         mentee.setActiveMentorId(999L);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.save(any(Mentorship.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        mentorshipService.cancelMentorship(2L, 100L, cancelDto("done"));
+
+        assertThat(mentee.getActiveMentorId()).isEqualTo(999L);
+    }
+
+    // ── End mentorship (#237) ───────────────────────────────────────────────
+
+    private EndMentorshipRequest endDto(String reason) {
+        EndMentorshipRequest dto = new EndMentorshipRequest();
+        dto.setReason(reason);
+        return dto;
+    }
+
+    @Test
+    void endMentorshipByMentorSetsCompletedAndCleansUp() {
+        Mentorship mentorship = activeMentorship();
+        mentee.setActiveMentorId(mentor.getId());
         when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
         when(mentorshipRepository.save(any(Mentorship.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        mentorshipService.cancelMentorship(1L, 100L, cancelDto("done"));
+        MentorshipResponse response = mentorshipService.endMentorship(1L, 100L, endDto("Goal achieved"));
 
-        assertThat(mentee.getActiveMentorId()).isEqualTo(999L);
+        assertThat(response.getStatus()).isEqualTo("COMPLETED");
+        assertThat(mentorship.getTerminatedByUserId()).isEqualTo(1L);
+        assertThat(mentorship.getTerminatedAt()).isNotNull();
+        assertThat(mentorship.getEndDate()).isEqualTo(mentorship.getTerminatedAt());
+        assertThat(mentee.getActiveMentorId()).isNull();
+        assertThat(mentor.getCurrentMenteeCount()).isEqualTo(0);
+        verify(mentorshipCleanupService).cleanupChildren(100L);
+        verify(notificationEventPublisher).publishMentorshipEnded(2L, "Ahmet", "Goal achieved");
+        verify(banService, never()).recordCancellation(any(), any());
+
+        ArgumentCaptor<MentorshipAuditLog> captor = ArgumentCaptor.forClass(MentorshipAuditLog.class);
+        verify(mentorshipAuditLogRepository).save(captor.capture());
+        MentorshipAuditLog logged = captor.getValue();
+        assertThat(logged.getFromStatus()).isEqualTo(MentorshipStatus.ACTIVE);
+        assertThat(logged.getToStatus()).isEqualTo(MentorshipStatus.COMPLETED);
+        assertThat(logged.getActorUserId()).isEqualTo(1L);
+    }
+
+    @Test
+    void endMentorshipRejectsMenteeActor() {
+        Mentorship mentorship = activeMentorship();
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorshipService.endMentorship(2L, 100L, endDto(null)))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("/cancel");
+        verify(mentorshipCleanupService, never()).cleanupChildren(any());
+    }
+
+    @Test
+    void endMentorshipRejectsAlreadyTerminated() {
+        Mentorship mentorship = activeMentorship();
+        mentorship.setStatus(MentorshipStatus.COMPLETED);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorshipService.endMentorship(1L, 100L, endDto(null)))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("not active");
+    }
+
+    // ── Extend mentorship (#237) ────────────────────────────────────────────
+
+    private ExtendMentorshipRequest extendDto(int additionalMonths) {
+        ExtendMentorshipRequest dto = new ExtendMentorshipRequest();
+        dto.setAdditionalMonths(additionalMonths);
+        return dto;
+    }
+
+    @Test
+    void extendMentorshipPushesEndDateAndAudits() {
+        Mentorship mentorship = activeMentorship();
+        OffsetDateTime originalEnd = mentorship.getEndDate();
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+        when(mentorshipRepository.save(any(Mentorship.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        MentorshipResponse response = mentorshipService.extendMentorship(1L, 100L, extendDto(3));
+
+        assertThat(response.getStatus()).isEqualTo("ACTIVE");
+        assertThat(mentorship.getEndDate()).isEqualTo(originalEnd.plusMonths(3));
+        assertThat(mentorship.getDuration()).isEqualTo(6);
+        verify(notificationEventPublisher).publishMentorshipExtended(2L, "Ahmet", 3, mentorship.getEndDate());
+
+        ArgumentCaptor<MentorshipAuditLog> captor = ArgumentCaptor.forClass(MentorshipAuditLog.class);
+        verify(mentorshipAuditLogRepository).save(captor.capture());
+        MentorshipAuditLog logged = captor.getValue();
+        assertThat(logged.getFromStatus()).isEqualTo(MentorshipStatus.ACTIVE);
+        assertThat(logged.getToStatus()).isEqualTo(MentorshipStatus.ACTIVE);
+        assertThat(logged.getReason()).contains("Extended by 3");
+    }
+
+    @Test
+    void extendMentorshipRejectsMenteeActor() {
+        Mentorship mentorship = activeMentorship();
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorshipService.extendMentorship(2L, 100L, extendDto(3)))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void extendMentorshipRejectsInvalidMonths() {
+        Mentorship mentorship = activeMentorship();
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorshipService.extendMentorship(1L, 100L, extendDto(2)))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("1, 3, or 6");
+    }
+
+    @Test
+    void extendMentorshipRejectsNotActive() {
+        Mentorship mentorship = activeMentorship();
+        mentorship.setStatus(MentorshipStatus.COMPLETED);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorshipService.extendMentorship(1L, 100L, extendDto(3)))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("not active");
     }
 
     // ── Accept request: cool-down + initial audit row (#133) ────────────────

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -62,3 +62,8 @@ app.meetings.scheduler.enabled=false
 app.bans.expiry-notification-enabled=false
 
 app.reminders.notification.enabled=false
+
+# MentorshipAutoCompletionScheduler (#237) — same pattern. Off by default;
+# tests invoke autoCompleteExpired() directly via the service so they don't
+# depend on a real cron firing.
+app.mentorships.auto-completion.enabled=false

--- a/frontend/e2e/specs/at02-mentorship-blog.spec.js
+++ b/frontend/e2e/specs/at02-mentorship-blog.spec.js
@@ -54,18 +54,25 @@ async function loginViaUi(page, { email, password }) {
   // that a tight 10s wait fires before the POST goes out, even though the
   // login itself succeeds shortly after); the swallow on the catch keeps
   // the timeout from masking the real navigation outcome below.
+  // Budget tracks the navigation wait below: response-fallback must outlive
+  // the nav assertion so a slow webkit POST surfaces its real status code
+  // instead of degrading to a generic "stuck on /login" message.
   const loginResponsePromise = page
     .waitForResponse(
       res => res.url().endsWith('/api/auth/login') && res.request().method() === 'POST',
-      { timeout: 30_000 },
+      { timeout: 45_000 },
     )
     .catch(() => null);
   await loginPage.signIn({ email, password });
   // Successful login navigates to /home; on failure we stay on /login. Wait
   // on the navigation as the source of truth — if it doesn't happen, fall
   // back to the captured response (if any) for a useful error message.
+  // 40s here absorbs CI webkit slowness: AT-01 webkit takes ~10s for the
+  // same login navigation against ~4s on chromium, so the previous 20s
+  // budget left no headroom once first-paint slack and framer-motion
+  // entrance stacked up under load.
   try {
-    await expect(page).toHaveURL(/\/home$/, { timeout: 20_000 });
+    await expect(page).toHaveURL(/\/home$/, { timeout: 40_000 });
   } catch (navErr) {
     const loginResponse = await loginResponsePromise;
     if (loginResponse && !loginResponse.ok()) {


### PR DESCRIPTION
## Summary

Closes #237. Builds the second half of the mentorship lifecycle on top of #133: a mentor can now end an active mentorship gracefully or extend it, the mentee's `/cancel` is plugged into the existing auto-ban system (#134), an hourly scheduler auto-completes mentorships whose `end_date` has passed, and mentees can rate their mentor once per mentorship — with the aggregate surfacing on `GET /api/users/{id}`.

> **Heads up:** this branch is stacked on top of [#133](https://github.com/bounswe/bounswe2026group7/pulls?q=is%3Apr+head%3Afeature%2F133-mentorship-cancellation). Until that lands on `dev`, this PR's base is `feature/133-mentorship-cancellation`. Switch the base to `dev` after #133 merges.

## Acceptance criteria

- [x] **`PATCH /api/mentorships/{id}/end`** (mentor) → `status=COMPLETED`, `endDate=now`, child cleanup, audit row, mentee notified.
- [x] **`PATCH /api/mentorships/{id}/extend`** (mentor, `{additionalMonths: 1|3|6}`) → pushes `endDate` forward, increments `duration`, audits the lifecycle event, notifies mentee.
- [x] **`POST /api/mentorships/{id}/cancel`** is now mentee-only (mentor → 403). Increments `mentee.cancelCount` via `BanService.recordCancellation` and feeds the same escalating-ban policy used for pending-request cancellations.
- [x] **Auto-termination scheduler** — hourly UTC cron sweeps `status=ACTIVE AND end_date < now`, flips to `COMPLETED`, cleans up children, audits, and notifies both participants.
- [x] **Banned mentees get 403** — already provided by `MentorshipRequestService.createRequest` via `UserBannedException` (#134); this PR just feeds it more violations.
- [x] **`POST /api/mentorships/{id}/rating`** (mentee, `{score: 1-5, comment?}`) — one rating per mentorship enforced both at the service layer (existsBy) and the DB (`UNIQUE(mentorship_id)`). Allowed after `COMPLETED` or `CANCELLED`.
- [x] **`GET /api/users/{id}`** response carries `averageRating` (Double, null when none) and `ratingCount` (long).
- [x] **Notification events** for end / extend / cancel / auto-completion.
- [x] **Tests** — 24 new unit tests + 13 new integration tests; full suite (1441 tests) green.

## Schema

`V33__mentorship_ratings.sql`:

```sql
CREATE TABLE mentor_ratings (
    id              BIGSERIAL PRIMARY KEY,
    mentorship_id   BIGINT NOT NULL UNIQUE REFERENCES mentorships(id) ON DELETE CASCADE,
    mentor_id       BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
    mentee_id       BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
    score           INTEGER NOT NULL CHECK (score BETWEEN 1 AND 5),
    comment         VARCHAR(1000) NULL,
    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
);
CREATE INDEX idx_mentor_ratings_mentor ON mentor_ratings (mentor_id);
```

`UNIQUE(mentorship_id)` is the race-safety net under the existsBy check; `idx_mentor_ratings_mentor` keeps the per-profile aggregate a single index scan. No schema change for `/end`, `/extend`, or auto-completion — `Mentorship` already has `endDate`, `terminatedAt`, `terminatedByUserId`, `cancellationReason`, `updatedAt`, plus the audit-log table from #133.

## API

| Method | Path | Auth | Notes |
|--------|------|------|-------|
| `PATCH` | `/api/mentorships/{id}/end` | mentor | Body `EndMentorshipRequest` (`reason` optional). 409 if not ACTIVE; 403 if mentee. |
| `PATCH` | `/api/mentorships/{id}/extend` | mentor | Body `ExtendMentorshipRequest` (`additionalMonths ∈ {1,3,6}`). 400 on invalid months; 403 if mentee; 409 if not ACTIVE. |
| `POST` | `/api/mentorships/{id}/cancel` | **mentee** | Was symmetric in #133; now mentee-only. Mentor → 403 with hint to use `/end`. |
| `POST` | `/api/mentorships/{id}/rating` | mentee | 201 on create; 409 if mentorship is still ACTIVE or already rated; 403 if mentor; 400 on bad score. |
| `GET`  | `/api/users/{id}`              | any  | Now also returns `averageRating`, `ratingCount`. Mentees pass through with `null/0`. |

Three new `NotificationType` values (`MENTORSHIP_ENDED`, `MENTORSHIP_EXTENDED`, `MENTORSHIP_AUTO_COMPLETED`). Like `MENTORSHIP_CANCELLED` from #133 and the ban events from #134, they bypass user opt-out — losing or extending an active mentorship affects ongoing tasks/meetings, so the user always sees the notice.

## Design decisions

- **`/cancel` mentee-only.** Mentor cancellation in #133 was symmetric; #237 splits semantics: mentor closes gracefully via `/end` (`COMPLETED`), mentee opts out via `/cancel` (`CANCELLED` + ban accounting). `TERMINATED` enum value stays defined but unused; reserved for an admin-driven flow if it ever becomes a thing.
- **Auto-completion uses `TransactionTemplate`, not `@Transactional` self-call.** A self-call to a `@Transactional` method silently bypasses Spring's AOP proxy — we hit this in the integration test (the sweep returned 0 even when the row was clearly expired). The `TransactionTemplate(REQUIRES_NEW)` keeps per-row failure isolation without depending on proxying.
- **Rating window is open-ended.** Once `COMPLETED` or `CANCELLED`, the mentee can rate anytime. No 30-day cap, no edit/delete; one and done.
- **`UserResponse.averageRating` is populated only on profile-detail endpoints** (`GET /api/users/{id}`, `/api/users/me`). List endpoints (search, all-mentors) leave it null/0 — uniform shape, no per-row N+1 query.
- **Auto-completion stays off in tests.** `app.mentorships.auto-completion.enabled=false` in `application-test.properties`, mirroring `BanExpiryScheduler`. Integration tests invoke `MentorshipAutoCompletionService.autoCompleteExpired()` directly.

## Files

**New (15)** — V33 migration, `MentorRating` entity + repository, three request DTOs (`EndMentorshipRequest`, `ExtendMentorshipRequest`, `CreateMentorRatingRequest`), two response DTOs (`MentorRatingResponse`, `UserRatingSummary`), `MentorRatingService`, `MentorshipAutoCompletionService` + its scheduler, four new test classes.

**Edited (13)** — `Mentorship` audit/cleanup wiring, `MentorshipController` (3 new endpoints + `/cancel` doc updates), `MentorshipService` (mentee-only `cancel`, new `endMentorship`/`extendMentorship`, ban hook), `UserService.getUserProfile` (rating aggregation), `UserResponse` (+2 fields), `MentorshipRepository` (`findActiveExpiredAt`), `NotificationType` + `UserNotificationPreferences` + `NotificationEventPublisher` (3 new types/methods), `application.properties` + `application-test.properties` (auto-completion config), and the existing tests adjusted for the new constructor deps and the mentee-only `/cancel`.

## Test plan

- [ ] CI green on backend module
- [ ] Manual smoke against a dev DB:
  - [ ] Mentor `PATCH /end` with reason → 200, status=COMPLETED, mentee.activeMentorId cleared, audit row appended, mentee notification fires.
  - [ ] Mentor `PATCH /extend` with `{additionalMonths: 3}` → 200, endDate += 3mo, duration += 3, audit row.
  - [ ] Mentor `POST /cancel` → 403; mentee `POST /cancel` → 200 and `mentee.cancelCount` increments.
  - [ ] Force a mentorship's `end_date` into the past, hit the auto-completion service (or wait for the cron) → status flips to COMPLETED, both sides notified.
  - [ ] Mentee `POST /rating` while ACTIVE → 409; complete → 201; second POST → 409.
  - [ ] `GET /api/users/<mentorId>` after rating → `averageRating ≈ score`, `ratingCount = 1`.

## Out of scope

- Auto-completion at end of mentorship for the per-row REQUIRES_NEW path: errors are logged-and-skipped; surfacing them to ops alerting is a follow-up if needed.
- Rating immutability: no edit/delete endpoint. Add later if product wants it.
- `TERMINATED` status remains reserved for a future admin-driven flow.
- Mentor → mentee ratings (issue scope is mentee → mentor only).
- Frontend / mobile UI; web is tracked under #276/#127/#278.
