### PR TITLE
refactor(backend): remove mentor-side branch from match-notification 

### DIFF
--- a/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
@@ -12,16 +12,6 @@ import java.util.List;
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
 
     /**
-     * IDs of all mentors with spare capacity, ordered for test determinism.
-     * Used by {@code MatchNotificationScheduler} as the eligibility list —
-     * only mentors who can accept new mentees are candidates for a "match
-     * found" notification. Returns just IDs to keep the per-tick memory
-     * bounded; the processor re-loads each mentor in its own transaction.
-     */
-    @Query("SELECT m.id FROM Mentor m WHERE m.currentMenteeCount < m.maxMenteeCapacity ORDER BY m.id")
-    List<Long> findIdsWithCapacity();
-
-    /**
      * Shared JPQL for {@link #searchByFilters} (Page, with count) and
      * {@link #findRankingCandidates} (List, without count). One source of
      * truth for the filter shape; the only difference between the two

--- a/backend/src/main/java/com/group7/backend/scheduler/MatchNotificationScheduler.java
+++ b/backend/src/main/java/com/group7/backend/scheduler/MatchNotificationScheduler.java
@@ -1,7 +1,6 @@
 package com.group7.backend.scheduler;
 
 import com.group7.backend.repository.MenteeRepository;
-import com.group7.backend.repository.MentorRepository;
 import com.group7.backend.service.MatchNotificationProcessor;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
@@ -17,25 +16,24 @@ import java.util.function.Supplier;
 
 /**
  * Daily cron driver for the change-detection match-notification path (#273).
- * For each eligible user (mentees with no active mentor; mentors with spare
- * capacity), invokes {@link MatchNotificationProcessor} in its own
- * {@code REQUIRES_NEW} transaction. The processor compares the current top
- * match's id to a per-user state row and publishes a {@code MATCH_FOUND}
+ * For each unattached mentee, invokes {@link MatchNotificationProcessor} in
+ * its own {@code REQUIRES_NEW} transaction. The processor compares the current
+ * top mentor's id to a per-user state row and publishes a {@code MATCH_FOUND}
  * event only when the value changed.
  *
  * <p><b>System component.</b> Bypasses controller-layer authorization
  * deliberately. Does not run in any authenticated user's context.
  *
- * <p><b>Failure isolation.</b> Each user is wrapped in its own try/catch:
+ * <p><b>Failure isolation.</b> Each mentee is wrapped in its own try/catch:
  * a thrown exception logs and the loop continues with the next user.
  * {@code IllegalStateException} (a precondition violation in the
  * processor's pure-rank delegate) is logged at ERROR — it indicates a
  * caller bug, not a transient operational problem. Other exceptions
  * (transient DB errors, etc.) are logged at WARN; the next scheduler tick
  * naturally retries since the user's state row was not advanced.
- * Each side ({@code notifyMentees}, {@code notifyMentors}) is additionally
- * wrapped in {@code runSafely} so a failure in the eligibility query for
- * one side does not skip the other.
+ * The mentee batch is additionally wrapped in {@code runSafely} so a
+ * failure in the eligibility query is logged once and the cron firing
+ * exits cleanly rather than propagating.
  *
  * <p><b>Multi-instance.</b> Two instances ticking at the same cron time
  * race harmlessly: PK uniqueness on {@code last_match_notifications}
@@ -70,7 +68,6 @@ public class MatchNotificationScheduler {
 
     private final MatchNotificationProcessor processor;
     private final MenteeRepository menteeRepository;
-    private final MentorRepository mentorRepository;
     private final String cronExpression;
     private final String zone;
 
@@ -85,12 +82,10 @@ public class MatchNotificationScheduler {
     public MatchNotificationScheduler(
             MatchNotificationProcessor processor,
             MenteeRepository menteeRepository,
-            MentorRepository mentorRepository,
             @Value("${app.matching.notification.cron:0 0 9 * * *}") String cronExpression,
             @Value("${app.matching.notification.zone:UTC}") String zone) {
         this.processor = processor;
         this.menteeRepository = menteeRepository;
-        this.mentorRepository = mentorRepository;
         this.cronExpression = cronExpression;
         this.zone = zone;
     }
@@ -109,39 +104,27 @@ public class MatchNotificationScheduler {
     }
 
     /**
-     * Runs daily at 09:00 UTC by default. Both sides processed sequentially
-     * inside one cron firing; each side's eligibility query and per-user loop
-     * is isolated by {@link #runSafely(String, Supplier)} so one side's
-     * failure does not skip the other.
+     * Runs daily at 09:00 UTC by default. Iterates eligible mentees inside a
+     * single cron firing; {@link #runSafely(String, Supplier)} guards the
+     * eligibility query so a transient DB failure logs once instead of
+     * propagating out of the @Scheduled method.
      */
     @Scheduled(
             cron = "${app.matching.notification.cron:0 0 9 * * *}",
             zone = "${app.matching.notification.zone:UTC}")
     public void notifyChangedMatches() {
         BatchResult mentees = runSafely("mentees", this::notifyMentees);
-        BatchResult mentors = runSafely("mentors", this::notifyMentors);
-        log.info(
-                "Match-notification check complete: "
-                        + "mentee_eligible={} mentee_publishes={} "
-                        + "mentor_eligible={} mentor_publishes={}",
-                mentees.eligible(), mentees.published(),
-                mentors.eligible(), mentors.published());
+        log.info("Match-notification check complete: mentee_eligible={} mentee_publishes={}",
+                mentees.eligible(), mentees.published());
     }
 
     /**
      * Iterates eligible mentees and dispatches each to the processor.
-     * Package-private so integration tests can invoke a single side without
+     * Package-private so integration tests can invoke the batch without
      * waiting for a cron tick.
      */
     BatchResult notifyMentees() {
         return processBatch("mentee", menteeRepository::findUnattachedIds, processor::processMentee);
-    }
-
-    /**
-     * Symmetric to {@link #notifyMentees} for the mentor side.
-     */
-    BatchResult notifyMentors() {
-        return processBatch("mentor", mentorRepository::findIdsWithCapacity, processor::processMentor);
     }
 
     /**
@@ -152,7 +135,7 @@ public class MatchNotificationScheduler {
      * so the loop keeps moving — the next tick naturally retries since the
      * user's state row was not advanced.
      *
-     * @param label    used in log messages ({@code "mentee"} / {@code "mentor"}).
+     * @param label    used in log messages (currently always {@code "mentee"}).
      * @param eligibilityQuery supplier for the list of ids to process.
      * @param processor returns true iff a notification was published.
      * @return eligible count (size of the list) and published count (true returns).
@@ -175,9 +158,9 @@ public class MatchNotificationScheduler {
     }
 
     /**
-     * Wraps a per-side batch so a failure in the eligibility query (e.g., a
-     * transient DB outage) does not abort the entire run — the other side
-     * still gets its turn.
+     * Wraps a batch so a failure in the eligibility query (e.g., a transient
+     * DB outage) is logged once instead of leaking out of the @Scheduled
+     * method. Returns an empty result so the run-summary log still renders.
      */
     private BatchResult runSafely(String label, Supplier<BatchResult> batch) {
         try {

--- a/backend/src/main/java/com/group7/backend/service/MatchNotificationProcessor.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchNotificationProcessor.java
@@ -4,7 +4,6 @@ import com.group7.backend.dto.response.MatchSummary;
 import com.group7.backend.entity.LastMatchNotification;
 import com.group7.backend.repository.LastMatchNotificationRepository;
 import com.group7.backend.repository.MenteeRepository;
-import com.group7.backend.repository.MentorRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -21,11 +20,11 @@ import java.util.function.Predicate;
 
 /**
  * Per-user transactional unit for the scheduled match-found notification path
- * (#273). Driven by {@code MatchNotificationScheduler}: for each eligible user
- * the scheduler invokes {@link #processMentee(Long)} or {@link #processMentor(Long)},
- * which re-ranks the user's matches, compares the current top match's id to
- * the persisted dedup state, and publishes a {@code MATCH_FOUND} event only
- * when the value changed.
+ * (#273). Driven by {@code MatchNotificationScheduler}: for each eligible
+ * mentee the scheduler invokes {@link #processMentee(Long)}, which re-ranks
+ * the mentee's top mentors, compares the current top match's id to the
+ * persisted dedup state, and publishes a {@code MATCH_FOUND} event only when
+ * the value changed.
  *
  * <p><b>System component.</b> Bypasses controller-layer authorization
  * deliberately — the scheduler is not invoked in any authenticated user's
@@ -38,7 +37,7 @@ import java.util.function.Predicate;
  * a separate bean (this one) and having the scheduler invoke it across the
  * proxy boundary is what makes the propagation hint actually take effect.
  *
- * <p><b>Failure isolation.</b> Each public method runs in its own
+ * <p><b>Failure isolation.</b> {@link #processMentee} runs in its own
  * {@code REQUIRES_NEW} transaction. If processing user A throws, A's
  * transaction rolls back (state row not updated, AFTER_COMMIT skipped, no
  * notification persisted), and the scheduler's per-user try/catch logs and
@@ -59,13 +58,11 @@ import java.util.function.Predicate;
  *       (e.g., a same-firstName collision across distinct counterparts).</li>
  * </ol>
  *
- * <p><b>Implementation note.</b> The mentee and mentor sides run the same
- * change-detection algorithm against different entity types. The shared
- * algorithm lives in {@link #processUser}; the public {@code processMentee}
- * / {@code processMentor} are thin adapters that supply the load /
- * eligibility / rank functions per side. Keeping the algorithm in one
- * place means a future addition (metrics, tracing, alternative dedup) is
- * applied once.
+ * <p><b>Implementation note.</b> The change-detection algorithm lives in the
+ * generic {@link #processUser}; {@code processMentee} is a thin adapter that
+ * supplies the load / eligibility / rank functions. The generic shape is
+ * retained because it keeps any future addition (metrics, tracing,
+ * alternative dedup) confined to a single place.
  */
 @Service
 public class MatchNotificationProcessor {
@@ -74,20 +71,17 @@ public class MatchNotificationProcessor {
 
     private final MatchingService matchingService;
     private final MenteeRepository menteeRepository;
-    private final MentorRepository mentorRepository;
     private final LastMatchNotificationRepository stateRepository;
     private final NotificationEventPublisher notificationEventPublisher;
     private final Clock clock;
 
     public MatchNotificationProcessor(MatchingService matchingService,
                                       MenteeRepository menteeRepository,
-                                      MentorRepository mentorRepository,
                                       LastMatchNotificationRepository stateRepository,
                                       NotificationEventPublisher notificationEventPublisher,
                                       Clock clock) {
         this.matchingService = matchingService;
         this.menteeRepository = menteeRepository;
-        this.mentorRepository = mentorRepository;
         this.stateRepository = stateRepository;
         this.notificationEventPublisher = notificationEventPublisher;
         this.clock = clock;
@@ -111,26 +105,12 @@ public class MatchNotificationProcessor {
     }
 
     /**
-     * Symmetric to {@link #processMentee} for the mentor side. Re-ranks the
-     * mentor's candidate-mentees, fires only when the top candidate changed.
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public boolean processMentor(Long mentorId) {
-        return processUser(
-                mentorId,
-                "mentee",
-                mentorRepository::findById,
-                m -> m.getCurrentMenteeCount() < m.getMaxMenteeCapacity(),
-                m -> matchingService.findCandidateMenteesFor(m, null));
-    }
-
-    /**
      * Generic change-detection: load the user, re-check eligibility (race
      * window since the scheduler's snapshot), rank, compare top match's id
      * against the persisted state, and fire-and-upsert if it changed.
      *
-     * @param userId       recipient id (mentee for mentor-matches, mentor for mentee-matches).
-     * @param matchLabel   human-readable role of the matched user ({@code "mentor"} / {@code "mentee"}),
+     * @param userId       recipient id (mentee, in the only current caller).
+     * @param matchLabel   human-readable role of the matched user ({@code "mentor"}),
      *                     used in the null-id error log.
      * @param loader       entity loader keyed by {@code userId}.
      * @param isEligible   second-chance eligibility predicate (race re-check).
@@ -159,10 +139,10 @@ public class MatchNotificationProcessor {
         MatchSummary top = ranked.get(0);
         Long topId = top.getId();
         if (topId == null) {
-            // The DTO factory (MentorMatchResponse.from / MenteeCandidateResponse.from)
-            // explicitly sets id from the entity. A null here means the ranker
-            // contract is broken — surface loudly so monitoring catches it,
-            // and skip so the rest of the batch keeps moving.
+            // The DTO factory (MentorMatchResponse.from) explicitly sets id
+            // from the entity. A null here means the ranker contract is
+            // broken — surface loudly so monitoring catches it, and skip so
+            // the rest of the batch keeps moving.
             log.error("Top {} for user {} has null id; skipping (DTO mapping bug)", matchLabel, userId);
             return false;
         }

--- a/backend/src/main/resources/db/migration/V38__purge_mentor_match_notification_state.sql
+++ b/backend/src/main/resources/db/migration/V38__purge_mentor_match_notification_state.sql
@@ -1,0 +1,19 @@
+-- Purge mentor-side state rows from the match-notification dedup table (#346).
+--
+-- Why: PR #329 wrote a row per mentor on each scheduler tick to dedup the
+-- mentor-side MATCH_FOUND notification. Requirements 1.1.1.2.4 and 1.1.2.2
+-- were dropped from the wiki (commit d0bb5e5), so the mentor-side branch
+-- has been removed from MatchNotificationScheduler/Processor in this PR.
+-- Existing mentor rows are now orphaned -- nothing reads or updates them.
+-- Drop them so the table only contains live mentee state.
+--
+-- Identification: there is no recipient_type discriminator on
+-- last_match_notifications. The mentors and mentees tables use JPA JOINED
+-- inheritance, so a user_id present in `mentors` is a mentor recipient.
+-- The DELETE selects exactly those rows.
+--
+-- Idempotent: re-running this migration on a clean table is a no-op.
+-- Rollback: not provided -- orphaned dedup rows have no recovery value.
+
+DELETE FROM last_match_notifications
+WHERE user_id IN (SELECT id FROM mentors);

--- a/backend/src/test/java/com/group7/backend/integration/MatchNotificationIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MatchNotificationIntegrationTest.java
@@ -104,21 +104,22 @@ class MatchNotificationIntegrationTest {
     // ── Tests ────────────────────────────────────────────────────────────────
 
     @Test
-    void firstRun_publishesAndUpsertsForEachEligibleUser() {
+    void firstRun_publishesAndUpsertsForEligibleMentee() {
         Mentee mentee = menteeRepository.save(newMentee("a", "Alice"));
         Mentor mentor = mentorRepository.save(newMentor("a", "Bob"));
 
         scheduler.notifyChangedMatches();
 
-        // Mentee got notified about the only mentor; mentor got notified about
-        // the only mentee. Both state rows are populated with the counterpart's id.
+        // Mentee got notified about the only mentor; the mentee's state row is
+        // populated with the mentor's id. The mentor is not a recipient — the
+        // mentor-side notification branch was removed in #346 — so no state
+        // row exists for the mentor.
         awaitNotificationsFor(mentee.getId(), 1);
-        awaitNotificationsFor(mentor.getId(), 1);
 
         LastMatchNotification menteeState = stateRepository.findById(mentee.getId()).orElseThrow();
         assertThat(menteeState.getNotifiedMatchUserId()).isEqualTo(mentor.getId());
-        LastMatchNotification mentorState = stateRepository.findById(mentor.getId()).orElseThrow();
-        assertThat(mentorState.getNotifiedMatchUserId()).isEqualTo(mentee.getId());
+        assertThat(countMatchFoundFor(mentor.getId())).isZero();
+        assertThat(stateRepository.findById(mentor.getId())).isEmpty();
     }
 
     @Test
@@ -175,25 +176,6 @@ class MatchNotificationIntegrationTest {
                 .untilAsserted(() -> {
                     assertThat(countMatchFoundFor(mentee.getId())).isZero();
                     assertThat(stateRepository.findById(mentee.getId())).isEmpty();
-                });
-    }
-
-    @Test
-    void run_skipsMentorAtFullCapacity() {
-        Mentor mentor = newMentor("e", "Bob");
-        mentor.setMaxMenteeCapacity(1);
-        mentor.setCurrentMenteeCount(1);  // full → ineligible
-        mentorRepository.save(mentor);
-        menteeRepository.save(newMentee("e", "Alice"));
-
-        scheduler.notifyChangedMatches();
-
-        // Mentor is excluded by findIdsWithCapacity; no notification, no state row.
-        Awaitility.await().pollDelay(Duration.ofMillis(500))
-                .atMost(Duration.ofSeconds(2))
-                .untilAsserted(() -> {
-                    assertThat(countMatchFoundFor(mentor.getId())).isZero();
-                    assertThat(stateRepository.findById(mentor.getId())).isEmpty();
                 });
     }
 

--- a/backend/src/test/java/com/group7/backend/repository/MatchNotificationEligibilityQueriesTest.java
+++ b/backend/src/test/java/com/group7/backend/repository/MatchNotificationEligibilityQueriesTest.java
@@ -19,9 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Real-Postgres coverage for the eligibility queries added in #273
- * ({@link MenteeRepository#findUnattachedIds()},
- * {@link MentorRepository#findIdsWithCapacity()}) plus the
+ * Real-Postgres coverage for the mentee eligibility query added in #273
+ * ({@link MenteeRepository#findUnattachedIds()}) plus the
  * {@link LastMatchNotificationRepository} round-trip.
  *
  * <p>Pinned to the {@code test} profile because the migrations expect Postgres
@@ -82,40 +81,6 @@ class MatchNotificationEligibilityQueriesTest {
     @Test
     void findUnattachedIds_returnsEmptyListWhenNoMenteesExist() {
         assertThat(menteeRepository.findUnattachedIds()).isEmpty();
-    }
-
-    // ── findIdsWithCapacity (mentor eligibility) ─────────────────────────────
-
-    @Test
-    void findIdsWithCapacity_returnsOnlyMentorsBelowCapacity() {
-        Mentor empty = saveMentorWithCapacity("mn273_capa_a@example.com", 3, 0);
-        Mentor partial = saveMentorWithCapacity("mn273_capa_b@example.com", 3, 2);
-        saveMentorWithCapacity("mn273_capa_c@example.com", 2, 2);  // at cap → excluded
-
-        List<Long> ids = mentorRepository.findIdsWithCapacity();
-
-        assertThat(ids).containsExactlyInAnyOrder(empty.getId(), partial.getId());
-    }
-
-    @Test
-    void findIdsWithCapacity_excludesMentorsAtExactlyMaxCapacity() {
-        // Boundary: currentMenteeCount == maxMenteeCapacity → strictly excluded
-        // (we use < not <=). Otherwise a mentor who *just* filled would receive
-        // a confusing notification.
-        saveMentorWithCapacity("mn273_capb@example.com", 3, 3);
-
-        assertThat(mentorRepository.findIdsWithCapacity()).isEmpty();
-    }
-
-    @Test
-    void findIdsWithCapacity_isOrderedByIdAscending() {
-        Mentor a = saveMentorWithCapacity("mn273_cord_a@example.com", 3, 0);
-        Mentor b = saveMentorWithCapacity("mn273_cord_b@example.com", 3, 0);
-        Mentor c = saveMentorWithCapacity("mn273_cord_c@example.com", 3, 0);
-
-        List<Long> ids = mentorRepository.findIdsWithCapacity();
-
-        assertThat(ids).containsExactly(a.getId(), b.getId(), c.getId());
     }
 
     // ── LastMatchNotificationRepository round-trip ───────────────────────────
@@ -242,18 +207,6 @@ class MatchNotificationEligibilityQueriesTest {
         m.setIsEmailVerified(true);
         m.setMaxMenteeCapacity(3);
         m.setCurrentMenteeCount(0);
-        return mentorRepository.save(m);
-    }
-
-    private Mentor saveMentorWithCapacity(String email, int max, int current) {
-        Mentor m = new Mentor();
-        m.setFirstName("M");
-        m.setLastName("L");
-        m.setEmail(email);
-        m.setPasswordHash("x");
-        m.setIsEmailVerified(true);
-        m.setMaxMenteeCapacity(max);
-        m.setCurrentMenteeCount(current);
         return mentorRepository.save(m);
     }
 }

--- a/backend/src/test/java/com/group7/backend/scheduler/MatchNotificationSchedulerTest.java
+++ b/backend/src/test/java/com/group7/backend/scheduler/MatchNotificationSchedulerTest.java
@@ -1,7 +1,6 @@
 package com.group7.backend.scheduler;
 
 import com.group7.backend.repository.MenteeRepository;
-import com.group7.backend.repository.MentorRepository;
 import com.group7.backend.scheduler.MatchNotificationScheduler.BatchResult;
 import com.group7.backend.service.MatchNotificationProcessor;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,15 +19,16 @@ import static org.mockito.Mockito.when;
 
 /**
  * Unit coverage for {@link MatchNotificationScheduler}'s loop semantics.
- * Asserts: (a) every eligible id from the repos reaches the processor;
+ * Asserts: (a) every eligible mentee id from the repo reaches the processor;
  * (b) per-user exceptions are caught + logged + the loop continues;
- * (c) per-side eligibility-query failures don't skip the other side;
- * (d) the {@link BatchResult} surfaced for the run-summary log carries the
- * eligibility-list size alongside the publish count.
+ * (c) an eligibility-query failure is logged once and doesn't propagate
+ * out of the @Scheduled method; (d) the {@link BatchResult} surfaced for
+ * the run-summary log carries the eligibility-list size alongside the
+ * publish count.
  *
  * <p>We don't try to assert that the cron fires on time — that's Spring's
  * responsibility. Tests invoke the package-private {@code notifyMentees()}
- * / {@code notifyMentors()} directly, matching the
+ * directly, matching the
  * {@link com.group7.backend.scheduler.AttachmentOrphanCleanupScheduler}
  * test idiom.
  */
@@ -37,14 +37,13 @@ class MatchNotificationSchedulerTest {
 
     @Mock private MatchNotificationProcessor processor;
     @Mock private MenteeRepository menteeRepository;
-    @Mock private MentorRepository mentorRepository;
 
     private MatchNotificationScheduler scheduler;
 
     @BeforeEach
     void setUp() {
         scheduler = new MatchNotificationScheduler(
-                processor, menteeRepository, mentorRepository,
+                processor, menteeRepository,
                 "0 0 9 * * *", "UTC");
     }
 
@@ -62,20 +61,6 @@ class MatchNotificationSchedulerTest {
         verify(processor).processMentee(1L);
         verify(processor).processMentee(2L);
         verify(processor).processMentee(3L);
-    }
-
-    @Test
-    void notifyMentors_iteratesAllEligibleIds() {
-        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of(10L, 20L));
-        when(processor.processMentor(10L)).thenReturn(true);
-        when(processor.processMentor(20L)).thenReturn(true);
-
-        BatchResult result = scheduler.notifyMentors();
-
-        assertThat(result.eligible()).isEqualTo(2);
-        assertThat(result.published()).isEqualTo(2);
-        verify(processor).processMentor(10L);
-        verify(processor).processMentor(20L);
     }
 
     @Test
@@ -113,32 +98,6 @@ class MatchNotificationSchedulerTest {
     }
 
     @Test
-    void notifyChangedMatches_isolatesMenteeSideFailureFromMentorSide() {
-        // findUnattachedIds throws — without runSafely, notifyMentors would
-        // never run. With runSafely, we still process the mentor side.
-        when(menteeRepository.findUnattachedIds()).thenThrow(new RuntimeException("DB outage"));
-        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of(10L));
-        when(processor.processMentor(10L)).thenReturn(true);
-
-        scheduler.notifyChangedMatches();
-
-        verify(processor, never()).processMentee(anyLong());
-        verify(processor).processMentor(10L);
-    }
-
-    @Test
-    void notifyChangedMatches_isolatesMentorSideFailureFromMenteeSide() {
-        when(menteeRepository.findUnattachedIds()).thenReturn(List.of(1L));
-        when(processor.processMentee(1L)).thenReturn(true);
-        when(mentorRepository.findIdsWithCapacity()).thenThrow(new RuntimeException("DB outage"));
-
-        scheduler.notifyChangedMatches();
-
-        verify(processor).processMentee(1L);
-        verify(processor, never()).processMentor(anyLong());
-    }
-
-    @Test
     void notifyMentees_emptyEligibilityListIsNoOp() {
         when(menteeRepository.findUnattachedIds()).thenReturn(List.of());
 
@@ -149,62 +108,28 @@ class MatchNotificationSchedulerTest {
         verify(processor, never()).processMentee(anyLong());
     }
 
-    // ── Symmetric mentor-side coverage ───────────────────────────────────────
-
-    @Test
-    void notifyMentors_swallowsPerUserExceptionsAndContinues() {
-        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of(10L, 20L, 30L));
-        when(processor.processMentor(10L)).thenReturn(true);
-        when(processor.processMentor(20L)).thenThrow(new RuntimeException("transient DB error"));
-        when(processor.processMentor(30L)).thenReturn(true);
-
-        BatchResult result = scheduler.notifyMentors();
-
-        assertThat(result.eligible()).isEqualTo(3);
-        assertThat(result.published()).isEqualTo(2);
-        verify(processor).processMentor(10L);
-        verify(processor).processMentor(20L);
-        verify(processor).processMentor(30L);
-    }
-
-    @Test
-    void notifyMentors_logsIllegalStateAtErrorButContinues() {
-        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of(10L, 20L));
-        when(processor.processMentor(10L)).thenThrow(new IllegalStateException("precondition broken"));
-        when(processor.processMentor(20L)).thenReturn(true);
-
-        BatchResult result = scheduler.notifyMentors();
-
-        assertThat(result.eligible()).isEqualTo(2);
-        assertThat(result.published()).isEqualTo(1);
-        verify(processor).processMentor(20L);
-    }
-
-    @Test
-    void notifyMentors_emptyEligibilityListIsNoOp() {
-        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of());
-
-        BatchResult result = scheduler.notifyMentors();
-
-        assertThat(result.eligible()).isZero();
-        assertThat(result.published()).isZero();
-        verify(processor, never()).processMentor(anyLong());
-    }
-
     // ── Run-summary semantics ────────────────────────────────────────────────
 
     @Test
-    void notifyChangedMatches_sumsBothSidesAndCompletesEvenWithZeroPublishes() {
+    void notifyChangedMatches_runsMenteeBatchAndCompletesEvenWithZeroPublishes() {
         when(menteeRepository.findUnattachedIds()).thenReturn(List.of());
-        when(mentorRepository.findIdsWithCapacity()).thenReturn(List.of());
 
         scheduler.notifyChangedMatches();
 
-        // Both eligibility queries ran exactly once; processor never invoked.
+        // Eligibility query ran exactly once; processor never invoked.
         verify(menteeRepository).findUnattachedIds();
-        verify(mentorRepository).findIdsWithCapacity();
         verify(processor, never()).processMentee(anyLong());
-        verify(processor, never()).processMentor(anyLong());
+    }
+
+    @Test
+    void notifyChangedMatches_swallowsEligibilityQueryFailure() {
+        // runSafely wraps the batch so a DB outage on findUnattachedIds
+        // is logged once and the @Scheduled method returns cleanly.
+        when(menteeRepository.findUnattachedIds()).thenThrow(new RuntimeException("DB outage"));
+
+        scheduler.notifyChangedMatches();   // must not throw
+
+        verify(processor, never()).processMentee(anyLong());
     }
 
     // ── Startup config log ───────────────────────────────────────────────────

--- a/backend/src/test/java/com/group7/backend/service/MatchNotificationProcessorTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MatchNotificationProcessorTest.java
@@ -1,13 +1,10 @@
 package com.group7.backend.service;
 
-import com.group7.backend.dto.response.MenteeCandidateResponse;
 import com.group7.backend.dto.response.MentorMatchResponse;
 import com.group7.backend.entity.LastMatchNotification;
 import com.group7.backend.entity.Mentee;
-import com.group7.backend.entity.Mentor;
 import com.group7.backend.repository.LastMatchNotificationRepository;
 import com.group7.backend.repository.MenteeRepository;
-import com.group7.backend.repository.MentorRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,7 +41,6 @@ class MatchNotificationProcessorTest {
 
     @Mock private MatchingService matchingService;
     @Mock private MenteeRepository menteeRepository;
-    @Mock private MentorRepository mentorRepository;
     @Mock private LastMatchNotificationRepository stateRepository;
     @Mock private NotificationEventPublisher notificationEventPublisher;
 
@@ -59,7 +54,6 @@ class MatchNotificationProcessorTest {
         processor = new MatchNotificationProcessor(
                 matchingService,
                 menteeRepository,
-                mentorRepository,
                 stateRepository,
                 notificationEventPublisher,
                 fixedClock);
@@ -75,24 +69,8 @@ class MatchNotificationProcessorTest {
         return m;
     }
 
-    private Mentor eligibleMentor(Long id) {
-        Mentor m = new Mentor();
-        m.setId(id);
-        m.setFirstName("Mentor" + id);
-        m.setMaxMenteeCapacity(3);
-        m.setCurrentMenteeCount(0);  // has capacity
-        return m;
-    }
-
     private MentorMatchResponse mentorMatch(Long id, String firstName) {
         MentorMatchResponse r = new MentorMatchResponse();
-        r.setId(id);
-        r.setFirstName(firstName);
-        return r;
-    }
-
-    private MenteeCandidateResponse menteeCandidate(Long id, String firstName) {
-        MenteeCandidateResponse r = new MenteeCandidateResponse();
         r.setId(id);
         r.setFirstName(firstName);
         return r;
@@ -211,109 +189,6 @@ class MatchNotificationProcessorTest {
                 .thenReturn(List.of(mentorMatch(null, "Ali")));
 
         boolean published = processor.processMentee(1L);
-
-        assertThat(published).isFalse();
-        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
-        verify(stateRepository, never()).save(any());
-    }
-
-    // ── Mentor side ──────────────────────────────────────────────────────────
-
-    @Test
-    void processMentor_publishesAndUpserts_whenStateRowAbsent() {
-        Mentor mentor = eligibleMentor(7L);
-        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
-        when(matchingService.findCandidateMenteesFor(mentor, null))
-                .thenReturn(List.of(menteeCandidate(101L, "Cara")));
-        when(stateRepository.findById(7L)).thenReturn(Optional.empty());
-
-        boolean published = processor.processMentor(7L);
-
-        assertThat(published).isTrue();
-        verify(notificationEventPublisher).publishMatchFound(7L, "Cara");
-        ArgumentCaptor<LastMatchNotification> saved = ArgumentCaptor.forClass(LastMatchNotification.class);
-        verify(stateRepository).save(saved.capture());
-        assertThat(saved.getValue().getUserId()).isEqualTo(7L);
-        assertThat(saved.getValue().getNotifiedMatchUserId()).isEqualTo(101L);
-    }
-
-    @Test
-    void processMentor_skips_whenTopMatchUnchanged() {
-        Mentor mentor = eligibleMentor(7L);
-        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
-        when(matchingService.findCandidateMenteesFor(mentor, null))
-                .thenReturn(List.of(menteeCandidate(101L, "Cara")));
-        when(stateRepository.findById(7L)).thenReturn(Optional.of(stateRow(7L, 101L)));
-
-        boolean published = processor.processMentor(7L);
-
-        assertThat(published).isFalse();
-        verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());
-        verify(stateRepository, never()).save(any());
-    }
-
-    @Test
-    void processMentor_skips_whenMentorRaceDeleted() {
-        when(mentorRepository.findById(7L)).thenReturn(Optional.empty());
-
-        boolean published = processor.processMentor(7L);
-
-        assertThat(published).isFalse();
-        verify(matchingService, never()).findCandidateMenteesFor(any(), any());
-    }
-
-    @Test
-    void processMentor_skips_whenMentorRaceFilledCapacity() {
-        Mentor mentor = eligibleMentor(7L);
-        mentor.setCurrentMenteeCount(mentor.getMaxMenteeCapacity());  // raced: now full
-        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
-
-        boolean published = processor.processMentor(7L);
-
-        assertThat(published).isFalse();
-        verify(matchingService, never()).findCandidateMenteesFor(any(), any());
-    }
-
-    @Test
-    void processMentor_skips_whenCandidateListEmpty() {
-        Mentor mentor = eligibleMentor(7L);
-        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
-        when(matchingService.findCandidateMenteesFor(mentor, null)).thenReturn(List.of());
-
-        boolean published = processor.processMentor(7L);
-
-        assertThat(published).isFalse();
-        verify(stateRepository, never()).findById(eq(7L));
-    }
-
-    @Test
-    void processMentor_publishesAndUpserts_whenTopMatchDiffers() {
-        Mentor mentor = eligibleMentor(7L);
-        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
-        when(matchingService.findCandidateMenteesFor(mentor, null))
-                .thenReturn(List.of(menteeCandidate(202L, "Dana")));
-        when(stateRepository.findById(7L))
-                .thenReturn(Optional.of(stateRow(7L, /*previously notified*/ 101L)));
-
-        boolean published = processor.processMentor(7L);
-
-        assertThat(published).isTrue();
-        verify(notificationEventPublisher).publishMatchFound(7L, "Dana");
-        ArgumentCaptor<LastMatchNotification> saved = ArgumentCaptor.forClass(LastMatchNotification.class);
-        verify(stateRepository).save(saved.capture());
-        assertThat(saved.getValue().getNotifiedMatchUserId()).isEqualTo(202L);
-    }
-
-    @Test
-    void processMentor_skips_whenTopMatchHasNullId() {
-        Mentor mentor = eligibleMentor(7L);
-        when(mentorRepository.findById(7L)).thenReturn(Optional.of(mentor));
-        // Symmetric to the mentee-side defensive guard: a DTO emit with id=null
-        // is logged + skipped rather than NPE-ing through equality compare.
-        when(matchingService.findCandidateMenteesFor(mentor, null))
-                .thenReturn(List.of(menteeCandidate(null, "Dana")));
-
-        boolean published = processor.processMentor(7L);
 
         assertThat(published).isFalse();
         verify(notificationEventPublisher, never()).publishMatchFound(anyLong(), anyString());


### PR DESCRIPTION
## Summary

Closes #346.

Requirements `1.1.1.2.4` and `1.1.2.2` were removed from the wiki in commit `d0bb5e5`, leaving the mentor-side branch of the match-notification path (added in #329) as dead code on a daily cron. This PR removes it surgically: scheduler, processor, repository query, four test classes, and a Flyway migration to purge orphaned mentor rows from `last_match_notifications`.

Mentee-side behavior is unchanged. Shared mentor-browse APIs (`MatchingService.findCandidateMenteesFor`, `MenteeCandidateResponse`, the capacity fields on `Mentor`) are untouched — only the *notification* leg of the mentor flow is gone.

## Changes

**Code**
- `MatchNotificationProcessor.processMentor` removed; `MentorRepository` dependency dropped from the processor (no other production caller after this change).
- `MatchNotificationScheduler.notifyMentors` removed; `notifyChangedMatches()` now drives only the mentee batch. `runSafely` / `processBatch` / `BatchResult` helpers are retained so the per-user `IllegalStateException`-vs-`Exception` split and the structured run-summary log are preserved for the mentee path.
- `MentorRepository.findIdsWithCapacity` removed; only callers were the scheduler and the now-deleted mentor-side tests.

**Tests**
- `MatchNotificationProcessorTest`: dropped 7 `processMentor_*` cases + the `MentorRepository` mock; kept all `processMentee_*` cases.
- `MatchNotificationSchedulerTest`: dropped 4 `notifyMentors_*` cases plus the two cross-side isolation tests (lose meaning with one side); rewrote the run-summary test for the mentee-only flow.
- `MatchNotificationEligibilityQueriesTest`: dropped 3 `findIdsWithCapacity_*` cases; kept `findUnattachedIds_*` and `lastMatchNotification_*` round-trip tests.
- `MatchNotificationIntegrationTest`: removed `run_skipsMentorAtFullCapacity`; narrowed `firstRun_publishesAndUpserts...` to mentee-only assertions (now also explicitly asserts no notification/state row for the mentor).

**Database**
- `V38__purge_mentor_match_notification_state.sql`: deletes orphaned mentor rows via `DELETE ... WHERE user_id IN (SELECT id FROM mentors)`. The table has no recipient-type discriminator; JPA `JOINED` inheritance means presence in the `mentors` table identifies the recipient as a mentor. Migration is idempotent.

## Diff size
`8 files changed, +82 / −375`

## Test plan
- [x] `mvn test` from `backend/` — **1506 passed, 0 failed** locally against a fresh Postgres
- [x] Targeted suite (`MatchNotificationProcessorTest`, `MatchNotificationSchedulerTest`, `MatchNotificationEligibilityQueriesTest`, `MatchNotificationIntegrationTest`) — 29/29 green
- [x] Flyway V38 applies cleanly on a populated schema; re-running is a no-op (idempotent `DELETE ... WHERE ... IN`)
- [ ] CI runs the full suite against a clean container DB
- [ ] Optional manual SQL check post-deploy: `SELECT COUNT(*) FROM last_match_notifications lmn JOIN mentors m ON m.id = lmn.user_id;` returns `0`

## Out of scope (verified, left intact)
- `MatchingService.findCandidateMenteesFor` — still used by the mentor-browse endpoint
- `MenteeCandidateResponse`, `MentorMatchResponse`, `MatchSummary` — used by general browsing
- `Mentor.currentMenteeCount` / `maxMenteeCapacity` — belong to the mentorship domain, not notifications
