### PR TITLE
feat(backend): admin ban/unban + admin messaging (#280)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/AdminController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AdminController.java
@@ -1,11 +1,23 @@
 package com.group7.backend.controller;
 
+import com.group7.backend.dto.request.AdminBanRequest;
+import com.group7.backend.dto.response.BanResponse;
+import com.group7.backend.service.BanService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +29,12 @@ import java.util.Map;
 @Tag(name = "Admin", description = "Admin-only operations")
 public class AdminController {
 
+    private final BanService banService;
+
+    public AdminController(BanService banService) {
+        this.banService = banService;
+    }
+
     @GetMapping("/me")
     @Operation(summary = "Get authenticated admin context")
     public ResponseEntity<Map<String, Object>> me(Authentication authentication) {
@@ -25,5 +43,44 @@ public class AdminController {
                 "email", authentication.getPrincipal(),
                 "role", "ADMIN"
         ));
+    }
+
+    @PostMapping("/users/{userId}/ban")
+    @Operation(summary = "Ban a user (#280)",
+            description = "Imposes a ban with the given reason and duration. Stacks on top "
+                    + "of any existing active ban; the row with the latest expiresAt wins "
+                    + "the ban-active gate. Banned users receive 403 BANNED_UNTIL on login.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Ban created",
+                    content = @Content(schema = @Schema(implementation = BanResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid duration", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Not an admin", content = @Content),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content)
+    })
+    public ResponseEntity<BanResponse> banUser(
+            @Parameter(description = "Target user id") @PathVariable Long userId,
+            @Valid @RequestBody AdminBanRequest body,
+            Authentication authentication) {
+        Long adminId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(BanResponse.from(
+                banService.imposeAdminBan(userId, adminId, body.getReason(), body.getDurationHours())));
+    }
+
+    @PostMapping("/users/{userId}/unban")
+    @Operation(summary = "Unban a user (#280)",
+            description = "Lifts the user's currently-active ban. Returns 404 if no active "
+                    + "ban exists so the admin gets a clear signal rather than a silent no-op.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Active ban lifted",
+                    content = @Content(schema = @Schema(implementation = BanResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Not an admin", content = @Content),
+            @ApiResponse(responseCode = "404", description = "No active ban for user",
+                    content = @Content)
+    })
+    public ResponseEntity<BanResponse> unbanUser(
+            @Parameter(description = "Target user id") @PathVariable Long userId,
+            Authentication authentication) {
+        Long adminId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(BanResponse.from(banService.unbanUser(userId, adminId)));
     }
 }

--- a/backend/src/main/java/com/group7/backend/controller/AdminMessagingController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AdminMessagingController.java
@@ -1,0 +1,99 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.dto.request.SendMessageRequest;
+import com.group7.backend.dto.response.MessageResponse;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.service.ConversationService;
+import com.group7.backend.service.MessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin-only messaging surface (#280): direct messages to any user (no
+ * mentorship required) and broadcast messages to every admin via the
+ * singleton {@code ADMIN_BROADCAST} conversation.
+ *
+ * <p>Mirrors {@code MentorPairMessageController} in shape: resolve the
+ * conversation via {@link ConversationService}, then delegate the actual
+ * message insert to {@link MessageService}. The role gate is enforced by
+ * {@code @PreAuthorize("hasRole('ADMIN')")} at class level; the conversation
+ * service additionally enforces "at least one admin in the pair" for
+ * defense in depth.
+ */
+@RestController
+@RequestMapping("/api/admin/messages")
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Admin Messages",
+        description = "Admin DMs to any user and broadcasts to every admin (#280)")
+public class AdminMessagingController {
+
+    private final MessageService messageService;
+    private final ConversationService conversationService;
+
+    public AdminMessagingController(MessageService messageService,
+                                    ConversationService conversationService) {
+        this.messageService = messageService;
+        this.conversationService = conversationService;
+    }
+
+    @PostMapping("/direct/{userId}")
+    @Operation(summary = "Send an admin DM to a user",
+            description = "Creates an ADMIN_DIRECT conversation with the target user on first "
+                    + "call and sends the message. No mentorship is required between admin "
+                    + "and user; the conversation is reused on subsequent calls.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Message sent",
+                    content = @Content(schema = @Schema(implementation = MessageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Self-DM or non-admin sender",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Caller is not an admin",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "Target user not found",
+                    content = @Content)
+    })
+    public ResponseEntity<MessageResponse> direct(
+            @Parameter(description = "Target user id") @PathVariable Long userId,
+            @Valid @RequestBody SendMessageRequest request,
+            Authentication authentication) {
+        Long adminId = (Long) authentication.getCredentials();
+        Conversation conversation = conversationService.findOrCreateForAdminDirect(adminId, userId);
+        MessageResponse created = messageService.send(adminId, conversation.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @PostMapping("/broadcast")
+    @Operation(summary = "Broadcast to all admins",
+            description = "Posts the message into the singleton ADMIN_BROADCAST conversation. "
+                    + "Every current admin is added as a participant on each broadcast send, "
+                    + "so newly-promoted admins start seeing broadcasts on the next post "
+                    + "without a separate registration step.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Broadcast sent",
+                    content = @Content(schema = @Schema(implementation = MessageResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Caller is not an admin",
+                    content = @Content)
+    })
+    public ResponseEntity<MessageResponse> broadcast(
+            @Valid @RequestBody SendMessageRequest request,
+            Authentication authentication) {
+        Long adminId = (Long) authentication.getCredentials();
+        Conversation conversation = conversationService.findOrCreateAdminBroadcast();
+        MessageResponse created = messageService.send(adminId, conversation.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/request/AdminBanRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/AdminBanRequest.java
@@ -1,0 +1,30 @@
+package com.group7.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Body for an admin-initiated ban (#280).")
+public class AdminBanRequest {
+
+    @NotBlank
+    @Size(max = 255, message = "Reason must not exceed 255 characters")
+    @Schema(description = "Human-readable reason recorded on the ban row and surfaced "
+            + "back to the user in the 403 BANNED_UNTIL response.",
+            example = "Repeated harassment of mentees",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private String reason;
+
+    @Positive(message = "durationHours must be positive")
+    @Schema(description = "Ban length in hours from the moment the request is processed.",
+            example = "168",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    private long durationHours;
+}

--- a/backend/src/main/java/com/group7/backend/entity/ConversationKind.java
+++ b/backend/src/main/java/com/group7/backend/entity/ConversationKind.java
@@ -6,11 +6,15 @@ package com.group7.backend.entity;
  * <ul>
  *   <li>{@link #MENTORSHIP} — mentor + mentee in an active mentorship (#245).</li>
  *   <li>{@link #MENTOR_PAIR} — two mentors exchanging peer messages (#284).</li>
+ *   <li>{@link #ADMIN_DIRECT} — admin DM with any user, no mentorship required (#280).</li>
+ *   <li>{@link #ADMIN_BROADCAST} — singleton conversation with every admin as participant (#280).</li>
  * </ul>
  *
  * Future kinds (system broadcasts, group chats) plug in here without schema change.
  */
 public enum ConversationKind {
     MENTORSHIP,
-    MENTOR_PAIR
+    MENTOR_PAIR,
+    ADMIN_DIRECT,
+    ADMIN_BROADCAST
 }

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -42,6 +42,10 @@ public class GlobalExceptionHandler {
                 request.getMethod(), request.getRequestURI(), ban.getUser().getId(), ban.getExpiresAt());
         Map<String, Object> body = new HashMap<>();
         body.put("error", "Forbidden");
+        // Stable client-facing code so the frontend can branch on banned vs.
+        // generic 403 without parsing the message string. Required by #280:
+        // "banned users get 403 BANNED_UNTIL response".
+        body.put("code", "BANNED_UNTIL");
         body.put("message", ex.getMessage());
         body.put("reason", ban.getReason());
         body.put("expiresAt", ban.getExpiresAt().toString());

--- a/backend/src/main/java/com/group7/backend/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/ConversationRepository.java
@@ -57,4 +57,12 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
                     + "WHERE cp.conversation = c AND cp.user.id = :userId)")
     Page<Conversation> findMentorPairConversationsForUserOrderedByLastMessage(
             @Param("userId") Long userId, Pageable pageable);
+
+    /**
+     * Lookup the singleton {@link ConversationKind#ADMIN_BROADCAST} row, if it
+     * has been created. Backed by the partial unique index
+     * {@code uq_conversations_admin_broadcast_singleton}, so at most one row
+     * matches and the query is constant-time.
+     */
+    Optional<Conversation> findFirstByKind(ConversationKind kind);
 }

--- a/backend/src/main/java/com/group7/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/UserRepository.java
@@ -42,4 +42,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
             """)
     List<User> findFollowRecommendationCandidates(@Param("viewerId") Long viewerId,
                                                   Pageable pageable);
+
+    /**
+     * Returns every admin user. Used by the admin broadcast flow (#280) to
+     * sync the singleton {@code ADMIN_BROADCAST} conversation's participant
+     * list — every admin who exists at broadcast send time becomes a
+     * participant and therefore sees every subsequent message in their inbox.
+     */
+    @Query("select u from User u where type(u) = com.group7.backend.entity.Admin")
+    List<User> findAllAdmins();
 }

--- a/backend/src/main/java/com/group7/backend/service/AuthService.java
+++ b/backend/src/main/java/com/group7/backend/service/AuthService.java
@@ -21,6 +21,7 @@ import com.group7.backend.exception.DuplicateEmailException;
 import com.group7.backend.exception.InvalidTokenException;
 import com.group7.backend.exception.RateLimitExceededException;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.exception.UserBannedException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +41,7 @@ public class AuthService {
     private final VerificationTokenRepository verificationTokenRepository;
     private final PasswordResetTokenRepository passwordResetTokenRepository;
     private final EmailService emailService;
+    private final BanService banService;
     private final Clock clock;
 
     @Value("${app.verification.token-expiry-hours}")
@@ -60,6 +62,7 @@ public class AuthService {
                        VerificationTokenRepository verificationTokenRepository,
                        PasswordResetTokenRepository passwordResetTokenRepository,
                        EmailService emailService,
+                       BanService banService,
                        Clock clock) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
@@ -67,6 +70,7 @@ public class AuthService {
         this.verificationTokenRepository = verificationTokenRepository;
         this.passwordResetTokenRepository = passwordResetTokenRepository;
         this.emailService = emailService;
+        this.banService = banService;
         this.clock = clock;
     }
 
@@ -135,6 +139,16 @@ public class AuthService {
             log.warn("Authentication blocked: email not verified for userId={}", user.getId());
             throw new AuthenticationFailedException("Email not verified. Please check your inbox.");
         }
+
+        // Ban gate (#280): a banned user must not receive a JWT. Throwing
+        // UserBannedException here surfaces 403 with reason + expiresAt + the
+        // BANNED_UNTIL code via GlobalExceptionHandler; the client can render
+        // the unban time without a follow-up request.
+        banService.getActiveBan(user.getId()).ifPresent(ban -> {
+            log.warn("Authentication blocked: user banned, userId={}, expiresAt={}",
+                    user.getId(), ban.getExpiresAt());
+            throw new UserBannedException(ban);
+        });
 
         String role = roleNameOf(user);
         String token = jwtService.generateToken(user.getId(), user.getEmail(), role);

--- a/backend/src/main/java/com/group7/backend/service/BanService.java
+++ b/backend/src/main/java/com/group7/backend/service/BanService.java
@@ -121,6 +121,64 @@ public class BanService {
         return Optional.of(saved);
     }
 
+    /**
+     * Admin-initiated ban (#280). Inserts a fresh row immediately; if the user
+     * already has an active ban it is left in place and the new row stacks
+     * (the {@link #getActiveBan} query takes the row with the latest
+     * {@code expiresAt}, so the longer ban wins).
+     *
+     * <p>Uses {@code countNonLiftedByUserId(...) + 1} for the ordinal so an
+     * admin override participates in the same escalation accounting as
+     * auto-bans — consistent with how {@link #recordCancellation} computes
+     * its ordinal.
+     *
+     * @throws ResourceNotFoundException 404 — target user or admin not found
+     * @throws IllegalArgumentException 400 — non-positive duration
+     */
+    @Transactional
+    public Ban imposeAdminBan(Long targetUserId, Long adminId,
+                              String reason, long durationHours) {
+        if (durationHours <= 0) {
+            throw new IllegalArgumentException("durationHours must be positive");
+        }
+        User target = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        // Admin existence is verified by the @PreAuthorize at the controller,
+        // but we still resolve the row to fail fast on a missing JWT subject.
+        userRepository.findById(adminId)
+                .orElseThrow(() -> new ResourceNotFoundException("Admin not found"));
+
+        long banOrdinal = banRepository.countNonLiftedByUserId(targetUserId) + 1;
+        OffsetDateTime now = OffsetDateTime.now(clock);
+
+        Ban ban = new Ban();
+        ban.setUser(target);
+        ban.setReason(reason);
+        ban.setBanCount((int) banOrdinal);
+        ban.setExpiresAt(now.plusHours(durationHours));
+        Ban saved = banRepository.save(ban);
+
+        notificationEventPublisher.publishUserBanned(
+                targetUserId, saved.getExpiresAt(), reason, saved.getBanCount());
+
+        log.warn("Admin-imposed ban: targetUserId={}, adminId={}, durationHours={}, expiresAt={}",
+                targetUserId, adminId, durationHours, saved.getExpiresAt());
+        return saved;
+    }
+
+    /**
+     * Admin unban (#280): lifts the user's currently-active ban. Returns the
+     * lifted ban; throws 404 if the user has no active ban so the admin gets
+     * a clear signal rather than a silent no-op.
+     */
+    @Transactional
+    public Ban unbanUser(Long targetUserId, Long adminId) {
+        Ban active = getActiveBan(targetUserId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "User has no active ban"));
+        return liftBan(active.getId(), adminId);
+    }
+
     /** Admin override. Idempotent — lifting an already-lifted ban is a no-op. */
     @Transactional
     public Ban liftBan(Long banId, Long adminId) {

--- a/backend/src/main/java/com/group7/backend/service/ConversationCreator.java
+++ b/backend/src/main/java/com/group7/backend/service/ConversationCreator.java
@@ -71,6 +71,64 @@ public class ConversationCreator {
         return saved;
     }
 
+    /**
+     * Admin DM conversation (#280). Same canonical-pair shape as MENTOR_PAIR;
+     * the role gate (one side must be admin) is enforced upstream in
+     * {@link ConversationService}.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Conversation createForAdminDirectInNewTx(User adminSide, User otherSide,
+                                                    long lower, long higher) {
+        Conversation conversation = new Conversation();
+        conversation.setKind(ConversationKind.ADMIN_DIRECT);
+        conversation.setPairAId(lower);
+        conversation.setPairBId(higher);
+        Conversation saved = conversationRepository.save(conversation);
+        participantRepository.save(participant(saved, adminSide));
+        participantRepository.save(participant(saved, otherSide));
+        log.info("Conversation created: id={}, kind=ADMIN_DIRECT, pair=({}, {})",
+                saved.getId(), lower, higher);
+        return saved;
+    }
+
+    /**
+     * Singleton admin-broadcast conversation (#280). Concurrent first-broadcast
+     * requests collapse to a single row via
+     * {@code uq_conversations_admin_broadcast_singleton}. Initial participants
+     * are seeded from the snapshot {@code admins} the caller passed in;
+     * subsequent broadcasts re-sync the participant set.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Conversation createForAdminBroadcastInNewTx(java.util.List<User> admins) {
+        Conversation conversation = new Conversation();
+        conversation.setKind(ConversationKind.ADMIN_BROADCAST);
+        Conversation saved = conversationRepository.save(conversation);
+        for (User admin : admins) {
+            participantRepository.save(participant(saved, admin));
+        }
+        log.info("Conversation created: id={}, kind=ADMIN_BROADCAST, initialParticipants={}",
+                saved.getId(), admins.size());
+        return saved;
+    }
+
+    /**
+     * Adds a single participant to an existing conversation in a fresh
+     * transaction. Race-tolerant: a concurrent insert of the same
+     * {@code (conversationId, userId)} pair raises a primary-key violation
+     * that the caller can ignore via re-check.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void addParticipantInNewTx(Conversation conversation, User user) {
+        try {
+            participantRepository.save(participant(conversation, user));
+            log.info("Conversation participant added: conversationId={}, userId={}",
+                    conversation.getId(), user.getId());
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            log.debug("Concurrent participant insert raced — already a member: "
+                    + "conversationId={}, userId={}", conversation.getId(), user.getId());
+        }
+    }
+
     private static ConversationParticipant participant(Conversation conversation, User user) {
         ConversationParticipant cp = new ConversationParticipant();
         cp.setConversation(conversation);

--- a/backend/src/main/java/com/group7/backend/service/ConversationService.java
+++ b/backend/src/main/java/com/group7/backend/service/ConversationService.java
@@ -1,5 +1,6 @@
 package com.group7.backend.service;
 
+import com.group7.backend.entity.Admin;
 import com.group7.backend.entity.Conversation;
 import com.group7.backend.entity.ConversationKind;
 import com.group7.backend.entity.Mentor;
@@ -8,6 +9,7 @@ import com.group7.backend.entity.MentorshipStatus;
 import com.group7.backend.entity.User;
 import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.ConversationParticipantRepository;
 import com.group7.backend.repository.ConversationRepository;
 import com.group7.backend.repository.MentorshipRepository;
 import com.group7.backend.repository.UserRepository;
@@ -16,7 +18,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -51,15 +55,18 @@ public class ConversationService {
     private final ConversationRepository conversationRepository;
     private final MentorshipRepository mentorshipRepository;
     private final UserRepository userRepository;
+    private final ConversationParticipantRepository participantRepository;
     private final ConversationCreator conversationCreator;
 
     public ConversationService(ConversationRepository conversationRepository,
                                MentorshipRepository mentorshipRepository,
                                UserRepository userRepository,
+                               ConversationParticipantRepository participantRepository,
                                ConversationCreator conversationCreator) {
         this.conversationRepository = conversationRepository;
         this.mentorshipRepository = mentorshipRepository;
         this.userRepository = userRepository;
+        this.participantRepository = participantRepository;
         this.conversationCreator = conversationCreator;
     }
 
@@ -189,6 +196,121 @@ public class ConversationService {
                                 "Mentor-pair creation race resolved with no row visible — "
                                         + "transaction isolation issue?", e);
                     });
+        }
+    }
+
+    // ── Admin direct + broadcast (#280) ─────────────────────────────────────
+
+    /**
+     * Returns the {@link ConversationKind#ADMIN_DIRECT} conversation between
+     * the calling admin and {@code otherUserId}, creating it on first call.
+     * Same race-recovery shape as {@link #findOrCreateForMentorPair} — the
+     * find/create flow stays non-transactional and the
+     * {@link DataIntegrityViolationException} on the unique-index race is
+     * resolved by re-read.
+     *
+     * <p>Authorization: at least one side of the pair must be an
+     * {@link Admin}. Admin <-> admin is allowed (both sides admins). The
+     * mentorship requirement is intentionally absent — that's the whole
+     * point of this kind.
+     *
+     * @throws IllegalArgumentException 400 — same id on both sides, or neither
+     *         side is an admin (admin DM requires admin authority).
+     * @throws ResourceNotFoundException 404 — either user id is unknown.
+     */
+    public Conversation findOrCreateForAdminDirect(Long adminId, Long otherUserId) {
+        if (Objects.equals(adminId, otherUserId)) {
+            throw new IllegalArgumentException(
+                    "Cannot start a conversation with yourself");
+        }
+
+        long lower = Math.min(adminId, otherUserId);
+        long higher = Math.max(adminId, otherUserId);
+        Optional<Conversation> existing = conversationRepository
+                .findByPairAIdAndPairBIdAndKind(lower, higher, ConversationKind.ADMIN_DIRECT);
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+
+        User adminUser = userRepository.findById(adminId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        User other = userRepository.findById(otherUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        if (!(adminUser instanceof Admin) && !(other instanceof Admin)) {
+            throw new IllegalArgumentException(
+                    "Admin direct conversations require at least one admin participant");
+        }
+
+        try {
+            return conversationCreator.createForAdminDirectInNewTx(adminUser, other, lower, higher);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Concurrent admin-direct creation for ({}, {}); resolving via re-find",
+                    lower, higher);
+            return conversationRepository
+                    .findByPairAIdAndPairBIdAndKind(lower, higher, ConversationKind.ADMIN_DIRECT)
+                    .orElseThrow(() -> {
+                        log.error("Admin-direct conversation race resolved with no row visible "
+                                + "(pair=({}, {})); transaction isolation misconfigured?",
+                                lower, higher, e);
+                        return new IllegalStateException(
+                                "Admin-direct creation race resolved with no row visible — "
+                                        + "transaction isolation issue?", e);
+                    });
+        }
+    }
+
+    /**
+     * Returns the singleton {@link ConversationKind#ADMIN_BROADCAST}
+     * conversation, creating it on first call and re-syncing its participant
+     * list to include every current admin. Re-syncing on each access is what
+     * lets a newly-added admin see broadcasts going forward without a
+     * dedicated "register-admin" hook — the cost is one extra query per
+     * broadcast, dominated by the message insert that follows.
+     *
+     * <p>Race recovery: the partial unique index pins the broadcast row to
+     * exactly one; concurrent first-call inserts collapse via the same
+     * insert-then-fallback shape as the other find-or-create methods.
+     */
+    public Conversation findOrCreateAdminBroadcast() {
+        Optional<Conversation> existing = conversationRepository.findFirstByKind(
+                ConversationKind.ADMIN_BROADCAST);
+        Conversation conversation;
+        if (existing.isPresent()) {
+            conversation = existing.get();
+        } else {
+            List<User> admins = userRepository.findAllAdmins();
+            try {
+                conversation = conversationCreator.createForAdminBroadcastInNewTx(admins);
+            } catch (DataIntegrityViolationException e) {
+                log.warn("Concurrent admin-broadcast creation; resolving via re-find");
+                conversation = conversationRepository.findFirstByKind(
+                        ConversationKind.ADMIN_BROADCAST)
+                        .orElseThrow(() -> {
+                            log.error("Admin-broadcast conversation race resolved with no row "
+                                    + "visible; transaction isolation misconfigured?", e);
+                            return new IllegalStateException(
+                                    "Admin-broadcast creation race resolved with no row "
+                                            + "visible — transaction isolation issue?", e);
+                        });
+            }
+        }
+        syncAdminBroadcastParticipants(conversation);
+        return conversation;
+    }
+
+    /**
+     * Adds any current admin who is not yet a participant of the broadcast
+     * conversation. Idempotent: existing participants are left alone, so
+     * re-running this on every send is cheap.
+     */
+    @Transactional
+    public void syncAdminBroadcastParticipants(Conversation broadcast) {
+        List<User> admins = userRepository.findAllAdmins();
+        for (User admin : admins) {
+            if (!participantRepository.existsByConversationIdAndUserId(
+                    broadcast.getId(), admin.getId())) {
+                conversationCreator.addParticipantInNewTx(broadcast, admin);
+            }
         }
     }
 

--- a/backend/src/main/java/com/group7/backend/service/MessageService.java
+++ b/backend/src/main/java/com/group7/backend/service/MessageService.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -95,15 +96,25 @@ public class MessageService {
         message.setSentAt(OffsetDateTime.now(clock));
         Message saved = messageRepository.save(message);
 
-        Long recipientId = participantRepository
-                .findOtherParticipantUserIds(conversation.getId(), senderId)
-                .stream()
-                .findFirst()
-                .orElse(null);
+        // Notification fan-out: every non-sender participant gets a NEW_MESSAGE
+        // notification (in-app row + FCM push when a device is registered).
+        // For the existing 1:1 kinds (MENTORSHIP, MENTOR_PAIR, ADMIN_DIRECT)
+        // the list has size 1 and this loop runs once. For ADMIN_BROADCAST it
+        // runs once per other admin so the broadcast actually reaches every
+        // admin's inbox, not just whichever participant happened to be first.
+        List<Long> otherParticipantIds = participantRepository
+                .findOtherParticipantUserIds(conversation.getId(), senderId);
+        // MessageSentEvent.recipientId is forward-compatible-nullable per its
+        // Javadoc; null signals "non-1:1, listeners route by topic" — the
+        // STOMP listener broadcasts to /topic/conversation/{id} either way,
+        // and the FCM fan-out below covers per-user push.
+        Long eventRecipientId = conversation.getKind() == ConversationKind.ADMIN_BROADCAST
+                ? null
+                : otherParticipantIds.stream().findFirst().orElse(null);
         applicationEventPublisher.publishEvent(
-                new MessageSentEvent(saved.getId(), conversation.getId(), senderId, recipientId));
-        if (recipientId != null) {
-            notificationEventPublisher.publishNewMessage(recipientId, sender.getFirstName());
+                new MessageSentEvent(saved.getId(), conversation.getId(), senderId, eventRecipientId));
+        for (Long rid : otherParticipantIds) {
+            notificationEventPublisher.publishNewMessage(rid, sender.getFirstName());
         }
 
         log.info("Message sent: messageId={}, conversationId={}, senderId={}",

--- a/backend/src/main/resources/db/migration/V34__admin_conversations.sql
+++ b/backend/src/main/resources/db/migration/V34__admin_conversations.sql
@@ -1,0 +1,70 @@
+-- Issue #280: extend conversations to carry admin-initiated DMs and broadcasts.
+--
+-- ADMIN_DIRECT reuses the (pair_a_id, pair_b_id) layout from MENTOR_PAIR — same
+-- canonical-key + uq_conversations_pair_kind treatment, just with a different
+-- authorization gate enforced in the service layer (one side must be ADMIN, no
+-- mentorship required). The existing partial unique index on
+-- (pair_a_id, pair_b_id, kind) already keys on `kind`, so it transparently
+-- accepts the new value without a re-create.
+--
+-- ADMIN_BROADCAST is a singleton conversation: at most one row exists, and all
+-- admins are participants via the junction table. The singleton property is
+-- enforced by a partial unique index on a constant expression so concurrent
+-- first-broadcast inserts collapse the same way mentorship and mentor-pair
+-- creation do.
+
+-- The original V14 inline `check (kind in (...))` produced an auto-named CHECK.
+-- Look it up by definition shape rather than guessing the generated name so
+-- this migration is portable across deployments where Postgres picked
+-- different identifiers for unnamed constraints.
+--
+-- Match shape: a single CHECK over only the `kind` column (no reference to
+-- `mentorship_id` or `pair_a_id`) that enumerates the legacy values. This
+-- excludes `conversations_kind_columns_consistent`, which is a multi-column
+-- CHECK and is dropped explicitly below.
+do $$
+declare
+    cname text;
+begin
+    for cname in
+        select conname from pg_constraint
+        where conrelid = 'conversations'::regclass
+          and contype = 'c'
+          and pg_get_constraintdef(oid) ilike '%kind%'
+          and pg_get_constraintdef(oid) ilike '%MENTORSHIP%'
+          and pg_get_constraintdef(oid) ilike '%MENTOR_PAIR%'
+          and pg_get_constraintdef(oid) not ilike '%ADMIN_DIRECT%'
+          and pg_get_constraintdef(oid) not ilike '%mentorship_id%'
+          and pg_get_constraintdef(oid) not ilike '%pair_a_id%'
+    loop
+        execute format('alter table conversations drop constraint %I', cname);
+    end loop;
+end$$;
+
+alter table conversations
+    add constraint conversations_kind_check
+    check (kind in ('MENTORSHIP', 'MENTOR_PAIR', 'ADMIN_DIRECT', 'ADMIN_BROADCAST'));
+
+-- Replace the V17 columns-consistent CHECK so it covers the two new kinds.
+alter table conversations
+    drop constraint conversations_kind_columns_consistent;
+
+alter table conversations
+    add constraint conversations_kind_columns_consistent check (
+        (kind = 'MENTORSHIP'      and mentorship_id is not null and pair_a_id is null)
+        or
+        (kind = 'MENTOR_PAIR'     and mentorship_id is null     and pair_a_id is not null)
+        or
+        (kind = 'ADMIN_DIRECT'    and mentorship_id is null     and pair_a_id is not null)
+        or
+        (kind = 'ADMIN_BROADCAST' and mentorship_id is null     and pair_a_id is null)
+    );
+
+-- Singleton enforcement for the broadcast conversation. Indexing on a constant
+-- expression makes "the row" the only row whose admin_broadcast key value is
+-- (TRUE), so a concurrent second insert raises a unique-violation that the
+-- service layer recovers via re-find — same pattern as mentorship and pair
+-- creation races.
+create unique index uq_conversations_admin_broadcast_singleton
+    on conversations ((true))
+    where kind = 'ADMIN_BROADCAST';

--- a/backend/src/test/java/com/group7/backend/integration/AdminBanAndMessagingIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/AdminBanAndMessagingIntegrationTest.java
@@ -1,0 +1,405 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
+import com.group7.backend.repository.BanRepository;
+import com.group7.backend.repository.ConversationParticipantRepository;
+import com.group7.backend.repository.ConversationRepository;
+import com.group7.backend.repository.MessageRepository;
+import com.group7.backend.repository.NotificationRepository;
+import com.group7.backend.repository.PasswordResetTokenRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #280 — Admin Role Infrastructure: end-to-end coverage for the admin
+ * ban/unban surface and admin-initiated messaging (direct DMs + broadcasts).
+ *
+ * <p>The auto-ban path is already covered by {@link BanIntegrationTest}; this
+ * suite focuses exclusively on the admin-initiated additions and the login
+ * gate that rejects banned users.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminBanAndMessagingIntegrationTest {
+
+    private static final String ADMIN_EMAIL = "admin280@test.local";
+    private static final String ADMIN_PASSWORD = "AdminInfra280Pwd";
+    private static final String ADMIN2_EMAIL = "admin280-second@test.local";
+    private static final String ADMIN2_PASSWORD = "AdminInfra280Pwd";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired private BanRepository banRepository;
+    @Autowired private MessageRepository messageRepository;
+    @Autowired private ConversationRepository conversationRepository;
+    @Autowired private ConversationParticipantRepository participantRepository;
+    @Autowired private NotificationRepository notificationRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        messageRepository.deleteAll();
+        // Conversation_participants cascades on conversation delete; deleting
+        // conversations first keeps the cleanup idempotent across reruns.
+        conversationRepository.deleteAll();
+        banRepository.deleteAll();
+        notificationRepository.deleteAll();
+        passwordResetTokenRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+        doNothing().when(emailService).sendPasswordResetEmail(any(), anyString());
+    }
+
+    // ── Ban / unban flow ──────────────────────────────────────────────────
+
+    @Test
+    void admin_canBanUser_andBannedUserGetsBannedUntilOnLogin() throws Exception {
+        seedAdmin(ADMIN_EMAIL, ADMIN_PASSWORD);
+        String adminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+        registerAndVerify("ban_target@test.com", false);
+        Long targetId = userRepository.findByEmail("ban_target@test.com").orElseThrow().getId();
+
+        // Pre-ban login works.
+        login("ban_target@test.com", "Password1", "MENTEE");
+
+        // Admin imposes a 24h ban.
+        mockMvc.perform(post("/api/admin/users/" + targetId + "/ban")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("reason", "Spam reports", "durationHours", 24))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(targetId))
+                .andExpect(jsonPath("$.reason").value("Spam reports"));
+
+        // Now login is blocked with the BANNED_UNTIL code + ban metadata.
+        LoginRequest login = new LoginRequest();
+        login.setEmail("ban_target@test.com");
+        login.setPassword("Password1");
+        MvcResult forbidden = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("BANNED_UNTIL"))
+                .andExpect(jsonPath("$.reason").value("Spam reports"))
+                .andExpect(jsonPath("$.expiresAt").exists())
+                .andExpect(jsonPath("$.banCount").value(1))
+                .andReturn();
+
+        // Body shape sanity: the banCount is the next ordinal for the user.
+        JsonNode body = objectMapper.readTree(forbidden.getResponse().getContentAsString());
+        assertThat(body.get("error").asText()).isEqualTo("Forbidden");
+    }
+
+    @Test
+    void admin_unbanUser_restoresLogin() throws Exception {
+        seedAdmin(ADMIN_EMAIL, ADMIN_PASSWORD);
+        String adminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+        registerAndVerify("unban_target@test.com", true);
+        Long targetId = userRepository.findByEmail("unban_target@test.com").orElseThrow().getId();
+
+        // Ban then unban.
+        mockMvc.perform(post("/api/admin/users/" + targetId + "/ban")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("reason", "Test", "durationHours", 48))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/admin/users/" + targetId + "/unban")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.liftedAt").exists());
+
+        // Login works again.
+        login("unban_target@test.com", "Password1", "MENTOR");
+    }
+
+    @Test
+    void unban_returns404_whenNoActiveBan() throws Exception {
+        seedAdmin(ADMIN_EMAIL, ADMIN_PASSWORD);
+        String adminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+        registerAndVerify("not_banned@test.com", false);
+        Long targetId = userRepository.findByEmail("not_banned@test.com").orElseThrow().getId();
+
+        mockMvc.perform(post("/api/admin/users/" + targetId + "/unban")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void nonAdmin_cannotCallBanOrUnbanEndpoints() throws Exception {
+        registerAndVerify("nonadmin@test.com", false);
+        String menteeToken = login("nonadmin@test.com", "Password1", "MENTEE");
+
+        mockMvc.perform(post("/api/admin/users/1/ban")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("reason", "no", "durationHours", 1))))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/admin/users/1/unban")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void banRequest_rejectsNonPositiveDuration() throws Exception {
+        seedAdmin(ADMIN_EMAIL, ADMIN_PASSWORD);
+        String adminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+        registerAndVerify("validation_target@test.com", false);
+        Long targetId = userRepository.findByEmail("validation_target@test.com").orElseThrow().getId();
+
+        mockMvc.perform(post("/api/admin/users/" + targetId + "/ban")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("reason", "x", "durationHours", 0))))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── Admin direct messaging ───────────────────────────────────────────
+
+    @Test
+    void admin_canDmAnyUser_withoutMentorship() throws Exception {
+        seedAdmin(ADMIN_EMAIL, ADMIN_PASSWORD);
+        String adminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+        registerAndVerify("dm_target@test.com", false);
+        Long targetId = userRepository.findByEmail("dm_target@test.com").orElseThrow().getId();
+
+        mockMvc.perform(post("/api/admin/messages/direct/" + targetId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "Hello from admin"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.content").value("Hello from admin"));
+
+        // Conversation row was created with kind=ADMIN_DIRECT.
+        List<Conversation> directs = conversationRepository.findAll().stream()
+                .filter(c -> c.getKind() == ConversationKind.ADMIN_DIRECT)
+                .toList();
+        assertThat(directs).hasSize(1);
+        Conversation direct = directs.get(0);
+        assertThat(direct.getMentorship()).isNull();
+        assertThat(direct.getPairAId()).isNotNull();
+        assertThat(direct.getPairBId()).isNotNull();
+        assertThat(direct.getPairAId()).isLessThan(direct.getPairBId());
+
+        // Both admin and target are participants — bypassing the mentorship gate.
+        Long adminId = userRepository.findByEmail(ADMIN_EMAIL).orElseThrow().getId();
+        assertThat(participantRepository.existsByConversationIdAndUserId(direct.getId(), adminId)).isTrue();
+        assertThat(participantRepository.existsByConversationIdAndUserId(direct.getId(), targetId)).isTrue();
+    }
+
+    @Test
+    void adminDirect_isIdempotentAcrossSends() throws Exception {
+        seedAdmin(ADMIN_EMAIL, ADMIN_PASSWORD);
+        String adminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+        registerAndVerify("dm_repeat@test.com", true);
+        Long targetId = userRepository.findByEmail("dm_repeat@test.com").orElseThrow().getId();
+
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(post("/api/admin/messages/direct/" + targetId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(Map.of("content", "msg " + i))))
+                    .andExpect(status().isCreated());
+        }
+
+        long directConvCount = conversationRepository.findAll().stream()
+                .filter(c -> c.getKind() == ConversationKind.ADMIN_DIRECT).count();
+        assertThat(directConvCount).isEqualTo(1L);
+    }
+
+    @Test
+    void adminDirect_selfDmReturns400() throws Exception {
+        Admin admin = seedAdmin(ADMIN_EMAIL, ADMIN_PASSWORD);
+        String adminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+
+        mockMvc.perform(post("/api/admin/messages/direct/" + admin.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "self"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void nonAdmin_cannotCallDirectMessageEndpoint() throws Exception {
+        registerAndVerify("dm_user@test.com", false);
+        registerAndVerify("dm_other@test.com", true);
+        String userToken = login("dm_user@test.com", "Password1", "MENTEE");
+        Long otherId = userRepository.findByEmail("dm_other@test.com").orElseThrow().getId();
+
+        mockMvc.perform(post("/api/admin/messages/direct/" + otherId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + userToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "no"))))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Admin broadcast ──────────────────────────────────────────────────
+
+    @Test
+    void admin_broadcast_createsSingleton_andIncludesAllAdmins() throws Exception {
+        Admin a1 = seedAdmin(ADMIN_EMAIL, ADMIN_PASSWORD);
+        Admin a2 = seedAdmin(ADMIN2_EMAIL, ADMIN2_PASSWORD);
+        String adminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+
+        mockMvc.perform(post("/api/admin/messages/broadcast")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "All-hands"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.content").value("All-hands"));
+
+        List<Conversation> broadcasts = conversationRepository.findAll().stream()
+                .filter(c -> c.getKind() == ConversationKind.ADMIN_BROADCAST)
+                .toList();
+        assertThat(broadcasts).hasSize(1);
+        Conversation broadcast = broadcasts.get(0);
+        assertThat(broadcast.getMentorship()).isNull();
+        assertThat(broadcast.getPairAId()).isNull();
+        assertThat(broadcast.getPairBId()).isNull();
+
+        // Every admin is a participant — both the sender and the second admin
+        // who has not yet posted, so #2 sees future broadcasts in their inbox.
+        assertThat(participantRepository.existsByConversationIdAndUserId(broadcast.getId(), a1.getId())).isTrue();
+        assertThat(participantRepository.existsByConversationIdAndUserId(broadcast.getId(), a2.getId())).isTrue();
+
+        // Second broadcast still resolves to the same singleton row.
+        mockMvc.perform(post("/api/admin/messages/broadcast")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "Round 2"))))
+                .andExpect(status().isCreated());
+        long broadcastCount = conversationRepository.findAll().stream()
+                .filter(c -> c.getKind() == ConversationKind.ADMIN_BROADCAST).count();
+        assertThat(broadcastCount).isEqualTo(1L);
+    }
+
+    @Test
+    void broadcast_promotedAdminPicksUpFutureBroadcasts() throws Exception {
+        // First admin sends one broadcast; second admin is added later and a
+        // third broadcast then re-syncs the participant list to include them.
+        Admin a1 = seedAdmin(ADMIN_EMAIL, ADMIN_PASSWORD);
+        String firstAdminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+
+        mockMvc.perform(post("/api/admin/messages/broadcast")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + firstAdminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "first"))))
+                .andExpect(status().isCreated());
+        Conversation broadcast = conversationRepository.findAll().stream()
+                .filter(c -> c.getKind() == ConversationKind.ADMIN_BROADCAST)
+                .findFirst().orElseThrow();
+        assertThat(participantRepository.existsByConversationIdAndUserId(broadcast.getId(), a1.getId())).isTrue();
+
+        // Second admin joins after the first broadcast.
+        Admin a2 = seedAdmin(ADMIN2_EMAIL, ADMIN2_PASSWORD);
+        assertThat(participantRepository.existsByConversationIdAndUserId(broadcast.getId(), a2.getId()))
+                .as("newly-promoted admin is not retroactively a participant until next broadcast")
+                .isFalse();
+
+        // Next broadcast re-syncs the admin set.
+        mockMvc.perform(post("/api/admin/messages/broadcast")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + firstAdminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "second"))))
+                .andExpect(status().isCreated());
+        assertThat(participantRepository.existsByConversationIdAndUserId(broadcast.getId(), a2.getId())).isTrue();
+    }
+
+    @Test
+    void nonAdmin_cannotBroadcast() throws Exception {
+        registerAndVerify("broadcaster@test.com", true);
+        String mentorToken = login("broadcaster@test.com", "Password1", "MENTOR");
+
+        mockMvc.perform(post("/api/admin/messages/broadcast")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("content", "no"))))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private Admin seedAdmin(String email, String password) {
+        Admin admin = new Admin();
+        admin.setFirstName("Bootstrap");
+        admin.setLastName("Admin");
+        admin.setEmail(email);
+        admin.setPasswordHash(passwordEncoder.encode(password));
+        admin.setIsEmailVerified(true);
+        return userRepository.save(admin);
+    }
+
+    private void registerAndVerify(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName(isMentor ? "Mentor" : "Mentee");
+        req.setLastName("User");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+    }
+
+    private String login(String email, String password, String expectedRole) throws Exception {
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword(password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value(expectedRole))
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/AuthServiceClockTest.java
+++ b/backend/src/test/java/com/group7/backend/service/AuthServiceClockTest.java
@@ -37,6 +37,7 @@ class AuthServiceClockTest {
     @Mock private VerificationTokenRepository verificationTokenRepository;
     @Mock private PasswordResetTokenRepository passwordResetTokenRepository;
     @Mock private EmailService emailService;
+    @Mock private com.group7.backend.service.BanService banService;
 
     private static final Instant FIXED = Instant.parse("2026-04-29T00:00:00Z");
     private final Clock fixedClock = Clock.fixed(FIXED, ZoneOffset.UTC);
@@ -52,6 +53,7 @@ class AuthServiceClockTest {
                 verificationTokenRepository,
                 passwordResetTokenRepository,
                 emailService,
+                banService,
                 fixedClock
         );
         ReflectionTestUtils.setField(authService, "tokenExpiryHours", 24);

--- a/backend/src/test/java/com/group7/backend/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/AuthServiceTest.java
@@ -58,6 +58,9 @@ class AuthServiceTest {
     @Mock
     private EmailService emailService;
 
+    @Mock
+    private com.group7.backend.service.BanService banService;
+
     @Spy
     private Clock clock = Clock.systemUTC();
 

--- a/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
@@ -36,6 +36,7 @@ class ConversationServiceTest {
     @Mock private ConversationRepository conversationRepository;
     @Mock private MentorshipRepository mentorshipRepository;
     @Mock private UserRepository userRepository;
+    @Mock private com.group7.backend.repository.ConversationParticipantRepository participantRepository;
     @Mock private ConversationCreator conversationCreator;
 
     private ConversationService conversationService;
@@ -48,7 +49,8 @@ class ConversationServiceTest {
     @BeforeEach
     void setUp() {
         conversationService = new ConversationService(
-                conversationRepository, mentorshipRepository, userRepository, conversationCreator);
+                conversationRepository, mentorshipRepository, userRepository,
+                participantRepository, conversationCreator);
 
         mentor = new Mentor();
         mentor.setId(1L);

--- a/backend/src/test/java/com/group7/backend/service/MessageServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MessageServiceTest.java
@@ -387,6 +387,46 @@ class MessageServiceTest {
                 .markAllAsReadForReader(any(), any(), any(OffsetDateTime.class));
     }
 
+    @Test
+    void send_inAdminBroadcast_fansOutToAllOtherParticipants_andEventCarriesNullRecipient() {
+        // Three admins in a broadcast: a1 sends, a2 + a3 should each receive a
+        // NEW_MESSAGE notification. MessageSentEvent.recipientId is null for
+        // ADMIN_BROADCAST per the event's documented contract.
+        com.group7.backend.entity.Admin a1 = new com.group7.backend.entity.Admin();
+        a1.setId(10L);
+        a1.setFirstName("Bootstrap");
+
+        Conversation broadcast = new Conversation();
+        broadcast.setId(700L);
+        broadcast.setKind(ConversationKind.ADMIN_BROADCAST);
+        // No mentorship, no pair columns — singleton row.
+
+        when(conversationRepository.findById(700L)).thenReturn(Optional.of(broadcast));
+        when(participantRepository.existsByConversationIdAndUserId(700L, 10L)).thenReturn(true);
+        when(participantRepository.findOtherParticipantUserIds(700L, 10L))
+                .thenReturn(List.of(20L, 30L));
+        when(userRepository.findById(10L)).thenReturn(Optional.of(a1));
+        when(messageRepository.save(any(Message.class))).thenAnswer(inv -> {
+            Message m = inv.getArgument(0);
+            m.setId(800L);
+            return m;
+        });
+
+        SendMessageRequest req = new SendMessageRequest();
+        req.setContent("All-hands");
+
+        messageService.send(10L, 700L, req);
+
+        ArgumentCaptor<MessageSentEvent> eventCaptor = ArgumentCaptor.forClass(MessageSentEvent.class);
+        verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+        // Forward-compatible-nullable contract: null signals "not 1:1".
+        assertThat(eventCaptor.getValue().recipientId()).isNull();
+
+        // Every non-sender admin receives a notification — fan-out, not findFirst.
+        verify(notificationEventPublisher).publishNewMessage(eq(20L), eq("Bootstrap"));
+        verify(notificationEventPublisher).publishNewMessage(eq(30L), eq("Bootstrap"));
+    }
+
     private Message newPersistedMessage(Long id, com.group7.backend.entity.User sender, String content) {
         Message m = new Message();
         m.setId(id);


### PR DESCRIPTION
## Summary

Closes #280. Builds on the PR #299 admin foundation (ADMIN role, seed admin via env, `/api/admin/me`) with the two remaining pieces:

- **Ban / unban**: admin-initiated bans with reason + duration, and a login-time gate that rejects banned users with `403 BANNED_UNTIL`.
- **Admin messaging**: admins can DM any user without a shared mentorship, and broadcast to every admin via a singleton `ADMIN_BROADCAST` conversation.

The existing auto-ban infrastructure (#134 — `Ban` entity, `BanService`, `BanAdminController`, `UserBannedException`) is reused; the user-table `bannedUntil` / `banReason` columns from the issue spec are unnecessary because `Ban.expiresAt` + `Ban.reason` already cover that and preserve audit history.

## What changed

### Ban / unban

- `BanService.imposeAdminBan(userId, adminId, reason, durationHours)` — inserts a fresh ban row, ordinal computed from `countNonLiftedByUserId + 1` so admin overrides participate in the same escalation accounting as auto-bans.
- `BanService.unbanUser(userId, adminId)` — lifts the active ban; 404 if none, so admins get a clear signal rather than a silent no-op.
- `AuthService.authenticate` — calls `banService.getActiveBan(...)` after the email-verified check and throws `UserBannedException` so banned users never receive a JWT.
- `GlobalExceptionHandler` — adds `code: "BANNED_UNTIL"` to the 403 body alongside the existing `reason` / `expiresAt` / `banCount` fields, so the client can branch on a stable code rather than message text.
- `AdminController` — `POST /api/admin/users/{userId}/ban` (with `AdminBanRequest { reason, durationHours }`) and `POST /api/admin/users/{userId}/unban`.

### Admin messaging

- `ConversationKind` — adds `ADMIN_DIRECT` and `ADMIN_BROADCAST`.
- Flyway `V34__admin_conversations.sql` — extends the `kind` CHECK and the `kind_columns_consistent` CHECK, plus a partial unique index that pins `ADMIN_BROADCAST` to a single row.
- `ConversationService.findOrCreateForAdminDirect` — same canonical-pair shape as `MENTOR_PAIR`, just with an "at least one side is admin" gate instead of the "both sides are mentors" gate; no mentorship required.
- `ConversationService.findOrCreateAdminBroadcast` — creates the singleton on first call and re-syncs every current admin as a participant on every access. A newly-promoted admin starts seeing broadcasts on the next post without a separate registration step.
- `ConversationCreator` — REQUIRES_NEW transactional helpers for both new kinds, plus an idempotent `addParticipantInNewTx` for the broadcast re-sync.
- `AdminMessagingController` — `POST /api/admin/messages/direct/{userId}` and `POST /api/admin/messages/broadcast`.

### API surface

| Method | Path                                    | Description                          |
|--------|-----------------------------------------|--------------------------------------|
| POST   | `/api/admin/users/{userId}/ban`         | Impose a ban with reason + duration  |
| POST   | `/api/admin/users/{userId}/unban`       | Lift the user's active ban           |
| POST   | `/api/admin/messages/direct/{userId}`   | Admin DM (no mentorship required)    |
| POST   | `/api/admin/messages/broadcast`         | Broadcast to every admin's inbox     |

All endpoints are gated by `@PreAuthorize("hasRole('ADMIN')")`.

### `403 BANNED_UNTIL` body shape

```json
{
  "error": "Forbidden",
  "code": "BANNED_UNTIL",
  "message": "User is currently banned until 2026-05-11T22:00:00Z: Spam reports",
  "reason": "Spam reports",
  "expiresAt": "2026-05-11T22:00:00Z",
  "banCount": 1
}
```

## Acceptance criteria

- [x] PR #299 foundation remains functional
- [x] Admins can ban/unban users; banned users get `403 BANNED_UNTIL`
- [x] Admins can DM any user without mentorship
- [x] Admin broadcasts appear in every admin's inbox (singleton conversation, participants synced on every send)
- [x] Non-admin requests to `/api/admin/**` return 403
- [x] All tests pass — full suite **1454 / 1454** green

## Test plan

12 new e2e tests in `AdminBanAndMessagingIntegrationTest`:

- [x] Admin bans a user → next login returns `403 BANNED_UNTIL` with the expected `reason` / `expiresAt` / `banCount` / `code` fields
- [x] Admin unban restores login
- [x] Unban with no active ban returns 404
- [x] Non-admin gets 403 on ban/unban endpoints
- [x] `durationHours = 0` rejected with 400
- [x] Admin DMs a mentee → `ADMIN_DIRECT` row created with both as participants, no mentorship in scope
- [x] Repeated admin DMs reuse the same conversation (idempotent)
- [x] Self-DM returns 400
- [x] Non-admin gets 403 on direct-message endpoint
- [x] First broadcast creates the singleton + adds every admin as a participant; second broadcast still resolves to the same row
- [x] An admin promoted between broadcasts is added on the next send (re-sync verified)
- [x] Non-admin gets 403 on broadcast endpoint

Plus regression coverage on the touched suites: `AuthServiceTest`, `AuthServiceClockTest`, `AuthIntegrationTest`, `BanIntegrationTest`, `AdminAuthorizationIntegrationTest`, `ConversationServiceTest`, `ConversationCreatorTest`, `MessagingIntegrationTest`, `MentorPairMessagingIntegrationTest`, `MentorPairInboxIntegrationTest`, `MessagingWebSocketIntegrationTest` — all green.

## Notes for reviewers

- The `V34` migration drops the legacy auto-named V14 `kind` CHECK by matching on definition shape (Postgres' generated names aren't guaranteed stable across deployments) and explicitly drops the V17 `kind_columns_consistent` CHECK by name. The DO block excludes multi-column CHECKs via `NOT ILIKE '%mentorship_id%'` so it can't accidentally remove the columns-consistent constraint.
- `ADMIN_DIRECT` reuses the existing `(pair_a_id, pair_b_id)` layout and the existing `uq_conversations_pair_kind` partial unique index (which already keys on `kind`), so no extra index was needed.
- Admin re-sync runs on every broadcast send. With admin counts in the single digits this is one cheap query per broadcast and dominated by the message insert that follows.
