### PR TITLE
fix(backend): surface real like and comment counts in list responses (#480)

### DIFF
--- a/backend/src/main/java/com/group7/backend/repository/FeedPostCommentRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostCommentRepository.java
@@ -1,10 +1,16 @@
 package com.group7.backend.repository;
 
 import com.group7.backend.entity.FeedPostComment;
+import com.group7.backend.repository.projection.PostCountTuple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
 
 @Repository
 public interface FeedPostCommentRepository extends JpaRepository<FeedPostComment, Long> {
@@ -17,4 +23,18 @@ public interface FeedPostCommentRepository extends JpaRepository<FeedPostComment
     Page<FeedPostComment> findByPostIdOrderByCreatedAtAscIdAsc(Long postId, Pageable pageable);
 
     long countByPostIdAndDeletedAtIsNull(Long postId);
+
+    /**
+     * Batch visible-comment-count projection across many posts in one
+     * round-trip. Excludes soft-deleted comments at the SQL layer so the
+     * surface matches what list endpoints render. Posts with no visible
+     * comments are absent from the result; callers fill those with zero.
+     */
+    @Query("""
+            SELECT new com.group7.backend.repository.projection.PostCountTuple(c.postId, COUNT(c))
+            FROM FeedPostComment c
+            WHERE c.postId IN :postIds AND c.deletedAt IS NULL
+            GROUP BY c.postId
+            """)
+    List<PostCountTuple> countVisibleByPostIdIn(@Param("postIds") Collection<Long> postIds);
 }

--- a/backend/src/main/java/com/group7/backend/repository/FeedPostLikeRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostLikeRepository.java
@@ -2,11 +2,15 @@ package com.group7.backend.repository;
 
 import com.group7.backend.entity.FeedPostLike;
 import com.group7.backend.entity.FeedPostLikeId;
+import com.group7.backend.repository.projection.PostCountTuple;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Repository for {@link FeedPostLike} (#347). Mirrors the idempotent-
@@ -29,4 +33,18 @@ public interface FeedPostLikeRepository extends JpaRepository<FeedPostLike, Feed
     long countByIdPostId(Long postId);
 
     boolean existsByIdPostIdAndIdUserId(Long postId, Long userId);
+
+    /**
+     * Batch like-count projection across many posts in one round-trip.
+     * Returns one row per post that has at least one like; callers fill
+     * missing ids with zero (the absent-postId-means-zero contract is
+     * enforced by {@code FeedInteractionService.batchCounts}).
+     */
+    @Query("""
+            SELECT new com.group7.backend.repository.projection.PostCountTuple(l.id.postId, COUNT(l))
+            FROM FeedPostLike l
+            WHERE l.id.postId IN :postIds
+            GROUP BY l.id.postId
+            """)
+    List<PostCountTuple> countByPostIdIn(@Param("postIds") Collection<Long> postIds);
 }

--- a/backend/src/main/java/com/group7/backend/repository/projection/PostCountTuple.java
+++ b/backend/src/main/java/com/group7/backend/repository/projection/PostCountTuple.java
@@ -1,0 +1,16 @@
+package com.group7.backend.repository.projection;
+
+/**
+ * Projection target for grouped feed-post count queries on
+ * {@code FeedPostLikeRepository} and {@code FeedPostCommentRepository}.
+ *
+ * <p>Both repositories use a JPQL constructor expression
+ * ({@code SELECT new PostCountTuple(...)}) so the read services never have to
+ * unpack a {@code List<Object[]>} when populating per-post interaction counts
+ * across a page of feed items.
+ */
+public record PostCountTuple(
+        Long postId,
+        Long count
+) {
+}

--- a/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
@@ -16,6 +16,7 @@ import com.group7.backend.repository.FeedPostLikeRepository;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.FeedPostShareRepository;
 import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.projection.PostCountTuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
@@ -26,7 +27,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,6 +56,15 @@ import java.util.stream.Collectors;
 @Service
 @Transactional(readOnly = true)
 public class FeedInteractionService {
+
+    /**
+     * Per-post like/comment counts assembled by {@link #batchCounts}.
+     * Tightly scoped to the read fan-out path; not a wire DTO. The two
+     * fields mirror {@code FeedPostListItem.likeCount} /
+     * {@code commentCount} positions so the caller can splat them
+     * straight into the record constructor.
+     */
+    public record PostCounts(long likeCount, long commentCount) {}
 
     private static final Logger log = LoggerFactory.getLogger(FeedInteractionService.class);
 
@@ -156,21 +168,58 @@ public class FeedInteractionService {
                 .map(byId::get)
                 .filter(p -> p != null && p.getDeletedAt() == null)
                 .toList();
-        Map<Long, String> authorNames = new java.util.HashMap<>();
+        Map<Long, String> authorNames = new HashMap<>();
         userRepository.findAllById(ordered.stream().map(FeedPost::getAuthorId)
-                .collect(java.util.stream.Collectors.toSet()))
+                .collect(Collectors.toSet()))
                 .forEach(u -> authorNames.put(u.getId(), u.getFirstName()));
-        List<FeedPostListItem> items = ordered.stream().map(p -> new FeedPostListItem(
-                p.getId(),
-                p.getAuthorId(),
-                authorNames.getOrDefault(p.getAuthorId(), null),
-                p.getBody(),
-                p.getHashtags().stream().map(h -> h.getId().getTag()).sorted().toList(),
-                p.getCreatedAt(),
-                0L,
-                0L
-        )).toList();
+        Map<Long, PostCounts> counts = batchCounts(
+                ordered.stream().map(FeedPost::getId).toList());
+        List<FeedPostListItem> items = ordered.stream().map(p -> {
+            PostCounts c = counts.get(p.getId());
+            return new FeedPostListItem(
+                    p.getId(),
+                    p.getAuthorId(),
+                    authorNames.getOrDefault(p.getAuthorId(), null),
+                    p.getBody(),
+                    p.getHashtags().stream().map(h -> h.getId().getTag()).sorted().toList(),
+                    p.getCreatedAt(),
+                    c.likeCount(),
+                    c.commentCount()
+            );
+        }).toList();
         return new PageImpl<>(items, pageable, postIds.getTotalElements());
+    }
+
+    /**
+     * Aggregate like / visible-comment counts across many posts in a
+     * single round-trip per interaction type. Used by the feed list
+     * endpoints to avoid an N+1 fan-out when populating
+     * {@code FeedPostListItem.likeCount} / {@code commentCount}.
+     *
+     * <p>Contract: the returned map contains an entry for <b>every</b>
+     * postId supplied — posts with zero likes / zero visible comments
+     * surface as {@code new PostCounts(0L, 0L)} rather than being absent.
+     * Callers can therefore index directly without {@code getOrDefault}.
+     *
+     * <p>Short-circuits on an empty input: Postgres rejects
+     * {@code WHERE id IN ()}, so an empty {@code postIds} returns
+     * {@code Map.of()} before any SQL is issued.
+     */
+    public Map<Long, PostCounts> batchCounts(Collection<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, Long> likeCounts = likeRepository.countByPostIdIn(postIds).stream()
+                .collect(Collectors.toMap(PostCountTuple::postId, PostCountTuple::count));
+        Map<Long, Long> commentCounts = commentRepository.countVisibleByPostIdIn(postIds).stream()
+                .collect(Collectors.toMap(PostCountTuple::postId, PostCountTuple::count));
+        Map<Long, PostCounts> result = new LinkedHashMap<>(postIds.size());
+        for (Long id : postIds) {
+            result.put(id, new PostCounts(
+                    likeCounts.getOrDefault(id, 0L),
+                    commentCounts.getOrDefault(id, 0L)));
+        }
+        return result;
     }
 
     // ── Shares ─────────────────────────────────────────────────────────────

--- a/backend/src/main/java/com/group7/backend/service/FeedReadService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedReadService.java
@@ -69,6 +69,7 @@ public class FeedReadService {
     private final FollowRepository followRepository;
     private final HashtagNormalizer hashtagNormalizer;
     private final FeedRanker feedRanker;
+    private final FeedInteractionService feedInteractionService;
     private final int candidateWindow;
 
     public FeedReadService(FeedPostRepository feedPostRepository,
@@ -76,12 +77,14 @@ public class FeedReadService {
                            FollowRepository followRepository,
                            HashtagNormalizer hashtagNormalizer,
                            FeedRanker feedRanker,
+                           FeedInteractionService feedInteractionService,
                            @Value("${app.feed.forYou.candidate-window:200}") int candidateWindow) {
         this.feedPostRepository = feedPostRepository;
         this.userRepository = userRepository;
         this.followRepository = followRepository;
         this.hashtagNormalizer = hashtagNormalizer;
         this.feedRanker = feedRanker;
+        this.feedInteractionService = feedInteractionService;
         this.candidateWindow = candidateWindow;
     }
 
@@ -243,7 +246,10 @@ public class FeedReadService {
             return Page.empty(page.getPageable());
         }
         Map<Long, String> authorNames = resolveAuthorNames(page.getContent());
-        return page.map(p -> toListItem(p, authorNames));
+        Map<Long, FeedInteractionService.PostCounts> counts =
+                feedInteractionService.batchCounts(
+                        page.getContent().stream().map(FeedPost::getId).toList());
+        return page.map(p -> toListItem(p, authorNames, counts));
     }
 
     private Page<FeedPostListItem> slicePage(List<FeedPost> ranked, Pageable pageable) {
@@ -255,8 +261,11 @@ public class FeedReadService {
             return new PageImpl<>(List.of(), pageable, total);
         }
         Map<Long, String> authorNames = resolveAuthorNames(slice);
+        Map<Long, FeedInteractionService.PostCounts> counts =
+                feedInteractionService.batchCounts(
+                        slice.stream().map(FeedPost::getId).toList());
         List<FeedPostListItem> items = slice.stream()
-                .map(p -> toListItem(p, authorNames))
+                .map(p -> toListItem(p, authorNames, counts))
                 .toList();
         return new PageImpl<>(items, pageable, total);
     }
@@ -268,12 +277,15 @@ public class FeedReadService {
         return names;
     }
 
-    private static FeedPostListItem toListItem(FeedPost post, Map<Long, String> authorNames) {
+    private static FeedPostListItem toListItem(FeedPost post,
+                                               Map<Long, String> authorNames,
+                                               Map<Long, FeedInteractionService.PostCounts> counts) {
         List<String> tags = post.getHashtags().stream()
                 .map(FeedPostHashtag::getId)
                 .map(id -> id.getTag())
                 .sorted()
                 .toList();
+        FeedInteractionService.PostCounts c = counts.get(post.getId());
         return new FeedPostListItem(
                 post.getId(),
                 post.getAuthorId(),
@@ -281,8 +293,8 @@ public class FeedReadService {
                 post.getBody(),
                 tags,
                 post.getCreatedAt(),
-                0L,
-                0L
+                c.likeCount(),
+                c.commentCount()
         );
     }
 

--- a/backend/src/test/java/com/group7/backend/integration/FeedInteractionIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedInteractionIntegrationTest.java
@@ -183,6 +183,51 @@ class FeedInteractionIntegrationTest {
                 .andExpect(jsonPath("$.totalElements").value(0));
     }
 
+    @Test
+    void listBookmarks_surfacesLikeAndVisibleCommentCounts() throws Exception {
+        String authorToken = registerAndLogin("bm_counts_author@test.com");
+        String viewerToken = registerAndLogin("bm_counts_viewer@test.com");
+        long pid = createPost(authorToken, "post that gets bookmarked", List.of());
+
+        // Two likes + one visible comment + one deleted comment on the post.
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/like")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/like")
+                        .header("Authorization", "Bearer " + authorToken))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/comments")
+                        .header("Authorization", "Bearer " + viewerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"kept\"}"))
+                .andExpect(status().isCreated());
+        MvcResult dRes = mockMvc.perform(post("/api/feed/posts/" + pid + "/comments")
+                        .header("Authorization", "Bearer " + viewerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"to delete\"}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+        long doomed = objectMapper.readTree(dRes.getResponse().getContentAsString())
+                .get("id").asLong();
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .delete("/api/feed/comments/" + doomed)
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isNoContent());
+
+        // Viewer bookmarks the post and fetches their bookmark list.
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/bookmark")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/feed/me/bookmarks")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(pid))
+                .andExpect(jsonPath("$.content[0].likeCount").value(2))
+                .andExpect(jsonPath("$.content[0].commentCount").value(1));
+    }
+
     // ── Shares ─────────────────────────────────────────────────────────────
 
     @Test

--- a/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
@@ -57,6 +57,10 @@ class FeedReadIntegrationTest {
 
     @BeforeEach
     void cleanDb() {
+        jdbcTemplate.update("DELETE FROM feed_post_comments");
+        jdbcTemplate.update("DELETE FROM feed_post_shares");
+        jdbcTemplate.update("DELETE FROM feed_post_bookmarks");
+        jdbcTemplate.update("DELETE FROM feed_post_likes");
         jdbcTemplate.update("DELETE FROM feed_post_hashtags");
         jdbcTemplate.update("DELETE FROM feed_posts");
         jdbcTemplate.update("DELETE FROM follows");
@@ -483,5 +487,120 @@ class FeedReadIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn();
         return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();
+    }
+
+    private void likePost(String token, long postId) throws Exception {
+        mockMvc.perform(post("/api/feed/posts/" + postId + "/like")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+
+    private long addComment(String token, long postId, String body) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/feed/posts/" + postId + "/comments")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("body", body))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();
+    }
+
+    private void softDeleteComment(String token, long commentId) throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .delete("/api/feed/comments/" + commentId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+    }
+
+    private JsonNode postFromPage(JsonNode pageBody, long postId) {
+        return StreamSupport.stream(pageBody.get("content").spliterator(), false)
+                .filter(n -> n.get("id").asLong() == postId)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Post " + postId + " not found in page"));
+    }
+
+    // ── Interaction counts surfaced in list responses ───────────────────────
+
+    @Test
+    void forYouFeed_surfacesLikeAndVisibleCommentCounts() throws Exception {
+        String viewerToken = registerAndLogin("counts_viewer@test.com", true);
+        String authorToken = registerAndLogin("counts_author@test.com", true);
+        String likerToken = registerAndLogin("counts_liker@test.com", true);
+
+        long pidA = createPost(authorToken, "post A with engagement", List.of());
+        long pidB = createPost(authorToken, "post B no engagement", List.of());
+
+        // Post A: 3 likes (3 distinct users), 2 visible comments + 1 soft-deleted comment
+        likePost(viewerToken, pidA);
+        likePost(authorToken, pidA);
+        likePost(likerToken, pidA);
+        addComment(viewerToken, pidA, "kept 1");
+        addComment(likerToken, pidA, "kept 2");
+        long deletedComment = addComment(likerToken, pidA, "to be deleted");
+        softDeleteComment(likerToken, deletedComment);
+
+        // Post B: 1 like, 0 comments
+        likePost(viewerToken, pidB);
+
+        MvcResult result = mockMvc.perform(get("/api/feed/for-you").param("size", "20")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        JsonNode a = postFromPage(body, pidA);
+        assertThat(a.get("likeCount").asLong()).isEqualTo(3L);
+        assertThat(a.get("commentCount").asLong()).isEqualTo(2L);
+
+        JsonNode b = postFromPage(body, pidB);
+        assertThat(b.get("likeCount").asLong()).isEqualTo(1L);
+        assertThat(b.get("commentCount").asLong()).isEqualTo(0L);
+    }
+
+    @Test
+    void followingFeed_surfacesLikeAndVisibleCommentCounts() throws Exception {
+        String viewerToken = registerAndLogin("counts_follow_viewer@test.com", true);
+        String authorToken = registerAndLogin("counts_follow_author@test.com", true);
+
+        long authorId = userRepository.findByEmail("counts_follow_author@test.com").orElseThrow().getId();
+        mockMvc.perform(post("/api/users/" + authorId + "/follow")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().is2xxSuccessful());
+
+        long pid = createPost(authorToken, "followed-feed body", List.of());
+        likePost(viewerToken, pid);
+        addComment(viewerToken, pid, "follower comment");
+        addComment(authorToken, pid, "author own comment");
+
+        MvcResult result = mockMvc.perform(get("/api/feed/following").param("size", "20")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        JsonNode post = postFromPage(body, pid);
+        assertThat(post.get("likeCount").asLong()).isEqualTo(1L);
+        assertThat(post.get("commentCount").asLong()).isEqualTo(2L);
+    }
+
+    @Test
+    void searchFeed_surfacesLikeAndVisibleCommentCounts() throws Exception {
+        String viewerToken = registerAndLogin("counts_search_viewer@test.com", true);
+        String authorToken = registerAndLogin("counts_search_author@test.com", true);
+
+        long pid = createPost(authorToken, "uniquekeyword in body", List.of());
+        likePost(viewerToken, pid);
+        likePost(authorToken, pid);
+        addComment(viewerToken, pid, "search comment");
+
+        MvcResult result = mockMvc.perform(get("/api/feed/search").param("q", "uniquekeyword")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        JsonNode post = postFromPage(body, pid);
+        assertThat(post.get("likeCount").asLong()).isEqualTo(2L);
+        assertThat(post.get("commentCount").asLong()).isEqualTo(1L);
     }
 }


### PR DESCRIPTION
## Summary

Every feed list endpoint (`/api/feed/for-you`, `/following`, `/users/{authorId}/posts`, `/search`, `/me/bookmarks`) currently returns `likeCount: 0` and `commentCount: 0` for every post, regardless of actual engagement. The placeholder was added in #347 with a TODO to populate it once the interaction layer landed; the interaction layer shipped, but the placeholder was never replaced. This PR closes that gap by batching the counts so every list response surfaces real numbers without an N+1 fan-out.

## Changes

- **New projection** `repository/projection/PostCountTuple.java` — a record mirror of `ActionItemCountTuple`, consumed via a JPQL constructor expression so the service layer never has to unpack a raw `Object[]`.
- **`FeedPostLikeRepository.countByPostIdIn`** — JPQL `GROUP BY` over `feed_post_likes` for a collection of post ids.
- **`FeedPostCommentRepository.countVisibleByPostIdIn`** — same pattern, filtered on `c.deletedAt IS NULL` at the SQL layer so soft-deleted comments are excluded.
- **`FeedInteractionService.batchCounts(Collection<Long>)`** — issues both queries (two round-trips per page total) and assembles a `Map<Long, PostCounts>` where every requested post id is present, zero-filled for posts with no interactions. Empty input short-circuits to `Map.of()` to avoid the Postgres `WHERE id IN ()` syntax error.
- **`FeedInteractionService.PostCounts`** — public nested record on the service. Tightly scoped to the read fan-out path; not a wire DTO and not exposed in HTTP responses.
- **`FeedReadService.mapPage` / `slicePage` / `toListItem`** — refactored to call `batchCounts` once per page and splat the counts into the `FeedPostListItem` constructor. `FeedInteractionService` is now constructor-injected.
- **`FeedInteractionService.listBookmarks`** — same pattern, applied after the visible-post filter so we never query counts for posts the viewer will not see.

No DTO contract changes. `FeedPostListItem` retains the same field shape; the two existing slots simply now carry real values instead of placeholders.

## Acceptance criteria

- [x] `GET /api/feed/for-you` returns counts matching the underlying tables for each post in the page.
- [x] Same assertion holds for `/following`, `/search`, `/me/bookmarks`.
- [x] Soft-deleted comments do not contribute to `commentCount`.
- [x] An empty page does not crash on a `WHERE IN ()` query.
- [x] The change adds exactly two `GROUP BY` queries per page; total per-page query count stays under 10.

## Test coverage

Integration coverage extended:

- `FeedReadIntegrationTest.forYouFeed_surfacesLikeAndVisibleCommentCounts` — 2 posts, varied engagement (Post A: 3 likes + 2 visible comments + 1 soft-deleted comment; Post B: 1 like, 0 comments). Asserts both posts return the expected counts, soft-deleted comment excluded.
- `FeedReadIntegrationTest.followingFeed_surfacesLikeAndVisibleCommentCounts` — follower viewer over a post with 1 like and 2 comments.
- `FeedReadIntegrationTest.searchFeed_surfacesLikeAndVisibleCommentCounts` — keyword search over a post with 2 likes and 1 comment.
- `FeedInteractionIntegrationTest.listBookmarks_surfacesLikeAndVisibleCommentCounts` — bookmark + 2 likes + 1 visible + 1 deleted comment.

The existing `FeedReadIntegrationTest.cleanDb` hook was extended to delete `feed_post_comments`, `feed_post_shares`, `feed_post_bookmarks`, and `feed_post_likes` so the new seed-via-API tests do not leak rows across cases.

## Validation

- Backend CI (`mvn --batch-mode verify`) — 1511 tests, 0 failures, 0 errors, BUILD SUCCESS.
- Playwright e2e — chromium suite passes; no new failures introduced by this change.
- Manual API smoke against a running backend: created a post, applied one like and two comments, soft-deleted one comment, then verified `/for-you`, `/search`, and `/me/bookmarks` all return `likeCount: 1, commentCount: 1` (soft-deleted comment excluded).

## Frontend impact (non-breaking)

The wire shape of `FeedPostListItem` is unchanged — `likeCount` and `commentCount` were already part of the contract. After this fix, those fields begin returning real values instead of always-zero placeholders. Any frontend code that conditionally renders a like or comment badge based on `count > 0` will start showing real counts on existing posts. This is the intended behaviour but worth flagging to the web and mobile teams before deploy.

## Out of scope

- Adding `shareCount` / `bookmarkCount` to `FeedPostListItem` (separate DTO change, not required by the issue).
- Viewer-relative `viewerLiked` / `viewerBookmarked` flags in list responses (lives in `FeedPostInteractionState` on the detail endpoint; would require a separate viewer-side projection).
- Comment-level like counts (tracked under #483 with its own batch helper that mirrors this pattern).
- Service-level unit tests for `FeedReadService` / `FeedInteractionService` (tracked under #488).

Closes #480