### PR TITLE
feat(feed): add author-based feed posts endpoint (#471)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/FeedReadController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedReadController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -86,6 +87,22 @@ public class FeedReadController {
         Long viewerId = (Long) authentication.getCredentials();
         Pageable pageable = PageableSupport.clampPageable(page, size);
         return ResponseEntity.ok(feedReadService.followingFeed(viewerId, pageable));
+    }
+
+    @GetMapping("/users/{authorId}/posts")
+    @Operation(summary = "Author posts feed",
+            description = "Returns non-deleted posts authored by the given user id, "
+                    + "ordered by creation time descending.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paged author posts"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content)
+    })
+    public ResponseEntity<Page<FeedPostListItem>> postsByAuthor(
+            @Parameter(description = "Author user id") @PathVariable Long authorId,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size; clamped to [1, 100]") @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageableSupport.clampPageable(page, size);
+        return ResponseEntity.ok(feedReadService.postsByAuthor(authorId, pageable));
     }
 
     @GetMapping("/search")

--- a/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
@@ -79,6 +79,24 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
     Page<FeedPost> findFollowingFeed(@Param("viewerId") Long viewerId, Pageable pageable);
 
     /**
+     * Author-profile feed query (#471). Returns non-deleted posts for a
+     * specific author in reverse chronological order.
+     */
+    @Query(value = """
+            SELECT * FROM feed_posts p
+            WHERE p.deleted_at IS NULL
+              AND p.author_id = :authorId
+            ORDER BY p.created_at DESC, p.id DESC
+            """,
+            countQuery = """
+            SELECT COUNT(*) FROM feed_posts p
+            WHERE p.deleted_at IS NULL
+              AND p.author_id = :authorId
+            """,
+            nativeQuery = true)
+    Page<FeedPost> findByAuthorIdForFeed(@Param("authorId") Long authorId, Pageable pageable);
+
+    /**
      * For-You candidate fetch (#350). Returns the most recent N posts
      * eligible for ranking — excludes posts authored by the viewer
      * themselves (their own posts surface elsewhere) and soft-deleted

--- a/backend/src/main/java/com/group7/backend/service/FeedReadService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedReadService.java
@@ -126,6 +126,15 @@ public class FeedReadService {
     }
 
     /**
+     * Author profile posts feed (#471). Chronological over posts
+     * authored by the given user id.
+     */
+    public Page<FeedPostListItem> postsByAuthor(Long authorId, Pageable pageable) {
+        Page<FeedPost> page = feedPostRepository.findByAuthorIdForFeed(authorId, pageable);
+        return mapPage(page);
+    }
+
+    /**
      * Search (#350, requirement 1.1.7.7). Combined keyword + hashtag
      * filter. Either filter may be blank/null; both being blank returns
      * the full visible feed (paginated by recency).

--- a/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
@@ -115,6 +115,73 @@ class FeedReadIntegrationTest {
                 .andExpect(jsonPath("$.content.length()").value(0));
     }
 
+    @Test
+    void authorPostsFeed_returnsOnlyThatAuthorsPosts_chronologically() throws Exception {
+        String viewerToken = registerAndLogin("author_viewer@test.com", true);
+        String tokenA = registerAndLogin("author_a@test.com", true);
+        String tokenB = registerAndLogin("author_b@test.com", true);
+        Long authorAId = userRepository.findByEmail("author_a@test.com").orElseThrow().getId();
+
+        long a1 = createPost(tokenA, "A post 1", List.of());
+        Thread.sleep(20);
+        long b1 = createPost(tokenB, "B post 1", List.of());
+        Thread.sleep(20);
+        long a2 = createPost(tokenA, "A post 2", List.of());
+
+        MvcResult result = mockMvc.perform(get("/api/feed/users/" + authorAId + "/posts")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        List<Long> ids = StreamSupport.stream(body.get("content").spliterator(), false)
+                .map(n -> n.get("id").asLong())
+                .toList();
+        assertThat(ids).containsExactly(a2, a1);
+        assertThat(ids).doesNotContain(b1);
+    }
+
+    @Test
+    void authorPostsFeed_excludesSoftDeletedPosts() throws Exception {
+        String viewerToken = registerAndLogin("author_del_viewer@test.com", true);
+        String authorToken = registerAndLogin("author_del@test.com", true);
+        Long authorId = userRepository.findByEmail("author_del@test.com").orElseThrow().getId();
+
+        long live = createPost(authorToken, "live", List.of());
+        long deleted = createPost(authorToken, "deleted", List.of());
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .delete("/api/feed/posts/" + deleted)
+                        .header("Authorization", "Bearer " + authorToken))
+                .andExpect(status().isNoContent());
+
+        MvcResult result = mockMvc.perform(get("/api/feed/users/" + authorId + "/posts")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andReturn();
+
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        List<Long> ids = StreamSupport.stream(body.get("content").spliterator(), false)
+                .map(n -> n.get("id").asLong())
+                .toList();
+        assertThat(ids).containsExactly(live);
+    }
+
+    @Test
+    void authorPostsFeed_whenAuthorHasNoPosts_returnsEmpty() throws Exception {
+        String viewerToken = registerAndLogin("author_empty_viewer@test.com", true);
+        registerAndLogin("author_empty@test.com", true);
+        Long authorId = userRepository.findByEmail("author_empty@test.com").orElseThrow().getId();
+
+        mockMvc.perform(get("/api/feed/users/" + authorId + "/posts")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.content.length()").value(0));
+    }
+
     // ── Search ──────────────────────────────────────────────────────────────
 
     @Test
@@ -349,6 +416,7 @@ class FeedReadIntegrationTest {
         mockMvc.perform(get("/api/feed/for-you")).andExpect(status().isForbidden());
         mockMvc.perform(get("/api/feed/following")).andExpect(status().isForbidden());
         mockMvc.perform(get("/api/feed/search")).andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/feed/users/1/posts")).andExpect(status().isForbidden());
     }
 
     // ── Page-size clamp ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Implements issue #471 by adding an endpoint to list feed posts by author id for profile-based post viewing.

## Changes Made
- Added new endpoint:
  - `GET /api/feed/users/{authorId}/posts?page=0&size=20`
- Extended feed read controller with author-posts route.
- Added service method in `FeedReadService` for author-based feed retrieval.
- Added repository query in `FeedPostRepository`:
  - filters `deleted_at IS NULL`
  - orders by `created_at DESC, id DESC`
- Added integration test coverage in `FeedReadIntegrationTest` for:
  - returns only target author’s posts
  - chronological ordering
  - excludes soft-deleted posts
  - empty result when author has no posts
  - unauthenticated access returns forbidden


## Endpoint Contract
- **Method:** `GET`
- **Path:** `/api/feed/users/{authorId}/posts`
- **Query params:** `page`, `size` (clamped via existing pageable support)
- **Auth:** required (same as other feed read endpoints)
- **Response:** `Page<FeedPostListItem>`

## Validation
- Local integration tests for `FeedReadIntegrationTest` were executed in Dockerized Maven setup against project Postgres network.
- Verified locally with Dockerized backend test run: mvn verify passed successfully (Tests run: 1507, Failures: 0, Errors: 0, Skipped: 0; BUILD SUCCESS).
