### PR TITLE
feat(backend): mentor and mentee dashboard stats endpoints (#253)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/StatsController.java
+++ b/backend/src/main/java/com/group7/backend/controller/StatsController.java
@@ -1,0 +1,65 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.dto.response.MenteeStatsResponse;
+import com.group7.backend.dto.response.MentorStatsResponse;
+import com.group7.backend.service.StatsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stats")
+@Tag(name = "Stats", description = "Aggregated dashboard statistics for mentors and mentees")
+public class StatsController {
+
+    private final StatsService statsService;
+
+    public StatsController(StatsService statsService) {
+        this.statsService = statsService;
+    }
+
+    @GetMapping("/mentor/me")
+    @Operation(
+            summary = "Get mentor dashboard stats",
+            description = "Returns aggregated counts for the authenticated mentor: mentees, "
+                    + "mentorship lifecycle counts, task progress, completed meeting hours, and "
+                    + "pending requests. The response is implicitly scoped to the caller — there "
+                    + "is no path parameter, so cross-user access is not possible. A user with "
+                    + "no mentor activity gets a zero-valued payload (200, not 404)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Mentor stats payload",
+                    content = @Content(schema = @Schema(implementation = MentorStatsResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Unauthenticated", content = @Content)
+    })
+    public ResponseEntity<MentorStatsResponse> getMentorStats(Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(statsService.getMentorStats(userId));
+    }
+
+    @GetMapping("/mentee/me")
+    @Operation(
+            summary = "Get mentee dashboard stats",
+            description = "Returns aggregated counts for the authenticated mentee: active "
+                    + "mentorships, task progress, upcoming meetings, distinct mentors worked "
+                    + "with, and total requests sent. Implicit caller scope, same as the mentor "
+                    + "endpoint. A user with no mentee activity gets a zero-valued payload."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Mentee stats payload",
+                    content = @Content(schema = @Schema(implementation = MenteeStatsResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Unauthenticated", content = @Content)
+    })
+    public ResponseEntity<MenteeStatsResponse> getMenteeStats(Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(statsService.getMenteeStats(userId));
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MenteeStatsResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MenteeStatsResponse.java
@@ -1,0 +1,35 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Aggregated mentee-side dashboard statistics (#253).")
+public record MenteeStatsResponse(
+        @Schema(description = "Mentorships the mentee currently has in ACTIVE status. Typically "
+                + "0 or 1, but the field is a count so the contract stays symmetric with the "
+                + "mentor side and tolerates concurrent active mentorships.",
+                example = "1")
+        long activeMentorshipsCount,
+
+        @Schema(description = "Tasks across all the mentee's mentorships in COMPLETED status",
+                example = "12")
+        long completedTasksCount,
+
+        @Schema(description = "Tasks the mentee still owes work on (PENDING or REVISION_REQUESTED)",
+                example = "3")
+        long pendingTasksCount,
+
+        @Schema(description = "Future meetings the mentee is part of in PENDING_CONFIRMATION or "
+                + "CONFIRMED status (startTime > now)",
+                example = "2")
+        long upcomingMeetingsCount,
+
+        @Schema(description = "Distinct mentors the mentee has worked with across the mentorship "
+                + "history",
+                example = "2")
+        long totalMentorsWorkedWith,
+
+        @Schema(description = "Total mentorship requests the mentee has ever sent, in any status",
+                example = "5")
+        long requestsSent
+) {
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorStatsResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorStatsResponse.java
@@ -1,0 +1,42 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Aggregated mentor-side dashboard statistics (#253).")
+public record MentorStatsResponse(
+        @Schema(description = "Distinct mentees the mentor has worked with across all mentorships",
+                example = "12")
+        long totalMentees,
+
+        @Schema(description = "Mentorships currently in ACTIVE status", example = "3")
+        long activeMentorships,
+
+        @Schema(description = "Mentorships currently in COMPLETED status", example = "9")
+        long completedMentorships,
+
+        @Schema(description = "All tasks the mentor has assigned across their mentorships",
+                example = "47")
+        long totalTasksAssigned,
+
+        @Schema(description = "Tasks in COMPLETED status", example = "31")
+        long totalTasksCompleted,
+
+        @Schema(description = "Total hours of meetings in COMPLETED status across all mentorships, "
+                + "computed as SUM(end_time - start_time) in hours.",
+                example = "18.5")
+        double totalMeetingHours,
+
+        @Schema(description = "Average rating the mentor has received from mentees, in [1.0, 5.0]. "
+                + "Null when the mentor has not received any ratings yet, or when the rating "
+                + "feature is not yet wired in (issue #237).",
+                example = "4.6", nullable = true)
+        Double averageRating,
+
+        @Schema(description = "Total number of ratings the mentor has received", example = "8")
+        long ratingCount,
+
+        @Schema(description = "Mentorship requests addressed to this mentor that are still PENDING",
+                example = "2")
+        long pendingRequests
+) {
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorshipProgressResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorshipProgressResponse.java
@@ -4,7 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.OffsetDateTime;
 
-@Schema(description = "Aggregated mentorship progress across tasks and milestones (#334).")
+@Schema(description = "Aggregated mentorship progress across tasks and milestones (#334), "
+        + "extended with session attendance and time-remaining for the dashboard view (#253).")
 public record MentorshipProgressResponse(
         @Schema(description = "Mentorship id", example = "42")
         long mentorshipId,
@@ -27,12 +28,22 @@ public record MentorshipProgressResponse(
 
         @Schema(description = "Combined progress as a ratio in [0.0, 1.0]. Equal-weighted across " +
                 "the two surfaces when both have entries; falls back to a single-surface ratio " +
-                "when only one surface has entries; 0.0 when both are empty.",
+                "when only one surface has entries; 0.0 when both are empty. Multiply by 100 for " +
+                "the goal-achievement percentage.",
                 example = "0.325")
         float progressRatio,
 
         @Schema(description = "Latest activity timestamp across task submissions / reviews and " +
                 "milestone completions; null when neither domain has any activity.")
-        OffsetDateTime lastActivityAt
+        OffsetDateTime lastActivityAt,
+
+        @Schema(description = "Meetings of this mentorship in COMPLETED status (#253).",
+                example = "5")
+        long sessionsAttended,
+
+        @Schema(description = "Whole days remaining until the mentorship's endDate, clamped to 0 " +
+                "when the end date is in the past (#253).",
+                example = "27")
+        long daysRemaining
 ) {
 }

--- a/backend/src/main/java/com/group7/backend/repository/MeetingRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MeetingRepository.java
@@ -85,5 +85,29 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     @Modifying
     @Query("UPDATE Meeting m SET m.status = 'COMPLETED' WHERE m.id = :meetingId AND m.status = 'CONFIRMED'")
     int completeMeeting(@Param("meetingId") Long meetingId);
+
+    // Stats aggregations (#253).
+
+    long countByMentorshipIdAndStatus(Long mentorshipId, MeetingStatus status);
+
+    @Query("SELECT COUNT(m) FROM Meeting m "
+            + "WHERE m.mentorship.mentee.id = :menteeId "
+            + "AND m.startTime > :now "
+            + "AND m.status IN :statuses")
+    long countUpcomingByMenteeId(@Param("menteeId") Long menteeId,
+                                 @Param("now") OffsetDateTime now,
+                                 @Param("statuses") Collection<MeetingStatus> statuses);
+
+    /**
+     * Total completed meeting hours for a mentor across all their mentorships.
+     * Native query because JPQL has no portable interval-to-seconds conversion;
+     * Postgres' {@code EXTRACT(EPOCH FROM interval)} is the cleanest single-row
+     * aggregate. Returns 0.0 (not null) for mentors with zero completed meetings.
+     */
+    @Query(value = "SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (m.end_time - m.start_time)) / 3600.0), 0) "
+            + "FROM meetings m JOIN mentorships ms ON m.mentorship_id = ms.id "
+            + "WHERE ms.mentor_id = :mentorId AND m.status = 'COMPLETED'",
+            nativeQuery = true)
+    double sumCompletedMeetingHoursForMentor(@Param("mentorId") Long mentorId);
 }
 

--- a/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
@@ -26,5 +26,21 @@ public interface MentorshipRepository extends JpaRepository<Mentorship, Long> {
 
     @Query(value = "SELECT pg_advisory_xact_lock(:lockId)", nativeQuery = true)
     void acquireAdvisoryLock(@Param("lockId") Long lockId);
+
+    // Stats aggregations (#253) — single-row COUNTs scoped to one user.
+
+    @Query("SELECT COUNT(m) FROM Mentorship m WHERE m.mentor.id = :mentorId AND m.status = :status")
+    long countByMentorIdAndStatus(@Param("mentorId") Long mentorId,
+                                  @Param("status") MentorshipStatus status);
+
+    @Query("SELECT COUNT(m) FROM Mentorship m WHERE m.mentee.id = :menteeId AND m.status = :status")
+    long countByMenteeIdAndStatus(@Param("menteeId") Long menteeId,
+                                  @Param("status") MentorshipStatus status);
+
+    @Query("SELECT COUNT(DISTINCT m.mentee.id) FROM Mentorship m WHERE m.mentor.id = :mentorId")
+    long countDistinctMenteesByMentorId(@Param("mentorId") Long mentorId);
+
+    @Query("SELECT COUNT(DISTINCT m.mentor.id) FROM Mentorship m WHERE m.mentee.id = :menteeId")
+    long countDistinctMentorsByMenteeId(@Param("menteeId") Long menteeId);
 }
 

--- a/backend/src/main/java/com/group7/backend/repository/MentorshipRequestRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorshipRequestRepository.java
@@ -27,4 +27,10 @@ public interface MentorshipRequestRepository extends JpaRepository<MentorshipReq
             + "WHERE r.mentee.id = :menteeId AND r.status = com.group7.backend.entity.MentorshipRequestStatus.PENDING "
             + "AND r.id != :excludeId")
     int cancelOtherPendingRequests(@Param("menteeId") Long menteeId, @Param("excludeId") Long excludeId);
+
+    // Stats aggregations (#253).
+
+    long countByMentor_IdAndStatus(Long mentorId, MentorshipRequestStatus status);
+
+    long countByMentee_Id(Long menteeId);
 }

--- a/backend/src/main/java/com/group7/backend/repository/TaskRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/TaskRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,4 +47,20 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
             + "WHERE t.status IN ('PENDING', 'REVISION_REQUESTED') "
             + "AND t.dueDate BETWEEN :from AND :to")
     List<Task> findPendingTasksDueWithin(@Param("from") OffsetDateTime from, @Param("to") OffsetDateTime to);
+
+    // Stats aggregations (#253). Two-hop nested predicate (`t.mentorship.mentor.id`)
+    // requires explicit JPQL; Spring Data derived names get unwieldy at this depth.
+
+    @Query("SELECT COUNT(t) FROM Task t WHERE t.mentorship.mentor.id = :mentorId")
+    long countByMentorId(@Param("mentorId") Long mentorId);
+
+    @Query("SELECT COUNT(t) FROM Task t WHERE t.mentorship.mentor.id = :mentorId AND t.status = :status")
+    long countByMentorIdAndStatus(@Param("mentorId") Long mentorId, @Param("status") TaskStatus status);
+
+    @Query("SELECT COUNT(t) FROM Task t WHERE t.mentorship.mentee.id = :menteeId AND t.status = :status")
+    long countByMenteeIdAndStatus(@Param("menteeId") Long menteeId, @Param("status") TaskStatus status);
+
+    @Query("SELECT COUNT(t) FROM Task t WHERE t.mentorship.mentee.id = :menteeId AND t.status IN :statuses")
+    long countByMenteeIdAndStatusIn(@Param("menteeId") Long menteeId,
+                                    @Param("statuses") Collection<TaskStatus> statuses);
 }

--- a/backend/src/main/java/com/group7/backend/service/MentorshipProgressService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipProgressService.java
@@ -1,9 +1,11 @@
 package com.group7.backend.service;
 
 import com.group7.backend.dto.response.MentorshipProgressResponse;
+import com.group7.backend.entity.MeetingStatus;
 import com.group7.backend.entity.Mentorship;
 import com.group7.backend.entity.MilestoneStatus;
 import com.group7.backend.entity.TaskStatus;
+import com.group7.backend.repository.MeetingRepository;
 import com.group7.backend.repository.MilestoneRepository;
 import com.group7.backend.repository.TaskRepository;
 import com.group7.backend.repository.TaskSubmissionRepository;
@@ -11,6 +13,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Read-only aggregator for mentorship progress (#334, spec 1.1.5.5).
@@ -25,15 +29,18 @@ public class MentorshipProgressService {
     private final TaskRepository taskRepository;
     private final TaskSubmissionRepository taskSubmissionRepository;
     private final MilestoneRepository milestoneRepository;
+    private final MeetingRepository meetingRepository;
 
     public MentorshipProgressService(MentorshipService mentorshipService,
                                      TaskRepository taskRepository,
                                      TaskSubmissionRepository taskSubmissionRepository,
-                                     MilestoneRepository milestoneRepository) {
+                                     MilestoneRepository milestoneRepository,
+                                     MeetingRepository meetingRepository) {
         this.mentorshipService = mentorshipService;
         this.taskRepository = taskRepository;
         this.taskSubmissionRepository = taskSubmissionRepository;
         this.milestoneRepository = milestoneRepository;
+        this.meetingRepository = meetingRepository;
     }
 
     @Transactional(readOnly = true)
@@ -54,6 +61,10 @@ public class MentorshipProgressService {
 
         OffsetDateTime lastActivityAt = computeLastActivity(mid);
 
+        long sessionsAttended =
+                meetingRepository.countByMentorshipIdAndStatus(mid, MeetingStatus.COMPLETED);
+        long daysRemaining = computeDaysRemaining(mentorship.getEndDate());
+
         return new MentorshipProgressResponse(
                 mid,
                 taskTotal,
@@ -62,8 +73,22 @@ public class MentorshipProgressService {
                 milestoneTotal,
                 milestoneCompleted,
                 progressRatio,
-                lastActivityAt
+                lastActivityAt,
+                sessionsAttended,
+                daysRemaining
         );
+    }
+
+    /**
+     * Whole days from now until {@code endDate}, never negative. A null end date — which
+     * the schema disallows but defensive code is cheap — returns 0.
+     */
+    private static long computeDaysRemaining(OffsetDateTime endDate) {
+        if (endDate == null) {
+            return 0L;
+        }
+        long days = ChronoUnit.DAYS.between(OffsetDateTime.now(ZoneOffset.UTC), endDate);
+        return Math.max(0L, days);
     }
 
     /**

--- a/backend/src/main/java/com/group7/backend/service/StatsService.java
+++ b/backend/src/main/java/com/group7/backend/service/StatsService.java
@@ -1,0 +1,117 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.MenteeStatsResponse;
+import com.group7.backend.dto.response.MentorStatsResponse;
+import com.group7.backend.entity.MeetingStatus;
+import com.group7.backend.entity.MentorshipRequestStatus;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.entity.TaskStatus;
+import com.group7.backend.repository.MeetingRepository;
+import com.group7.backend.repository.MentorshipRepository;
+import com.group7.backend.repository.MentorshipRequestRepository;
+import com.group7.backend.repository.TaskRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.EnumSet;
+
+/**
+ * Read-only aggregator for mentor and mentee dashboards (#253).
+ *
+ * <p>Each public method issues a small fixed set of single-row COUNT/SUM queries; no
+ * collections are loaded. Authorization is implicit: the caller's user id (from the
+ * security context) is the only filter, so a mentor cannot see another mentor's stats
+ * and a mentee cannot see another mentee's.
+ */
+@Service
+public class StatsService {
+
+    /**
+     * Statuses that represent a meeting still on the mentee's calendar (#253). Confirmed
+     * sessions count, and so do ones still awaiting the other party's confirmation —
+     * both are upcoming work the dashboard should surface.
+     */
+    private static final EnumSet<MeetingStatus> UPCOMING_MEETING_STATUSES =
+            EnumSet.of(MeetingStatus.PENDING_CONFIRMATION, MeetingStatus.CONFIRMED);
+
+    /**
+     * Pending task statuses for the mentee (#253). REVISION_REQUESTED is included
+     * because the mentee still owes work — same convention as
+     * {@code TaskRepository.findPendingTasksDueWithin}.
+     */
+    private static final EnumSet<TaskStatus> PENDING_TASK_STATUSES =
+            EnumSet.of(TaskStatus.PENDING, TaskStatus.REVISION_REQUESTED);
+
+    private final MentorshipRepository mentorshipRepository;
+    private final MentorshipRequestRepository mentorshipRequestRepository;
+    private final TaskRepository taskRepository;
+    private final MeetingRepository meetingRepository;
+
+    public StatsService(MentorshipRepository mentorshipRepository,
+                        MentorshipRequestRepository mentorshipRequestRepository,
+                        TaskRepository taskRepository,
+                        MeetingRepository meetingRepository) {
+        this.mentorshipRepository = mentorshipRepository;
+        this.mentorshipRequestRepository = mentorshipRequestRepository;
+        this.taskRepository = taskRepository;
+        this.meetingRepository = meetingRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public MentorStatsResponse getMentorStats(Long mentorId) {
+        long totalMentees = mentorshipRepository.countDistinctMenteesByMentorId(mentorId);
+        long active = mentorshipRepository.countByMentorIdAndStatus(
+                mentorId, MentorshipStatus.ACTIVE);
+        long completed = mentorshipRepository.countByMentorIdAndStatus(
+                mentorId, MentorshipStatus.COMPLETED);
+        long tasksAssigned = taskRepository.countByMentorId(mentorId);
+        long tasksCompleted = taskRepository.countByMentorIdAndStatus(
+                mentorId, TaskStatus.COMPLETED);
+        double meetingHours = meetingRepository.sumCompletedMeetingHoursForMentor(mentorId);
+        long pendingRequests = mentorshipRequestRepository.countByMentor_IdAndStatus(
+                mentorId, MentorshipRequestStatus.PENDING);
+
+        // Rating aggregation lands with #237 (MentorRating). Until that PR merges into
+        // dev, return null/0 so the contract is stable for the dashboard.
+        Double averageRating = null;
+        long ratingCount = 0L;
+
+        return new MentorStatsResponse(
+                totalMentees,
+                active,
+                completed,
+                tasksAssigned,
+                tasksCompleted,
+                meetingHours,
+                averageRating,
+                ratingCount,
+                pendingRequests
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public MenteeStatsResponse getMenteeStats(Long menteeId) {
+        long active = mentorshipRepository.countByMenteeIdAndStatus(
+                menteeId, MentorshipStatus.ACTIVE);
+        long completedTasks = taskRepository.countByMenteeIdAndStatus(
+                menteeId, TaskStatus.COMPLETED);
+        long pendingTasks = taskRepository.countByMenteeIdAndStatusIn(
+                menteeId, PENDING_TASK_STATUSES);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        long upcomingMeetings = meetingRepository.countUpcomingByMenteeId(
+                menteeId, now, UPCOMING_MEETING_STATUSES);
+        long mentorsWorkedWith = mentorshipRepository.countDistinctMentorsByMenteeId(menteeId);
+        long requestsSent = mentorshipRequestRepository.countByMentee_Id(menteeId);
+
+        return new MenteeStatsResponse(
+                active,
+                completedTasks,
+                pendingTasks,
+                upcomingMeetings,
+                mentorsWorkedWith,
+                requestsSent
+        );
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
@@ -359,7 +359,8 @@ class MentorshipControllerTest {
     private MentorshipProgressResponse sampleProgress() {
         return new MentorshipProgressResponse(
                 100L, 10L, 4L, 2L, 4L, 1L, 0.325f,
-                java.time.OffsetDateTime.of(2026, 5, 5, 0, 0, 0, 0, java.time.ZoneOffset.UTC));
+                java.time.OffsetDateTime.of(2026, 5, 5, 0, 0, 0, 0, java.time.ZoneOffset.UTC),
+                5L, 27L);
     }
 
     @Test

--- a/backend/src/test/java/com/group7/backend/controller/StatsControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/StatsControllerTest.java
@@ -1,0 +1,115 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.MenteeStatsResponse;
+import com.group7.backend.dto.response.MentorStatsResponse;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.StatsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StatsController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class StatsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StatsService statsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    private void mockMentorJwt(String token, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn("mentor@example.com");
+        when(jwtService.extractRole(token)).thenReturn("MENTOR");
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private void mockMenteeJwt(String token, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn("mentee@example.com");
+        when(jwtService.extractRole(token)).thenReturn("MENTEE");
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    // ── /mentor/me ──────────────────────────────────────────────────────────
+
+    @Test
+    void mentorStatsReturns200WithBody() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(statsService.getMentorStats(1L)).thenReturn(new MentorStatsResponse(
+                12L, 3L, 9L, 47L, 31L, 18.5, null, 0L, 2L));
+
+        mockMvc.perform(get("/api/stats/mentor/me")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalMentees").value(12))
+                .andExpect(jsonPath("$.activeMentorships").value(3))
+                .andExpect(jsonPath("$.completedMentorships").value(9))
+                .andExpect(jsonPath("$.totalTasksAssigned").value(47))
+                .andExpect(jsonPath("$.totalTasksCompleted").value(31))
+                .andExpect(jsonPath("$.totalMeetingHours").value(18.5))
+                .andExpect(jsonPath("$.averageRating").doesNotExist())
+                .andExpect(jsonPath("$.ratingCount").value(0))
+                .andExpect(jsonPath("$.pendingRequests").value(2));
+    }
+
+    @Test
+    void mentorStatsRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/stats/mentor/me"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void mentorStatsReturns200ForMenteeRoleToo() throws Exception {
+        // Endpoint authorization is by token presence, not role: a user with no mentor
+        // activity gets a zero-valued payload, not a 403. The spec says role-specific
+        // *content*, not role-gated *access*.
+        mockMenteeJwt("mentee-token", 2L);
+        when(statsService.getMentorStats(2L)).thenReturn(new MentorStatsResponse(
+                0L, 0L, 0L, 0L, 0L, 0.0, null, 0L, 0L));
+
+        mockMvc.perform(get("/api/stats/mentor/me")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalMentees").value(0));
+    }
+
+    // ── /mentee/me ──────────────────────────────────────────────────────────
+
+    @Test
+    void menteeStatsReturns200WithBody() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+        when(statsService.getMenteeStats(2L)).thenReturn(new MenteeStatsResponse(
+                1L, 12L, 3L, 2L, 2L, 5L));
+
+        mockMvc.perform(get("/api/stats/mentee/me")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeMentorshipsCount").value(1))
+                .andExpect(jsonPath("$.completedTasksCount").value(12))
+                .andExpect(jsonPath("$.pendingTasksCount").value(3))
+                .andExpect(jsonPath("$.upcomingMeetingsCount").value(2))
+                .andExpect(jsonPath("$.totalMentorsWorkedWith").value(2))
+                .andExpect(jsonPath("$.requestsSent").value(5));
+    }
+
+    @Test
+    void menteeStatsRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/stats/mentee/me"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/StatsIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/StatsIntegrationTest.java
@@ -1,0 +1,299 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.Meeting;
+import com.group7.backend.entity.MeetingStatus;
+import com.group7.backend.entity.MeetingType;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipRequest;
+import com.group7.backend.entity.MentorshipRequestStatus;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.entity.Task;
+import com.group7.backend.entity.TaskStatus;
+import com.group7.backend.repository.MeetingRepository;
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.repository.MentorshipRepository;
+import com.group7.backend.repository.MentorshipRequestRepository;
+import com.group7.backend.repository.PasswordResetTokenRepository;
+import com.group7.backend.repository.TaskRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end check of {@code /api/stats/mentor/me} and {@code /api/stats/mentee/me} (#253).
+ *
+ * <p>Exercises the JPQL aggregations and the native {@code EXTRACT(EPOCH ...)} sum against
+ * a real Postgres so a JPQL typo or PG-only function regression surfaces here, not in
+ * production.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StatsIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private MentorshipRequestRepository mentorshipRequestRepository;
+    @Autowired private MentorshipRepository mentorshipRepository;
+    @Autowired private TaskRepository taskRepository;
+    @Autowired private MeetingRepository meetingRepository;
+
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        // Order matters: child rows first.
+        meetingRepository.deleteAll();
+        taskRepository.deleteAll();
+        mentorshipRepository.deleteAll();
+        mentorshipRequestRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+        doNothing().when(emailService).sendPasswordResetEmail(any(), anyString());
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Test");
+        req.setLastName("User");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private Mentor fetchMentor(String email) {
+        return mentorRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals(email))
+                .findFirst().orElseThrow();
+    }
+
+    private Mentee fetchMentee(String email) {
+        return menteeRepository.findAll().stream()
+                .filter(m -> m.getEmail().equals(email))
+                .findFirst().orElseThrow();
+    }
+
+    private MentorshipRequest seedRequest(Mentee mentee, Mentor mentor, MentorshipRequestStatus status) {
+        MentorshipRequest req = new MentorshipRequest();
+        req.setMentee(mentee);
+        req.setMentor(mentor);
+        req.setMessage("Please mentor me!");
+        req.setStatus(status);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        req.setCreatedAt(now);
+        req.setUpdatedAt(now);
+        return mentorshipRequestRepository.save(req);
+    }
+
+    private Mentorship seedMentorship(Mentor mentor, Mentee mentee, MentorshipRequest acceptedRequest,
+                                      MentorshipStatus status) {
+        Mentorship m = new Mentorship();
+        m.setMentor(mentor);
+        m.setMentee(mentee);
+        m.setRequest(acceptedRequest);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        m.setStartDate(now.minusDays(10));
+        m.setEndDate(now.plusDays(80));
+        m.setDuration(3);
+        m.setStatus(status);
+        return mentorshipRepository.save(m);
+    }
+
+    private void seedTask(Mentorship mentorship, TaskStatus status) {
+        Task t = new Task();
+        t.setMentorship(mentorship);
+        t.setTitle("Task " + status);
+        t.setStatus(status);
+        taskRepository.save(t);
+    }
+
+    private void seedMeeting(Mentorship mentorship, MeetingStatus status,
+                             OffsetDateTime startTime, OffsetDateTime endTime,
+                             com.group7.backend.entity.User createdBy) {
+        Meeting m = new Meeting();
+        m.setMentorship(mentorship);
+        m.setTitle("Meeting " + status);
+        m.setStartTime(startTime);
+        m.setEndTime(endTime);
+        m.setStatus(status);
+        m.setMeetingType(MeetingType.ONLINE);
+        m.setCreatedBy(createdBy);
+        meetingRepository.save(m);
+    }
+
+    // ── Mentor stats ────────────────────────────────────────────────────────
+
+    @Test
+    void mentorStats_returnsAggregatedCountsForSeededState() throws Exception {
+        String mentorToken = registerAndLogin("stats_mentor@example.com", true);
+        registerAndLogin("stats_mentee@example.com", false);
+        registerAndLogin("stats_mentee2@example.com", false);
+
+        Mentor mentor = fetchMentor("stats_mentor@example.com");
+        Mentee mentee = fetchMentee("stats_mentee@example.com");
+        Mentee mentee2 = fetchMentee("stats_mentee2@example.com");
+
+        // 1 active mentorship with mentee #1 (built from an accepted request)
+        MentorshipRequest accepted = seedRequest(mentee, mentor, MentorshipRequestStatus.ACCEPTED);
+        Mentorship active = seedMentorship(mentor, mentee, accepted, MentorshipStatus.ACTIVE);
+
+        // 1 pending request from mentee #2 → counts toward pendingRequests
+        seedRequest(mentee2, mentor, MentorshipRequestStatus.PENDING);
+
+        // 3 tasks: 2 COMPLETED, 1 PENDING
+        seedTask(active, TaskStatus.COMPLETED);
+        seedTask(active, TaskStatus.COMPLETED);
+        seedTask(active, TaskStatus.PENDING);
+
+        // 1 completed meeting of exactly 1 hour → totalMeetingHours = 1.0
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        seedMeeting(active, MeetingStatus.COMPLETED,
+                now.minusHours(2), now.minusHours(1), mentor);
+
+        MvcResult res = mockMvc.perform(get("/api/stats/mentor/me")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalMentees").value(1))
+                .andExpect(jsonPath("$.activeMentorships").value(1))
+                .andExpect(jsonPath("$.completedMentorships").value(0))
+                .andExpect(jsonPath("$.totalTasksAssigned").value(3))
+                .andExpect(jsonPath("$.totalTasksCompleted").value(2))
+                .andExpect(jsonPath("$.pendingRequests").value(1))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(res.getResponse().getContentAsString());
+        // 1.0 ± 0.01h = ±36s — generous so the test isn't flaky on slow CI runners.
+        assertThat(body.get("totalMeetingHours").asDouble()).isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.01));
+        // Rating not yet wired (#237) — null + 0 per the documented stub.
+        assertThat(body.get("averageRating").isNull()).isTrue();
+        assertThat(body.get("ratingCount").asLong()).isZero();
+    }
+
+    @Test
+    void mentorStats_returnsAllZeroesForFreshUser() throws Exception {
+        String mentorToken = registerAndLogin("stats_lonely_mentor@example.com", true);
+
+        mockMvc.perform(get("/api/stats/mentor/me")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalMentees").value(0))
+                .andExpect(jsonPath("$.activeMentorships").value(0))
+                .andExpect(jsonPath("$.totalTasksAssigned").value(0))
+                .andExpect(jsonPath("$.totalMeetingHours").value(0.0))
+                .andExpect(jsonPath("$.pendingRequests").value(0));
+    }
+
+    // ── Mentee stats ────────────────────────────────────────────────────────
+
+    @Test
+    void menteeStats_returnsAggregatedCountsForSeededState() throws Exception {
+        registerAndLogin("stats_mentor3@example.com", true);
+        String menteeToken = registerAndLogin("stats_mentee3@example.com", false);
+
+        Mentor mentor = fetchMentor("stats_mentor3@example.com");
+        Mentee mentee = fetchMentee("stats_mentee3@example.com");
+
+        MentorshipRequest accepted = seedRequest(mentee, mentor, MentorshipRequestStatus.ACCEPTED);
+        Mentorship active = seedMentorship(mentor, mentee, accepted, MentorshipStatus.ACTIVE);
+
+        // 1 PENDING + 1 REVISION_REQUESTED both count as "still owe work"; 2 COMPLETED.
+        seedTask(active, TaskStatus.COMPLETED);
+        seedTask(active, TaskStatus.COMPLETED);
+        seedTask(active, TaskStatus.PENDING);
+        seedTask(active, TaskStatus.REVISION_REQUESTED);
+
+        // Upcoming: 1 CONFIRMED future + 1 PENDING_CONFIRMATION future = 2 upcoming.
+        // 1 COMPLETED past meeting must be excluded.
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        seedMeeting(active, MeetingStatus.CONFIRMED,
+                now.plusDays(2), now.plusDays(2).plusHours(1), mentor);
+        seedMeeting(active, MeetingStatus.PENDING_CONFIRMATION,
+                now.plusDays(5), now.plusDays(5).plusHours(1), mentor);
+        seedMeeting(active, MeetingStatus.COMPLETED,
+                now.minusDays(1), now.minusDays(1).plusHours(1), mentor);
+
+        // 2 requests sent by the mentee total (1 ACCEPTED above + 1 we add now)
+        Mentor unrelatedMentor = mentor; // same mentor is fine for "requestsSent"
+        seedRequest(mentee, unrelatedMentor, MentorshipRequestStatus.PENDING);
+
+        mockMvc.perform(get("/api/stats/mentee/me")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeMentorshipsCount").value(1))
+                .andExpect(jsonPath("$.completedTasksCount").value(2))
+                .andExpect(jsonPath("$.pendingTasksCount").value(2))
+                .andExpect(jsonPath("$.upcomingMeetingsCount").value(2))
+                .andExpect(jsonPath("$.totalMentorsWorkedWith").value(1))
+                .andExpect(jsonPath("$.requestsSent").value(2));
+    }
+
+    // ── Auth ────────────────────────────────────────────────────────────────
+
+    @Test
+    void unauthenticatedRequestsAreRejected() throws Exception {
+        mockMvc.perform(get("/api/stats/mentor/me")).andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/stats/mentee/me")).andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorshipProgressServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipProgressServiceTest.java
@@ -1,6 +1,7 @@
 package com.group7.backend.service;
 
 import com.group7.backend.dto.response.MentorshipProgressResponse;
+import com.group7.backend.entity.MeetingStatus;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.entity.Mentorship;
@@ -8,6 +9,7 @@ import com.group7.backend.entity.MentorshipStatus;
 import com.group7.backend.entity.MilestoneStatus;
 import com.group7.backend.entity.TaskStatus;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.MeetingRepository;
 import com.group7.backend.repository.MilestoneRepository;
 import com.group7.backend.repository.TaskRepository;
 import com.group7.backend.repository.TaskSubmissionRepository;
@@ -34,6 +36,7 @@ class MentorshipProgressServiceTest {
     @Mock private TaskRepository taskRepository;
     @Mock private TaskSubmissionRepository taskSubmissionRepository;
     @Mock private MilestoneRepository milestoneRepository;
+    @Mock private MeetingRepository meetingRepository;
 
     @InjectMocks
     private MentorshipProgressService progressService;
@@ -82,6 +85,11 @@ class MentorshipProgressServiceTest {
         lenient().when(taskSubmissionRepository.findMaxSubmittedAtForMentorship(MID)).thenReturn(sub);
         lenient().when(taskSubmissionRepository.findMaxReviewedAtForMentorship(MID)).thenReturn(rev);
         lenient().when(milestoneRepository.findMaxCompletedAtForMentorship(MID)).thenReturn(mile);
+    }
+
+    private void stubSessionsAttended(long count) {
+        lenient().when(meetingRepository.countByMentorshipIdAndStatus(MID, MeetingStatus.COMPLETED))
+                .thenReturn(count);
     }
 
     // ── Authorization (delegated to MentorshipService.findForParticipant) ──
@@ -271,5 +279,57 @@ class MentorshipProgressServiceTest {
         MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
 
         assertThat(r.lastActivityAt()).isNull();
+    }
+
+    // ── #253 dashboard extensions: sessionsAttended + daysRemaining ─────────
+
+    @Test
+    void sessionsAttended_reflectsCompletedMeetingCount() {
+        stubFound(MENTOR_ID);
+        stubCounts(0, 0, 0, 0, 0);
+        stubTimestamps(null, null, null);
+        stubSessionsAttended(7L);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.sessionsAttended()).isEqualTo(7L);
+    }
+
+    @Test
+    void daysRemaining_isZeroWhenEndDateNull() {
+        stubFound(MENTOR_ID);
+        stubCounts(0, 0, 0, 0, 0);
+        stubTimestamps(null, null, null);
+        // mentorship.endDate left null in the @BeforeEach builder.
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.daysRemaining()).isEqualTo(0L);
+    }
+
+    @Test
+    void daysRemaining_isClampedToZeroWhenEndDateInPast() {
+        mentorship.setEndDate(OffsetDateTime.now(ZoneOffset.UTC).minusDays(5));
+        stubFound(MENTOR_ID);
+        stubCounts(0, 0, 0, 0, 0);
+        stubTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        assertThat(r.daysRemaining()).isEqualTo(0L);
+    }
+
+    @Test
+    void daysRemaining_countsWholeDaysUntilFutureEndDate() {
+        mentorship.setEndDate(OffsetDateTime.now(ZoneOffset.UTC).plusDays(30).plusHours(2));
+        stubFound(MENTOR_ID);
+        stubCounts(0, 0, 0, 0, 0);
+        stubTimestamps(null, null, null);
+
+        MentorshipProgressResponse r = progressService.getProgress(MENTOR_ID, MID);
+
+        // ChronoUnit.DAYS.between truncates: 30d2h ≈ 30 whole days. Allow 29-30 to absorb
+        // the millisecond drift between OffsetDateTime.now() in test vs in service.
+        assertThat(r.daysRemaining()).isBetween(29L, 30L);
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/StatsServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/StatsServiceTest.java
@@ -1,0 +1,157 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.MenteeStatsResponse;
+import com.group7.backend.dto.response.MentorStatsResponse;
+import com.group7.backend.entity.MeetingStatus;
+import com.group7.backend.entity.MentorshipRequestStatus;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.entity.TaskStatus;
+import com.group7.backend.repository.MeetingRepository;
+import com.group7.backend.repository.MentorshipRepository;
+import com.group7.backend.repository.MentorshipRequestRepository;
+import com.group7.backend.repository.TaskRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StatsServiceTest {
+
+    private static final long MENTOR_ID = 11L;
+    private static final long MENTEE_ID = 22L;
+
+    @Mock private MentorshipRepository mentorshipRepository;
+    @Mock private MentorshipRequestRepository mentorshipRequestRepository;
+    @Mock private TaskRepository taskRepository;
+    @Mock private MeetingRepository meetingRepository;
+
+    @InjectMocks
+    private StatsService statsService;
+
+    // ── Mentor stats ────────────────────────────────────────────────────────
+
+    @Test
+    void mentorStats_mapsEachFieldToTheRightRepoCall() {
+        when(mentorshipRepository.countDistinctMenteesByMentorId(MENTOR_ID)).thenReturn(12L);
+        when(mentorshipRepository.countByMentorIdAndStatus(MENTOR_ID, MentorshipStatus.ACTIVE))
+                .thenReturn(3L);
+        when(mentorshipRepository.countByMentorIdAndStatus(MENTOR_ID, MentorshipStatus.COMPLETED))
+                .thenReturn(9L);
+        when(taskRepository.countByMentorId(MENTOR_ID)).thenReturn(47L);
+        when(taskRepository.countByMentorIdAndStatus(MENTOR_ID, TaskStatus.COMPLETED))
+                .thenReturn(31L);
+        when(meetingRepository.sumCompletedMeetingHoursForMentor(MENTOR_ID)).thenReturn(18.5);
+        when(mentorshipRequestRepository.countByMentor_IdAndStatus(
+                MENTOR_ID, MentorshipRequestStatus.PENDING))
+                .thenReturn(2L);
+
+        MentorStatsResponse r = statsService.getMentorStats(MENTOR_ID);
+
+        assertThat(r.totalMentees()).isEqualTo(12L);
+        assertThat(r.activeMentorships()).isEqualTo(3L);
+        assertThat(r.completedMentorships()).isEqualTo(9L);
+        assertThat(r.totalTasksAssigned()).isEqualTo(47L);
+        assertThat(r.totalTasksCompleted()).isEqualTo(31L);
+        assertThat(r.totalMeetingHours()).isEqualTo(18.5);
+        assertThat(r.pendingRequests()).isEqualTo(2L);
+        // Rating not yet wired (#237 stub) — assert the documented contract.
+        assertThat(r.averageRating()).isNull();
+        assertThat(r.ratingCount()).isEqualTo(0L);
+    }
+
+    @Test
+    void mentorStats_returnsZerosForUserWithNoMentorActivity() {
+        // No stubs: Mockito returns 0 / 0.0 / null for primitives + objects by default.
+
+        MentorStatsResponse r = statsService.getMentorStats(MENTOR_ID);
+
+        assertThat(r.totalMentees()).isZero();
+        assertThat(r.activeMentorships()).isZero();
+        assertThat(r.completedMentorships()).isZero();
+        assertThat(r.totalTasksAssigned()).isZero();
+        assertThat(r.totalTasksCompleted()).isZero();
+        assertThat(r.totalMeetingHours()).isZero();
+        assertThat(r.pendingRequests()).isZero();
+    }
+
+    // ── Mentee stats ────────────────────────────────────────────────────────
+
+    @Test
+    void menteeStats_mapsEachFieldToTheRightRepoCall() {
+        when(mentorshipRepository.countByMenteeIdAndStatus(MENTEE_ID, MentorshipStatus.ACTIVE))
+                .thenReturn(1L);
+        when(taskRepository.countByMenteeIdAndStatus(MENTEE_ID, TaskStatus.COMPLETED))
+                .thenReturn(12L);
+        when(taskRepository.countByMenteeIdAndStatusIn(eq(MENTEE_ID), any()))
+                .thenReturn(3L);
+        when(meetingRepository.countUpcomingByMenteeId(eq(MENTEE_ID), any(), any()))
+                .thenReturn(2L);
+        when(mentorshipRepository.countDistinctMentorsByMenteeId(MENTEE_ID)).thenReturn(2L);
+        when(mentorshipRequestRepository.countByMentee_Id(MENTEE_ID)).thenReturn(5L);
+
+        MenteeStatsResponse r = statsService.getMenteeStats(MENTEE_ID);
+
+        assertThat(r.activeMentorshipsCount()).isEqualTo(1L);
+        assertThat(r.completedTasksCount()).isEqualTo(12L);
+        assertThat(r.pendingTasksCount()).isEqualTo(3L);
+        assertThat(r.upcomingMeetingsCount()).isEqualTo(2L);
+        assertThat(r.totalMentorsWorkedWith()).isEqualTo(2L);
+        assertThat(r.requestsSent()).isEqualTo(5L);
+    }
+
+    @Test
+    void menteeStats_passesPendingTaskStatusSetToRepo() {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<TaskStatus>> statusesCaptor =
+                ArgumentCaptor.forClass(Collection.class);
+
+        when(taskRepository.countByMenteeIdAndStatusIn(eq(MENTEE_ID), statusesCaptor.capture()))
+                .thenReturn(0L);
+        // Other stubs left default (return 0).
+        when(meetingRepository.countUpcomingByMenteeId(eq(MENTEE_ID), any(), any()))
+                .thenReturn(0L);
+
+        statsService.getMenteeStats(MENTEE_ID);
+
+        // PENDING + REVISION_REQUESTED are both "still owe work" — see the constant
+        // in StatsService and the documented convention in TaskRepository.
+        assertThat(statusesCaptor.getValue())
+                .containsExactlyInAnyOrder(TaskStatus.PENDING, TaskStatus.REVISION_REQUESTED);
+    }
+
+    @Test
+    void menteeStats_passesUpcomingMeetingStatusSetAndNowToRepo() {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<MeetingStatus>> statusesCaptor =
+                ArgumentCaptor.forClass(Collection.class);
+        ArgumentCaptor<OffsetDateTime> nowCaptor =
+                ArgumentCaptor.forClass(OffsetDateTime.class);
+
+        OffsetDateTime before = OffsetDateTime.now();
+        when(meetingRepository.countUpcomingByMenteeId(
+                eq(MENTEE_ID), nowCaptor.capture(), statusesCaptor.capture()))
+                .thenReturn(0L);
+
+        statsService.getMenteeStats(MENTEE_ID);
+
+        OffsetDateTime after = OffsetDateTime.now();
+        assertThat(statusesCaptor.getValue())
+                .containsExactlyInAnyOrderElementsOf(
+                        EnumSet.of(MeetingStatus.PENDING_CONFIRMATION, MeetingStatus.CONFIRMED));
+        // The "now" passed to the repo must be roughly the call site's clock — assert
+        // it is in the [before, after] window so a clock-skew bug surfaces here.
+        assertThat(nowCaptor.getValue()).isBetween(before, after);
+    }
+}


### PR DESCRIPTION
Closes #253

## Summary
- New `GET /api/stats/mentor/me` and `GET /api/stats/mentee/me` endpoints aggregate dashboard stats with a single round-trip; all numbers come from JPQL `COUNT`/`SUM`/`AVG` queries scoped to the authenticated user (no in-memory loops, no cross-user access).
- Extends `GET /api/mentorships/{id}/progress` with `sessionsAttended` and `daysRemaining` (additive, non-breaking — existing fields untouched).
- `totalMeetingHours` uses a Postgres-native `EXTRACT(EPOCH FROM (end_time - start_time))` because JPQL has no portable interval-to-seconds conversion; integration test exercises it against the real Postgres profile.

## Endpoint contracts
- **Mentor stats**: `totalMentees`, `activeMentorships`, `completedMentorships`, `totalTasksAssigned`, `totalTasksCompleted`, `totalMeetingHours`, `averageRating` (nullable), `ratingCount`, `pendingRequests`
- **Mentee stats**: `activeMentorshipsCount`, `completedTasksCount`, `pendingTasksCount`, `upcomingMeetingsCount`, `totalMentorsWorkedWith`, `requestsSent`
- **Per-mentorship progress** (extended): existing fields + `sessionsAttended`, `daysRemaining`. `progressRatio * 100` is the goal-achievement percentage from the issue spec.

## Authorization
- `mentor/me` and `mentee/me`: implicit caller scope — the user id is read from the JWT and used as the only filter, so cross-user access is structurally impossible. A user with no mentor/mentee activity gets a zero-valued payload (200), not 404.
- `/{id}/progress`: unchanged — `MentorshipService.findForParticipant` already returns 404 for non-participants.

## Note on `averageRating`
`MentorRating` (the rating entity from #237) has not landed on `dev` yet. To keep the dashboard contract stable, `averageRating` returns `null` and `ratingCount` returns `0` for now, with a TODO in `StatsService` pointing at #237. Once #237 merges, swapping the stub for `mentorRatingRepository.aggregateForMentor(...)` is a two-line change.

## Test plan
- [x] `StatsServiceTest` — 5 unit tests, Mockito; per-field repo mapping + zero-state default
- [x] `StatsControllerTest` — 5 `@WebMvcTest` tests; 200 with body, 403 unauthenticated, role-agnostic access
- [x] `StatsIntegrationTest` — 4 `@SpringBootTest` tests against real Postgres; seeds users + mentorship + tasks + meetings + requests, verifies aggregated payloads end-to-end (including the native `EXTRACT(EPOCH...)` sum)
- [x] `MentorshipProgressServiceTest` — extended with `sessionsAttended` + `daysRemaining` cases (zero/null/past/future end-date branches)
- [x] Full backend suite green: `1395 tests, 0 failures, 0 errors`

## Out of scope
- Frontend / mobile dashboard rendering (separate issues)
- Stats caching (`@Cacheable`) — left as a follow-up; current queries are single-row aggregates well under the 500ms target
- Replacing the existing `/progress` field set — additive only
