### PR TITLE
Fix blank page on mentee profile view from mentor dashboard

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -339,7 +339,7 @@ export default function HomePage() {
                           <button
                             className="view-profile-btn"
                             style={{ fontSize: '13px', padding: '7px 14px' }}
-                            onClick={() => navigate(`/profile/${req.menteeId}`)}
+                            onClick={() => navigate(`/users/${req.menteeId}`)}
                           >
                             View Profile
                           </button>


### PR DESCRIPTION
## 📝 Summary
Resolved a routing issue on the mentor dashboard where clicking the "View Profile" button for an incoming mentorship request resulted in a blank page. The navigation path was incorrectly mapped to an unmatched route, causing React Router to render an empty outlet.

## 🔑 Key Changes
* Updated `frontend/src/pages/HomePage.jsx` to use the correct `/users/:id` route instead of the invalid `/profile/:id` route for viewing mentee profiles.
* Restored proper navigation flow from the mentor's pending requests list to the detailed user profile page without triggering a silent render failure.

Releated to #433 