### PR TITLE
fix(backend): preserve terminated mentorship timeline and add explicit cleanup endpoint (#478)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
@@ -281,4 +281,26 @@ public class MentorshipController {
         Long userId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(mentorshipService.getAuditTrail(userId, id));
     }
+
+    @DeleteMapping("/{id}/data")
+    @Operation(
+            summary = "Delete mentorship timeline/progress data for a past mentorship (#478)",
+            description = "Deletes mentorship-scoped timeline/progress artifacts (tasks, milestones, meetings and "
+                    + "their children). Only participants may call this endpoint, and only after the mentorship is "
+                    + "no longer ACTIVE."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Mentorship data deleted"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found or caller is not a participant",
+                    content = @Content),
+            @ApiResponse(responseCode = "409", description = "Mentorship is still ACTIVE", content = @Content)
+    })
+    public ResponseEntity<Void> deleteMentorshipData(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        mentorshipService.deleteMentorshipData(userId, id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/group7/backend/service/MentorshipAutoCompletionService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipAutoCompletionService.java
@@ -20,9 +20,9 @@ import java.util.Objects;
 
 /**
  * Auto-terminates ACTIVE mentorships whose {@code endDate} has passed
- * (#237). Each row goes through the same cleanup + audit + notification
- * machinery as a mentor /end, but with {@code terminatedByUserId = null}
- * to denote a system-initiated transition.
+ * (#237). Each row records the same status/audit/notification transition as
+ * a mentor /end, but with {@code terminatedByUserId = null} to denote a
+ * system-initiated transition.
  *
  * <p>Invoked by {@link com.group7.backend.scheduler.MentorshipAutoCompletionScheduler}
  * (and directly from tests). Each row is processed in its own
@@ -36,20 +36,17 @@ public class MentorshipAutoCompletionService {
 
     private final MentorshipRepository mentorshipRepository;
     private final MentorshipAuditLogRepository mentorshipAuditLogRepository;
-    private final MentorshipCleanupService mentorshipCleanupService;
     private final NotificationEventPublisher notificationEventPublisher;
     private final Clock clock;
     private final TransactionTemplate perRowTx;
 
     public MentorshipAutoCompletionService(MentorshipRepository mentorshipRepository,
                                            MentorshipAuditLogRepository mentorshipAuditLogRepository,
-                                           MentorshipCleanupService mentorshipCleanupService,
                                            NotificationEventPublisher notificationEventPublisher,
                                            Clock clock,
                                            PlatformTransactionManager transactionManager) {
         this.mentorshipRepository = mentorshipRepository;
         this.mentorshipAuditLogRepository = mentorshipAuditLogRepository;
-        this.mentorshipCleanupService = mentorshipCleanupService;
         this.notificationEventPublisher = notificationEventPublisher;
         this.clock = clock;
         // Per-row REQUIRES_NEW transaction. Keeps the sweep resilient — one
@@ -115,7 +112,6 @@ public class MentorshipAutoCompletionService {
             mentor.setCurrentMenteeCount(mentor.getCurrentMenteeCount() - 1);
         }
 
-        mentorshipCleanupService.cleanupChildren(mentorshipId);
         mentorshipRepository.save(mentorship);
 
         mentorshipAuditLogRepository.save(MentorshipAuditLog.of(

--- a/backend/src/main/java/com/group7/backend/service/MentorshipService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipService.java
@@ -208,8 +208,6 @@ public class MentorshipService {
             mentor.setCurrentMenteeCount(mentor.getCurrentMenteeCount() - 1);
         }
 
-        mentorshipCleanupService.cleanupChildren(mentorshipId);
-
         Mentorship saved = mentorshipRepository.save(mentorship);
 
         mentorshipAuditLogRepository.save(MentorshipAuditLog.of(
@@ -268,8 +266,6 @@ public class MentorshipService {
         if (mentor.getCurrentMenteeCount() > 0) {
             mentor.setCurrentMenteeCount(mentor.getCurrentMenteeCount() - 1);
         }
-
-        mentorshipCleanupService.cleanupChildren(mentorshipId);
 
         Mentorship saved = mentorshipRepository.save(mentorship);
 
@@ -333,6 +329,21 @@ public class MentorshipService {
         log.info("Mentorship extended: mentorshipId={}, mentorId={}, additionalMonths={}, newEndDate={}",
                 mentorshipId, mentorUserId, additional, newEndDate);
         return MentorshipResponse.from(saved);
+    }
+
+    /**
+     * Explicitly deletes mentorship timeline/progress artifacts for a past
+     * mentorship (#478). Only participants may invoke this method, and only
+     * when the mentorship is no longer ACTIVE.
+     */
+    @Transactional
+    public void deleteMentorshipData(Long actorUserId, Long mentorshipId) {
+        Mentorship mentorship = findForParticipant(actorUserId, mentorshipId);
+        if (mentorship.getStatus() == MentorshipStatus.ACTIVE) {
+            throw new MentorshipRequestException(
+                    "Mentorship data can only be deleted after the mentorship is no longer active");
+        }
+        mentorshipCleanupService.cleanupChildren(mentorshipId);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -528,5 +529,26 @@ class MentorshipControllerTest {
                         .param("from", "banana")
                         .header("Authorization", "Bearer mentor-token"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void deleteMentorshipDataReturns204ForParticipant() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        doNothing().when(mentorshipService).deleteMentorshipData(1L, 100L);
+
+        mockMvc.perform(delete("/api/mentorships/100/data")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deleteMentorshipDataReturns409WhenActive() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        doThrow(new MentorshipRequestException("Mentorship data can only be deleted after the mentorship is no longer active"))
+                .when(mentorshipService).deleteMentorshipData(1L, 100L);
+
+        mockMvc.perform(delete("/api/mentorships/100/data")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isConflict());
     }
 }

--- a/backend/src/test/java/com/group7/backend/integration/EndToEndWorkflowTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/EndToEndWorkflowTest.java
@@ -108,23 +108,22 @@ class EndToEndWorkflowTest extends AbstractE2ETest {
         assertThat(meetingRepository.findById(meetingId)).isPresent();
 
         // End the mentorship — #237's rating endpoint requires COMPLETED /
-        // CANCELLED status, and MentorshipCleanupService wipes tasks /
-        // meetings / milestones as a side effect.
+        // CANCELLED status.
         api.endMentorship(mentor, mentorshipId, "Goal achieved");
 
         Long ratingId = api.rateMentor(mentee, mentorshipId,
                 5, "Great mentor — supportive and clear.");
 
-        // ── Post-end assertions: status flipped, children cleaned, rating present.
+        // ── Post-end assertions: status flipped, history preserved, rating present.
         assertThat(mentorshipRepository.findById(mentorshipId))
                 .isPresent()
                 .hasValueSatisfying(m -> assertThat(m.getStatus()).isEqualTo(MentorshipStatus.COMPLETED));
         assertThat(taskRepository.findById(taskId))
-                .as("cleanupChildren should remove the task when mentorship ends")
-                .isEmpty();
+                .as("ended mentorship should preserve task history")
+                .isPresent();
         assertThat(meetingRepository.findById(meetingId))
-                .as("cleanupChildren should remove the meeting when mentorship ends")
-                .isEmpty();
+                .as("ended mentorship should preserve meeting history")
+                .isPresent();
         assertThat(mentorRatingRepository.findById(ratingId))
                 .isPresent()
                 .hasValueSatisfying(r -> {

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipCancellationIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipCancellationIntegrationTest.java
@@ -40,8 +40,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
- * End-to-end coverage for #133 — mentorship cancellation, related-data
- * cleanup, audit trail, and re-match cool-down.
+ * End-to-end coverage for #133/#478 — mentorship cancellation, related-data
+ * retention by default, explicit data deletion, audit trail, and re-match
+ * cool-down.
  *
  * <p>The cool-down property is shrunk to 1 hour for fast tests and the
  * production {@link Clock} is overridden with a {@link MutableClock} so
@@ -188,7 +189,7 @@ class MentorshipCancellationIntegrationTest {
     // ── Tests ───────────────────────────────────────────────────────────────
 
     @Test
-    void cancelMentorshipFlipsStatusAndDeletesChildren() throws Exception {
+    void cancelMentorshipFlipsStatusAndPreservesChildrenByDefault() throws Exception {
         CanceledFixture f = acceptMentorship("c_mentor1@test.com", "c_mentee1@test.com");
         seedTaskAndMilestone(f.mentorshipId());
         assertThat(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(f.mentorshipId())).hasSize(1);
@@ -206,13 +207,42 @@ class MentorshipCancellationIntegrationTest {
         Mentorship after = mentorshipRepository.findById(f.mentorshipId()).orElseThrow();
         assertThat(after.getTerminatedAt()).isNotNull();
         assertThat(after.getTerminatedByUserId()).isEqualTo(f.menteeId());
-        assertThat(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(f.mentorshipId())).isEmpty();
-        assertThat(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(f.mentorshipId())).isEmpty();
+        assertThat(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(f.mentorshipId())).hasSize(1);
+        assertThat(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(f.mentorshipId())).hasSize(1);
 
         Mentee mentee = menteeRepository.findById(f.menteeId()).orElseThrow();
         assertThat(mentee.getActiveMentorId()).isNull();
         Mentor mentor = mentorRepository.findById(f.mentorId()).orElseThrow();
         assertThat(mentor.getCurrentMenteeCount()).isZero();
+    }
+
+    @Test
+    void deleteMentorshipDataRemovesChildrenForPastMentorship() throws Exception {
+        CanceledFixture f = acceptMentorship("c_mentor_data1@test.com", "c_mentee_data1@test.com");
+        seedTaskAndMilestone(f.mentorshipId());
+
+        mockMvc.perform(post("/api/mentorships/" + f.mentorshipId() + "/cancel")
+                        .header("Authorization", "Bearer " + f.menteeToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("reason", "cleanup later"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/api/mentorships/" + f.mentorshipId() + "/data")
+                        .header("Authorization", "Bearer " + f.menteeToken()))
+                .andExpect(status().isNoContent());
+
+        assertThat(taskRepository.findByMentorshipIdOrderByCreatedAtDesc(f.mentorshipId())).isEmpty();
+        assertThat(milestoneRepository.findByMentorshipIdOrderByOrderIndexAsc(f.mentorshipId())).isEmpty();
+    }
+
+    @Test
+    void deleteMentorshipDataRejectsActiveMentorship() throws Exception {
+        CanceledFixture f = acceptMentorship("c_mentor_data2@test.com", "c_mentee_data2@test.com");
+        seedTaskAndMilestone(f.mentorshipId());
+
+        mockMvc.perform(delete("/api/mentorships/" + f.mentorshipId() + "/data")
+                        .header("Authorization", "Bearer " + f.menteeToken()))
+                .andExpect(status().isConflict());
     }
 
     @Test

--- a/backend/src/test/java/com/group7/backend/service/MentorshipAutoCompletionServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipAutoCompletionServiceTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -41,7 +40,6 @@ class MentorshipAutoCompletionServiceTest {
 
     @Mock private MentorshipRepository mentorshipRepository;
     @Mock private MentorshipAuditLogRepository mentorshipAuditLogRepository;
-    @Mock private MentorshipCleanupService mentorshipCleanupService;
     @Mock private NotificationEventPublisher notificationEventPublisher;
     @Mock private PlatformTransactionManager transactionManager;
 
@@ -55,7 +53,7 @@ class MentorshipAutoCompletionServiceTest {
         // the empty-list short-circuit before TransactionTemplate is touched).
         lenient().when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
         service = new MentorshipAutoCompletionService(mentorshipRepository,
-                mentorshipAuditLogRepository, mentorshipCleanupService,
+                mentorshipAuditLogRepository,
                 notificationEventPublisher, clock, transactionManager);
     }
 
@@ -104,8 +102,6 @@ class MentorshipAutoCompletionServiceTest {
         assertThat(processed).isEqualTo(2);
         assertThat(m1.getStatus()).isEqualTo(MentorshipStatus.COMPLETED);
         assertThat(m2.getStatus()).isEqualTo(MentorshipStatus.COMPLETED);
-        verify(mentorshipCleanupService).cleanupChildren(100L);
-        verify(mentorshipCleanupService).cleanupChildren(101L);
         // Both participants of each mentorship receive a notification:
         // m1 -> recipients 1L (mentor) and 2L (mentee); m2 -> 3L and 4L.
         verify(notificationEventPublisher).publishMentorshipAutoCompleted(eq(1L), anyString());
@@ -164,7 +160,6 @@ class MentorshipAutoCompletionServiceTest {
         int processed = service.autoCompleteExpired();
 
         assertThat(processed).isEqualTo(1);
-        verify(mentorshipCleanupService, never()).cleanupChildren(anyLong());
         verify(mentorshipAuditLogRepository, never()).save(any());
     }
 
@@ -176,13 +171,13 @@ class MentorshipAutoCompletionServiceTest {
                 .thenReturn(List.of(m1, m2));
         when(mentorshipRepository.findById(100L)).thenReturn(Optional.of(m1));
         when(mentorshipRepository.findById(101L)).thenReturn(Optional.of(m2));
-        doThrow(new RuntimeException("cleanup boom"))
-                .when(mentorshipCleanupService).cleanupChildren(100L);
+        doThrow(new RuntimeException("save boom"))
+                .when(mentorshipRepository).save(m1);
 
         int processed = service.autoCompleteExpired();
 
         assertThat(processed).isEqualTo(1);
         assertThat(m2.getStatus()).isEqualTo(MentorshipStatus.COMPLETED);
-        verify(mentorshipCleanupService).cleanupChildren(101L);
+        verify(mentorshipRepository).save(m2);
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorshipServiceTest.java
@@ -448,7 +448,7 @@ class MentorshipServiceTest {
     }
 
     @Test
-    void cancelMentorshipByMenteeMarksCancelledAndCleansUp() {
+    void cancelMentorshipByMenteeMarksCancelledAndPreservesDataByDefault() {
         Mentorship mentorship = activeMentorship();
         mentee.setActiveMentorId(mentor.getId());
         when(mentorshipRepository.findByIdAndParticipant(100L, 2L)).thenReturn(Optional.of(mentorship));
@@ -462,7 +462,7 @@ class MentorshipServiceTest {
         assertThat(mentorship.getTerminatedByUserId()).isEqualTo(2L);
         assertThat(mentee.getActiveMentorId()).isNull();
         assertThat(mentor.getCurrentMenteeCount()).isEqualTo(0);
-        verify(mentorshipCleanupService).cleanupChildren(100L);
+        verify(mentorshipCleanupService, never()).cleanupChildren(any());
         verify(notificationEventPublisher).publishMentorshipCancelled(1L, "Elif", "Schedule clash");
         verify(banService).recordCancellation(2L, "Cancelled active mentorship: Schedule clash");
 
@@ -534,7 +534,7 @@ class MentorshipServiceTest {
     }
 
     @Test
-    void endMentorshipByMentorSetsCompletedAndCleansUp() {
+    void endMentorshipByMentorSetsCompletedAndPreservesDataByDefault() {
         Mentorship mentorship = activeMentorship();
         mentee.setActiveMentorId(mentor.getId());
         when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
@@ -548,7 +548,7 @@ class MentorshipServiceTest {
         assertThat(mentorship.getEndDate()).isEqualTo(mentorship.getTerminatedAt());
         assertThat(mentee.getActiveMentorId()).isNull();
         assertThat(mentor.getCurrentMenteeCount()).isEqualTo(0);
-        verify(mentorshipCleanupService).cleanupChildren(100L);
+        verify(mentorshipCleanupService, never()).cleanupChildren(any());
         verify(notificationEventPublisher).publishMentorshipEnded(2L, "Ahmet", "Goal achieved");
         verify(banService, never()).recordCancellation(any(), any());
 
@@ -580,6 +580,28 @@ class MentorshipServiceTest {
         assertThatThrownBy(() -> mentorshipService.endMentorship(1L, 100L, endDto(null)))
                 .isInstanceOf(MentorshipRequestException.class)
                 .hasMessageContaining("not active");
+    }
+
+    @Test
+    void deleteMentorshipDataForPastMentorshipRunsCleanup() {
+        Mentorship mentorship = activeMentorship();
+        mentorship.setStatus(MentorshipStatus.COMPLETED);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+
+        mentorshipService.deleteMentorshipData(1L, 100L);
+
+        verify(mentorshipCleanupService).cleanupChildren(100L);
+    }
+
+    @Test
+    void deleteMentorshipDataRejectsActiveMentorship() {
+        Mentorship mentorship = activeMentorship();
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L)).thenReturn(Optional.of(mentorship));
+
+        assertThatThrownBy(() -> mentorshipService.deleteMentorshipData(1L, 100L))
+                .isInstanceOf(MentorshipRequestException.class)
+                .hasMessageContaining("no longer active");
+        verify(mentorshipCleanupService, never()).cleanupChildren(any());
     }
 
     // ── Extend mentorship (#237) ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Implements #478 by preserving mentorship timeline/progress artifacts after mentorship termination, and adding an explicit endpoint to delete mentorship data when desired.

## Changes Made
- Stopped automatic child-data cleanup on:
  - `PATCH /api/mentorships/{id}/end`
  - `POST /api/mentorships/{id}/cancel`
  - auto-completion termination flow
- Added explicit cleanup endpoint:
  - `DELETE /api/mentorships/{id}/data`
- Added guardrails for delete endpoint:
  - only mentorship participants can invoke (existing participant gate)
  - only non-`ACTIVE` mentorships can be cleaned (`409` if active)
- Kept mentorship lifecycle/audit behavior intact.

## Why
Past mentorships should retain progress/timeline history by default. Data deletion should be an explicit user action, not an automatic side effect of end/cancel.

## Validation
- Full backend suite run locally in Docker:
  - `Tests run: 1513, Failures: 0, Errors: 0, Skipped: 0`
  - `BUILD SUCCESS`
- Updated service/controller/integration tests for retention-by-default + explicit deletion behavior.
