### PR TITLE
feat(backend): social feed API ergonomics (#489)

### DIFF
--- a/backend/src/main/java/com/group7/backend/config/PageTotalCountHeaderAdvice.java
+++ b/backend/src/main/java/com/group7/backend/config/PageTotalCountHeaderAdvice.java
@@ -1,0 +1,63 @@
+package com.group7.backend.config;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * Adds the conventional {@code X-Total-Count} header to any response whose
+ * body is a Spring Data {@link Page}. Coexists with the JSON envelope's
+ * {@code totalElements} field — purely additive, never removes anything.
+ *
+ * <p>Why a header, not just the envelope: it's the de-facto convention
+ * (GitHub, Stripe, Atlassian) and lets clients short-circuit on
+ * {@code HEAD} / cursor-paginated probes without reading the body.
+ *
+ * <p>{@link Order} is one rank ahead of {@link com.group7.backend.config.jsonld.JsonLdResponseBodyAdvice}
+ * ({@code LOWEST_PRECEDENCE}) so the header is set before any
+ * content-type rewriting; the two advices touch disjoint concerns
+ * (header vs. body), so the relative order is mostly cosmetic, but
+ * keeping the header set first means downstream advices can rely on it.
+ *
+ * <p><b>{@code supports()} returns {@code true} unconditionally.</b> The
+ * controllers in this project return {@code ResponseEntity<Page<T>>},
+ * so {@link MethodParameter#getParameterType()} reports
+ * {@code ResponseEntity.class}, not {@code Page.class}. A naive
+ * {@code Page.class.isAssignableFrom(...)} check would silently skip
+ * every paged endpoint. Spring unwraps the {@code ResponseEntity<X>}
+ * and passes {@code X} as {@code body}, so the real discriminator lives
+ * in {@link #beforeBodyWrite}'s {@code instanceof Page} check — a
+ * single instanceof per response is negligible cost.
+ */
+@ControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE - 10)
+public class PageTotalCountHeaderAdvice implements ResponseBodyAdvice<Object> {
+
+    static final String HEADER_NAME = "X-Total-Count";
+
+    @Override
+    public boolean supports(MethodParameter returnType,
+                            Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+        if (body instanceof Page<?> page) {
+            response.getHeaders().set(HEADER_NAME, Long.toString(page.getTotalElements()));
+        }
+        return body;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/group7/backend/config/SecurityConfig.java
@@ -174,6 +174,12 @@ public class SecurityConfig {
         }
         config.addAllowedMethod("*");
         config.addAllowedHeader("*");
+        // Browsers ignore non-CORS-safelisted response headers unless the
+        // server explicitly lists them in Access-Control-Expose-Headers.
+        // X-Total-Count is set by PageTotalCountHeaderAdvice on paged
+        // responses; without this line, JS clients on a different origin
+        // cannot read it.
+        config.addExposedHeader("X-Total-Count");
         config.setAllowCredentials(true);
         config.setMaxAge(3600L);
 

--- a/backend/src/main/java/com/group7/backend/controller/FeedInteractionController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedInteractionController.java
@@ -202,6 +202,25 @@ public class FeedInteractionController {
         return ResponseEntity.ok(interactionService.editComment(id, requesterId, request.body()));
     }
 
+    @GetMapping("/comments/{id:\\d+}")
+    @Operation(summary = "Get a single comment by id (permalink)",
+            description = "Returns the comment if present, not soft-deleted, AND its parent "
+                    + "post is still visible. 404 if any of those conditions fail.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Comment",
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.FEED_COMMENT_RESPONSE))),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Comment soft-deleted or parent post not visible", content = @Content)
+    })
+    public ResponseEntity<FeedCommentResponse> getComment(
+            @Parameter(description = "Comment id") @PathVariable Long id,
+            Authentication authentication) {
+        Long viewerId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(interactionService.getComment(id, viewerId));
+    }
+
     @DeleteMapping("/comments/{id:\\d+}")
     @Operation(summary = "Soft-delete a comment (author-only)")
     @ApiResponses({

--- a/backend/src/main/java/com/group7/backend/controller/FeedInteractionController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedInteractionController.java
@@ -1,6 +1,7 @@
 package com.group7.backend.controller;
 
 import com.group7.backend.controller.support.PageableSupport;
+import com.group7.backend.docs.feed.FeedApiExamples;
 import com.group7.backend.dto.request.FeedCommentRequest;
 import com.group7.backend.dto.response.FeedCommentResponse;
 import com.group7.backend.dto.response.FeedPostInteractionState;
@@ -9,6 +10,7 @@ import com.group7.backend.service.FeedInteractionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -77,7 +79,11 @@ public class FeedInteractionController {
     @Operation(summary = "Toggle like on a feed post",
             description = "Idempotent toggle. Returns the updated interaction state.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Toggle applied; current state returned"),
+            @ApiResponse(responseCode = "200", description = "Toggle applied; current state returned",
+                    content = @Content(examples = {
+                            @ExampleObject(name = "now-liked",   value = FeedApiExamples.TOGGLE_LIKE_RESPONSE_LIKED),
+                            @ExampleObject(name = "now-unliked", value = FeedApiExamples.TOGGLE_LIKE_RESPONSE_UNLIKED)
+                    })),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
             @ApiResponse(responseCode = "404", description = "Post not found or soft-deleted", content = @Content)
     })
@@ -139,9 +145,16 @@ public class FeedInteractionController {
     // ── Comments ───────────────────────────────────────────────────────────
 
     @PostMapping("/posts/{id:\\d+}/comments")
-    @Operation(summary = "Add a comment to a feed post")
+    @Operation(summary = "Add a comment to a feed post",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.ADD_COMMENT_REQUEST))))
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Comment created"),
+            @ApiResponse(responseCode = "201", description = "Comment created",
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.FEED_COMMENT_RESPONSE))),
             @ApiResponse(responseCode = "400", description = "Validation failure", content = @Content),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
             @ApiResponse(responseCode = "404", description = "Post not found", content = @Content)

--- a/backend/src/main/java/com/group7/backend/controller/FeedInteractionController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedInteractionController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -61,7 +62,13 @@ public class FeedInteractionController {
             @Parameter(description = "Feed post id") @PathVariable Long id,
             Authentication authentication) {
         Long viewerId = (Long) authentication.getCredentials();
-        return ResponseEntity.ok(interactionService.getInteractionState(id, viewerId));
+        // Cache-Control: no-cache so likers' updates surface immediately and
+        // viewer-relative flags (viewerHasLiked / viewerHasBookmarked) stay
+        // fresh. Symmetric with the static GET /api/feed/posts/{id} endpoint
+        // which uses ETag + private/max-age=30.
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noCache())
+                .body(interactionService.getInteractionState(id, viewerId));
     }
 
     // ── Likes ──────────────────────────────────────────────────────────────

--- a/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
@@ -22,6 +22,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.WebRequest;
+
+import java.time.OffsetDateTime;
 
 /**
  * REST surface for the social-feed posts core (#348).
@@ -83,17 +86,41 @@ public class FeedPostController {
     @GetMapping("/{id:\\d+}")
     @Operation(summary = "Get a feed post by id",
             description = "Returns the post if present and not soft-deleted. The viewer's "
-                    + "id is reflected in the response's isAuthor flag.")
+                    + "id is reflected in the response's isAuthor flag. Participates in "
+                    + "conditional GET: clients may send If-None-Match with the ETag from "
+                    + "a prior response to receive 304 when the post body is unchanged.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Post body"),
+            @ApiResponse(responseCode = "304", description = "Not Modified — If-None-Match matched current ETag"),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
             @ApiResponse(responseCode = "404", description = "Post not found or soft-deleted", content = @Content)
     })
     public ResponseEntity<FeedPostResponse> getById(
             @Parameter(description = "Feed post id") @PathVariable Long id,
-            Authentication authentication) {
+            Authentication authentication,
+            WebRequest webRequest) {
         Long viewerId = (Long) authentication.getCredentials();
-        return ResponseEntity.ok(feedPostService.getById(id, viewerId));
+        FeedPostResponse post = feedPostService.getById(id, viewerId);
+        // ETag derived from updatedAt (falls back to createdAt) — the only
+        // post-shape mutation point. Counters / viewer flags live on the
+        // separate /interactions endpoint with no-cache, so they never
+        // invalidate this cache.
+        OffsetDateTime lastModified = post.updatedAt() != null ? post.updatedAt() : post.createdAt();
+        long lastModifiedMillis = lastModified.toInstant().toEpochMilli();
+        String etag = "\"" + lastModifiedMillis + "\"";
+        if (webRequest.checkNotModified(etag, lastModifiedMillis)) {
+            // Spring writes 304 from the WebRequest hint; null return is the
+            // documented Spring 6 pattern for conditional-GET short-circuit.
+            return null;
+        }
+        // private because isAuthor is viewer-relative; max-age=30 is short
+        // enough that staleness is harmless and long enough to absorb
+        // typical UI-render reload bursts.
+        return ResponseEntity.ok()
+                .eTag(etag)
+                .lastModified(lastModifiedMillis)
+                .header("Cache-Control", "private, max-age=30")
+                .body(post);
     }
 
     @PatchMapping("/{id:\\d+}")

--- a/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
@@ -1,5 +1,6 @@
 package com.group7.backend.controller;
 
+import com.group7.backend.docs.feed.FeedApiExamples;
 import com.group7.backend.dto.request.CreateFeedPostRequest;
 import com.group7.backend.dto.request.UpdateFeedPostRequest;
 import com.group7.backend.dto.response.FeedPostResponse;
@@ -7,6 +8,7 @@ import com.group7.backend.service.FeedPostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -68,9 +70,16 @@ public class FeedPostController {
     @Operation(summary = "Create a feed post",
             description = "Creates a new feed post on behalf of the authenticated user. "
                     + "Mentors and mentees can post; admins are rejected (403). Hashtags "
-                    + "are server-normalised (lowercase, leading '#' stripped, dedupe).")
+                    + "are server-normalised (lowercase, leading '#' stripped, dedupe).",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.CREATE_FEED_POST_REQUEST))))
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "Post created"),
+            @ApiResponse(responseCode = "201", description = "Post created",
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.FEED_POST_RESPONSE))),
             @ApiResponse(responseCode = "400", description = "Validation failure (blank body, oversize, too many tags)", content = @Content),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
             @ApiResponse(responseCode = "403", description = "Admin requester (admins cannot post)", content = @Content)
@@ -90,7 +99,10 @@ public class FeedPostController {
                     + "conditional GET: clients may send If-None-Match with the ETag from "
                     + "a prior response to receive 304 when the post body is unchanged.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Post body"),
+            @ApiResponse(responseCode = "200", description = "Post body",
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.FEED_POST_RESPONSE))),
             @ApiResponse(responseCode = "304", description = "Not Modified — If-None-Match matched current ETag"),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
             @ApiResponse(responseCode = "404", description = "Post not found or soft-deleted", content = @Content)

--- a/backend/src/main/java/com/group7/backend/controller/FeedReadController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedReadController.java
@@ -1,11 +1,13 @@
 package com.group7.backend.controller;
 
 import com.group7.backend.controller.support.PageableSupport;
+import com.group7.backend.docs.feed.FeedApiExamples;
 import com.group7.backend.dto.response.FeedPostListItem;
 import com.group7.backend.service.FeedReadService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -60,7 +62,10 @@ public class FeedReadController {
                     + "not the global post count — the For-You feed deliberately ranks a "
                     + "rolling window of recent candidates and caps at that size.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Paged ranked posts"),
+            @ApiResponse(responseCode = "200", description = "Paged ranked posts",
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.FOR_YOU_RESPONSE))),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content)
     })
     public ResponseEntity<Page<FeedPostListItem>> forYou(
@@ -77,7 +82,10 @@ public class FeedReadController {
             description = "Returns posts authored by users the viewer follows, ordered by "
                     + "creation time descending. Empty when the viewer follows nobody.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Paged followed-author posts"),
+            @ApiResponse(responseCode = "200", description = "Paged followed-author posts",
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.FOLLOWING_RESPONSE))),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content)
     })
     public ResponseEntity<Page<FeedPostListItem>> following(
@@ -94,7 +102,10 @@ public class FeedReadController {
             description = "Returns non-deleted posts authored by the given user id, "
                     + "ordered by creation time descending.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Paged author posts"),
+            @ApiResponse(responseCode = "200", description = "Paged author posts",
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.POSTS_BY_AUTHOR_RESPONSE))),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content)
     })
     public ResponseEntity<Page<FeedPostListItem>> postsByAuthor(
@@ -115,7 +126,10 @@ public class FeedReadController {
                     + "leading-# stripped); a hashtag that fails normalisation returns an "
                     + "empty page rather than 400. Combined queries AND the two predicates.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "Paged matching posts"),
+            @ApiResponse(responseCode = "200", description = "Paged matching posts",
+                    content = @Content(examples = @ExampleObject(
+                            name = "default",
+                            value = FeedApiExamples.SEARCH_RESPONSE))),
             @ApiResponse(responseCode = "400", description = "Both `q` and `hashtag` missing", content = @Content),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content)
     })

--- a/backend/src/main/java/com/group7/backend/docs/feed/FeedApiExamples.java
+++ b/backend/src/main/java/com/group7/backend/docs/feed/FeedApiExamples.java
@@ -1,0 +1,221 @@
+package com.group7.backend.docs.feed;
+
+/**
+ * Concrete JSON payload examples surfaced through Swagger UI / OpenAPI
+ * for the social-feed read and write endpoints (#489).
+ *
+ * <p>Lives in a single file so frontend and mobile developers can scan
+ * one source for shapes, and so payload edits show up as a single PR
+ * diff rather than scattered controller edits. Constants are valid,
+ * compact-formatted JSON literals — the Swagger renderer pretty-prints
+ * them.
+ *
+ * <p>Examples avoid PII and use the same fake-name conventions as the
+ * mentor seed data: "Ada", "Esra", "Selin". Timestamps are deliberately
+ * fixed (not "now") so the docs are reproducible regardless of when
+ * the spec is regenerated.
+ */
+public final class FeedApiExamples {
+
+    private FeedApiExamples() {
+        // constants holder — no instances
+    }
+
+    // ── Read responses (list endpoints) ───────────────────────────────────
+
+    public static final String FOR_YOU_RESPONSE = """
+            {
+              "content": [
+                {
+                  "id": 42,
+                  "authorId": 17,
+                  "authorFirstName": "Ada",
+                  "body": "Just wrapped a clinical-research methods workshop — slides in the comments.",
+                  "hashtags": ["clinical", "research"],
+                  "createdAt": "2026-05-09T10:15:00Z",
+                  "likeCount": 12,
+                  "commentCount": 3
+                },
+                {
+                  "id": 41,
+                  "authorId": 22,
+                  "authorFirstName": "Esra",
+                  "body": "Embedding-based mentor search beats keyword matching on cold-start queries.",
+                  "hashtags": ["ml", "recommendations"],
+                  "createdAt": "2026-05-09T09:48:11Z",
+                  "likeCount": 7,
+                  "commentCount": 1
+                }
+              ],
+              "pageable": { "pageNumber": 0, "pageSize": 20, "offset": 0, "paged": true, "unpaged": false },
+              "totalElements": 42,
+              "totalPages": 3,
+              "first": true,
+              "last": false,
+              "number": 0,
+              "size": 20,
+              "numberOfElements": 2,
+              "empty": false
+            }
+            """;
+
+    public static final String FOLLOWING_RESPONSE = """
+            {
+              "content": [
+                {
+                  "id": 39,
+                  "authorId": 22,
+                  "authorFirstName": "Esra",
+                  "body": "Looking for a mentee interested in graph-based recommenders. DM me.",
+                  "hashtags": ["graphs", "recommendations"],
+                  "createdAt": "2026-05-09T08:02:43Z",
+                  "likeCount": 4,
+                  "commentCount": 2
+                }
+              ],
+              "pageable": { "pageNumber": 0, "pageSize": 20, "offset": 0, "paged": true, "unpaged": false },
+              "totalElements": 1,
+              "totalPages": 1,
+              "first": true,
+              "last": true,
+              "number": 0,
+              "size": 20,
+              "numberOfElements": 1,
+              "empty": false
+            }
+            """;
+
+    public static final String SEARCH_RESPONSE = """
+            {
+              "content": [
+                {
+                  "id": 42,
+                  "authorId": 17,
+                  "authorFirstName": "Ada",
+                  "body": "Just wrapped a clinical-research methods workshop — slides in the comments.",
+                  "hashtags": ["clinical", "research"],
+                  "createdAt": "2026-05-09T10:15:00Z",
+                  "likeCount": 12,
+                  "commentCount": 3
+                }
+              ],
+              "pageable": { "pageNumber": 0, "pageSize": 20, "offset": 0, "paged": true, "unpaged": false },
+              "totalElements": 1,
+              "totalPages": 1,
+              "first": true,
+              "last": true,
+              "number": 0,
+              "size": 20,
+              "numberOfElements": 1,
+              "empty": false
+            }
+            """;
+
+    public static final String POSTS_BY_AUTHOR_RESPONSE = """
+            {
+              "content": [
+                {
+                  "id": 42,
+                  "authorId": 17,
+                  "authorFirstName": "Ada",
+                  "body": "Just wrapped a clinical-research methods workshop — slides in the comments.",
+                  "hashtags": ["clinical", "research"],
+                  "createdAt": "2026-05-09T10:15:00Z",
+                  "likeCount": 12,
+                  "commentCount": 3
+                },
+                {
+                  "id": 38,
+                  "authorId": 17,
+                  "authorFirstName": "Ada",
+                  "body": "Reviewing manuscripts for the systematic-review track.",
+                  "hashtags": ["clinical"],
+                  "createdAt": "2026-05-07T13:21:08Z",
+                  "likeCount": 2,
+                  "commentCount": 0
+                }
+              ],
+              "pageable": { "pageNumber": 0, "pageSize": 20, "offset": 0, "paged": true, "unpaged": false },
+              "totalElements": 2,
+              "totalPages": 1,
+              "first": true,
+              "last": true,
+              "number": 0,
+              "size": 20,
+              "numberOfElements": 2,
+              "empty": false
+            }
+            """;
+
+    // ── Single-post detail ────────────────────────────────────────────────
+
+    public static final String FEED_POST_RESPONSE = """
+            {
+              "id": 42,
+              "authorId": 17,
+              "authorFirstName": "Ada",
+              "body": "Just wrapped a clinical-research methods workshop — slides in the comments.",
+              "hashtags": ["clinical", "research"],
+              "createdAt": "2026-05-09T10:15:00Z",
+              "updatedAt": "2026-05-09T11:02:34Z",
+              "isEdited": true,
+              "isAuthor": false
+            }
+            """;
+
+    // ── Create / update request bodies ────────────────────────────────────
+
+    public static final String CREATE_FEED_POST_REQUEST = """
+            {
+              "body": "Excited to share thoughts on data science and graph-based recommenders.",
+              "hashtags": ["DataScience", "#Graphs"]
+            }
+            """;
+
+    // ── Interaction state (toggle responses) ──────────────────────────────
+
+    public static final String TOGGLE_LIKE_RESPONSE_LIKED = """
+            {
+              "likeCount": 13,
+              "commentCount": 3,
+              "shareCount": 1,
+              "bookmarkCount": 2,
+              "viewerHasLiked": true,
+              "viewerHasBookmarked": false
+            }
+            """;
+
+    public static final String TOGGLE_LIKE_RESPONSE_UNLIKED = """
+            {
+              "likeCount": 12,
+              "commentCount": 3,
+              "shareCount": 1,
+              "bookmarkCount": 2,
+              "viewerHasLiked": false,
+              "viewerHasBookmarked": false
+            }
+            """;
+
+    // ── Comment payloads ──────────────────────────────────────────────────
+
+    public static final String ADD_COMMENT_REQUEST = """
+            {
+              "body": "Great session! Sharing the slides with my cohort, hope that's OK."
+            }
+            """;
+
+    public static final String FEED_COMMENT_RESPONSE = """
+            {
+              "id": 101,
+              "postId": 42,
+              "authorId": 17,
+              "authorFirstName": "Ada",
+              "body": "Great session! Sharing the slides with my cohort, hope that's OK.",
+              "createdAt": "2026-05-09T12:00:00Z",
+              "updatedAt": "2026-05-09T12:00:00Z",
+              "isEdited": false,
+              "isAuthor": true,
+              "isDeleted": false
+            }
+            """;
+}

--- a/backend/src/main/java/com/group7/backend/repository/FeedPostCommentRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostCommentRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface FeedPostCommentRepository extends JpaRepository<FeedPostComment, Long> {
@@ -23,6 +24,15 @@ public interface FeedPostCommentRepository extends JpaRepository<FeedPostComment
     Page<FeedPostComment> findByPostIdOrderByCreatedAtAscIdAsc(Long postId, Pageable pageable);
 
     long countByPostIdAndDeletedAtIsNull(Long postId);
+
+    /**
+     * Permalink lookup (#489): returns the comment only when it is not
+     * soft-deleted. Used by {@code GET /api/feed/comments/{id}} to back
+     * the single-comment view. Derived method name matches the
+     * project-wide convention set by
+     * {@code FeedPostRepository.findByIdAndDeletedAtIsNull}.
+     */
+    Optional<FeedPostComment> findByIdAndDeletedAtIsNull(Long id);
 
     /**
      * Batch visible-comment-count projection across many posts in one

--- a/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
@@ -296,6 +296,30 @@ public class FeedInteractionService {
         log.info("Soft-deleted comment: id={}, authorId={}", commentId, requesterId);
     }
 
+    /**
+     * Single-comment read (#489 permalink). Returns the comment iff it is
+     * not soft-deleted AND its parent post is still visible — without
+     * the parent-visibility check, a permalink to a comment on a
+     * soft-deleted post would surface orphan content with no navigation
+     * affordance. 404 on either condition.
+     *
+     * <p>Lives on this service (not {@code FeedReadService}) because
+     * every other single-comment operation already lives here; splitting
+     * one comment op into a different service would fragment the
+     * comment logic.
+     */
+    public FeedCommentResponse getComment(Long commentId, Long viewerId) {
+        FeedPostComment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Comment not found with id: " + commentId));
+        // Orphan-permalink guard: 404 when the parent post is soft-deleted.
+        // Same exception message as the comment-missing branch — distinguishing
+        // the two would leak whether the comment id ever existed, an
+        // unnecessary information disclosure for anyone probing ids.
+        feedPostRepository.findByIdAndDeletedAtIsNull(comment.getPostId())
+                .orElseThrow(() -> new ResourceNotFoundException("Comment not found with id: " + commentId));
+        return mapComment(comment, viewerId, resolveAuthorName(comment.getAuthorId()));
+    }
+
     // ── Aggregate state ────────────────────────────────────────────────────
 
     /**

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -192,6 +192,16 @@ app.ratelimit.rules.feed-comment.key-strategy=USER
 app.ratelimit.rules.feed-comment.capacity=${APP_FEED_INTERACTION_CAPACITY:60}
 app.ratelimit.rules.feed-comment.refill=PT1M
 
+# Comment-permalink endpoint (#489). Cheap read, but worth a per-user
+# cap so a single client cannot scrape comments at arbitrary rates.
+# 60/min/user is conservative; reuses the existing feed-interaction
+# envelope variable so ops can tune all four feed read/write caps together.
+app.ratelimit.rules.feed-comment-permalink.method=GET
+app.ratelimit.rules.feed-comment-permalink.pattern=/api/feed/comments/*
+app.ratelimit.rules.feed-comment-permalink.key-strategy=USER
+app.ratelimit.rules.feed-comment-permalink.capacity=${APP_FEED_INTERACTION_CAPACITY:60}
+app.ratelimit.rules.feed-comment-permalink.refill=PT1M
+
 # IP-keyed cap on the anonymous iCalendar export endpoint (#250). The path
 # is permitAll so calendar apps can subscribe; this rule prevents drive-by
 # enumeration of mentor IDs. 30/min per IP is generous for legitimate

--- a/backend/src/test/java/com/group7/backend/config/PageTotalCountHeaderAdviceTest.java
+++ b/backend/src/test/java/com/group7/backend/config/PageTotalCountHeaderAdviceTest.java
@@ -1,0 +1,91 @@
+package com.group7.backend.config;
+
+import com.group7.backend.config.jsonld.JsonLdResponseBodyAdvice;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.ServerHttpResponse;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for {@link PageTotalCountHeaderAdvice}. Verifies:
+ * <ul>
+ *   <li>{@code supports()} returns {@code true} unconditionally — see the
+ *       javadoc on the advice for why this is correct vs. checking the
+ *       return type.</li>
+ *   <li>{@code beforeBodyWrite()} sets {@code X-Total-Count} from the
+ *       page's {@code totalElements} when the body is a {@link Page}.</li>
+ *   <li>Non-{@link Page} bodies don't trigger the header.</li>
+ *   <li>The advice's {@code @Order} is strictly ahead of
+ *       {@link JsonLdResponseBodyAdvice} so the header is set before
+ *       any content-type rewriting.</li>
+ * </ul>
+ */
+class PageTotalCountHeaderAdviceTest {
+
+    private final PageTotalCountHeaderAdvice advice = new PageTotalCountHeaderAdvice();
+
+    @Test
+    void supports_returnsTrueUnconditionally() {
+        // The discriminator lives in beforeBodyWrite (instanceof Page) so
+        // supports() must not gate on returnType — see advice javadoc.
+        assertThat(advice.supports(null, null)).isTrue();
+    }
+
+    @Test
+    void beforeBodyWrite_setsHeaderForPageBody() {
+        Page<String> page = new PageImpl<>(List.of("a", "b"), PageRequest.of(0, 20), 42L);
+        ServerHttpResponse response = mock(ServerHttpResponse.class);
+        HttpHeaders headers = new HttpHeaders();
+        when(response.getHeaders()).thenReturn(headers);
+
+        Object out = advice.beforeBodyWrite(page, null, null, null, null, response);
+
+        assertThat(out).isSameAs(page);
+        assertThat(headers.getFirst("X-Total-Count")).isEqualTo("42");
+    }
+
+    @Test
+    void beforeBodyWrite_doesNotSetHeaderForNonPageBody() {
+        ServerHttpResponse response = mock(ServerHttpResponse.class);
+        HttpHeaders headers = new HttpHeaders();
+        when(response.getHeaders()).thenReturn(headers);
+
+        advice.beforeBodyWrite("not a page", null, null, null, null, response);
+
+        assertThat(headers.getFirst("X-Total-Count")).isNull();
+    }
+
+    @Test
+    void beforeBodyWrite_handlesEmptyPage() {
+        Page<String> page = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0L);
+        ServerHttpResponse response = mock(ServerHttpResponse.class);
+        HttpHeaders headers = new HttpHeaders();
+        when(response.getHeaders()).thenReturn(headers);
+
+        advice.beforeBodyWrite(page, null, null, null, null, response);
+
+        assertThat(headers.getFirst("X-Total-Count")).isEqualTo("0");
+    }
+
+    @Test
+    void order_isAheadOfJsonLdAdvice() {
+        // Two advices, sorted by AnnotationAwareOrderComparator. Our advice
+        // is LOWEST_PRECEDENCE - 10, JsonLd is LOWEST_PRECEDENCE. After
+        // sorting, ours comes first — proves the relative ordering at the
+        // annotation level.
+        JsonLdResponseBodyAdvice jsonLd = new JsonLdResponseBodyAdvice(List.of());
+        List<Object> ordered = new java.util.ArrayList<>(List.of(jsonLd, advice));
+        AnnotationAwareOrderComparator.sort(ordered);
+        assertThat(ordered.get(0)).isSameAs(advice);
+        assertThat(ordered.get(1)).isSameAs(jsonLd);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/FeedInteractionControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FeedInteractionControllerTest.java
@@ -2,6 +2,7 @@ package com.group7.backend.controller;
 
 import com.group7.backend.config.JwtAuthenticationFilter;
 import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.FeedCommentResponse;
 import com.group7.backend.dto.response.FeedPostInteractionState;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.service.FeedInteractionService;
@@ -13,6 +14,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.OffsetDateTime;
+
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -20,11 +23,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Web-layer coverage for {@link FeedInteractionController} read endpoints
- * with cache-discipline expectations: {@code GET /api/feed/posts/{id}/interactions}
- * carries {@code Cache-Control: no-cache} so likers' updates and viewer-relative
- * flags surface immediately, in contrast to the static
- * {@code GET /api/feed/posts/{id}} endpoint which serves an ETag.
+ * Web-layer coverage for {@link FeedInteractionController}'s read endpoints:
+ * the new comment permalink (#489) and the cache-discipline contract on
+ * {@code GET /api/feed/posts/{id}/interactions}.
+ *
+ * <p>Toggle / list / mutation endpoints are integration-tested elsewhere;
+ * this slice focuses on the surfaces #489 introduces or modifies at the
+ * header level.
  */
 @WebMvcTest(FeedInteractionController.class)
 @Import({SecurityConfig.class, JwtAuthenticationFilter.class})
@@ -42,6 +47,8 @@ class FeedInteractionControllerTest {
         when(jwtService.extractRole(TOKEN)).thenReturn("MENTEE");
         when(jwtService.extractUserId(TOKEN)).thenReturn(userId);
     }
+
+    // ── GET /api/feed/posts/{id}/interactions — cache discipline ──────────
 
     @Test
     void getInteractions_emitsNoCacheControl() throws Exception {
@@ -63,6 +70,63 @@ class FeedInteractionControllerTest {
                 .thenThrow(new ResourceNotFoundException("Feed post not found with id: 42"));
 
         mockMvc.perform(get("/api/feed/posts/42/interactions")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isNotFound());
+    }
+
+    // ── GET /api/feed/comments/{id} — permalink ──────────────────────────
+
+    @Test
+    void getComment_happyPath_returnsComment() throws Exception {
+        mockMenteeJwt(1L);
+        FeedCommentResponse stub = new FeedCommentResponse(
+                101L, 42L, 1L, "Carol", "Great post!",
+                OffsetDateTime.parse("2026-05-09T12:00:00Z"),
+                OffsetDateTime.parse("2026-05-09T12:00:00Z"),
+                false, true, false);
+        when(interactionService.getComment(101L, 1L)).thenReturn(stub);
+
+        mockMvc.perform(get("/api/feed/comments/101")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(101))
+                .andExpect(jsonPath("$.postId").value(42))
+                .andExpect(jsonPath("$.body").value("Great post!"))
+                .andExpect(jsonPath("$.isAuthor").value(true));
+    }
+
+    @Test
+    void getComment_softDeletedComment_returns404() throws Exception {
+        mockMenteeJwt(1L);
+        when(interactionService.getComment(101L, 1L))
+                .thenThrow(new ResourceNotFoundException("Comment not found with id: 101"));
+
+        mockMvc.perform(get("/api/feed/comments/101")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getComment_parentPostSoftDeleted_returns404() throws Exception {
+        mockMenteeJwt(1L);
+        when(interactionService.getComment(101L, 1L))
+                .thenThrow(new ResourceNotFoundException("Comment not found with id: 101"));
+
+        mockMvc.perform(get("/api/feed/comments/101")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getComment_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/feed/comments/101"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getComment_nonNumericId_returns404FromRouteRegex() throws Exception {
+        mockMenteeJwt(1L);
+        mockMvc.perform(get("/api/feed/comments/bogus")
                         .header("Authorization", "Bearer " + TOKEN))
                 .andExpect(status().isNotFound());
     }

--- a/backend/src/test/java/com/group7/backend/controller/FeedInteractionControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FeedInteractionControllerTest.java
@@ -1,0 +1,69 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.FeedPostInteractionState;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.service.FeedInteractionService;
+import com.group7.backend.service.JwtService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Web-layer coverage for {@link FeedInteractionController} read endpoints
+ * with cache-discipline expectations: {@code GET /api/feed/posts/{id}/interactions}
+ * carries {@code Cache-Control: no-cache} so likers' updates and viewer-relative
+ * flags surface immediately, in contrast to the static
+ * {@code GET /api/feed/posts/{id}} endpoint which serves an ETag.
+ */
+@WebMvcTest(FeedInteractionController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class FeedInteractionControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private FeedInteractionService interactionService;
+    @MockitoBean private JwtService jwtService;
+
+    private static final String TOKEN = "carol-token";
+
+    private void mockMenteeJwt(Long userId) {
+        when(jwtService.isTokenValid(TOKEN)).thenReturn(true);
+        when(jwtService.extractEmail(TOKEN)).thenReturn("u" + userId + "@test.com");
+        when(jwtService.extractRole(TOKEN)).thenReturn("MENTEE");
+        when(jwtService.extractUserId(TOKEN)).thenReturn(userId);
+    }
+
+    @Test
+    void getInteractions_emitsNoCacheControl() throws Exception {
+        mockMenteeJwt(1L);
+        when(interactionService.getInteractionState(42L, 1L))
+                .thenReturn(new FeedPostInteractionState(12, 3, 1, 2, true, false));
+
+        mockMvc.perform(get("/api/feed/posts/42/interactions")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Cache-Control", "no-cache"))
+                .andExpect(jsonPath("$.likeCount").value(12));
+    }
+
+    @Test
+    void getInteractions_softDeletedPost_returns404() throws Exception {
+        mockMenteeJwt(1L);
+        when(interactionService.getInteractionState(42L, 1L))
+                .thenThrow(new ResourceNotFoundException("Feed post not found with id: 42"));
+
+        mockMvc.perform(get("/api/feed/posts/42/interactions")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
@@ -33,6 +33,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -180,6 +182,69 @@ class FeedPostControllerTest {
     void getById_unauthenticated_returns403() throws Exception {
         mockMvc.perform(get("/api/feed/posts/42"))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void getById_setsETagLastModifiedAndCacheControlHeaders() throws Exception {
+        mockMenteeJwt(TOKEN, 1L);
+        // Fixed timestamps so the assertion is deterministic.
+        OffsetDateTime t0 = OffsetDateTime.parse("2026-05-09T10:15:00Z");
+        FeedPostResponse fixed = new FeedPostResponse(42L, 1L, "Alice", "Hello",
+                List.of("data"), t0, t0, false, true);
+        when(feedPostService.getById(42L, 1L)).thenReturn(fixed);
+
+        mockMvc.perform(get("/api/feed/posts/42").header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("ETag"))
+                .andExpect(header().exists("Last-Modified"))
+                .andExpect(header().string("Cache-Control", "private, max-age=30"));
+    }
+
+    @Test
+    void getById_returns304WhenIfNoneMatchMatches() throws Exception {
+        mockMenteeJwt(TOKEN, 1L);
+        OffsetDateTime t0 = OffsetDateTime.parse("2026-05-09T10:15:00Z");
+        FeedPostResponse fixed = new FeedPostResponse(42L, 1L, "Alice", "Hello",
+                List.of("data"), t0, t0, false, true);
+        when(feedPostService.getById(42L, 1L)).thenReturn(fixed);
+
+        // First fetch — capture the ETag.
+        String etag = mockMvc.perform(get("/api/feed/posts/42")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getHeader("ETag");
+
+        // Conditional GET with the same ETag — server short-circuits to 304
+        // with no body (controller returns null after checkNotModified).
+        mockMvc.perform(get("/api/feed/posts/42")
+                        .header("Authorization", "Bearer " + TOKEN)
+                        .header("If-None-Match", etag))
+                .andExpect(status().isNotModified())
+                .andExpect(content().bytes(new byte[0]));
+    }
+
+    @Test
+    void getById_etagChangesAfterEdit() throws Exception {
+        mockMenteeJwt(TOKEN, 1L);
+        OffsetDateTime created = OffsetDateTime.parse("2026-05-09T10:15:00Z");
+        OffsetDateTime edited = OffsetDateTime.parse("2026-05-09T11:02:34Z");
+        FeedPostResponse before = new FeedPostResponse(42L, 1L, "Alice", "Hello",
+                List.of("data"), created, created, false, true);
+        FeedPostResponse after = new FeedPostResponse(42L, 1L, "Alice", "Hello edited",
+                List.of("data"), created, edited, true, true);
+        when(feedPostService.getById(42L, 1L)).thenReturn(before, after);
+
+        String etagBefore = mockMvc.perform(get("/api/feed/posts/42")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getHeader("ETag");
+        String etagAfter = mockMvc.perform(get("/api/feed/posts/42")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getHeader("ETag");
+
+        org.junit.jupiter.api.Assertions.assertNotEquals(etagBefore, etagAfter,
+                "ETag must change after an edit bumps updatedAt");
     }
 
     @Test

--- a/backend/src/test/java/com/group7/backend/integration/FeedInteractionIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedInteractionIntegrationTest.java
@@ -418,6 +418,54 @@ class FeedInteractionIntegrationTest {
                 .andExpect(status().isNotFound());
     }
 
+    // ── Comment permalink (#489) ──────────────────────────────────────────
+
+    @Test
+    void commentPermalink_happyPath_returnsComment() throws Exception {
+        String tokenA = registerAndLogin("perma_a@test.com");
+        String tokenB = registerAndLogin("perma_b@test.com");
+        long pid = createPost(tokenA, "permalink target", List.of());
+        long commentId = addComment(tokenB, pid, "linkable comment");
+
+        mockMvc.perform(get("/api/feed/comments/" + commentId)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(commentId))
+                .andExpect(jsonPath("$.postId").value(pid))
+                .andExpect(jsonPath("$.body").value("linkable comment"))
+                .andExpect(jsonPath("$.isDeleted").value(false));
+    }
+
+    @Test
+    void commentPermalink_softDeletedComment_returns404() throws Exception {
+        String tokenA = registerAndLogin("perma_del_a@test.com");
+        long pid = createPost(tokenA, "post", List.of());
+        long commentId = addComment(tokenA, pid, "to be deleted");
+
+        mockMvc.perform(delete("/api/feed/comments/" + commentId)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/feed/comments/" + commentId)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void commentPermalink_parentPostSoftDeleted_returns404() throws Exception {
+        String tokenA = registerAndLogin("perma_parent_a@test.com");
+        long pid = createPost(tokenA, "orphan parent", List.of());
+        long commentId = addComment(tokenA, pid, "comment on soon-deleted post");
+
+        mockMvc.perform(delete("/api/feed/posts/" + pid)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/feed/comments/" + commentId)
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isNotFound());
+    }
+
     // ── Auth gate ──────────────────────────────────────────────────────────
 
     @Test
@@ -428,6 +476,7 @@ class FeedInteractionIntegrationTest {
         mockMvc.perform(post("/api/feed/posts/1/comments")).andExpect(status().isForbidden());
         mockMvc.perform(get("/api/feed/me/bookmarks")).andExpect(status().isForbidden());
         mockMvc.perform(get("/api/feed/posts/1/interactions")).andExpect(status().isForbidden());
+        mockMvc.perform(get("/api/feed/comments/1")).andExpect(status().isForbidden());
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────
@@ -468,6 +517,19 @@ class FeedInteractionIntegrationTest {
                         .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();
+    }
+
+    private long addComment(String token, long postId, String body) throws Exception {
+        // ObjectMapper-based body construction so future tests can pass
+        // bodies containing quotes or backslashes without breaking the
+        // JSON literal.
+        MvcResult res = mockMvc.perform(post("/api/feed/posts/" + postId + "/comments")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("body", body))))
                 .andExpect(status().isCreated())
                 .andReturn();
         return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();

--- a/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -421,6 +422,36 @@ class FeedReadIntegrationTest {
         mockMvc.perform(get("/api/feed/following")).andExpect(status().isForbidden());
         mockMvc.perform(get("/api/feed/search")).andExpect(status().isForbidden());
         mockMvc.perform(get("/api/feed/users/1/posts")).andExpect(status().isForbidden());
+    }
+
+    // ── X-Total-Count header (#489) ────────────────────────────────────────
+
+    @Test
+    void xTotalCountHeader_presentOnEachPagedFeedEndpoint() throws Exception {
+        String token = registerAndLogin("xtotal@test.com", true);
+        String tokenOther = registerAndLogin("xtotal_other@test.com", true);
+        Long otherId = userRepository.findByEmail("xtotal_other@test.com").orElseThrow().getId();
+
+        // Create one followed-author post and one own post so each paged
+        // endpoint has at least one row to count.
+        mockMvc.perform(post("/api/users/" + otherId + "/follow")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isCreated());
+        createPost(tokenOther, "trackable content", List.of("xt"));
+        createPost(token, "own content", List.of());
+
+        String[] urls = new String[] {
+                "/api/feed/for-you",
+                "/api/feed/following",
+                "/api/feed/search?q=trackable",
+                "/api/feed/users/" + otherId + "/posts",
+                "/api/feed/me/bookmarks"
+        };
+        for (String url : urls) {
+            mockMvc.perform(get(url).header("Authorization", "Bearer " + token))
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("X-Total-Count"));
+        }
     }
 
     // ── Page-size clamp ─────────────────────────────────────────────────────

--- a/backend/src/test/java/com/group7/backend/integration/FollowIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FollowIntegrationTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -122,6 +123,24 @@ class FollowIntegrationTest {
                         .header("Authorization", "Bearer " + p.tokenA))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content.length()").value(0));
+    }
+
+    // ── X-Total-Count project-wide smoke (#489) ───────────────────────────
+
+    @Test
+    void followersList_carriesXTotalCountHeader() throws Exception {
+        // Proves PageTotalCountHeaderAdvice fires on non-feed paged
+        // endpoints — guards against a regression that scopes the advice
+        // to feed routes silently.
+        Pair p = registerTwo("xtc_a@test.com", "xtc_b@test.com");
+        mockMvc.perform(post("/api/users/" + p.idB + "/follow")
+                        .header("Authorization", "Bearer " + p.tokenA))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/users/" + p.idB + "/followers")
+                        .header("Authorization", "Bearer " + p.tokenA))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Total-Count", "1"));
     }
 
     // ── Self-follow: project-standard {error, message} body ───────────────


### PR DESCRIPTION
Closes #489.

## Summary

Four cohesive API ergonomics improvements to the social-feed read surface, packaged as one PR because they share a scope, but split into four reviewable commits so a partial revert is clean.

| Deliverable | Commit |
|---|---|
| `X-Total-Count` header on every paged response + CORS exposed-header | [`5d1059b`](../commit/5d1059b) |
| ETag / Last-Modified on `GET /api/feed/posts/{id}`; `no-cache` on `/interactions` | [`90f6b12`](../commit/90f6b12) |
| OpenAPI examples on every feed read/write endpoint | [`78d3125`](../commit/78d3125) |
| New `GET /api/feed/comments/{id}` permalink endpoint | [`00e35c8`](../commit/00e35c8) |

No DB migration. Every change is additive — existing payload shapes, status codes, and rate-limit envelopes are preserved.

## Why

- Web and mobile clients had no `X-Total-Count` header; they had to parse the JSON envelope for pagination totals, which won't survive a future cursor-pagination migration.
- `GET /api/feed/posts/{id}` re-downloaded the full payload on every refresh because the endpoint had no conditional-GET support. Counts live on the separate `/interactions` endpoint, so the static-content endpoint can safely participate in `ETag` + `If-None-Match` without ever invalidating on a like.
- Swagger UI for feed endpoints was schema-only. Frontend and mobile engineers had to read tests or source to learn what a real response looks like.
- A comment permalink required fetching the whole comment list for the parent post and locating the row in JSON. The new endpoint returns a single comment by id and 404s when either the comment is soft-deleted or its parent post is soft-deleted (no orphan content).

## API surface changes

| Method | Path | What changed |
|---|---|---|
| `GET` | `/api/feed/{for-you, following, search, users/{id}/posts, me/bookmarks}` | Now returns `X-Total-Count` header (CORS-exposed) |
| `GET` | `/api/users/{id}/{followers, following}` | Same — advice is project-wide, not feed-only |
| `GET` | `/api/feed/posts/{id}` | New `ETag`, `Last-Modified`, `Cache-Control: private, max-age=30`; participates in conditional GET (`304` on `If-None-Match` match) |
| `GET` | `/api/feed/posts/{id}/interactions` | New `Cache-Control: no-cache` so likers' updates surface immediately |
| `GET` | `/api/feed/comments/{id:\d+}` | New endpoint — single-comment permalink |
| `POST` | `/api/feed/posts/{id}/like` | Swagger UI now renders two named examples (`now-liked`, `now-unliked`) |
| All feed endpoints | — | OpenAPI now ships at least one concrete example payload per endpoint |

`isAuthor` stays on `FeedPostResponse` — the mobile app at `mobile-app/app/(tabs)/feed.tsx` consumes it in five places, so removing it would break the mobile client. `Cache-Control` is therefore `private`, not `public`.

## Cache discipline contract

| Endpoint | Body | `Cache-Control` | `ETag` |
|---|---|---|---|
| `GET /api/feed/posts/{id}` | static content (body + hashtags + edit metadata) | `private, max-age=30` | `"<updatedAtMillis>"` |
| `GET /api/feed/posts/{id}/interactions` | counters + viewer flags | `no-cache` | — |

ETag is derived from `updatedAt` only (falling back to `createdAt` when null), never from counters. Liking or commenting therefore cannot invalidate the static-content cache.

## Rate limiting

The new permalink endpoint adds one property-driven rule keyed `feed-comment-permalink` to `application.properties`:

```
app.ratelimit.rules.feed-comment-permalink.method=GET
app.ratelimit.rules.feed-comment-permalink.pattern=/api/feed/comments/*
app.ratelimit.rules.feed-comment-permalink.key-strategy=USER
app.ratelimit.rules.feed-comment-permalink.capacity=${APP_FEED_INTERACTION_CAPACITY:60}
app.ratelimit.rules.feed-comment-permalink.refill=PT1M
```

The capacity reuses the existing `APP_FEED_INTERACTION_CAPACITY` envelope variable so all four feed read/write caps can be tuned together in ops.

## Test coverage

- `PageTotalCountHeaderAdviceTest` — instanceof guard, non-Page bodies untouched, order strictly ahead of `JsonLdResponseBodyAdvice` via `AnnotationAwareOrderComparator`.
- `FeedPostControllerTest` — three new ETag tests: header presence, `304` with empty body on matching `If-None-Match`, and ETag change after a `PATCH` bumps `updatedAt`.
- `FeedInteractionControllerTest` (new slice) — `Cache-Control: no-cache` on `/interactions`, all four 404 branches on the permalink, unauthenticated 403, non-numeric path 404.
- `FeedReadIntegrationTest` — `X-Total-Count` smoke across all five feed paged endpoints.
- `FollowIntegrationTest` — `X-Total-Count` smoke on `/api/users/{id}/followers` to prove the advice is genuinely project-wide.
- `FeedInteractionIntegrationTest` — permalink end-to-end against the real DB: happy path, soft-deleted comment, soft-deleted parent post.

Local `mvn --batch-mode verify` on Postgres 16: 1690 tests, 0 failures, 0 errors, JaCoCo coverage gate met.

## Manual smoke

Verified end-to-end against a locally running backend:

- `X-Total-Count` present + `Access-Control-Expose-Headers: X-Total-Count` on CORS preflight.
- ETag `"<millis>"` set; `If-None-Match` returns `304` with `0` bytes; `PATCH` bumps the ETag (`"1778536402515"` → `"1778536426397"`).
- `/interactions` returns `Cache-Control: no-cache`.
- `/v3/api-docs` renders the named examples for every annotated endpoint, including the `now-liked` / `now-unliked` toggle dropdown.
- Permalink: happy path returns the comment; soft-deleting the comment or its parent post both return `404`.

## Test plan

- [ ] Backend CI green on `feature/489-feed-api-ergonomics`.
- [ ] Smoke `GET /api/feed/for-you` from a browser — verify the JS client reads `X-Total-Count`.
- [ ] Reload `GET /api/feed/posts/{id}` twice with the same browser session — verify the second call returns `304`.
- [ ] Open Swagger UI — verify every feed endpoint has at least one example, and `toggleLike` renders two.
- [ ] Hit `GET /api/feed/comments/{id}` from the deployed instance — verify response shape matches `FeedCommentResponse`.

## Out of scope (deliberate)

- Removing `isAuthor` from `FeedPostResponse` (would break the mobile app).
- Cursor pagination (a future change will deprecate the JSON envelope's `totalElements` and rely on the header).
- ETag on list endpoints (per-page invalidation is harder; deferred until cursor pagination lands).
- ETag on `/interactions` (explicitly `no-cache`).
- Comment likes (`viewerHasLiked` / `likeCount`) on the permalink response — gated on #483.