### PR TITLE
feat(feed): engagement notifications for like / comment / share / follow (#482)

### DIFF
--- a/backend/src/main/java/com/group7/backend/dto/request/NotificationPreferencesUpdateRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/NotificationPreferencesUpdateRequest.java
@@ -24,4 +24,6 @@ public class NotificationPreferencesUpdateRequest {
     private Boolean requestsEnabled;
     private Boolean taskDeadlineRemindersEnabled;
     private Boolean milestoneRemindersEnabled;
+    private Boolean feedEngagementEnabled;
+    private Boolean newFollowerEnabled;
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/UserNotificationPreferencesResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/UserNotificationPreferencesResponse.java
@@ -23,6 +23,8 @@ public class UserNotificationPreferencesResponse {
     private boolean requestsEnabled;
     private boolean taskDeadlineRemindersEnabled;
     private boolean milestoneRemindersEnabled;
+    private boolean feedEngagementEnabled;
+    private boolean newFollowerEnabled;
     private OffsetDateTime updatedAt;
 
     public static UserNotificationPreferencesResponse from(UserNotificationPreferences prefs) {
@@ -34,6 +36,8 @@ public class UserNotificationPreferencesResponse {
                 prefs.isRequestsEnabled(),
                 prefs.isTaskDeadlineRemindersEnabled(),
                 prefs.isMilestoneRemindersEnabled(),
+                prefs.isFeedEngagementEnabled(),
+                prefs.isNewFollowerEnabled(),
                 prefs.getUpdatedAt());
     }
 }

--- a/backend/src/main/java/com/group7/backend/entity/NotificationType.java
+++ b/backend/src/main/java/com/group7/backend/entity/NotificationType.java
@@ -42,5 +42,16 @@ public enum NotificationType {
     // when end_date passes; both participants receive it.
     MENTORSHIP_ENDED,
     MENTORSHIP_EXTENDED,
-    MENTORSHIP_AUTO_COMPLETED
+    MENTORSHIP_AUTO_COMPLETED,
+    // Social-feed engagement. FEED_LIKE / FEED_COMMENT / FEED_SHARE fire to
+    // the post author when another user interacts with their post. Self-likes
+    // / self-comments / self-shares are skipped at the publisher call site.
+    // FEED_LIKE is deduplicated against the 24h same-body window so a single
+    // actor liking multiple posts collapses to one notification per day.
+    FEED_LIKE,
+    FEED_COMMENT,
+    FEED_SHARE,
+    // Sent to the followee when another user follows them. Self-follow is
+    // already blocked upstream by SelfFollowException.
+    NEW_FOLLOWER
 }

--- a/backend/src/main/java/com/group7/backend/entity/UserNotificationPreferences.java
+++ b/backend/src/main/java/com/group7/backend/entity/UserNotificationPreferences.java
@@ -58,6 +58,12 @@ public class UserNotificationPreferences {
     @Column(name = "milestone_reminders_enabled", nullable = false)
     private boolean milestoneRemindersEnabled = true;
 
+    @Column(name = "feed_engagement_enabled", nullable = false)
+    private boolean feedEngagementEnabled = true;
+
+    @Column(name = "new_follower_enabled", nullable = false)
+    private boolean newFollowerEnabled = true;
+
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
 
@@ -99,6 +105,8 @@ public class UserNotificationPreferences {
             // auto-completion all change the user's relationship status and
             // their pending tasks/meetings, so always-on.
             case MENTORSHIP_ENDED, MENTORSHIP_EXTENDED, MENTORSHIP_AUTO_COMPLETED -> true;
+            case FEED_LIKE, FEED_COMMENT, FEED_SHARE -> feedEngagementEnabled;
+            case NEW_FOLLOWER -> newFollowerEnabled;
         };
     }
 }

--- a/backend/src/main/java/com/group7/backend/event/NotificationEventListener.java
+++ b/backend/src/main/java/com/group7/backend/event/NotificationEventListener.java
@@ -52,10 +52,10 @@ public class NotificationEventListener {
             return;
         }
 
-        if (event.type() == NotificationType.MATCH_FOUND) {
+        if (event.type() == NotificationType.MATCH_FOUND || event.type() == NotificationType.FEED_LIKE) {
             boolean existsRecent = notificationRepository.existsByRecipient_IdAndTypeAndBodyAndCreatedAtAfter(
                     event.recipientId(),
-                    NotificationType.MATCH_FOUND,
+                    event.type(),
                     event.body(),
                     OffsetDateTime.now(clock).minusHours(24)
             );

--- a/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
@@ -63,6 +63,7 @@ public class FeedInteractionService {
     private final FeedPostCommentRepository commentRepository;
     private final UserRepository userRepository;
     private final FeedPostMapper feedPostMapper;
+    private final NotificationEventPublisher notificationEventPublisher;
 
     public FeedInteractionService(FeedPostRepository feedPostRepository,
                                    FeedPostLikeRepository likeRepository,
@@ -70,7 +71,8 @@ public class FeedInteractionService {
                                    FeedPostShareRepository shareRepository,
                                    FeedPostCommentRepository commentRepository,
                                    UserRepository userRepository,
-                                   FeedPostMapper feedPostMapper) {
+                                   FeedPostMapper feedPostMapper,
+                                   NotificationEventPublisher notificationEventPublisher) {
         this.feedPostRepository = feedPostRepository;
         this.likeRepository = likeRepository;
         this.bookmarkRepository = bookmarkRepository;
@@ -78,6 +80,7 @@ public class FeedInteractionService {
         this.commentRepository = commentRepository;
         this.userRepository = userRepository;
         this.feedPostMapper = feedPostMapper;
+        this.notificationEventPublisher = notificationEventPublisher;
     }
 
     // ── Likes ──────────────────────────────────────────────────────────────
@@ -103,7 +106,7 @@ public class FeedInteractionService {
      */
     @Transactional
     public FeedPostInteractionState toggleLike(Long postId, Long userId) {
-        requireVisiblePost(postId);
+        FeedPost post = requireVisiblePost(postId);
         FeedPostLikeId id = new FeedPostLikeId(postId, userId);
         boolean nowLiked;
         if (likeRepository.existsByIdPostIdAndIdUserId(postId, userId)) {
@@ -114,6 +117,10 @@ public class FeedInteractionService {
             nowLiked = true;
         }
         log.info("Toggle like: postId={}, userId={}, nowLiked={}", postId, userId, nowLiked);
+        if (nowLiked && !userId.equals(post.getAuthorId())) {
+            notificationEventPublisher.publishFeedLike(
+                    post.getAuthorId(), resolveAuthorName(userId), postId);
+        }
         return interactionState(postId, userId);
     }
 
@@ -177,9 +184,13 @@ public class FeedInteractionService {
 
     @Transactional
     public FeedPostInteractionState recordShare(Long postId, Long sharerId) {
-        requireVisiblePost(postId);
+        FeedPost post = requireVisiblePost(postId);
         shareRepository.save(new FeedPostShare(postId, sharerId));
         log.info("Recorded share: postId={}, sharerId={}", postId, sharerId);
+        if (!sharerId.equals(post.getAuthorId())) {
+            notificationEventPublisher.publishFeedShare(
+                    post.getAuthorId(), resolveAuthorName(sharerId), postId);
+        }
         return interactionState(postId, sharerId);
     }
 
@@ -187,7 +198,7 @@ public class FeedInteractionService {
 
     @Transactional
     public FeedCommentResponse addComment(Long postId, Long authorId, String body) {
-        requireVisiblePost(postId);
+        FeedPost post = requireVisiblePost(postId);
         if (body == null || body.isBlank()) {
             throw new IllegalArgumentException("Comment body must not be blank");
         }
@@ -197,7 +208,12 @@ public class FeedInteractionService {
         comment.setUpdatedAt(now);
         FeedPostComment saved = commentRepository.save(comment);
         log.info("Created comment: id={}, postId={}, authorId={}", saved.getId(), postId, authorId);
-        return mapComment(saved, authorId, resolveAuthorName(authorId));
+        String actorFirstName = resolveAuthorName(authorId);
+        if (!authorId.equals(post.getAuthorId())) {
+            notificationEventPublisher.publishFeedComment(
+                    post.getAuthorId(), actorFirstName, postId);
+        }
+        return mapComment(saved, authorId, actorFirstName);
     }
 
     public Page<FeedCommentResponse> listComments(Long postId, Long viewerId, Pageable pageable) {
@@ -286,8 +302,8 @@ public class FeedInteractionService {
 
     // ── Helpers ────────────────────────────────────────────────────────────
 
-    private void requireVisiblePost(Long postId) {
-        feedPostRepository.findByIdAndDeletedAtIsNull(postId)
+    private FeedPost requireVisiblePost(Long postId) {
+        return feedPostRepository.findByIdAndDeletedAtIsNull(postId)
                 .orElseThrow(() -> new ResourceNotFoundException("Feed post not found with id: " + postId));
     }
 

--- a/backend/src/main/java/com/group7/backend/service/FollowService.java
+++ b/backend/src/main/java/com/group7/backend/service/FollowService.java
@@ -53,10 +53,14 @@ public class FollowService {
 
     private final FollowRepository followRepository;
     private final UserRepository userRepository;
+    private final NotificationEventPublisher notificationEventPublisher;
 
-    public FollowService(FollowRepository followRepository, UserRepository userRepository) {
+    public FollowService(FollowRepository followRepository,
+                         UserRepository userRepository,
+                         NotificationEventPublisher notificationEventPublisher) {
         this.followRepository = followRepository;
         this.userRepository = userRepository;
+        this.notificationEventPublisher = notificationEventPublisher;
     }
 
     /**
@@ -75,6 +79,13 @@ public class FollowService {
             throw new ResourceNotFoundException("User not found with id: " + followeeId);
         }
         int inserted = followRepository.upsertFollow(followerId, followeeId);
+        if (inserted == 1) {
+            String followerFirstName = userRepository.findById(followerId)
+                    .map(User::getFirstName)
+                    .orElse(null);
+            notificationEventPublisher.publishNewFollower(
+                    followeeId, followerFirstName, followerId);
+        }
         return new FollowResult(followerId, followeeId, inserted == 1);
     }
 

--- a/backend/src/main/java/com/group7/backend/service/NotificationEventPublisher.java
+++ b/backend/src/main/java/com/group7/backend/service/NotificationEventPublisher.java
@@ -277,6 +277,54 @@ public class NotificationEventPublisher {
         );
     }
 
+    /** Fires FEED_LIKE to the post author. Body collapses cross-post likes per actor under the 24h dedup gate. */
+    public void publishFeedLike(Long recipientId, String actorFirstName, Long postId) {
+        applicationEventPublisher.publishEvent(new NotificationCreatedEvent(
+                recipientId,
+                NotificationType.FEED_LIKE,
+                "New like",
+                actorFirstName + " liked your post.",
+                postId,
+                null
+        ));
+    }
+
+    /** Fires FEED_COMMENT to the post author for each new visible comment. */
+    public void publishFeedComment(Long recipientId, String actorFirstName, Long postId) {
+        applicationEventPublisher.publishEvent(new NotificationCreatedEvent(
+                recipientId,
+                NotificationType.FEED_COMMENT,
+                "New comment",
+                actorFirstName + " commented on your post.",
+                postId,
+                null
+        ));
+    }
+
+    /** Fires FEED_SHARE to the post author whenever someone shares the post. */
+    public void publishFeedShare(Long recipientId, String actorFirstName, Long postId) {
+        applicationEventPublisher.publishEvent(new NotificationCreatedEvent(
+                recipientId,
+                NotificationType.FEED_SHARE,
+                "Post shared",
+                actorFirstName + " shared your post.",
+                postId,
+                null
+        ));
+    }
+
+    /** Fires NEW_FOLLOWER to the followee. entityId carries the follower's user id for deep-link context. */
+    public void publishNewFollower(Long recipientId, String followerFirstName, Long followerId) {
+        applicationEventPublisher.publishEvent(new NotificationCreatedEvent(
+                recipientId,
+                NotificationType.NEW_FOLLOWER,
+                "New follower",
+                followerFirstName + " started following you.",
+                followerId,
+                null
+        ));
+    }
+
     public void publish(Long recipientId, NotificationType type, String title, String body) {
         applicationEventPublisher.publishEvent(new NotificationCreatedEvent(recipientId, type, title, body));
     }

--- a/backend/src/main/java/com/group7/backend/service/UserNotificationPreferencesService.java
+++ b/backend/src/main/java/com/group7/backend/service/UserNotificationPreferencesService.java
@@ -44,6 +44,8 @@ public class UserNotificationPreferencesService {
         if (request.getRequestsEnabled() != null) prefs.setRequestsEnabled(request.getRequestsEnabled());
         if (request.getTaskDeadlineRemindersEnabled() != null) prefs.setTaskDeadlineRemindersEnabled(request.getTaskDeadlineRemindersEnabled());
         if (request.getMilestoneRemindersEnabled() != null) prefs.setMilestoneRemindersEnabled(request.getMilestoneRemindersEnabled());
+        if (request.getFeedEngagementEnabled() != null) prefs.setFeedEngagementEnabled(request.getFeedEngagementEnabled());
+        if (request.getNewFollowerEnabled() != null) prefs.setNewFollowerEnabled(request.getNewFollowerEnabled());
         return UserNotificationPreferencesResponse.from(repository.save(prefs));
     }
 

--- a/backend/src/main/resources/db/migration/V39__add_feed_notification_preferences.sql
+++ b/backend/src/main/resources/db/migration/V39__add_feed_notification_preferences.sql
@@ -1,0 +1,3 @@
+ALTER TABLE user_notification_preferences
+    ADD COLUMN feed_engagement_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    ADD COLUMN new_follower_enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/src/test/java/com/group7/backend/controller/UserNotificationPreferencesControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/UserNotificationPreferencesControllerTest.java
@@ -47,7 +47,7 @@ class UserNotificationPreferencesControllerTest {
     void getReturns200WithDefaults() throws Exception {
         mockMenteeJwt("tok", 7L);
         UserNotificationPreferencesResponse response = new UserNotificationPreferencesResponse(
-                true, true, true, true, true, true, true, OffsetDateTime.now(ZoneOffset.UTC));
+                true, true, true, true, true, true, true, true, true, OffsetDateTime.now(ZoneOffset.UTC));
         when(service.get(7L)).thenReturn(response);
 
         mockMvc.perform(get("/api/users/me/notification-preferences")
@@ -61,7 +61,7 @@ class UserNotificationPreferencesControllerTest {
     void patchAppliesPartialUpdate() throws Exception {
         mockMenteeJwt("tok", 7L);
         UserNotificationPreferencesResponse response = new UserNotificationPreferencesResponse(
-                false, true, true, true, true, true, true, OffsetDateTime.now(ZoneOffset.UTC));
+                false, true, true, true, true, true, true, true, true, OffsetDateTime.now(ZoneOffset.UTC));
         when(service.update(eq(7L), any(NotificationPreferencesUpdateRequest.class)))
                 .thenReturn(response);
 

--- a/backend/src/test/java/com/group7/backend/integration/FeedInteractionIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedInteractionIntegrationTest.java
@@ -5,12 +5,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.group7.backend.dto.request.LoginRequest;
 import com.group7.backend.dto.request.RegisterRequest;
 import com.group7.backend.entity.User;
+import com.group7.backend.entity.Notification;
+import com.group7.backend.entity.NotificationType;
 import com.group7.backend.repository.FeedPostLikeRepository;
+import com.group7.backend.repository.NotificationRepository;
 import com.group7.backend.repository.UserRepository;
 import com.group7.backend.repository.VerificationTokenRepository;
 import com.group7.backend.service.EmailService;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -57,6 +63,7 @@ class FeedInteractionIntegrationTest {
     @Autowired private UserRepository userRepository;
     @Autowired private VerificationTokenRepository verificationTokenRepository;
     @Autowired private FeedPostLikeRepository likeRepository;
+    @Autowired private NotificationRepository notificationRepository;
     @Autowired private JdbcTemplate jdbcTemplate;
     @MockitoBean private EmailService emailService;
 
@@ -426,5 +433,117 @@ class FeedInteractionIntegrationTest {
                 .andExpect(status().isCreated())
                 .andReturn();
         return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();
+    }
+
+    private long userIdByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow().getId();
+    }
+
+    private List<Notification> notificationsFor(Long userId, NotificationType type) {
+        return notificationRepository.findForUser(userId, false).stream()
+                .filter(n -> n.getType() == type)
+                .toList();
+    }
+
+    private List<Notification> awaitNotifications(Long userId, NotificationType type, int expectedCount) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(50))
+                .untilAsserted(() -> assertThat(notificationsFor(userId, type)).hasSize(expectedCount));
+        return notificationsFor(userId, type);
+    }
+
+    // ── Engagement notifications ───────────────────────────────────────────
+
+    @Test
+    void toggleLike_publishesFeedLikeNotification_toPostAuthorOnly() throws Exception {
+        String authorToken = registerAndLogin("notif_like_author@test.com");
+        String likerToken = registerAndLogin("notif_like_liker@test.com");
+        long pid = createPost(authorToken, "post to like", List.of());
+        long authorId = userIdByEmail("notif_like_author@test.com");
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/like")
+                        .header("Authorization", "Bearer " + likerToken))
+                .andExpect(status().isOk());
+
+        List<Notification> rows = awaitNotifications(authorId, NotificationType.FEED_LIKE, 1);
+        assertThat(rows.get(0).getBody()).contains("liked your post.");
+
+        // Author self-likes → no extra notification (self-actor skip).
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/like")
+                        .header("Authorization", "Bearer " + authorToken))
+                .andExpect(status().isOk());
+        // Give the async listener a beat; it should still settle at 1.
+        Thread.sleep(200);
+        assertThat(notificationsFor(authorId, NotificationType.FEED_LIKE)).hasSize(1);
+    }
+
+    @Test
+    void toggleLike_secondLikeAcrossPosts_collapsesUnder24hDedup() throws Exception {
+        String authorToken = registerAndLogin("notif_dedup_author@test.com");
+        String likerToken = registerAndLogin("notif_dedup_liker@test.com");
+        long pidA = createPost(authorToken, "post A", List.of());
+        long pidB = createPost(authorToken, "post B", List.of());
+        long authorId = userIdByEmail("notif_dedup_author@test.com");
+
+        mockMvc.perform(post("/api/feed/posts/" + pidA + "/like")
+                        .header("Authorization", "Bearer " + likerToken))
+                .andExpect(status().isOk());
+        awaitNotifications(authorId, NotificationType.FEED_LIKE, 1);
+        mockMvc.perform(post("/api/feed/posts/" + pidB + "/like")
+                        .header("Authorization", "Bearer " + likerToken))
+                .andExpect(status().isOk());
+        // Same body "<firstName> liked your post." → second insert is deduped.
+        // Give the listener time to run and confirm it stays at 1.
+        Thread.sleep(300);
+        assertThat(notificationsFor(authorId, NotificationType.FEED_LIKE)).hasSize(1);
+    }
+
+    @Test
+    void addComment_publishesFeedCommentNotification_toPostAuthor() throws Exception {
+        String authorToken = registerAndLogin("notif_cmt_author@test.com");
+        String commenterToken = registerAndLogin("notif_cmt_commenter@test.com");
+        long pid = createPost(authorToken, "post to comment", List.of());
+        long authorId = userIdByEmail("notif_cmt_author@test.com");
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/comments")
+                        .header("Authorization", "Bearer " + commenterToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"hi\"}"))
+                .andExpect(status().isCreated());
+
+        List<Notification> rows = awaitNotifications(authorId, NotificationType.FEED_COMMENT, 1);
+        assertThat(rows.get(0).getBody()).contains("commented on your post.");
+
+        // Author self-comments → no extra notification (self-actor skip).
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/comments")
+                        .header("Authorization", "Bearer " + authorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"my own\"}"))
+                .andExpect(status().isCreated());
+        Thread.sleep(200);
+        assertThat(notificationsFor(authorId, NotificationType.FEED_COMMENT)).hasSize(1);
+    }
+
+    @Test
+    void recordShare_publishesFeedShareNotification_toPostAuthor() throws Exception {
+        String authorToken = registerAndLogin("notif_share_author@test.com");
+        String sharerToken = registerAndLogin("notif_share_sharer@test.com");
+        long pid = createPost(authorToken, "post to share", List.of());
+        long authorId = userIdByEmail("notif_share_author@test.com");
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/share")
+                        .header("Authorization", "Bearer " + sharerToken))
+                .andExpect(status().isOk());
+
+        List<Notification> rows = awaitNotifications(authorId, NotificationType.FEED_SHARE, 1);
+        assertThat(rows.get(0).getBody()).contains("shared your post.");
+
+        // Author self-shares → no extra notification.
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/share")
+                        .header("Authorization", "Bearer " + authorToken))
+                .andExpect(status().isOk());
+        Thread.sleep(200);
+        assertThat(notificationsFor(authorId, NotificationType.FEED_SHARE)).hasSize(1);
     }
 }

--- a/backend/src/test/java/com/group7/backend/integration/FollowIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FollowIntegrationTest.java
@@ -4,12 +4,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.group7.backend.dto.request.LoginRequest;
 import com.group7.backend.dto.request.RegisterRequest;
 import com.group7.backend.entity.User;
+import com.group7.backend.entity.Notification;
+import com.group7.backend.entity.NotificationType;
 import com.group7.backend.repository.FollowRepository;
+import com.group7.backend.repository.NotificationRepository;
 import com.group7.backend.repository.UserRepository;
 import com.group7.backend.repository.VerificationTokenRepository;
 import com.group7.backend.service.EmailService;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -64,6 +70,7 @@ class FollowIntegrationTest {
     @Autowired private UserRepository userRepository;
     @Autowired private VerificationTokenRepository verificationTokenRepository;
     @Autowired private FollowRepository followRepository;
+    @Autowired private NotificationRepository notificationRepository;
     @Autowired private JdbcTemplate jdbcTemplate;
     @MockitoBean private EmailService emailService;
 
@@ -332,6 +339,38 @@ class FollowIntegrationTest {
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────
+
+    // ── Engagement notifications ───────────────────────────────────────────
+
+    @Test
+    void follow_publishesNewFollowerNotification_andSkipsOnIdempotentReFollow() throws Exception {
+        Pair p = registerTwo("notif_follow_a@test.com", "notif_follow_b@test.com");
+
+        // First follow → NEW_FOLLOWER row appears on user B.
+        mockMvc.perform(post("/api/users/" + p.idB() + "/follow")
+                        .header("Authorization", "Bearer " + p.tokenA()))
+                .andExpect(status().is2xxSuccessful());
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(50))
+                .untilAsserted(() -> {
+                    List<Notification> rows = notificationRepository.findForUser(p.idB(), false).stream()
+                            .filter(n -> n.getType() == NotificationType.NEW_FOLLOWER)
+                            .toList();
+                    assertThat(rows).hasSize(1);
+                    assertThat(rows.get(0).getBody()).contains("started following you.");
+                });
+
+        // Re-follow (idempotent) → no second row.
+        mockMvc.perform(post("/api/users/" + p.idB() + "/follow")
+                        .header("Authorization", "Bearer " + p.tokenA()))
+                .andExpect(status().is2xxSuccessful());
+        Thread.sleep(300);
+        List<Notification> after2 = notificationRepository.findForUser(p.idB(), false).stream()
+                .filter(n -> n.getType() == NotificationType.NEW_FOLLOWER)
+                .toList();
+        assertThat(after2).hasSize(1);
+    }
 
     private record Pair(String tokenA, String tokenB, Long idA, Long idB) {
     }

--- a/backend/src/test/java/com/group7/backend/service/FollowServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FollowServiceTest.java
@@ -59,6 +59,7 @@ class FollowServiceTest {
 
     @Mock private FollowRepository followRepository;
     @Mock private UserRepository userRepository;
+    @Mock private NotificationEventPublisher notificationEventPublisher;
     @InjectMocks private FollowService followService;
 
     private static final Long ALICE = 1L;


### PR DESCRIPTION
## Summary

Engagement notifications close the gap between the social-feed surfaces and the existing notification pipeline. Post authors now receive a `Notification` row plus a push when another user likes, comments on, or shares their post; users receive one when another user starts following them. The change plugs into the mature `NotificationEventPublisher` / `NotificationEventListener` infrastructure rather than introducing a new dispatcher.

## Changes

- **Migration V38** (`V38__add_feed_notification_preferences.sql`) extends `user_notification_preferences` with two boolean opt-out columns: `feed_engagement_enabled` (covers like / comment / share as a single category) and `new_follower_enabled`. Both default to `TRUE`, mirroring V31's shape exactly.
- **`NotificationType`** gains four new values: `FEED_LIKE`, `FEED_COMMENT`, `FEED_SHARE`, `NEW_FOLLOWER`.
- **`UserNotificationPreferences`** gains two boolean fields and the corresponding cases in the exhaustive `isEnabledFor` switch — the compiler enforces completeness at build time, so a missing case fails the build.
- **`NotificationPreferencesUpdateRequest`**, **`UserNotificationPreferencesResponse`**, and **`UserNotificationPreferencesService.update`** each gain the two new fields, so `PATCH /api/users/me/notification-preferences` continues to expose the complete category set as the user-facing toggle surface.
- **`NotificationEventPublisher`** gains four `publishXxx` methods (`publishFeedLike`, `publishFeedComment`, `publishFeedShare`, `publishNewFollower`). Each builds a short title plus body string and fires a `NotificationCreatedEvent` via the six-arg constructor so `entityId` (post id for feed events, follower id for new-follower) reaches `PushDeliveryService` for push deep-link context.
- **`NotificationEventListener`** widens the existing 24-hour same-body dedup gate from `MATCH_FOUND` to `MATCH_FOUND || FEED_LIKE`. The same `existsByRecipient_IdAndTypeAndBodyAndCreatedAtAfter` query handles both types, and the body string `<actorName> liked your post.` makes the gate collapse same-actor likes across the recipient's posts within 24 hours — the standard Twitter / Mastodon UX.
- **`FeedInteractionService`** widens `requireVisiblePost` from `void` to return `FeedPost`, so the three mutation paths (`toggleLike`, `recordShare`, `addComment`) can read the post's `authorId` for the notification recipient without a second DB round-trip. Three new publish call-sites are gated by `if (!actorId.equals(post.getAuthorId()))` so a user liking, sharing, or commenting on their own post does not produce a self-notification.
- **`FollowService.follow`** gains one publish call-site, gated on `inserted == 1` so the idempotent re-follow path stays silent. Self-follow is already rejected upstream via `SelfFollowException`, so no additional self-actor guard is required here.

`FeedPostInteractionState`, `/api/notifications` JSON shape, and existing controller contracts are unchanged. The four new `NotificationType` values appear in the existing `type` field of notification list responses; clients that already handle the enum see new strings and either render them or fall back to the unknown-type handler added in #459.

## Acceptance criteria

- [x] Post author receives a `Notification` row when another user likes, comments on, or shares their post.
- [x] Followee receives a `Notification` row when another user follows them.
- [x] User does not receive a notification for their own like, comment, share, or follow.
- [x] Same actor liking multiple of the recipient's posts within 24 hours collapses to a single notification.
- [x] Idempotent re-follow does not produce a second notification.
- [x] Disabling `feed_engagement_enabled` suppresses push delivery but the in-app `Notification` row is still saved (preserves the existing source-of-truth design).
- [x] `PATCH /api/users/me/notification-preferences` accepts and round-trips `feedEngagementEnabled` and `newFollowerEnabled`.

## Test coverage

Integration tests extended:

- `FeedInteractionIntegrationTest` — four new tests cover `FEED_LIKE` publication including self-actor skip, `FEED_LIKE` 24-hour cross-post dedup, `FEED_COMMENT` publication including self-actor skip, and `FEED_SHARE` publication including self-actor skip.
- `FollowIntegrationTest` — one new test covers `NEW_FOLLOWER` publication on fresh follow and the absence of a second row on idempotent re-follow.
- Async listener observation uses Awaitility with a 5-second timeout and 50 ms poll so the tests are stable on CI without leaning on arbitrary sleeps.

Unit-level test fixes:

- `FollowServiceTest` adds `@Mock NotificationEventPublisher` so `@InjectMocks` continues to satisfy the widened constructor.
- `UserNotificationPreferencesControllerTest` updates two response-fixture constructions to match the extended `UserNotificationPreferencesResponse` arity.

## Validation

- Backend CI (`mvn --batch-mode verify`) — 1512 tests, 0 failures, 0 errors, BUILD SUCCESS.
- Playwright e2e suite — 8 passed, 2 flaky (AT-01 / AT-02). These are the same pre-existing login-URL navigation timing flakes that surfaced on PR #492 / #480; they are unrelated to this change. The change is backend-only and no UI specs depend on engagement notifications.
- Manual API smoke against a running backend confirmed end-to-end behavior: a single user creating a post and a second user liking, commenting on, sharing, and following the first user produces exactly four notification rows of distinct types; the author self-liking, self-commenting, or self-sharing does not produce additional rows; the actor toggling their like off and back on within seconds yields only one `FEED_LIKE` row (dedup); and with `feed_engagement_enabled=false` set on the recipient, a fresh `FEED_COMMENT` event still produces an in-app row (push is suppressed, in-app is preserved).

## Out of scope

- **In-app click-through from notification cards.** The `Notification` entity does not persist an `entity_id` column (it carries `type`, `title`, `body`, and audit fields only); the new publishers therefore propagate `entityId = postId` (or `followerId` for `NEW_FOLLOWER`) only through the `NotificationCreatedEvent` payload to `PushDeliveryService`, so push notifications can deep-link but in-app cards render text only. Adding an `entity_id` column to `notifications` is a separate schema change tracked outside this issue.
- **Granular sub-toggles** (separate like / comment / share preferences). A single `feed_engagement_enabled` covers all three categories; splitting is a future enhancement if product calls for it.
- **`FEED_COMMENT` aggregation** (\"X and 5 others commented\"). v1 fires one row per comment; aggregation is a separate design pass.
- **Frontend handling of the four new notification types** (icons, click routing). Separate frontend ticket; the web client falls back to a safe unknown-type handler added in #459, so the deployment surface does not break.
- **Service-level unit tests for the new publisher methods.** Tracked under #488 (test backfill); this PR locks the behavior at the integration level only.

Closes #482