### PR TITLE
feat(feed): image attachments on posts

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/FeedMediaDownloadController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedMediaDownloadController.java
@@ -1,0 +1,141 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.entity.Attachment;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.AttachmentRepository;
+import com.group7.backend.service.AttachmentStorageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Authenticated download endpoint for feed-post image attachments (#485).
+ *
+ * <p>Sibling to {@link AttachmentDownloadController}; both serve files from
+ * the same upload directory, but the gate is intentionally different:
+ * <ul>
+ *   <li>The chat controller verifies the caller is a participant of a
+ *       conversation referencing the attachment ({@code existsAttachmentVisibleToUser}).</li>
+ *   <li>This controller only verifies the attachment is referenced by some
+ *       feed post's junction row ({@code existsAsFeedAttachment}). Feed
+ *       images are public to any authenticated viewer — there is no
+ *       per-user ACL.</li>
+ * </ul>
+ *
+ * <p>{@code Authentication} is not a parameter because nothing here uses the
+ * caller's identity beyond Spring Security's URL-pattern enforcement
+ * ({@code /api/uploads/feed-media/**} falls through to
+ * {@code .anyRequest().authenticated()}). Adding the parameter would be
+ * misleading. Anonymous callers receive 401 from the security filter chain
+ * before reaching this handler.
+ *
+ * <p>Path traversal is structurally impossible — the path variable is a
+ * UUID (Spring rejects malformed values with 404 before this method runs)
+ * and the on-disk filename is derived from the persisted attachment row,
+ * never from client input. The {@code startsWith(uploadDir)} check is a
+ * second line of defence in case the upload directory ever moves at
+ * runtime.
+ *
+ * <p>Cache header differs from chat: {@code public} (vs the chat path's
+ * {@code private}) reflects that feed images are visible to any
+ * authenticated user, so a shared HTTP cache is acceptable.
+ *
+ * <p>The map of allowed extensions is the image subset of the chat
+ * controller's table — non-image content types are rejected at post
+ * create / update time in {@code FeedPostService}, but if a file with a
+ * surprising extension somehow lands here we fall through to
+ * {@code application/octet-stream} (forcing the browser to treat it as a
+ * download, not render it inline).
+ */
+@RestController
+@RequestMapping("/api/uploads/feed-media")
+@Tag(name = "Feed Media",
+        description = "Authenticated download of images attached to feed posts (#485)")
+public class FeedMediaDownloadController {
+
+    private static final Map<String, MediaType> EXTENSION_TO_IMAGE_TYPE = Map.of(
+            "jpg", MediaType.IMAGE_JPEG,
+            "jpeg", MediaType.IMAGE_JPEG,
+            "png", MediaType.IMAGE_PNG,
+            "gif", MediaType.IMAGE_GIF,
+            "webp", MediaType.parseMediaType("image/webp"));
+
+    private final AttachmentRepository attachmentRepository;
+    private final AttachmentStorageService attachmentStorageService;
+
+    public FeedMediaDownloadController(AttachmentRepository attachmentRepository,
+                                       AttachmentStorageService attachmentStorageService) {
+        this.attachmentRepository = attachmentRepository;
+        this.attachmentStorageService = attachmentStorageService;
+    }
+
+    @GetMapping("/{attachmentId}")
+    @Operation(summary = "Download a feed-post image",
+            description = "Returns the bytes of an image attached to a feed post. Any "
+                    + "authenticated user may download. Attachments not referenced by any "
+                    + "feed post (chat-only uploads, orphan-window uploads) are rejected with "
+                    + "404 — the response shape is uniform so callers cannot probe whether "
+                    + "the id exists in another context.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Image bytes"),
+            @ApiResponse(responseCode = "401", description = "Not authenticated", content = @Content),
+            @ApiResponse(responseCode = "404",
+                    description = "Attachment not found, or not referenced by any feed post",
+                    content = @Content)
+    })
+    public ResponseEntity<Resource> download(@PathVariable UUID attachmentId) {
+        Attachment attachment = attachmentRepository.findById(attachmentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Attachment not found"));
+
+        if (!attachmentRepository.existsAsFeedAttachment(attachmentId)) {
+            // Uniform 404 — callers cannot use this path to probe whether an
+            // id exists as a chat attachment.
+            throw new ResourceNotFoundException("Attachment not found");
+        }
+
+        Path uploadDir = attachmentStorageService.getUploadPath().toAbsolutePath().normalize();
+        Path filePath = uploadDir.resolve(attachment.getFilename()).normalize();
+        if (!filePath.startsWith(uploadDir)) {
+            throw new ResourceNotFoundException("Attachment not found");
+        }
+        Resource resource = new FileSystemResource(filePath);
+        if (!resource.exists() || !resource.isReadable()) {
+            throw new ResourceNotFoundException("Attachment not found");
+        }
+
+        return ResponseEntity.ok()
+                .contentType(resolveMediaType(attachment.getFilename()))
+                .cacheControl(CacheControl.maxAge(1, TimeUnit.HOURS).cachePublic())
+                .header("X-Content-Type-Options", "nosniff")
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        "inline; filename=\"" + attachment.getFilename() + "\"")
+                .body(resource);
+    }
+
+    private static MediaType resolveMediaType(String filename) {
+        int dot = filename.lastIndexOf('.');
+        if (dot < 0 || dot == filename.length() - 1) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
+        String ext = filename.substring(dot + 1).toLowerCase(Locale.ROOT);
+        return EXTENSION_TO_IMAGE_TYPE.getOrDefault(ext, MediaType.APPLICATION_OCTET_STREAM);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
@@ -76,7 +76,8 @@ public class FeedPostController {
             @Valid @RequestBody CreateFeedPostRequest request,
             Authentication authentication) {
         Long authorId = (Long) authentication.getCredentials();
-        FeedPostResponse body = feedPostService.create(authorId, request.body(), request.hashtags());
+        FeedPostResponse body = feedPostService.create(
+                authorId, request.body(), request.hashtags(), request.attachmentIds());
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 
@@ -114,7 +115,8 @@ public class FeedPostController {
             Authentication authentication) {
         Long requesterId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(
-                feedPostService.update(id, requesterId, request.body(), request.hashtags()));
+                feedPostService.update(id, requesterId, request.body(), request.hashtags(),
+                        request.attachmentIds()));
     }
 
     @DeleteMapping("/{id:\\d+}")

--- a/backend/src/main/java/com/group7/backend/dto/request/CreateFeedPostRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/CreateFeedPostRequest.java
@@ -3,9 +3,11 @@ package com.group7.backend.dto.request;
 import com.group7.backend.dto.feed.FeedPostLimits;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Request body for {@code POST /api/feed/posts} (#348).
@@ -28,6 +30,14 @@ public record CreateFeedPostRequest(
         @Schema(description = "Optional hashtags. Server normalises (lowercase, strip leading '#', dedupe). Max 10.",
                 example = "[\"DataScience\", \"#NLP\"]")
         @Size(max = FeedPostLimits.MAX_HASHTAGS)
-        List<@Size(max = FeedPostLimits.MAX_HASHTAG_LENGTH) String> hashtags
+        List<@Size(max = FeedPostLimits.MAX_HASHTAG_LENGTH) String> hashtags,
+
+        @Schema(description = "Optional image-attachment ids returned by POST /api/messages/attachments. "
+                + "Max 4 per post. Each id must belong to the post's author and have an image "
+                + "content type (image/jpeg, image/png, image/gif, image/webp). Null or empty "
+                + "creates a text-only post.",
+                example = "[\"5b9c1f0a-2c2c-4cf2-8f1d-9d4f1a0e6b5e\"]")
+        @Size(max = 4, message = "A post can carry at most 4 attachments")
+        List<@NotNull UUID> attachmentIds
 ) {
 }

--- a/backend/src/main/java/com/group7/backend/dto/request/UpdateFeedPostRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/UpdateFeedPostRequest.java
@@ -2,9 +2,11 @@ package com.group7.backend.dto.request;
 
 import com.group7.backend.dto.feed.FeedPostLimits;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Request body for {@code PATCH /api/feed/posts/{id}} (#348). Both
@@ -25,6 +27,12 @@ public record UpdateFeedPostRequest(
 
         @Schema(description = "New hashtags, or null to leave unchanged. Server applies the same normalisation as create.")
         @Size(max = FeedPostLimits.MAX_HASHTAGS)
-        List<@Size(max = FeedPostLimits.MAX_HASHTAG_LENGTH) String> hashtags
+        List<@Size(max = FeedPostLimits.MAX_HASHTAG_LENGTH) String> hashtags,
+
+        @Schema(description = "New attachment id set, or null to leave unchanged. Empty list clears all "
+                + "attachments. Otherwise replaces the post's attachment list with the supplied ids in "
+                + "order (validation rules match the create path).")
+        @Size(max = 4, message = "A post can carry at most 4 attachments")
+        List<@NotNull UUID> attachmentIds
 ) {
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/FeedPostListItem.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FeedPostListItem.java
@@ -50,6 +50,10 @@ public record FeedPostListItem(
                 + "Codes from the advanced ranker are namespaced with a `feed:` prefix; the "
                 + "frontend strips the prefix and maps each code to a localized chip.",
                 example = "[\"feed:semantic-match:0.82\", \"feed:fresh\", \"feed:follow-boost\"]")
-        List<String> factors
+        List<String> factors,
+
+        @Schema(description = "Image attachments on the post, in author-specified order. Empty when "
+                + "the post has no media (#485).")
+        List<AttachmentSummary> attachments
 ) {
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/FeedPostResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FeedPostResponse.java
@@ -49,6 +49,12 @@ public record FeedPostResponse(
         boolean isEdited,
 
         @Schema(description = "True if the viewer is the post author")
-        boolean isAuthor
+        boolean isAuthor,
+
+        @Schema(description = "Image attachments on the post, in author-specified order. Empty when "
+                + "the post has no media (#485). Each downloadUrl resolves to the feed-scoped "
+                + "/api/uploads/feed-media/{id} endpoint, which requires authentication but no "
+                + "per-user ACL.")
+        List<AttachmentSummary> attachments
 ) {
 }

--- a/backend/src/main/java/com/group7/backend/entity/FeedPost.java
+++ b/backend/src/main/java/com/group7/backend/entity/FeedPost.java
@@ -7,8 +7,12 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import lombok.Getter;
@@ -17,7 +21,9 @@ import lombok.Setter;
 import org.hibernate.annotations.BatchSize;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -167,6 +173,42 @@ public class FeedPost {
     @OrderBy("id.tag ASC")
     @BatchSize(size = 100)
     private Set<FeedPostHashtag> hashtags = new LinkedHashSet<>();
+
+    /**
+     * Image attachments attached to this post. Owns the
+     * {@code feed_post_attachments} junction; the {@link Attachment} entity
+     * itself is uploaded and lifecycle-managed by
+     * {@code AttachmentStorageService}, so there is deliberately no cascade
+     * here — saving the post must not create or merge an attachment row, it
+     * must only manage the junction rows.
+     *
+     * <p>Position is written by Hibernate via {@code @OrderColumn}. Only
+     * {@code clear() + addAll()} mutations preserve the column's invariants;
+     * partial mutations ({@code list.set(int, x)}, {@code list.remove(int)})
+     * desynchronise the position. The service paths in
+     * {@code FeedPostService.create / update} use only that pattern.
+     *
+     * <p>{@code @BatchSize(100)} collapses the otherwise-N-queries lazy fetch
+     * across the For-You / Following / search list endpoints — for a page of
+     * 20 posts Hibernate issues a single junction-join query instead of one
+     * per post. Mirrors {@link #hashtags}.
+     *
+     * <p>Soft-delete leaves this collection untouched; the junction rows
+     * survive a {@code DELETE /api/feed/posts/{id}} so a future restore
+     * would recover the images. Hard-delete (cascade from user delete or
+     * the planned 30-day purge in {@code #487}) drops the junction rows via
+     * the DB-level {@code ON DELETE CASCADE} on {@code post_id}, and the
+     * orphan-cleanup scheduler then reclaims the now-unreferenced
+     * {@link Attachment} rows.
+     */
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "feed_post_attachments",
+            joinColumns = @JoinColumn(name = "post_id"),
+            inverseJoinColumns = @JoinColumn(name = "attachment_id"))
+    @OrderColumn(name = "position")
+    @BatchSize(size = 100)
+    private List<Attachment> attachments = new ArrayList<>();
 
     /**
      * Convenience constructor for the create flow. Sets identity fields

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -70,6 +71,24 @@ public class GlobalExceptionHandler {
                 request.getMethod(), request.getRequestURI(), ex.getClass().getSimpleName());
         return buildErrorResponse(HttpStatus.CONFLICT, "Conflict",
                 "This action conflicted with a concurrent update. Please retry.");
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Map<String, String>> handleDataIntegrityViolation(DataIntegrityViolationException ex,
+                                                                            HttpServletRequest request) {
+        // Database integrity violations — UNIQUE collisions, FK or CHECK
+        // breaches — surface as 409 Conflict. The specific case driving this
+        // handler is the {@code feed_post_attachments_unique_attachment}
+        // constraint (#485): claiming an attachment id that is already
+        // referenced by another feed post. Service-layer pre-checks short-
+        // circuit the common case with cleaner messages; this handler is the
+        // race-window backstop and the uniform response for any other
+        // integrity violation that bubbles past the service.
+        log.warn("Data integrity violation: method={}, path={}, mostSpecificCause={}",
+                request.getMethod(), request.getRequestURI(),
+                ex.getMostSpecificCause() != null ? ex.getMostSpecificCause().getMessage() : ex.getMessage());
+        return buildErrorResponse(HttpStatus.CONFLICT, "Conflict",
+                "This action conflicts with the current state of the resource (constraint violation).");
     }
 
     @ExceptionHandler(OverlappingSlotException.class)

--- a/backend/src/main/java/com/group7/backend/repository/AttachmentRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/AttachmentRepository.java
@@ -31,6 +31,21 @@ public interface AttachmentRepository extends JpaRepository<Attachment, UUID> {
                                           @Param("userId") Long userId);
 
     /**
+     * Resolves the read-time gate for the feed-scoped download path: returns
+     * true iff the attachment is referenced from any row in
+     * {@code feed_post_attachments}. Lets {@code FeedMediaDownloadController}
+     * reject chat-only uploads with a uniform 404 — no per-user ACL because
+     * feed images are public to any authenticated viewer.
+     */
+    @Query(value =
+            "SELECT EXISTS ("
+            + "  SELECT 1 FROM feed_post_attachments fpa "
+            + "  WHERE fpa.attachment_id = :attachmentId"
+            + ")",
+            nativeQuery = true)
+    boolean existsAsFeedAttachment(@Param("attachmentId") UUID attachmentId);
+
+    /**
      * Counts uploads by {@code uploaderId} created strictly after {@code since}.
      * Backs the per-user hourly upload quota.
      */
@@ -40,33 +55,58 @@ public interface AttachmentRepository extends JpaRepository<Attachment, UUID> {
                               @Param("since") OffsetDateTime since);
 
     /**
-     * Returns attachments older than {@code cutoff} that are not referenced by
-     * any persisted {@link com.group7.backend.entity.Message}. Used by the
-     * orphan-cleanup scheduler to reclaim disk and DB space for uploads that
-     * were never sent.
+     * Returns attachments older than {@code cutoff} that are not referenced
+     * by any persisted message <i>or</i> feed post. Used by the orphan-cleanup
+     * scheduler to reclaim disk and DB space for uploads that were never
+     * referenced.
      *
      * <p>The 24-hour cutoff (set at the call site) is the fairness window: a
      * client may legitimately upload, then take some time to compose the
-     * outgoing message before referencing the id. Sweeping immediately would
-     * race the user-visible flow.
+     * outgoing message or feed post before referencing the id. Sweeping
+     * immediately would race the user-visible flow.
+     *
+     * <p>Native query because the {@code feed_post_attachments} junction is
+     * not exposed as a JPA entity (the link is materialised through the
+     * {@code @ManyToMany} on {@link com.group7.backend.entity.FeedPost}). The
+     * column names ({@code messages.attachment_id}, V15;
+     * {@code feed_post_attachments.attachment_id}, V41) are the source of
+     * truth — keep them in sync with the migrations if the schema evolves.
      */
-    @Query("SELECT a FROM Attachment a "
-            + "WHERE a.createdAt < :cutoff "
-            + "AND NOT EXISTS (SELECT 1 FROM Message m WHERE m.attachment.id = a.id)")
+    @Query(value =
+            "SELECT * FROM attachments a "
+            + "WHERE a.created_at < :cutoff "
+            + "  AND NOT EXISTS ("
+            + "    SELECT 1 FROM messages m WHERE m.attachment_id = a.id"
+            + "  ) "
+            + "  AND NOT EXISTS ("
+            + "    SELECT 1 FROM feed_post_attachments fpa WHERE fpa.attachment_id = a.id"
+            + "  )",
+            nativeQuery = true)
     List<Attachment> findOrphansOlderThan(@Param("cutoff") OffsetDateTime cutoff);
 
     /**
-     * Deletes the attachment row only if no message has come to reference it
-     * since the last orphan scan. Returns the number of rows deleted (0 or 1).
+     * Deletes the attachment row only if no message or feed post has come to
+     * reference it since the last orphan scan. Returns the number of rows
+     * deleted (0 or 1).
      *
      * <p>This closes the race between {@link #findOrphansOlderThan} and the
-     * scheduler's deletion: if a {@code POST /messages} lands in the gap and
-     * persists a message with this attachment, the {@code NOT EXISTS} clause
-     * rejects the delete and the just-attached message keeps its FK intact.
+     * scheduler's deletion: if a {@code POST /messages} or feed-post create
+     * lands in the gap and references this attachment, the {@code NOT EXISTS}
+     * clauses reject the delete and the new owner keeps its FK intact.
+     *
+     * <p>Native for the same reason as {@link #findOrphansOlderThan} — the
+     * junction has no JPA entity.
      */
     @Modifying
-    @Query("DELETE FROM Attachment a "
+    @Query(value =
+            "DELETE FROM attachments a "
             + "WHERE a.id = :id "
-            + "AND NOT EXISTS (SELECT 1 FROM Message m WHERE m.attachment.id = a.id)")
+            + "  AND NOT EXISTS ("
+            + "    SELECT 1 FROM messages m WHERE m.attachment_id = a.id"
+            + "  ) "
+            + "  AND NOT EXISTS ("
+            + "    SELECT 1 FROM feed_post_attachments fpa WHERE fpa.attachment_id = a.id"
+            + "  )",
+            nativeQuery = true)
     int deleteIfStillOrphan(@Param("id") UUID id);
 }

--- a/backend/src/main/java/com/group7/backend/service/AttachmentUrlBuilder.java
+++ b/backend/src/main/java/com/group7/backend/service/AttachmentUrlBuilder.java
@@ -6,10 +6,21 @@ import org.springframework.stereotype.Component;
 import java.util.UUID;
 
 /**
- * Single source of truth for the URL layout of authenticated chat-attachment
- * downloads. Every component that surfaces an attachment URL — upload
- * response, message response, JSON-LD payload — resolves it here, so URL-shape
- * changes need a single edit.
+ * Single source of truth for the URL layout of authenticated attachment
+ * downloads. Every component that surfaces an attachment URL — chat upload
+ * response, message response, JSON-LD payload, feed post response — resolves
+ * it here, so URL-shape changes need a single edit.
+ *
+ * <p>Two download paths share the same {@code attachments} table but enforce
+ * different ACLs at the controller level:
+ * <ul>
+ *   <li>{@link #downloadUrl} → {@code /api/uploads/attachments/{id}}: requires
+ *       the caller to be a participant of a conversation containing a message
+ *       that references the attachment.</li>
+ *   <li>{@link #feedMediaUrl} → {@code /api/uploads/feed-media/{id}}: requires
+ *       authentication and that the attachment is referenced by some feed
+ *       post's junction row. No per-user filter.</li>
+ * </ul>
  */
 @Component
 public class AttachmentUrlBuilder {
@@ -24,5 +35,15 @@ public class AttachmentUrlBuilder {
 
     public String downloadUrl(UUID attachmentId) {
         return baseUrl + "/api/uploads/attachments/" + attachmentId;
+    }
+
+    /**
+     * Public URL for a feed-post image. Resolves to the feed-scoped download
+     * controller which does not enforce the conversation-participant ACL —
+     * only authentication. Same UUID space as {@link #downloadUrl}; the path
+     * disambiguates the ACL gate at the controller level.
+     */
+    public String feedMediaUrl(UUID attachmentId) {
+        return baseUrl + "/api/uploads/feed-media/" + attachmentId;
     }
 }

--- a/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
@@ -183,28 +183,13 @@ public class FeedInteractionService {
                 .map(byId::get)
                 .filter(p -> p != null && p.getDeletedAt() == null)
                 .toList();
-        Map<Long, String> authorNames = new HashMap<>();
-        userRepository.findAllById(ordered.stream().map(FeedPost::getAuthorId)
-                .collect(Collectors.toSet()))
-                .forEach(u -> authorNames.put(u.getId(), u.getFirstName()));
+        // Single source of truth for the list-item shape — author-name batching,
+        // attachment URL construction, and per-post counts all routed through
+        // the mapper + batchCounts. Keeps list rendering identical across
+        // /for-you, /following, /search, /author posts, and /me/bookmarks.
         Map<Long, PostCounts> counts = batchCounts(
                 ordered.stream().map(FeedPost::getId).toList());
-        List<FeedPostListItem> items = ordered.stream().map(p -> {
-            PostCounts c = counts.get(p.getId());
-            long likeCount = (c == null) ? 0L : c.likeCount();
-            long commentCount = (c == null) ? 0L : c.commentCount();
-            return new FeedPostListItem(
-                    p.getId(),
-                    p.getAuthorId(),
-                    authorNames.getOrDefault(p.getAuthorId(), null),
-                    p.getBody(),
-                    p.getHashtags().stream().map(h -> h.getId().getTag()).sorted().toList(),
-                    p.getCreatedAt(),
-                    likeCount,
-                    commentCount,
-                    List.of()
-            );
-        }).toList();
+        List<FeedPostListItem> items = feedPostMapper.toListItems(ordered, userId, counts);
         return new PageImpl<>(items, pageable, postIds.getTotalElements());
     }
 

--- a/backend/src/main/java/com/group7/backend/service/FeedPostMapper.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedPostMapper.java
@@ -1,9 +1,11 @@
 package com.group7.backend.service;
 
+import com.group7.backend.dto.response.AttachmentSummary;
+import com.group7.backend.dto.response.FeedPostListItem;
 import com.group7.backend.dto.response.FeedPostResponse;
+import com.group7.backend.entity.Attachment;
 import com.group7.backend.entity.FeedPost;
 import com.group7.backend.entity.FeedPostHashtag;
-import com.group7.backend.entity.User;
 import com.group7.backend.repository.UserRepository;
 import org.springframework.stereotype.Component;
 
@@ -23,9 +25,14 @@ import java.util.stream.Collectors;
  * downstream feed reads in {@code #350} reuse to keep their list
  * endpoints N+1-free.
  *
+ * <p>Constructor-injects {@link AttachmentUrlBuilder} so every emitted
+ * attachment URL — list or detail — routes through the single source of
+ * truth and gets the feed-scoped path ({@code /api/uploads/feed-media/}).
+ *
  * <p><b>Transactional context required.</b> Both methods touch the
- * lazy {@link FeedPost#getHashtags()} collection; calling either
- * outside an open {@code @Transactional} boundary will surface
+ * lazy {@link FeedPost#getHashtags()} and
+ * {@code FeedPost.getAttachments()} collections; calling either outside
+ * an open {@code @Transactional} boundary will surface
  * {@code LazyInitializationException}. The convention across this
  * codebase is that DTO mapping happens inside the service-layer
  * transaction before the entity is returned to the controller.
@@ -34,9 +41,11 @@ import java.util.stream.Collectors;
 public class FeedPostMapper {
 
     private final UserRepository userRepository;
+    private final AttachmentUrlBuilder attachmentUrlBuilder;
 
-    public FeedPostMapper(UserRepository userRepository) {
+    public FeedPostMapper(UserRepository userRepository, AttachmentUrlBuilder attachmentUrlBuilder) {
         this.userRepository = userRepository;
+        this.attachmentUrlBuilder = attachmentUrlBuilder;
     }
 
     /**
@@ -53,7 +62,9 @@ public class FeedPostMapper {
      * List mapping. Collects all author ids first, does one batch
      * {@code findAllById} for the user lookup, then maps each post.
      * This is the design move that keeps {@code #350}'s list endpoints
-     * free of N+1 reads.
+     * free of N+1 reads. The attachments {@code @ManyToMany} is
+     * {@code @BatchSize(100)}, so a page of 20 posts collapses to one
+     * junction-join query rather than 20.
      */
     public List<FeedPostResponse> toResponses(List<FeedPost> posts, Long viewerId) {
         if (posts == null || posts.isEmpty()) {
@@ -68,13 +79,54 @@ public class FeedPostMapper {
                 .toList();
     }
 
+    /**
+     * Slim list-item mapping for the feed read endpoints in {@code #350}.
+     * Callers pre-compute the per-post like / comment counts via
+     * {@link FeedInteractionService#batchCounts} (single round-trip per
+     * interaction type — N+1-free), then hand them in here so DTO assembly
+     * is a pure transformation. Attachments are read from the entity's
+     * {@code @BatchSize(100)} collection, which Hibernate collapses into
+     * one junction-join query per page.
+     *
+     * <p>If a post id is missing from {@code counts} or {@code factors}
+     * (race between the page fetch and the count fetch, or a non-ranked
+     * feed) we default to zero / empty rather than crashing the response.
+     * Callers that want strict mapping can verify the maps cover every id
+     * before calling.
+     *
+     * @param factors per-post ranker explanation codes. Pass {@link Map#of()}
+     *                for non-ranked feeds (Following, search, profile posts);
+     *                pass a populated map for ranked feeds (For-You) so the
+     *                frontend can render the "why this post" chips.
+     */
+    public List<FeedPostListItem> toListItems(List<FeedPost> posts, Long viewerId,
+                                              Map<Long, FeedInteractionService.PostCounts> counts,
+                                              Map<Long, List<String>> factors) {
+        if (posts == null || posts.isEmpty()) {
+            return List.of();
+        }
+        Set<Long> authorIds = posts.stream()
+                .map(FeedPost::getAuthorId)
+                .collect(Collectors.toSet());
+        Map<Long, String> names = resolveAuthorNames(authorIds);
+        return posts.stream()
+                .map(p -> mapListItem(p, names, counts, factors))
+                .toList();
+    }
+
+    /** Convenience overload for non-ranked feeds — empty factors map. */
+    public List<FeedPostListItem> toListItems(List<FeedPost> posts, Long viewerId,
+                                              Map<Long, FeedInteractionService.PostCounts> counts) {
+        return toListItems(posts, viewerId, counts, Map.of());
+    }
+
     private Map<Long, String> resolveAuthorNames(Set<Long> authorIds) {
         Map<Long, String> names = new HashMap<>();
         userRepository.findAllById(authorIds).forEach(u -> names.put(u.getId(), u.getFirstName()));
         return names;
     }
 
-    private static FeedPostResponse mapOne(FeedPost post, Long viewerId, Map<Long, String> names) {
+    private FeedPostResponse mapOne(FeedPost post, Long viewerId, Map<Long, String> names) {
         boolean isAuthor = viewerId != null && viewerId.equals(post.getAuthorId());
         // Strict isAfter: the service explicitly sets createdAt and
         // updatedAt to the exact same OffsetDateTime instance on create,
@@ -105,8 +157,47 @@ public class FeedPostMapper {
                 post.getCreatedAt(),
                 post.getUpdatedAt(),
                 isEdited,
-                isAuthor
+                isAuthor,
+                toSummaries(post.getAttachments())
         );
     }
 
+    private FeedPostListItem mapListItem(FeedPost post,
+                                         Map<Long, String> names,
+                                         Map<Long, FeedInteractionService.PostCounts> counts,
+                                         Map<Long, List<String>> factors) {
+        List<String> tags = post.getHashtags().stream()
+                .map(FeedPostHashtag::getId)
+                .map(id -> id.getTag())
+                .sorted()
+                .toList();
+        FeedInteractionService.PostCounts c =
+                counts.getOrDefault(post.getId(), new FeedInteractionService.PostCounts(0L, 0L));
+        return new FeedPostListItem(
+                post.getId(),
+                post.getAuthorId(),
+                names.getOrDefault(post.getAuthorId(), null),
+                post.getBody(),
+                tags,
+                post.getCreatedAt(),
+                c.likeCount(),
+                c.commentCount(),
+                factors.getOrDefault(post.getId(), List.of()),
+                toSummaries(post.getAttachments())
+        );
+    }
+
+    /**
+     * Maps an ordered list of {@link Attachment} entities to their public
+     * feed-media DTO shape. Returns an immutable empty list for the no-media
+     * case so JSON consumers always see a stable type.
+     */
+    private List<AttachmentSummary> toSummaries(List<Attachment> attachments) {
+        if (attachments == null || attachments.isEmpty()) {
+            return List.of();
+        }
+        return attachments.stream()
+                .map(a -> AttachmentSummary.of(a, attachmentUrlBuilder.feedMediaUrl(a.getId())))
+                .toList();
+    }
 }

--- a/backend/src/main/java/com/group7/backend/service/FeedPostService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedPostService.java
@@ -2,10 +2,12 @@ package com.group7.backend.service;
 
 import com.group7.backend.dto.response.FeedPostResponse;
 import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Attachment;
 import com.group7.backend.entity.FeedPost;
 import com.group7.backend.entity.FeedPostHashtag;
 import com.group7.backend.entity.User;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.AttachmentRepository;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.UserRepository;
 import org.slf4j.Logger;
@@ -15,8 +17,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Service surface for the social-feed posts core (#348).
@@ -68,19 +74,40 @@ public class FeedPostService {
 
     private static final Logger log = LoggerFactory.getLogger(FeedPostService.class);
 
+    /**
+     * Hard cap on attachments per post (#485). Mirrored at the request DTO
+     * layer ({@code @Size(max = 4)}) and at the DB layer (junction CHECK
+     * {@code position BETWEEN 0 AND 3}). Defense in depth: the DTO bound
+     * fails fast on user input; the service constant catches programmatic
+     * callers; the DB CHECK is the final invariant.
+     */
+    private static final int MAX_ATTACHMENTS_PER_POST = 4;
+
+    /**
+     * Feed-only image content-type allow-list. The shared upload pipeline
+     * accepts PDF / DOCX / text for chat, but the feed surface restricts to
+     * statically-renderable image types — animated / video / document media
+     * is out of scope for v1 per the issue spec.
+     */
+    private static final Set<String> ALLOWED_IMAGE_CONTENT_TYPES = Set.of(
+            "image/jpeg", "image/png", "image/gif", "image/webp");
+
     private final FeedPostRepository feedPostRepository;
     private final UserRepository userRepository;
+    private final AttachmentRepository attachmentRepository;
     private final HashtagNormalizer hashtagNormalizer;
     private final FeedPostMapper feedPostMapper;
     private final FeedPostEventPublisher feedPostEventPublisher;
 
     public FeedPostService(FeedPostRepository feedPostRepository,
                            UserRepository userRepository,
+                           AttachmentRepository attachmentRepository,
                            HashtagNormalizer hashtagNormalizer,
                            FeedPostMapper feedPostMapper,
                            FeedPostEventPublisher feedPostEventPublisher) {
         this.feedPostRepository = feedPostRepository;
         this.userRepository = userRepository;
+        this.attachmentRepository = attachmentRepository;
         this.hashtagNormalizer = hashtagNormalizer;
         this.feedPostMapper = feedPostMapper;
         this.feedPostEventPublisher = feedPostEventPublisher;
@@ -90,11 +117,18 @@ public class FeedPostService {
      * Creates a fresh post on behalf of {@code authorId}. Rejects
      * {@link Admin} requesters with {@link AccessDeniedException}.
      * Validates body non-blank (defensive — DTO {@code @NotBlank} and
-     * DB CHECK are backstops), normalises hashtags, persists, and
-     * returns the DTO mapped inside this transaction.
+     * DB CHECK are backstops), normalises hashtags, attaches any supplied
+     * image attachments after their provenance + content-type checks pass,
+     * persists, and returns the DTO mapped inside this transaction.
+     *
+     * @param attachmentIds optional image-attachment UUIDs (0-4). Each must
+     *                      be owned by {@code authorId} and have an image
+     *                      content type. Null or empty creates a text-only
+     *                      post.
      */
     @Transactional
-    public FeedPostResponse create(Long authorId, String body, List<String> rawHashtags) {
+    public FeedPostResponse create(Long authorId, String body, List<String> rawHashtags,
+                                    List<UUID> attachmentIds) {
         User author = userRepository.findById(authorId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + authorId));
         if (author instanceof Admin) {
@@ -106,6 +140,7 @@ public class FeedPostService {
             throw new IllegalArgumentException("body must not be blank");
         }
         Set<String> normalisedTags = hashtagNormalizer.normalize(rawHashtags);
+        List<Attachment> resolvedAttachments = resolveAttachments(attachmentIds, authorId);
 
         FeedPost post = new FeedPost(authorId, body);
         OffsetDateTime now = OffsetDateTime.now();
@@ -118,10 +153,19 @@ public class FeedPostService {
         for (String tag : normalisedTags) {
             saved.getHashtags().add(new FeedPostHashtag(saved, tag));
         }
-        // Cascade=PERSIST flushes the children at @Transactional commit.
+        if (!resolvedAttachments.isEmpty()) {
+            // @OrderColumn writes positions 0..n in iteration order on flush.
+            // The list is empty at this point — adding to a fresh ArrayList is
+            // the only mutation the @ManyToMany ever sees on the create path,
+            // so the @OrderColumn-fragile partial-mutation case cannot arise.
+            saved.getAttachments().addAll(resolvedAttachments);
+        }
+        // Cascade=PERSIST flushes the hashtag children, and the dirty
+        // @ManyToMany collection writes the junction rows, at @Transactional
+        // commit.
 
-        log.info("Created feed post: id={}, authorId={}, hashtags={}",
-                saved.getId(), authorId, normalisedTags.size());
+        log.info("Created feed post: id={}, authorId={}, hashtags={}, attachments={}",
+                saved.getId(), authorId, normalisedTags.size(), resolvedAttachments.size());
 
         // Publish inside the @Transactional boundary so AFTER_COMMIT
         // delivery in FeedFanoutListener is bound to a real commit (#349).
@@ -149,10 +193,15 @@ public class FeedPostService {
      * service can distinguish 403 (non-author) from 404 (deleted /
      * missing) cleanly. {@code null} fields on the request are not
      * touched (the codebase's partial-update convention).
+     *
+     * <p>{@code attachmentIds == null} leaves the existing attachment list
+     * unchanged; an empty list removes all attachments; a non-empty list
+     * fully replaces the set in the supplied order.
      */
     @Transactional
     public FeedPostResponse update(Long postId, Long requesterId,
-                                    String body, List<String> rawHashtags) {
+                                    String body, List<String> rawHashtags,
+                                    List<UUID> attachmentIds) {
         FeedPost post = feedPostRepository.findById(postId)
                 .orElseThrow(() -> new ResourceNotFoundException("Feed post not found with id: " + postId));
         assertAuthor(post, requesterId);
@@ -179,12 +228,24 @@ public class FeedPostService {
             }
             modified = true;
         }
+        if (attachmentIds != null) {
+            // Resolve + authorise BEFORE mutating the collection — if any id
+            // fails the provenance or content-type gate we abort with a 4xx
+            // before the @OrderColumn delete/re-insert begins.
+            List<Attachment> resolved = resolveAttachments(attachmentIds, requesterId);
+            // @OrderColumn-driven @ManyToMany: only clear() + addAll()
+            // preserves the position invariant. Partial mutations
+            // ({@code list.set}, {@code list.remove(int)}) de-sync the column.
+            post.getAttachments().clear();
+            post.getAttachments().addAll(resolved);
+            modified = true;
+        }
         if (modified) {
             post.setUpdatedAt(OffsetDateTime.now());
         }
         FeedPost saved = feedPostRepository.save(post);
-        log.info("Updated feed post: id={}, authorId={}, bodyTouched={}, hashtagsTouched={}",
-                postId, requesterId, body != null, rawHashtags != null);
+        log.info("Updated feed post: id={}, authorId={}, bodyTouched={}, hashtagsTouched={}, attachmentsTouched={}",
+                postId, requesterId, body != null, rawHashtags != null, attachmentIds != null);
         return feedPostMapper.toResponse(saved, requesterId);
     }
 
@@ -216,5 +277,68 @@ public class FeedPostService {
                     post.getId(), requesterId, post.getAuthorId());
             throw new AccessDeniedException("Only the post author can perform this action");
         }
+    }
+
+    /**
+     * Resolves an optional list of attachment ids into managed entities for
+     * the create / update paths, applying size + duplicate + provenance +
+     * content-type checks in that order. Returns an empty list for the
+     * {@code null} / empty case so callers can pass the result to
+     * {@code addAll} unconditionally.
+     *
+     * <p>"Already attached to another post" is intentionally NOT pre-checked
+     * here — the DB UNIQUE on {@code feed_post_attachments(attachment_id)}
+     * is the single source of truth and surfaces as
+     * {@code DataIntegrityViolationException} → 409 via the global handler.
+     * A service-level pre-check would race with concurrent PATCHes and add
+     * an extra SELECT per id for no integrity gain.
+     *
+     * @throws IllegalArgumentException   list exceeds the max, contains
+     *                                    duplicates, or an attachment has a
+     *                                    non-image content type (400)
+     * @throws ResourceNotFoundException  an id does not resolve to an
+     *                                    attachment row (404)
+     * @throws AccessDeniedException      an attachment was uploaded by
+     *                                    someone other than the author (403)
+     */
+    private List<Attachment> resolveAttachments(List<UUID> attachmentIds, Long authorId) {
+        if (attachmentIds == null || attachmentIds.isEmpty()) {
+            return List.of();
+        }
+        if (attachmentIds.size() > MAX_ATTACHMENTS_PER_POST) {
+            throw new IllegalArgumentException(
+                    "A post can carry at most " + MAX_ATTACHMENTS_PER_POST + " attachments");
+        }
+        if (new HashSet<>(attachmentIds).size() != attachmentIds.size()) {
+            throw new IllegalArgumentException("Duplicate attachment ids in request");
+        }
+        List<Attachment> resolved = new ArrayList<>(attachmentIds.size());
+        for (UUID id : attachmentIds) {
+            resolved.add(loadAndAuthorizeFeedAttachment(id, authorId));
+        }
+        return resolved;
+    }
+
+    /**
+     * Resolves and authorises a single attachment id at post create / update
+     * time. Mirrors the {@code MessageService} provenance gate ("only the
+     * uploader can attach") so the same invariant holds across chat and
+     * feed, and adds the feed-only image content-type allow-list.
+     */
+    private Attachment loadAndAuthorizeFeedAttachment(UUID attachmentId, Long authorId) {
+        Attachment attachment = attachmentRepository.findById(attachmentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Attachment not found: " + attachmentId));
+        Long uploaderId = attachment.getUploader() != null ? attachment.getUploader().getId() : null;
+        if (!Objects.equals(uploaderId, authorId)) {
+            log.warn("Non-uploader attempted to attach to feed post: attachmentId={}, requesterId={}, uploaderId={}",
+                    attachmentId, authorId, uploaderId);
+            throw new AccessDeniedException("You may only attach files you uploaded yourself");
+        }
+        if (!ALLOWED_IMAGE_CONTENT_TYPES.contains(attachment.getContentType())) {
+            throw new IllegalArgumentException(
+                    "Feed attachments must be one of image/jpeg, image/png, image/gif, image/webp "
+                            + "(got: " + attachment.getContentType() + ")");
+        }
+        return attachment;
     }
 }

--- a/backend/src/main/java/com/group7/backend/service/FeedReadService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedReadService.java
@@ -2,7 +2,6 @@ package com.group7.backend.service;
 
 import com.group7.backend.dto.response.FeedPostListItem;
 import com.group7.backend.entity.FeedPost;
-import com.group7.backend.entity.FeedPostHashtag;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.entity.User;
@@ -24,13 +23,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Read service for the social-feed surfaces in #350 — For-You,
@@ -74,6 +71,7 @@ public class FeedReadService {
     private final FeedRanker feedRanker;
     private final FeedInteractionService feedInteractionService;
     private final Optional<ForYouScoringPipeline> forYouPipeline;
+    private final FeedPostMapper feedPostMapper;
     private final int candidateWindow;
 
     public FeedReadService(FeedPostRepository feedPostRepository,
@@ -83,6 +81,7 @@ public class FeedReadService {
                            FeedRanker feedRanker,
                            FeedInteractionService feedInteractionService,
                            Optional<ForYouScoringPipeline> forYouPipeline,
+                           FeedPostMapper feedPostMapper,
                            @Value("${app.feed.forYou.candidate-window:200}") int candidateWindow) {
         this.feedPostRepository = feedPostRepository;
         this.userRepository = userRepository;
@@ -91,6 +90,7 @@ public class FeedReadService {
         this.feedRanker = feedRanker;
         this.feedInteractionService = feedInteractionService;
         this.forYouPipeline = forYouPipeline;
+        this.feedPostMapper = feedPostMapper;
         this.candidateWindow = candidateWindow;
     }
 
@@ -131,7 +131,7 @@ public class FeedReadService {
                 .map(p -> new Scored(feedRanker.score(p, context), p))
                 .sorted(Comparator.comparingInt((Scored s) -> s.result().score()).reversed())
                 .toList();
-        return slicePage(ranked, pageable);
+        return slicePage(ranked, pageable, viewerId);
     }
 
     /**
@@ -162,39 +162,16 @@ public class FeedReadService {
         }
         List<FeedPost> rankedPosts = ranked.stream()
                 .map(ForYouScoringPipeline.RankedFeedPost::post).toList();
-        Map<Long, String> authorNames = resolveAuthorNames(rankedPosts);
         Map<Long, FeedInteractionService.PostCounts> counts =
                 feedInteractionService.batchCounts(
                         rankedPosts.stream().map(FeedPost::getId).toList());
-        List<FeedPostListItem> items = ranked.stream()
-                .map(r -> toListItemFromRanked(r, authorNames, counts))
-                .toList();
+        Map<Long, List<String>> factorsByPostId = ranked.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        r -> r.post().getId(),
+                        ForYouScoringPipeline.RankedFeedPost::factors));
+        List<FeedPostListItem> items = feedPostMapper.toListItems(
+                rankedPosts, viewerId, counts, factorsByPostId);
         return new PageImpl<>(items, pageable, candidates.size());
-    }
-
-    private static FeedPostListItem toListItemFromRanked(ForYouScoringPipeline.RankedFeedPost ranked,
-                                                        Map<Long, String> authorNames,
-                                                        Map<Long, FeedInteractionService.PostCounts> counts) {
-        FeedPost post = ranked.post();
-        List<String> tags = post.getHashtags().stream()
-                .map(FeedPostHashtag::getId)
-                .map(id -> id.getTag())
-                .sorted()
-                .toList();
-        FeedInteractionService.PostCounts c = counts.get(post.getId());
-        long likeCount = (c == null) ? 0L : c.likeCount();
-        long commentCount = (c == null) ? 0L : c.commentCount();
-        return new FeedPostListItem(
-                post.getId(),
-                post.getAuthorId(),
-                authorNames.getOrDefault(post.getAuthorId(), null),
-                post.getBody(),
-                tags,
-                post.getCreatedAt(),
-                likeCount,
-                commentCount,
-                ranked.factors()
-        );
     }
 
     /**
@@ -203,7 +180,7 @@ public class FeedReadService {
      */
     public Page<FeedPostListItem> followingFeed(Long viewerId, Pageable pageable) {
         Page<FeedPost> page = feedPostRepository.findFollowingFeed(viewerId, pageable);
-        return mapPage(page);
+        return mapPage(page, viewerId);
     }
 
     /**
@@ -212,7 +189,7 @@ public class FeedReadService {
      */
     public Page<FeedPostListItem> postsByAuthor(Long authorId, Pageable pageable) {
         Page<FeedPost> page = feedPostRepository.findByAuthorIdForFeed(authorId, pageable);
-        return mapPage(page);
+        return mapPage(page, null);
     }
 
     /**
@@ -249,7 +226,7 @@ public class FeedReadService {
                     "Search requires at least one of 'q' or 'hashtag' — use /api/feed/for-you or /api/feed/following for the full feed");
         }
         Page<FeedPost> page = feedPostRepository.searchPosts(normalisedKeyword, normalisedHashtag, pageable);
-        return mapPage(page);
+        return mapPage(page, null);
     }
 
     /**
@@ -319,18 +296,25 @@ public class FeedReadService {
         return hashtagNormalizer.normalize(labels);
     }
 
-    private Page<FeedPostListItem> mapPage(Page<FeedPost> page) {
+    /**
+     * Maps a JPA {@link Page} of posts into list-item DTOs while preserving
+     * pagination metadata. Delegates DTO assembly to {@link FeedPostMapper}
+     * so the single source of truth for author-name batching and attachment
+     * URL construction stays in one place.
+     */
+    private Page<FeedPostListItem> mapPage(Page<FeedPost> page, Long viewerId) {
         if (page.isEmpty()) {
             return Page.empty(page.getPageable());
         }
-        Map<Long, String> authorNames = resolveAuthorNames(page.getContent());
         Map<Long, FeedInteractionService.PostCounts> counts =
                 feedInteractionService.batchCounts(
                         page.getContent().stream().map(FeedPost::getId).toList());
-        return page.map(p -> toListItem(p, authorNames, counts, List.of()));
+        List<FeedPostListItem> items = feedPostMapper.toListItems(
+                page.getContent(), viewerId, counts);
+        return new PageImpl<>(items, page.getPageable(), page.getTotalElements());
     }
 
-    private Page<FeedPostListItem> slicePage(List<Scored> ranked, Pageable pageable) {
+    private Page<FeedPostListItem> slicePage(List<Scored> ranked, Pageable pageable, Long viewerId) {
         int total = ranked.size();
         int from = Math.min((int) pageable.getOffset(), total);
         int to = Math.min(from + pageable.getPageSize(), total);
@@ -339,46 +323,16 @@ public class FeedReadService {
             return new PageImpl<>(List.of(), pageable, total);
         }
         List<FeedPost> posts = slice.stream().map(Scored::post).toList();
-        Map<Long, String> authorNames = resolveAuthorNames(posts);
         Map<Long, FeedInteractionService.PostCounts> counts =
                 feedInteractionService.batchCounts(
                         posts.stream().map(FeedPost::getId).toList());
-        List<FeedPostListItem> items = slice.stream()
-                .map(s -> toListItem(s.post(), authorNames, counts, s.result().factors()))
-                .toList();
+        Map<Long, List<String>> factorsByPostId = slice.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        s -> s.post().getId(),
+                        s -> s.result().factors()));
+        List<FeedPostListItem> items = feedPostMapper.toListItems(
+                posts, viewerId, counts, factorsByPostId);
         return new PageImpl<>(items, pageable, total);
-    }
-
-    private Map<Long, String> resolveAuthorNames(List<FeedPost> posts) {
-        Set<Long> ids = posts.stream().map(FeedPost::getAuthorId).collect(Collectors.toSet());
-        Map<Long, String> names = new HashMap<>();
-        userRepository.findAllById(ids).forEach(u -> names.put(u.getId(), u.getFirstName()));
-        return names;
-    }
-
-    private static FeedPostListItem toListItem(FeedPost post,
-                                               Map<Long, String> authorNames,
-                                               Map<Long, FeedInteractionService.PostCounts> counts,
-                                               List<String> factors) {
-        List<String> tags = post.getHashtags().stream()
-                .map(FeedPostHashtag::getId)
-                .map(id -> id.getTag())
-                .sorted()
-                .toList();
-        FeedInteractionService.PostCounts c = counts.get(post.getId());
-        long likeCount = (c == null) ? 0L : c.likeCount();
-        long commentCount = (c == null) ? 0L : c.commentCount();
-        return new FeedPostListItem(
-                post.getId(),
-                post.getAuthorId(),
-                authorNames.getOrDefault(post.getAuthorId(), null),
-                post.getBody(),
-                tags,
-                post.getCreatedAt(),
-                likeCount,
-                commentCount,
-                factors
-        );
     }
 
     /** Holds a feed post alongside its scoring result so the sort key is

--- a/backend/src/main/resources/db/migration/V41__create_feed_post_attachments.sql
+++ b/backend/src/main/resources/db/migration/V41__create_feed_post_attachments.sql
@@ -1,0 +1,47 @@
+-- Junction table linking feed posts to their image attachments.
+--
+-- The attachments table itself (V15) is the single source of binary uploads
+-- across chat and feed; this junction lets a feed post own 0..4 of those rows
+-- in a specific display order.
+--
+-- Schema rationale:
+--   * Composite PK (post_id, attachment_id) — disallows duplicate pairs.
+--   * UNIQUE (attachment_id) — enforces the spec rule that one attachment
+--     belongs to at most one feed post. Surface as 409 on second-post create.
+--   * UNIQUE (post_id, position) — no two slots on the same post collide.
+--   * CHECK (position BETWEEN 0 AND 3) — caps at four ordered slots
+--     (Twitter / Bluesky / Mastodon convention; service layer enforces the
+--     same with @Size(max = 4) on the request DTO).
+--   * post_id REFERENCES feed_posts(id) ON DELETE CASCADE — when a post is
+--     hard-deleted the junction rows go automatically; the next orphan sweep
+--     reclaims the newly-unreferenced attachments. Soft-delete sets only
+--     feed_posts.deleted_at and does not touch this table, so a restored
+--     post keeps its images.
+--   * attachment_id REFERENCES attachments(id) [NO ACTION] — refuses to
+--     delete an attachment row while a junction row still references it.
+--     Defense in depth: the orphan-cleanup queries in AttachmentRepository
+--     skip attachments that appear here, so a delete attempt should never
+--     fire — but if it does, the FK rejects it cleanly.
+--
+-- Index:
+--   * (post_id, position) accelerates the @ManyToMany @OrderColumn fetch
+--     ordered by position. The composite PK already covers most predicates,
+--     but adding the explicit ordered index lets Postgres serve the typical
+--     "fetch this post's images in order" query as an index-only scan.
+
+CREATE TABLE feed_post_attachments (
+    post_id        BIGINT  NOT NULL REFERENCES feed_posts(id) ON DELETE CASCADE,
+    attachment_id  UUID    NOT NULL REFERENCES attachments(id),
+    position       INTEGER NOT NULL,
+    PRIMARY KEY (post_id, attachment_id),
+    CONSTRAINT feed_post_attachments_unique_attachment UNIQUE (attachment_id),
+    CONSTRAINT feed_post_attachments_unique_position   UNIQUE (post_id, position),
+    CONSTRAINT feed_post_attachments_position_range    CHECK (position BETWEEN 0 AND 3)
+);
+-- Note: position is INTEGER (not SMALLINT) to align with the default JPA type
+-- that Hibernate emits for {@code @OrderColumn} (java int → SQL int4). The
+-- CHECK constraint already bounds the range to 0..3, so the 2-byte space
+-- savings of SMALLINT are not worth the schema-validation friction.
+
+CREATE INDEX idx_feed_post_attachments_post_position
+    ON feed_post_attachments (post_id, position);

--- a/backend/src/test/java/com/group7/backend/controller/FeedMediaDownloadControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FeedMediaDownloadControllerTest.java
@@ -1,0 +1,197 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.entity.Attachment;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.AttachmentRepository;
+import com.group7.backend.service.AttachmentStorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit slice for {@link FeedMediaDownloadController} (#485). Mirrors the
+ * shape of {@code AttachmentDownloadControllerTest} but exercises the
+ * feed-scoped ACL ({@code existsAsFeedAttachment}) and asserts the
+ * publicly-cacheable response shape ({@code Cache-Control: public}).
+ *
+ * <p>Auth is enforced at the Spring Security URL-pattern layer, not in the
+ * controller body, so anonymous-call behaviour is verified at the
+ * integration level rather than here.
+ */
+@ExtendWith(MockitoExtension.class)
+class FeedMediaDownloadControllerTest {
+
+    @Mock private AttachmentRepository attachmentRepository;
+    @Mock private AttachmentStorageService attachmentStorageService;
+
+    private FeedMediaDownloadController controller;
+
+    @TempDir Path uploadDir;
+
+    @BeforeEach
+    void setUp() {
+        controller = new FeedMediaDownloadController(attachmentRepository, attachmentStorageService);
+    }
+
+    private Attachment imageRow(UUID id, String filename, String contentType) {
+        Mentor uploader = new Mentor();
+        uploader.setId(99L);
+        Attachment a = new Attachment();
+        a.setId(id);
+        a.setFilename(filename);
+        a.setContentType(contentType);
+        a.setSizeBytes(8);
+        a.setUploader(uploader);
+        return a;
+    }
+
+    @Test
+    void download_returnsImage_whenAttachmentIsFeedReferenced() throws Exception {
+        UUID id = UUID.randomUUID();
+        String filename = id + ".png";
+        Files.write(uploadDir.resolve(filename), new byte[]{1, 2, 3, 4, 5, 6, 7, 8});
+
+        when(attachmentRepository.findById(id)).thenReturn(Optional.of(imageRow(id, filename, "image/png")));
+        when(attachmentRepository.existsAsFeedAttachment(eq(id))).thenReturn(true);
+        when(attachmentStorageService.getUploadPath()).thenReturn(uploadDir);
+
+        ResponseEntity<Resource> response = controller.download(id);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.IMAGE_PNG);
+        assertThat(response.getHeaders().getFirst("X-Content-Type-Options")).isEqualTo("nosniff");
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION)).contains(filename);
+        // public + max-age=3600 — feed images are visible to any authenticated
+        // viewer, so shared HTTP caches are allowed (unlike chat downloads).
+        assertThat(response.getHeaders().getCacheControl())
+                .isEqualTo("max-age=3600, public");
+        Resource body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.contentLength()).isEqualTo(8);
+    }
+
+    @Test
+    void download_throwsNotFound_whenAttachmentRowMissing() {
+        UUID id = UUID.randomUUID();
+        when(attachmentRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> controller.download(id))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(attachmentRepository, never()).existsAsFeedAttachment(eq(id));
+    }
+
+    @Test
+    void download_throwsNotFound_whenAttachmentIsChatOnly() {
+        // The id exists in the attachments table but no feed_post_attachments
+        // row references it — caller used the wrong path. Uniform 404 so the
+        // feed-media endpoint cannot probe chat attachment existence.
+        UUID id = UUID.randomUUID();
+        when(attachmentRepository.findById(id))
+                .thenReturn(Optional.of(imageRow(id, id + ".pdf", "application/pdf")));
+        when(attachmentRepository.existsAsFeedAttachment(eq(id))).thenReturn(false);
+
+        assertThatThrownBy(() -> controller.download(id))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(attachmentStorageService, never()).getUploadPath();
+    }
+
+    @Test
+    void download_throwsNotFound_whenFileMissingFromDisk() {
+        UUID id = UUID.randomUUID();
+        when(attachmentRepository.findById(id))
+                .thenReturn(Optional.of(imageRow(id, id + ".png", "image/png")));
+        when(attachmentRepository.existsAsFeedAttachment(eq(id))).thenReturn(true);
+        when(attachmentStorageService.getUploadPath()).thenReturn(uploadDir);
+
+        assertThatThrownBy(() -> controller.download(id))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void download_throwsNotFound_whenStoredFilenameEscapesUploadDir() {
+        UUID id = UUID.randomUUID();
+        when(attachmentRepository.findById(id))
+                .thenReturn(Optional.of(imageRow(id, "../../etc/passwd", "image/png")));
+        when(attachmentRepository.existsAsFeedAttachment(eq(id))).thenReturn(true);
+        when(attachmentStorageService.getUploadPath()).thenReturn(uploadDir);
+
+        assertThatThrownBy(() -> controller.download(id))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    /**
+     * {@code resolveMediaType} is private; we exercise the image branches and
+     * the defence-in-depth fallbacks directly. Production reaches only the
+     * five image branches because {@code FeedPostService} rejects non-image
+     * uploads before they ever land in {@code feed_post_attachments}.
+     */
+    @Nested
+    class ResolveMediaType {
+        @Test
+        void jpegExtensionMapsToImageJpeg() {
+            assertThat(invoke("x.jpg")).isEqualTo(MediaType.IMAGE_JPEG);
+            assertThat(invoke("x.jpeg")).isEqualTo(MediaType.IMAGE_JPEG);
+        }
+
+        @Test
+        void webpExtensionMapsToImageWebp() {
+            assertThat(invoke("x.webp")).isEqualTo(MediaType.parseMediaType("image/webp"));
+        }
+
+        @Test
+        void uppercaseExtensionResolves() {
+            assertThat(invoke("MIXED.PNG")).isEqualTo(MediaType.IMAGE_PNG);
+        }
+
+        @Test
+        void unknownExtensionFallsBackToOctetStream() {
+            assertThat(invoke("x.pdf")).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+            assertThat(invoke("x.txt")).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+        }
+
+        @Test
+        void filenameWithoutDotFallsBackToOctetStream() {
+            assertThat(invoke("noext")).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+        }
+
+        @Test
+        void filenameWithTrailingDotFallsBackToOctetStream() {
+            assertThat(invoke("trailing.")).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+        }
+
+        private MediaType invoke(String filename) {
+            try {
+                Method m = FeedMediaDownloadController.class
+                        .getDeclaredMethod("resolveMediaType", String.class);
+                m.setAccessible(true);
+                return (MediaType) m.invoke(null, filename);
+            } catch (ReflectiveOperationException e) {
+                throw new AssertionError(e);
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
@@ -68,7 +68,7 @@ class FeedPostControllerTest {
 
     private static FeedPostResponse stub(Long id, Long authorId) {
         return new FeedPostResponse(id, authorId, "Alice", "Hello", List.of("data"),
-                OffsetDateTime.now(), OffsetDateTime.now(), false, true);
+                OffsetDateTime.now(), OffsetDateTime.now(), false, true, List.of());
     }
 
     // ── POST /api/feed/posts ────────────────────────────────────────────────
@@ -76,9 +76,9 @@ class FeedPostControllerTest {
     @Test
     void create_happyPath_returns201() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        when(feedPostService.create(eq(1L), any(), any())).thenReturn(stub(42L, 1L));
+        when(feedPostService.create(eq(1L), any(), any(), any())).thenReturn(stub(42L, 1L));
 
-        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of("data"));
+        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of("data"), null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -93,7 +93,7 @@ class FeedPostControllerTest {
 
     @Test
     void create_unauthenticated_returns403() throws Exception {
-        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of());
+        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of(), null);
         mockMvc.perform(post("/api/feed/posts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))
@@ -103,7 +103,7 @@ class FeedPostControllerTest {
     @Test
     void create_blankBody_returns400() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        CreateFeedPostRequest body = new CreateFeedPostRequest("", List.of());
+        CreateFeedPostRequest body = new CreateFeedPostRequest("", List.of(), null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -116,7 +116,7 @@ class FeedPostControllerTest {
     void create_oversizeBody_returns400() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
         String tooLong = "x".repeat(FeedPostLimits.MAX_BODY_LENGTH + 1);
-        CreateFeedPostRequest body = new CreateFeedPostRequest(tooLong, List.of());
+        CreateFeedPostRequest body = new CreateFeedPostRequest(tooLong, List.of(), null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -130,7 +130,7 @@ class FeedPostControllerTest {
         mockMenteeJwt(TOKEN, 1L);
         List<String> tooMany = IntStream.range(0, FeedPostLimits.MAX_HASHTAGS + 1)
                 .mapToObj(i -> "tag" + i).collect(Collectors.toList());
-        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", tooMany);
+        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", tooMany, null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -142,10 +142,10 @@ class FeedPostControllerTest {
     @Test
     void create_adminRequester_returns403() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        when(feedPostService.create(eq(1L), any(), any()))
+        when(feedPostService.create(eq(1L), any(), any(), any()))
                 .thenThrow(new AccessDeniedException("Admins cannot create feed posts"));
 
-        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of());
+        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of(), null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -197,9 +197,9 @@ class FeedPostControllerTest {
     @Test
     void update_happyPath_returns200() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        when(feedPostService.update(eq(42L), eq(1L), any(), any())).thenReturn(stub(42L, 1L));
+        when(feedPostService.update(eq(42L), eq(1L), any(), any(), any())).thenReturn(stub(42L, 1L));
 
-        UpdateFeedPostRequest body = new UpdateFeedPostRequest("Updated", null);
+        UpdateFeedPostRequest body = new UpdateFeedPostRequest("Updated", null, null);
 
         mockMvc.perform(patch("/api/feed/posts/42")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -212,10 +212,10 @@ class FeedPostControllerTest {
     @Test
     void update_nonAuthor_returns403() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        when(feedPostService.update(eq(42L), eq(1L), any(), any()))
+        when(feedPostService.update(eq(42L), eq(1L), any(), any(), any()))
                 .thenThrow(new AccessDeniedException("Only the post author can perform this action"));
 
-        UpdateFeedPostRequest body = new UpdateFeedPostRequest("hostile", null);
+        UpdateFeedPostRequest body = new UpdateFeedPostRequest("hostile", null, null);
 
         mockMvc.perform(patch("/api/feed/posts/42")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -227,10 +227,10 @@ class FeedPostControllerTest {
     @Test
     void update_softDeleted_returns404() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        when(feedPostService.update(eq(42L), eq(1L), any(), any()))
+        when(feedPostService.update(eq(42L), eq(1L), any(), any(), any()))
                 .thenThrow(new ResourceNotFoundException("Feed post not found with id: 42"));
 
-        UpdateFeedPostRequest body = new UpdateFeedPostRequest("late edit", null);
+        UpdateFeedPostRequest body = new UpdateFeedPostRequest("late edit", null, null);
 
         mockMvc.perform(patch("/api/feed/posts/42")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -242,10 +242,10 @@ class FeedPostControllerTest {
     @Test
     void update_concurrentModification_returns409() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        when(feedPostService.update(eq(42L), eq(1L), any(), any()))
+        when(feedPostService.update(eq(42L), eq(1L), any(), any(), any()))
                 .thenThrow(new OptimisticLockingFailureException("stale version"));
 
-        UpdateFeedPostRequest body = new UpdateFeedPostRequest("v1", null);
+        UpdateFeedPostRequest body = new UpdateFeedPostRequest("v1", null, null);
 
         mockMvc.perform(patch("/api/feed/posts/42")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -256,7 +256,7 @@ class FeedPostControllerTest {
 
     @Test
     void update_unauthenticated_returns403() throws Exception {
-        UpdateFeedPostRequest body = new UpdateFeedPostRequest("x", null);
+        UpdateFeedPostRequest body = new UpdateFeedPostRequest("x", null, null);
         mockMvc.perform(patch("/api/feed/posts/42")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))

--- a/backend/src/test/java/com/group7/backend/integration/FeedMediaIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedMediaIntegrationTest.java
@@ -1,0 +1,463 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.scheduler.AttachmentOrphanCleanupScheduler;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the feed image-attachment surface (#485) against
+ * real Postgres. Walks the full path: upload via the shared
+ * {@code /api/messages/attachments} endpoint → attach at post create →
+ * download via the feed-scoped endpoint → soft-delete preserves junction
+ * rows → orphan-cleanup scheduler skips feed-referenced attachments.
+ *
+ * <p>Negative paths cover the five rejection modes the spec calls out (5+
+ * attachments, non-uploader, non-image content type, duplicate ids in the
+ * request, attaching an id already owned by another post) plus the
+ * cross-controller probe (chat-only id rejected with 404 on the
+ * feed-media path) and the unauthenticated baseline.
+ *
+ * <p>Test profile disables rate-limiting so the smoke test is not coupled
+ * to bucket capacities.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class FeedMediaIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private AttachmentOrphanCleanupScheduler orphanCleanupScheduler;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        // Children first by FK, then parents. feed_post_attachments references
+        // both feed_posts.id (ON DELETE CASCADE) and attachments.id (NO ACTION) —
+        // truncating in reverse-FK order keeps the cleanup deterministic across
+        // schedule reruns and avoids deferred-constraint surprises.
+        jdbcTemplate.update("DELETE FROM feed_post_attachments");
+        jdbcTemplate.update("DELETE FROM feed_post_hashtags");
+        jdbcTemplate.update("DELETE FROM feed_posts");
+        // Messages reference attachments via SET NULL; clearing messages first
+        // ensures attachment-row deletes do not orphan a message_id reference.
+        jdbcTemplate.update("DELETE FROM messages");
+        jdbcTemplate.update("DELETE FROM attachments");
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    // ── 1. Happy path: single image post ────────────────────────────────────
+
+    @Test
+    void singleImagePost_create_download_succeeds() throws Exception {
+        String token = registerAndLogin("alice@test.com");
+        UUID attachmentId = uploadPng(token, "alice.png");
+
+        // Create a post with the image attached
+        MvcResult createResult = mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "body", "first image post",
+                                "hashtags", List.of("test"),
+                                "attachmentIds", List.of(attachmentId.toString())))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.attachments").isArray())
+                .andExpect(jsonPath("$.attachments.length()").value(1))
+                .andExpect(jsonPath("$.attachments[0].id").value(attachmentId.toString()))
+                .andExpect(jsonPath("$.attachments[0].contentType").value("image/png"))
+                .andExpect(jsonPath("$.attachments[0].downloadUrl")
+                        .value(org.hamcrest.Matchers.containsString(
+                                "/api/uploads/feed-media/" + attachmentId)))
+                .andReturn();
+        long postId = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("id").asLong();
+        assertThat(postId).isPositive();
+
+        // Download via the feed-scoped endpoint
+        mockMvc.perform(get("/api/uploads/feed-media/" + attachmentId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "image/png"))
+                .andExpect(header().string("Cache-Control", "max-age=3600, public"))
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"))
+                .andExpect(header().exists("Content-Disposition"));
+    }
+
+    // ── 2. Happy path: 4 images, ordering preserved ─────────────────────────
+
+    @Test
+    void fourImagePost_preservesOrder() throws Exception {
+        String token = registerAndLogin("bob@test.com");
+        UUID a0 = uploadPng(token, "a0.png");
+        UUID a1 = uploadPng(token, "a1.png");
+        UUID a2 = uploadPng(token, "a2.png");
+        UUID a3 = uploadPng(token, "a3.png");
+        List<String> orderedIds = List.of(a0.toString(), a1.toString(), a2.toString(), a3.toString());
+
+        mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "body", "four images",
+                                "attachmentIds", orderedIds))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.attachments.length()").value(4))
+                .andExpect(jsonPath("$.attachments[0].id").value(a0.toString()))
+                .andExpect(jsonPath("$.attachments[1].id").value(a1.toString()))
+                .andExpect(jsonPath("$.attachments[2].id").value(a2.toString()))
+                .andExpect(jsonPath("$.attachments[3].id").value(a3.toString()));
+    }
+
+    // ── 3. Reject 5+ attachments at the DTO boundary ────────────────────────
+
+    @Test
+    void fiveAttachments_rejectedAt400() throws Exception {
+        String token = registerAndLogin("carol@test.com");
+        // Random UUIDs — they won't be reached because @Size(max = 4) fires
+        // at Bean Validation before the service even loads the rows.
+        List<String> ids = List.of(
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString());
+        mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "body", "too many",
+                                "attachmentIds", ids))))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── 4. Reject non-uploader attachment (provenance gate) ─────────────────
+
+    @Test
+    void nonUploaderAttachment_rejectedAt403() throws Exception {
+        String aliceToken = registerAndLogin("dave@test.com");
+        String bobToken = registerAndLogin("eve@test.com");
+        UUID aliceUpload = uploadPng(aliceToken, "alice.png");
+
+        mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + bobToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "body", "stealing alice's upload",
+                                "attachmentIds", List.of(aliceUpload.toString())))))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── 5. Reject non-image content type ────────────────────────────────────
+
+    @Test
+    void nonImageAttachment_rejectedAt400() throws Exception {
+        String token = registerAndLogin("frank@test.com");
+        UUID pdfId = uploadPdf(token, "doc.pdf");
+
+        mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "body", "pdf in feed?",
+                                "attachmentIds", List.of(pdfId.toString())))))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── 6. DB UNIQUE on attachment_id → 409 on second-post attach ───────────
+
+    @Test
+    void attachmentAlreadyOnAnotherPost_rejectedAt409() throws Exception {
+        String token = registerAndLogin("grace@test.com");
+        UUID attachmentId = uploadPng(token, "shared.png");
+
+        // Post 1 owns the attachment.
+        mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "body", "first owner",
+                                "attachmentIds", List.of(attachmentId.toString())))))
+                .andExpect(status().isCreated());
+
+        // Post 2 tries to claim the same id — DB UNIQUE fires.
+        mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "body", "second owner",
+                                "attachmentIds", List.of(attachmentId.toString())))))
+                .andExpect(status().isConflict());
+    }
+
+    // ── 7. Reject duplicate id in the same request ──────────────────────────
+
+    @Test
+    void duplicateAttachmentIdInRequest_rejectedAt400() throws Exception {
+        String token = registerAndLogin("heidi@test.com");
+        UUID attachmentId = uploadPng(token, "dup.png");
+
+        mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "body", "dup ids",
+                                "attachmentIds", List.of(
+                                        attachmentId.toString(), attachmentId.toString())))))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── 8. Chat-only attachment 404s on the feed-media endpoint ─────────────
+
+    @Test
+    void chatOnlyAttachment_404OnFeedMediaPath() throws Exception {
+        String token = registerAndLogin("ivan@test.com");
+        UUID pdfId = uploadPdf(token, "doc.pdf");
+
+        mockMvc.perform(get("/api/uploads/feed-media/" + pdfId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    // ── 9. Anonymous request is rejected by Spring Security ─────────────────
+
+    @Test
+    void anonymousFeedMediaDownload_isRejectedBySecurity() throws Exception {
+        // The project's JwtAuthenticationFilter + default access-denied handler
+        // surfaces missing/invalid credentials as 403 (not 401) — the existing
+        // chat AttachmentDownloadController tests follow the same convention.
+        // Either status means "you cannot have this resource without auth";
+        // 403 is what the codebase emits today.
+        UUID someUuid = UUID.randomUUID();
+        mockMvc.perform(get("/api/uploads/feed-media/" + someUuid))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── 10. Soft-delete preserves junction + attachment rows ────────────────
+
+    @Test
+    void softDeletePost_preservesAttachmentJunction() throws Exception {
+        String token = registerAndLogin("judy@test.com");
+        UUID attachmentId = uploadPng(token, "keep.png");
+
+        long postId = createPostWithAttachment(token, "keep me", attachmentId);
+
+        // Soft-delete the post.
+        mockMvc.perform(delete("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+
+        Integer junctionRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_attachments WHERE post_id = ?",
+                Integer.class, postId);
+        assertThat(junctionRows).isEqualTo(1);
+
+        // Attachment row also survives.
+        Integer attachmentRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM attachments WHERE id = ?",
+                Integer.class, attachmentId);
+        assertThat(attachmentRows).isEqualTo(1);
+    }
+
+    // ── 11. PATCH replaces attachment set (clear + addAll semantics) ────────
+
+    @Test
+    void patchAttachmentIds_replacesSet() throws Exception {
+        String token = registerAndLogin("kate@test.com");
+        UUID firstId = uploadPng(token, "first.png");
+        UUID secondId = uploadPng(token, "second.png");
+
+        long postId = createPostWithAttachment(token, "before patch", firstId);
+
+        // Clear all attachments.
+        mockMvc.perform(patch("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "attachmentIds", List.of()))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.attachments.length()").value(0));
+
+        // Reattach a different image.
+        mockMvc.perform(patch("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "attachmentIds", List.of(secondId.toString())))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.attachments.length()").value(1))
+                .andExpect(jsonPath("$.attachments[0].id").value(secondId.toString()));
+
+        // First id no longer referenced from the post → DB has no junction row.
+        Integer firstStillLinked = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_attachments WHERE attachment_id = ?",
+                Integer.class, firstId);
+        assertThat(firstStillLinked).isZero();
+    }
+
+    // ── 12. Orphan-cleanup skips feed-referenced attachments ────────────────
+
+    @Test
+    void orphanCleanup_skipsFeedReferencedAttachments() throws Exception {
+        String token = registerAndLogin("leo@test.com");
+        UUID linkedId = uploadPng(token, "linked.png");
+        UUID orphanId = uploadPng(token, "orphan.png");
+
+        createPostWithAttachment(token, "linked", linkedId);
+
+        // Age both attachments past the retention window so the sweeper picks
+        // them up. The query predicate is created_at < cutoff; the cutoff is
+        // now() - retentionHours, so dating both 25 hours in the past makes
+        // them eligible (or eligible-modulo-references).
+        jdbcTemplate.update(
+                "UPDATE attachments SET created_at = NOW() - INTERVAL '25 hours' WHERE id IN (?, ?)",
+                linkedId, orphanId);
+
+        orphanCleanupScheduler.sweepOrphans();
+
+        Integer linkedRemaining = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM attachments WHERE id = ?", Integer.class, linkedId);
+        assertThat(linkedRemaining)
+                .as("Feed-referenced attachment must survive the sweep")
+                .isEqualTo(1);
+
+        Integer orphanRemaining = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM attachments WHERE id = ?", Integer.class, orphanId);
+        assertThat(orphanRemaining)
+                .as("Truly unreferenced attachment must be reclaimed")
+                .isZero();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private long createPostWithAttachment(String token, String body, UUID attachmentId) throws Exception {
+        MvcResult res = mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "body", body,
+                                "attachmentIds", List.of(attachmentId.toString())))))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();
+    }
+
+    private UUID uploadPng(String token, String filename) throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", filename, "image/png", pngBody());
+        MvcResult res = mockMvc.perform(multipart("/api/messages/attachments")
+                        .file(file)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return UUID.fromString(objectMapper.readTree(res.getResponse().getContentAsString())
+                .get("id").asText());
+    }
+
+    private UUID uploadPdf(String token, String filename) throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", filename, "application/pdf", pdfBody());
+        MvcResult res = mockMvc.perform(multipart("/api/messages/attachments")
+                        .file(file)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return UUID.fromString(objectMapper.readTree(res.getResponse().getContentAsString())
+                .get("id").asText());
+    }
+
+    private String registerAndLogin(String email) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Feed");
+        req.setLastName("Tester");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(true);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    /**
+     * Minimal PNG body that satisfies {@code AttachmentStorageService}'s
+     * magic-byte check: 8-byte PNG signature + IHDR chunk header. The
+     * validator inspects only the leading bytes, so a stub like this passes
+     * without being a fully-valid renderable PNG.
+     */
+    private static byte[] pngBody() {
+        return new byte[]{
+                (byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+                0x00, 0x00, 0x00, 0x0D, 'I', 'H', 'D', 'R',
+                0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+                0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, (byte) 0xC4, (byte) 0x89,
+                0x00, 0x00, 0x00, 0x0D, 'I', 'D', 'A', 'T',
+                0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, (byte) 0xAE, 0x42, 0x60, (byte) 0x82
+        };
+    }
+
+    private static byte[] pdfBody() {
+        byte[] header = new byte[]{0x25, 0x50, 0x44, 0x46};  // %PDF
+        byte[] tail = "payload".getBytes();
+        byte[] result = new byte[header.length + tail.length];
+        System.arraycopy(header, 0, result, 0, header.length);
+        System.arraycopy(tail, 0, result, header.length, tail.length);
+        return result;
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/FeedPostIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedPostIntegrationTest.java
@@ -69,8 +69,15 @@ class FeedPostIntegrationTest {
     void cleanDb() {
         // Children first by FK, then parents. Cascade would handle this,
         // but explicit ordering is more debuggable when something goes wrong.
+        // feed_post_attachments references attachments with NO ACTION, so any
+        // junction rows must be cleared before the attachments DELETE.
+        jdbcTemplate.update("DELETE FROM feed_post_attachments");
         jdbcTemplate.update("DELETE FROM feed_post_hashtags");
         jdbcTemplate.update("DELETE FROM feed_posts");
+        // Messages reference attachments via SET NULL — clearing messages
+        // first ensures attachment-row deletes don't trip the FK.
+        jdbcTemplate.update("DELETE FROM messages");
+        jdbcTemplate.update("DELETE FROM attachments");
         verificationTokenRepository.deleteAll();
         userRepository.deleteAll();
         doNothing().when(emailService).sendVerificationEmail(any(), anyString());

--- a/backend/src/test/java/com/group7/backend/service/FeedPostMapperTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostMapperTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 class FeedPostMapperTest {
 
     @Mock private UserRepository userRepository;
+    @Mock private AttachmentUrlBuilder attachmentUrlBuilder;
     @InjectMocks private FeedPostMapper feedPostMapper;
 
     @Test

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
@@ -6,6 +6,7 @@ import com.group7.backend.entity.FeedPost;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.AttachmentRepository;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,7 @@ class FeedPostServiceTest {
 
     @Mock private FeedPostRepository feedPostRepository;
     @Mock private UserRepository userRepository;
+    @Mock private AttachmentRepository attachmentRepository;
     @Mock private HashtagNormalizer hashtagNormalizer;
     @Mock private FeedPostMapper feedPostMapper;
     @Mock private FeedPostEventPublisher feedPostEventPublisher;
@@ -49,7 +51,7 @@ class FeedPostServiceTest {
         Admin admin = admin(99L);
         when(userRepository.findById(99L)).thenReturn(Optional.of(admin));
 
-        assertThatThrownBy(() -> feedPostService.create(99L, "Hello", List.of()))
+        assertThatThrownBy(() -> feedPostService.create(99L, "Hello", List.of(), null))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessageContaining("Admins cannot create");
 
@@ -61,7 +63,7 @@ class FeedPostServiceTest {
         Mentor author = mentor(1L);
         when(userRepository.findById(1L)).thenReturn(Optional.of(author));
 
-        assertThatThrownBy(() -> feedPostService.create(1L, "   ", List.of()))
+        assertThatThrownBy(() -> feedPostService.create(1L, "   ", List.of(), null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("body must not be blank");
 
@@ -73,7 +75,7 @@ class FeedPostServiceTest {
         Mentor author = mentor(1L);
         when(userRepository.findById(1L)).thenReturn(Optional.of(author));
 
-        assertThatThrownBy(() -> feedPostService.create(1L, null, List.of()))
+        assertThatThrownBy(() -> feedPostService.create(1L, null, List.of(), null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -81,7 +83,7 @@ class FeedPostServiceTest {
     void create_rejectsMissingAuthor_with404() {
         when(userRepository.findById(404L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> feedPostService.create(404L, "ok", List.of()))
+        assertThatThrownBy(() -> feedPostService.create(404L, "ok", List.of(), null))
                 .isInstanceOf(ResourceNotFoundException.class);
 
         verify(feedPostRepository, never()).save(any(FeedPost.class));
@@ -100,7 +102,7 @@ class FeedPostServiceTest {
         FeedPostResponse expected = stubResponse(42L, 1L);
         when(feedPostMapper.toResponse(any(FeedPost.class), any())).thenReturn(expected);
 
-        FeedPostResponse result = feedPostService.create(1L, "Hello", List.of("DATA", "ai"));
+        FeedPostResponse result = feedPostService.create(1L, "Hello", List.of("DATA", "ai"), null);
 
         assertThat(result).isSameAs(expected);
         verify(feedPostRepository).save(any(FeedPost.class));
@@ -118,7 +120,7 @@ class FeedPostServiceTest {
         });
         when(feedPostMapper.toResponse(any(FeedPost.class), any())).thenReturn(stubResponse(42L, 1L));
 
-        feedPostService.create(1L, "Hello", List.of());
+        feedPostService.create(1L, "Hello", List.of(), null);
 
         // Verify the facade is invoked with the saved post + author. The
         // FeedPostEventPublisherTest pins the event-shape contract; here
@@ -137,7 +139,7 @@ class FeedPostServiceTest {
         when(feedPostRepository.save(any(FeedPost.class)))
                 .thenThrow(new RuntimeException("DB down"));
 
-        assertThatThrownBy(() -> feedPostService.create(1L, "Hello", List.of()))
+        assertThatThrownBy(() -> feedPostService.create(1L, "Hello", List.of(), null))
                 .isInstanceOf(RuntimeException.class);
 
         verify(feedPostEventPublisher, never()).publishCreated(any(), any());
@@ -171,7 +173,7 @@ class FeedPostServiceTest {
     void update_throws404_whenPostMissing() {
         when(feedPostRepository.findById(404L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> feedPostService.update(404L, 1L, "new body", null))
+        assertThatThrownBy(() -> feedPostService.update(404L, 1L, "new body", null, null))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
 
@@ -180,7 +182,7 @@ class FeedPostServiceTest {
         FeedPost post = freshPost(7L, 1L, "Body");
         when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
 
-        assertThatThrownBy(() -> feedPostService.update(7L, 999L, "hostile", null))
+        assertThatThrownBy(() -> feedPostService.update(7L, 999L, "hostile", null, null))
                 .isInstanceOf(AccessDeniedException.class);
 
         verify(feedPostRepository, never()).save(any(FeedPost.class));
@@ -192,7 +194,7 @@ class FeedPostServiceTest {
         post.setDeletedAt(OffsetDateTime.now());
         when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
 
-        assertThatThrownBy(() -> feedPostService.update(7L, 1L, "new", null))
+        assertThatThrownBy(() -> feedPostService.update(7L, 1L, "new", null, null))
                 .isInstanceOf(ResourceNotFoundException.class);
 
         verify(feedPostRepository, never()).save(any(FeedPost.class));
@@ -206,7 +208,7 @@ class FeedPostServiceTest {
         when(feedPostRepository.save(post)).thenReturn(post);
         when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
 
-        feedPostService.update(7L, 1L, null, null);
+        feedPostService.update(7L, 1L, null, null, null);
 
         // Both fields null = no modification = updatedAt unchanged
         assertThat(post.getBody()).isEqualTo("Original");
@@ -218,7 +220,7 @@ class FeedPostServiceTest {
         FeedPost post = freshPost(7L, 1L, "Original");
         when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
 
-        assertThatThrownBy(() -> feedPostService.update(7L, 1L, "   ", null))
+        assertThatThrownBy(() -> feedPostService.update(7L, 1L, "   ", null, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -231,7 +233,7 @@ class FeedPostServiceTest {
         when(feedPostRepository.save(post)).thenReturn(post);
         when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
 
-        feedPostService.update(7L, 1L, null, List.of("new"));
+        feedPostService.update(7L, 1L, null, List.of("new"), null);
 
         assertThat(post.getUpdatedAt()).isAfterOrEqualTo(origUpdated);
         // Hashtags were touched — the LinkedHashSet has the new tag.
@@ -310,6 +312,6 @@ class FeedPostServiceTest {
 
     private static FeedPostResponse stubResponse(Long id, Long authorId) {
         return new FeedPostResponse(id, authorId, "U" + authorId, "body", List.of(),
-                OffsetDateTime.now(), OffsetDateTime.now(), false, true);
+                OffsetDateTime.now(), OffsetDateTime.now(), false, true, List.of());
     }
 }


### PR DESCRIPTION
Closes #485.

## Summary
- Junction table `feed_post_attachments` (V41) with composite PK, `UNIQUE (attachment_id)` (one attachment, one post), `UNIQUE (post_id, position)`, `CHECK (position BETWEEN 0 AND 3)`, `ON DELETE CASCADE` on `post_id`, and an ordered `(post_id, position)` index.
- `FeedPost.attachments` `@ManyToMany` with `@OrderColumn(position)` and `@BatchSize(100)`; no cascade — `Attachment` lifecycle is owned by the upload pipeline.
- Image content-type allow-list (`image/jpeg`, `image/png`, `image/gif`, `image/webp`) enforced in `FeedPostService.loadAndAuthorizeFeedAttachment`; provenance gate ("only the uploader can attach") mirrors `MessageService`.
- `CreateFeedPostRequest` and `UpdateFeedPostRequest` gain `@Size(max = 4) List<@NotNull UUID> attachmentIds`; PATCH semantics: `null` keeps current, `[]` clears all, `[…]` replaces.
- `FeedPostResponse` and `FeedPostListItem` gain `List<AttachmentSummary> attachments`, populated through `AttachmentUrlBuilder.feedMediaUrl(UUID)`.
- New `FeedMediaDownloadController` at `GET /api/uploads/feed-media/{uuid}`: gates on `existsAsFeedAttachment` (no per-user ACL), path-traversal defence, `Cache-Control: public, max-age=3600`, `X-Content-Type-Options: nosniff`. Anonymous → 403 via Spring Security URL-pattern.
- `AttachmentRepository.findOrphansOlderThan` and `deleteIfStillOrphan` rewritten as native SQL that also excludes attachments referenced from `feed_post_attachments` — fixes a latent bug where the daily orphan-sweep would have failed on feed media.
- `DataIntegrityViolationException → 409` global handler covers the DB UNIQUE race window when two posts try to claim the same attachment id concurrently (service-layer check would still race).
- `FeedPostMapper` is now instance-bound (drops `static` on `mapOne`) and owns the single source of truth for list-item construction; `FeedReadService` and `FeedInteractionService.listBookmarks` delegate to it instead of building items inline.

## Test plan
- [x] `mvn verify` against isolated Postgres: 1530 tests pass, 0 failures, 0 errors.
- [x] New `FeedMediaIntegrationTest` covers 12 scenarios end-to-end against real Postgres + MockMvc: happy paths (1 image, 4-image order preserved), all five rejection modes (5+, non-uploader 403, non-image 400, already-attached 409, duplicate id 400), cross-controller probe (chat-only 404 on feed-media path), anonymous baseline (403), soft-delete junction preservation, PATCH attachment-set replacement, orphan-cleanup feed-bound skip.
- [x] New `FeedMediaDownloadControllerTest` (slice): 5 controller paths + 6 `resolveMediaType` cases.
- [x] `FeedPostIntegrationTest` cleanup hook updated for the new FK ordering (`feed_post_attachments` and `attachments` cleared before `messages` cleanup); 10/10 still green.

## Notes for reviewers
- `position` column is `INTEGER` (not `SMALLINT`) — Hibernate's default `@OrderColumn` type is int4, and a SMALLINT mismatch trips `ddl-auto=validate` at boot. The `CHECK` already bounds the range to `0..3`, so the 2-byte saving was not worth the validator friction.
- The `@ManyToMany` collection must be mutated only via `clear() + addAll()`. Partial mutations (`list.set(i, x)` / `list.remove(int)`) de-sync `@OrderColumn`. The service paths use only the safe pattern; the entity javadoc documents the constraint.
- Mevcut V38, V47, V48 migration'ları başka worktree'lerden geliyor — V41 onlardan bağımsız tablo (`feed_post_attachments`); merge sırasında bir conflict beklemiyorum.

## Related
- Spec: `1.1.7.2` (text + hashtag posts) genişletildi; image attachments demo-impact için eklendi.
- Co-evolves with: #480 (counts), #482 (notifications) — fileset disjoint.