### PR TITLE
feat(backend): social feed soft-delete lifecycle, edit history, restore, trending (#487)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
@@ -3,6 +3,7 @@ package com.group7.backend.controller;
 import com.group7.backend.docs.feed.FeedApiExamples;
 import com.group7.backend.dto.request.CreateFeedPostRequest;
 import com.group7.backend.dto.request.UpdateFeedPostRequest;
+import com.group7.backend.dto.response.FeedPostEditEntry;
 import com.group7.backend.dto.response.FeedPostResponse;
 import com.group7.backend.service.FeedPostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,9 +14,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -23,10 +27,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.WebRequest;
 
 import java.time.OffsetDateTime;
+
+import java.util.List;
 
 /**
  * REST surface for the social-feed posts core (#348).
@@ -55,6 +62,7 @@ import java.time.OffsetDateTime;
  */
 @RestController
 @RequestMapping("/api/feed/posts")
+@Validated  // enables MethodValidationPostProcessor for @Min/@Max on @RequestParam
 @Tag(name = "Feed Posts",
         description = "Author-owned social-feed posts (text + hashtags). Soft-delete preserves "
                 + "referential integrity for downstream interactions and feed reads (#348).")
@@ -175,5 +183,26 @@ public class FeedPostController {
         Long requesterId = (Long) authentication.getCredentials();
         feedPostService.delete(id, requesterId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{id:\\d+}/history")
+    @Operation(summary = "Get edit history for a feed post (author or admin)",
+            description = "Returns the post's edit history newest-first, capped at 50 entries. "
+                    + "editorId is the snapshot editor's user id at edit time; the client "
+                    + "resolves display names via the existing user-summary endpoint when needed. "
+                    + "Visible to the post author and to any admin; everyone else gets 403.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "History entries (newest first)"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Not the post author and not an admin", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Post never existed", content = @Content)
+    })
+    public ResponseEntity<List<FeedPostEditEntry>> history(
+            @Parameter(description = "Feed post id") @PathVariable Long id,
+            @Parameter(description = "Maximum number of entries (1..50)")
+            @RequestParam(defaultValue = "50") @Min(1) @Max(50) int limit,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(feedPostService.getPostHistory(id, requesterId, limit));
     }
 }

--- a/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
@@ -185,6 +185,27 @@ public class FeedPostController {
         return ResponseEntity.noContent().build();
     }
 
+    @PostMapping("/{id:\\d+}/restore")
+    @Operation(summary = "Restore a soft-deleted feed post (author-only, within 30 days)",
+            description = "Resurrects a soft-deleted post that is still within the configured "
+                    + "restore window (app.feed.cleanup.restore-window-days, default 30). "
+                    + "The post becomes visible again on the public feed surfaces; no fanout "
+                    + "is emitted to followers (a restore is a quiet rollback, not a publish).")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Post restored"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Non-author cannot restore", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Post never existed", content = @Content),
+            @ApiResponse(responseCode = "409", description = "Post is not deleted (nothing to restore)", content = @Content),
+            @ApiResponse(responseCode = "410", description = "Restore window has expired", content = @Content)
+    })
+    public ResponseEntity<FeedPostResponse> restore(
+            @Parameter(description = "Feed post id") @PathVariable Long id,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(feedPostService.restorePost(id, requesterId));
+    }
+
     @GetMapping("/{id:\\d+}/history")
     @Operation(summary = "Get edit history for a feed post (author or admin)",
             description = "Returns the post's edit history newest-first, capped at 50 entries. "

--- a/backend/src/main/java/com/group7/backend/controller/FeedTrendingController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedTrendingController.java
@@ -1,0 +1,64 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.dto.response.FeedTrendingHashtag;
+import com.group7.backend.service.FeedTrendingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Read-only HTTP surface for the trending-hashtag aggregate (#487).
+ *
+ * <p>Backed by an hourly-refreshed materialized view, so the endpoint
+ * always serves a snapshot consistent across requests within the same
+ * refresh window. Authenticated by the project's standard JWT filter
+ * — there is no public/anonymous variant of this endpoint.
+ *
+ * <p>{@code @Validated} enables the {@code @Min}/{@code @Max} on the
+ * {@code limit} request param to surface as 400 (otherwise Spring
+ * silently passes invalid values straight through to the service,
+ * which would clamp them but lose the error signal).
+ */
+@RestController
+@RequestMapping("/api/feed/trending")
+@Validated
+@Tag(name = "Feed Trending",
+        description = "Hourly-refreshed trending hashtag aggregates over a 24-hour window.")
+public class FeedTrendingController {
+
+    private final FeedTrendingService trendingService;
+
+    public FeedTrendingController(FeedTrendingService trendingService) {
+        this.trendingService = trendingService;
+    }
+
+    @GetMapping("/hashtags")
+    @Operation(summary = "Top trending hashtags from the last 24 hours",
+            description = "Returns hashtags ordered by a composite engagement score "
+                    + "(postCount + 2 * uniqueLikers + 3 * commentCount). The result "
+                    + "reflects the most recent materialized-view refresh; the view "
+                    + "refreshes hourly at five-past-the-hour by default.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Trending hashtag list (newest refresh)"),
+            @ApiResponse(responseCode = "400", description = "limit out of range (1..50)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content)
+    })
+    public ResponseEntity<List<FeedTrendingHashtag>> hashtags(
+            @Parameter(description = "Maximum number of hashtags to return (1..50)")
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int limit) {
+        return ResponseEntity.ok(trendingService.listTrendingHashtags(limit));
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/FeedPostEditEntry.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FeedPostEditEntry.java
@@ -1,0 +1,39 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * One entry in the edit history of a feed post (#487). Returned by
+ * {@code GET /api/feed/posts/{id}/history} in reverse-chronological
+ * order. Each entry captures the post's body and hashtag set as they
+ * were before a particular edit was applied, so a UI can reconstruct
+ * the timeline by walking the entries oldest-first.
+ *
+ * <p>{@link #editorId} is the snapshot editor's user id only — display
+ * names are not denormalised here. The client batch-resolves names via
+ * the existing user-summary endpoint when it needs to render them. This
+ * keeps history reads cheap (no per-entry user lookup) and avoids
+ * stale-name bugs when a user updates their profile after editing a post.
+ */
+@Schema(description = "One edit-history entry for a feed post.")
+public record FeedPostEditEntry(
+        @Schema(description = "History entry id", example = "37")
+        Long id,
+
+        @Schema(description = "User id of the editor at edit time, or null if the editor's account was removed",
+                example = "17")
+        Long editorId,
+
+        @Schema(description = "Post body as it was before this edit", example = "Original body text")
+        String previousBody,
+
+        @Schema(description = "Hashtags attached to the post before this edit", example = "[\"datascience\", \"nlp\"]")
+        List<String> previousHashtags,
+
+        @Schema(description = "Server-side timestamp of the edit")
+        OffsetDateTime editedAt
+) {
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/FeedTrendingHashtag.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FeedTrendingHashtag.java
@@ -1,0 +1,38 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+/**
+ * One ranked entry in the trending-hashtag response (#487). Returned
+ * by {@code GET /api/feed/trending/hashtags}; ordered by descending
+ * {@link #score}, which is computed in the service layer from the
+ * raw materialized-view counts as
+ * {@code postCount + 2 * uniqueLikers + 3 * commentCount}.
+ *
+ * <p>The score is exposed in the DTO so the client can break ties
+ * consistently and so any future explainability UI can display the
+ * underlying signals.
+ */
+@Schema(description = "Trending hashtag entry over the last 24 hours.")
+public record FeedTrendingHashtag(
+        @Schema(description = "Lowercase hashtag string", example = "datascience")
+        String tag,
+
+        @Schema(description = "Distinct posts carrying this tag in the last 24h", example = "12")
+        long postCount,
+
+        @Schema(description = "Distinct users who liked any of those posts", example = "84")
+        long uniqueLikers,
+
+        @Schema(description = "Total comments across those posts", example = "37")
+        long commentCount,
+
+        @Schema(description = "Most recent timestamp at which a post with this tag was created")
+        OffsetDateTime latestPostAt,
+
+        @Schema(description = "Composite ranking score: postCount + 2*uniqueLikers + 3*commentCount", example = "291.0")
+        double score
+) {
+}

--- a/backend/src/main/java/com/group7/backend/entity/FeedPostEditHistory.java
+++ b/backend/src/main/java/com/group7/backend/entity/FeedPostEditHistory.java
@@ -1,0 +1,94 @@
+package com.group7.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Append-only audit of a {@link FeedPost} edit. Written by
+ * {@code FeedPostService.update} immediately before any body or hashtag
+ * mutation, so {@link #previousBody} and {@link #previousHashtags}
+ * capture the row's prior state inside the same transaction. The
+ * post-update mutation and this history insert commit together, or
+ * neither commits.
+ *
+ * <h2>Design choices</h2>
+ * <ul>
+ *   <li><b>No {@code @Version}.</b> The table is append-only; rows are
+ *       never UPDATEd, only INSERTed and (via post hard-delete cascade)
+ *       removed.</li>
+ *   <li><b>{@link #previousHashtags} stored as JSONB</b> via Hibernate 6's
+ *       native {@code @JdbcTypeCode(SqlTypes.JSON)}. Storing the snapshot
+ *       inside the row (rather than a many-to-many to {@code feed_post_hashtags})
+ *       means a later reset of the post's hashtag set does not corrupt
+ *       the audit trail.</li>
+ *   <li><b>{@link #editorId} nullable</b> + FK {@code ON DELETE SET NULL}:
+ *       preserves the audit row if the editor's account is removed.
+ *       Today the editor is always the post's author (so the post itself
+ *       cascades first via {@code post_id}), but the column shape
+ *       reserves the audit-preservation behaviour for a future
+ *       moderator-edit feature.</li>
+ *   <li><b>{@code editedAt} server-set</b> — the service injects
+ *       {@code OffsetDateTime.now()} explicitly; the {@link #onCreate}
+ *       callback is a defence-in-depth backstop for callers that forget
+ *       to set the field.</li>
+ * </ul>
+ */
+@Entity
+@Table(name = "feed_post_edit_history")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FeedPostEditHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "post_id", nullable = false, updatable = false)
+    private Long postId;
+
+    /**
+     * Snapshot of the editor at edit time. Nullable: the FK is
+     * {@code ON DELETE SET NULL} so the audit row survives an editor
+     * account removal.
+     */
+    @Column(name = "editor_id")
+    private Long editorId;
+
+    @Column(name = "previous_body", nullable = false, updatable = false, columnDefinition = "TEXT")
+    private String previousBody;
+
+    /**
+     * JSONB array of the post's hashtag values at the moment of the
+     * edit. Persisted as a JSONB column via Hibernate 6 native binding
+     * — unrelated to {@code feed_post_hashtags} so that subsequent
+     * mutations to the post's hashtag set do not retroactively rewrite
+     * history rows.
+     */
+    @Column(name = "previous_hashtags", nullable = false, updatable = false, columnDefinition = "jsonb")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<String> previousHashtags = List.of();
+
+    @Column(name = "edited_at", nullable = false, updatable = false)
+    private OffsetDateTime editedAt;
+
+    @PrePersist
+    void onCreate() {
+        if (editedAt == null) {
+            editedAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/exception/FeedPostExpiredRestoreException.java
+++ b/backend/src/main/java/com/group7/backend/exception/FeedPostExpiredRestoreException.java
@@ -1,0 +1,18 @@
+package com.group7.backend.exception;
+
+/**
+ * Thrown by {@code FeedPostService.restorePost} when the requested
+ * post was soft-deleted longer ago than the configured restore window
+ * ({@code app.feed.cleanup.restore-window-days}, default 30 days).
+ * Mapped to HTTP 410 Gone by {@code GlobalExceptionHandler}.
+ *
+ * <p>410 (rather than 404) is the precise semantic: the resource
+ * existed and is known to be unrecoverable through this endpoint —
+ * the cleanup scheduler will hard-delete it on the next run if it
+ * has not already.
+ */
+public class FeedPostExpiredRestoreException extends RuntimeException {
+    public FeedPostExpiredRestoreException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/exception/FeedPostNotDeletedException.java
+++ b/backend/src/main/java/com/group7/backend/exception/FeedPostNotDeletedException.java
@@ -1,0 +1,14 @@
+package com.group7.backend.exception;
+
+/**
+ * Thrown by {@code FeedPostService.restorePost} when the requested
+ * post is currently visible (i.e. {@code deletedAt IS NULL}).
+ * Mapped to HTTP 409 Conflict by {@code GlobalExceptionHandler} —
+ * a state-conflict signal that distinguishes "nothing to restore"
+ * from "restore window has expired" (410).
+ */
+public class FeedPostNotDeletedException extends RuntimeException {
+    public FeedPostNotDeletedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -242,6 +242,23 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.FORBIDDEN, "Forbidden", "Access denied");
     }
 
+    /**
+     * Handles {@code @Min}/{@code @Max}/{@code @Pattern} (and similar)
+     * violations on controller method parameters guarded by
+     * {@code @Validated}. Without this entry, the violation propagates
+     * as an unhandled 500. The cousin handler
+     * {@link #handleValidationErrors} covers {@code @Valid} on
+     * {@code @RequestBody}; this handler covers the corresponding
+     * shape for {@code @RequestParam} / {@code @PathVariable}.
+     */
+    @ExceptionHandler(jakarta.validation.ConstraintViolationException.class)
+    public ResponseEntity<Map<String, String>> handleConstraintViolation(
+            jakarta.validation.ConstraintViolationException ex, HttpServletRequest request) {
+        log.warn("Constraint violation: method={}, path={}, message={}",
+                request.getMethod(), request.getRequestURI(), ex.getMessage());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage());
+    }
+
     private ResponseEntity<Map<String, String>> buildErrorResponse(HttpStatus status, String error, String message) {
         Map<String, String> body = Map.of("error", error, "message", message);
         return ResponseEntity.status(status).body(body);

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -259,6 +259,34 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage());
     }
 
+    /**
+     * Restore window expired (#487). The post was soft-deleted longer
+     * ago than {@code app.feed.cleanup.restore-window-days}, so it is
+     * unrecoverable via the restore endpoint. 410 Gone differentiates
+     * "expired" from {@link FeedPostNotDeletedException}'s 409 ("not
+     * deleted") and from a plain 404 ("never existed").
+     */
+    @ExceptionHandler(FeedPostExpiredRestoreException.class)
+    public ResponseEntity<Map<String, String>> handleExpiredRestore(
+            FeedPostExpiredRestoreException ex, HttpServletRequest request) {
+        log.info("Expired restore: method={}, path={}, message={}",
+                request.getMethod(), request.getRequestURI(), ex.getMessage());
+        return buildErrorResponse(HttpStatus.GONE, "Gone", ex.getMessage());
+    }
+
+    /**
+     * Restore was requested on a live (non-deleted) post (#487).
+     * 409 Conflict is the precise semantic: the resource is in a
+     * state incompatible with the requested operation.
+     */
+    @ExceptionHandler(FeedPostNotDeletedException.class)
+    public ResponseEntity<Map<String, String>> handleNotDeleted(
+            FeedPostNotDeletedException ex, HttpServletRequest request) {
+        log.info("Restore on live post: method={}, path={}, message={}",
+                request.getMethod(), request.getRequestURI(), ex.getMessage());
+        return buildErrorResponse(HttpStatus.CONFLICT, "Conflict", ex.getMessage());
+    }
+
     private ResponseEntity<Map<String, String>> buildErrorResponse(HttpStatus status, String error, String message) {
         Map<String, String> body = Map.of("error", error, "message", message);
         return ResponseEntity.status(status).body(body);

--- a/backend/src/main/java/com/group7/backend/repository/FeedPostCommentRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostCommentRepository.java
@@ -5,10 +5,12 @@ import com.group7.backend.repository.projection.PostCountTuple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -47,4 +49,17 @@ public interface FeedPostCommentRepository extends JpaRepository<FeedPostComment
             GROUP BY c.postId
             """)
     List<PostCountTuple> countVisibleByPostIdIn(@Param("postIds") Collection<Long> postIds);
+
+    /**
+     * Hard-deletes comments soft-deleted earlier than {@code cutoff}
+     * (#487). Symmetric to {@code FeedPostRepository.hardDeletePostsSoftDeletedBefore};
+     * exists so comments soft-deleted independently of their parent
+     * post (a future moderator-comment-delete feature) still get
+     * reaped on the same schedule. Comments whose parent post is
+     * hard-deleted are already reaped via the FK
+     * {@code ON DELETE CASCADE} on {@code post_id}.
+     */
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query("DELETE FROM FeedPostComment c WHERE c.deletedAt IS NOT NULL AND c.deletedAt < :cutoff")
+    int hardDeleteCommentsSoftDeletedBefore(@Param("cutoff") OffsetDateTime cutoff);
 }

--- a/backend/src/main/java/com/group7/backend/repository/FeedPostEditHistoryRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostEditHistoryRepository.java
@@ -1,0 +1,26 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.FeedPostEditHistory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Repository for {@link FeedPostEditHistory} (#487). Append-only —
+ * exposes a single read pattern (newest-first listing for a post) plus
+ * the inherited {@code save}. There is no update or delete API; rows
+ * are reaped only via the {@code post_id ON DELETE CASCADE} when the
+ * parent {@code feed_posts} row is hard-deleted.
+ */
+@Repository
+public interface FeedPostEditHistoryRepository extends JpaRepository<FeedPostEditHistory, Long> {
+
+    /**
+     * Newest-first listing of edit-history entries for a given post.
+     * Bounded by the supplied {@link Pageable}; the controller caps
+     * the page size at 50 to keep the endpoint cheap.
+     */
+    List<FeedPostEditHistory> findByPostIdOrderByEditedAtDesc(Long postId, Pageable pageable);
+}

--- a/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
@@ -4,10 +4,12 @@ import com.group7.backend.entity.FeedPost;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -186,4 +188,28 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
     long countUnreadFollowingPostsCapped(@Param("viewerId") Long viewerId,
                                           @Param("since") java.time.OffsetDateTime since,
                                           @Param("capPlusOne") int capPlusOne);
+
+    /**
+     * Hard-deletes feed posts soft-deleted earlier than {@code cutoff}
+     * (#487). Used by {@code FeedSoftDeleteCleanupScheduler}; backed
+     * by the partial index {@code idx_feed_posts_deleted_at_pending_cleanup}
+     * (V43) so the scan walks only matching rows.
+     *
+     * <p>Hibernate's bulk delete bypasses entity lifecycle callbacks
+     * but Postgres still honours the {@code ON DELETE CASCADE} FKs
+     * on {@code feed_post_likes}, {@code feed_post_bookmarks},
+     * {@code feed_post_shares}, {@code feed_post_comments}, and
+     * {@code feed_post_edit_history}, so all child rows are reaped
+     * atomically.
+     *
+     * <p>{@code flushAutomatically = true} flushes any pending JPA
+     * writes before the bulk delete runs — matches the project
+     * convention used in {@code FollowRepository.upsertFollow}.
+     * {@code clearAutomatically = false} keeps unrelated entities
+     * cached in the persistence context (the scheduler is the only
+     * mutator in its transaction, so cache eviction would be wasteful).
+     */
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query("DELETE FROM FeedPost p WHERE p.deletedAt IS NOT NULL AND p.deletedAt < :cutoff")
+    int hardDeletePostsSoftDeletedBefore(@Param("cutoff") OffsetDateTime cutoff);
 }

--- a/backend/src/main/java/com/group7/backend/repository/FeedTrendingRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedTrendingRepository.java
@@ -1,0 +1,95 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.repository.projection.TrendingHashtagTuple;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Tuple;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Repository for the {@code feed_trending_24h} materialized view (#487).
+ * Not a {@code JpaRepository} interface — the materialized view has no
+ * managed entity and we only need two operations: {@link #refreshConcurrently}
+ * (DDL-ish) and {@link #findTopTrending} (a read-only ranked query).
+ *
+ * <p>{@link #refreshConcurrently} requires the unique index on
+ * {@code (tag)} created by V45; without it Postgres rejects the
+ * {@code CONCURRENTLY} form. The non-concurrent fallback would
+ * {@code AccessExclusiveLock} the view against readers for the duration
+ * of the refresh, which is exactly what the materialised-view
+ * approach exists to avoid.
+ *
+ * <p>Read uses {@link Tuple} projection rather than a constructor
+ * expression because the materialised view is unmanaged — Hibernate
+ * cannot directly project a native query into a record without
+ * extra mapping configuration. The mapping is done by hand in
+ * {@link #findTopTrending}, which is concise and avoids a
+ * {@code @SqlResultSetMapping} ceremony.
+ */
+@Repository
+public class FeedTrendingRepository {
+
+    private final EntityManager em;
+
+    public FeedTrendingRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    /**
+     * Refresh the materialized view without blocking concurrent reads.
+     * Wrapped in its own transaction so the caller (a scheduler) does
+     * not have to manage one.
+     */
+    @Transactional
+    public void refreshConcurrently() {
+        em.createNativeQuery("REFRESH MATERIALIZED VIEW CONCURRENTLY feed_trending_24h")
+                .executeUpdate();
+    }
+
+    /**
+     * Returns the top {@code limit} hashtags ranked by the score
+     * expression (matching the V45 expression index so the read is
+     * an index scan).
+     */
+    @Transactional(readOnly = true)
+    @SuppressWarnings("unchecked")
+    public List<TrendingHashtagTuple> findTopTrending(int limit) {
+        List<Tuple> rows = em.createNativeQuery("""
+                        SELECT tag, post_count, unique_likers, comment_count, latest_post_at
+                        FROM feed_trending_24h
+                        ORDER BY (post_count * 1.0 + unique_likers * 2.0 + comment_count * 3.0) DESC,
+                                 latest_post_at DESC
+                        LIMIT :lim
+                        """, Tuple.class)
+                .setParameter("lim", limit)
+                .getResultList();
+        return rows.stream()
+                .map(t -> new TrendingHashtagTuple(
+                        (String) t.get("tag"),
+                        ((Number) t.get("post_count")).longValue(),
+                        ((Number) t.get("unique_likers")).longValue(),
+                        ((Number) t.get("comment_count")).longValue(),
+                        toOffsetDateTime(t.get("latest_post_at"))))
+                .toList();
+    }
+
+    private static OffsetDateTime toOffsetDateTime(Object raw) {
+        // Postgres TIMESTAMPTZ surfaces as java.time.OffsetDateTime in
+        // most setups, but some Hibernate dialects give us
+        // java.sql.Timestamp. Handle both defensively so a future
+        // dialect change does not break the trending endpoint.
+        if (raw instanceof OffsetDateTime odt) {
+            return odt;
+        }
+        if (raw instanceof java.sql.Timestamp ts) {
+            return ts.toInstant().atOffset(java.time.ZoneOffset.UTC);
+        }
+        if (raw instanceof java.time.Instant i) {
+            return i.atOffset(java.time.ZoneOffset.UTC);
+        }
+        throw new IllegalStateException("Unexpected latest_post_at type: " + raw.getClass());
+    }
+}

--- a/backend/src/main/java/com/group7/backend/repository/projection/TrendingHashtagTuple.java
+++ b/backend/src/main/java/com/group7/backend/repository/projection/TrendingHashtagTuple.java
@@ -1,0 +1,23 @@
+package com.group7.backend.repository.projection;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Projection of one row in the {@code feed_trending_24h} materialized
+ * view (#487). Returned by {@code FeedTrendingRepository.findTopTrending}
+ * as the raw shape; the service layer wraps each tuple in a
+ * {@code FeedTrendingHashtag} DTO with the computed score.
+ *
+ * <p>{@code postCount}, {@code uniqueLikers}, and {@code commentCount}
+ * are boxed {@link Long} because Hibernate's native-query projection
+ * defaults to boxed types regardless of the underlying SQL aggregate
+ * type.
+ */
+public record TrendingHashtagTuple(
+        String tag,
+        Long postCount,
+        Long uniqueLikers,
+        Long commentCount,
+        OffsetDateTime latestPostAt
+) {
+}

--- a/backend/src/main/java/com/group7/backend/scheduler/FeedSoftDeleteCleanupScheduler.java
+++ b/backend/src/main/java/com/group7/backend/scheduler/FeedSoftDeleteCleanupScheduler.java
@@ -1,0 +1,85 @@
+package com.group7.backend.scheduler;
+
+import com.group7.backend.repository.FeedPostCommentRepository;
+import com.group7.backend.repository.FeedPostRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Daily sweep that hard-deletes feed posts and comments soft-deleted
+ * longer ago than the configured restore window (#487). Runs at 03:45 UTC
+ * by default — off-peak across both Turkey and Europe timezones, and a
+ * slot unused by the existing schedulers (03:15 attachment-orphan, 03:30
+ * bot-signal, 09:00 match-notification).
+ *
+ * <p>Bound to the same {@code app.feed.cleanup.restore-window-days} value
+ * that {@code FeedPostService.restorePost} consults, so the moment a post
+ * becomes ineligible for restore (410 Gone) is exactly the moment it
+ * becomes eligible for hard-delete here.
+ *
+ * <h2>Concurrency</h2>
+ * <p>ShedLock is not wired in this project (see
+ * {@code MatchNotificationScheduler}'s javadoc). The deploy is single-node;
+ * if multi-node ever ships, the bulk DELETE
+ * ({@code WHERE deleted_at IS NOT NULL AND deleted_at < cutoff}) is
+ * monotonic — a duplicate run from a second node reaps zero rows because
+ * the first run already moved the cutoff. No double-delete, no harm.
+ *
+ * <h2>Cascade</h2>
+ * <p>Hard-deleting a {@code feed_posts} row reaps every related row via
+ * the existing FK {@code ON DELETE CASCADE} constraints:
+ * {@code feed_post_likes}, {@code feed_post_bookmarks},
+ * {@code feed_post_shares}, {@code feed_post_comments},
+ * {@code feed_post_hashtags}, and {@code feed_post_edit_history}.
+ * Comments soft-deleted independently of their parent post are reaped
+ * by the symmetric comment-side delete.
+ *
+ * <h2>Test gating</h2>
+ * <p>{@code @ConditionalOnProperty(matchIfMissing = true)} means the
+ * scheduler is on by default in production. The test profile sets
+ * {@code app.feed.cleanup.enabled=false} so the scheduler bean is not
+ * created during the bulk test suite; the dedicated integration test
+ * for this scheduler flips the flag back on via {@code @TestPropertySource}.
+ */
+@Component
+@ConditionalOnProperty(name = "app.feed.cleanup.enabled",
+        havingValue = "true", matchIfMissing = true)
+public class FeedSoftDeleteCleanupScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(FeedSoftDeleteCleanupScheduler.class);
+
+    private final FeedPostRepository postRepository;
+    private final FeedPostCommentRepository commentRepository;
+    private final int restoreWindowDays;
+
+    public FeedSoftDeleteCleanupScheduler(
+            FeedPostRepository postRepository,
+            FeedPostCommentRepository commentRepository,
+            @Value("${app.feed.cleanup.restore-window-days:30}") int restoreWindowDays) {
+        this.postRepository = postRepository;
+        this.commentRepository = commentRepository;
+        // Defensive clamp: a misconfigured 0 would reap everything on
+        // every run. Mirrors FeedPostService's restoreWindowDays clamp.
+        this.restoreWindowDays = Math.max(1, restoreWindowDays);
+    }
+
+    @Scheduled(cron = "${app.feed.cleanup.cron:0 45 3 * * *}",
+            zone = "${app.feed.cleanup.zone:UTC}")
+    @Transactional
+    public void purgeExpiredSoftDeletes() {
+        OffsetDateTime cutoff = OffsetDateTime.now().minusDays(restoreWindowDays);
+        int posts = postRepository.hardDeletePostsSoftDeletedBefore(cutoff);
+        int comments = commentRepository.hardDeleteCommentsSoftDeletedBefore(cutoff);
+        if (posts > 0 || comments > 0) {
+            log.info("feed-cleanup purged: posts={}, comments={}, cutoff={}, windowDays={}",
+                    posts, comments, cutoff, restoreWindowDays);
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/scheduler/FeedTrendingRefreshScheduler.java
+++ b/backend/src/main/java/com/group7/backend/scheduler/FeedTrendingRefreshScheduler.java
@@ -1,0 +1,54 @@
+package com.group7.backend.scheduler;
+
+import com.group7.backend.service.FeedTrendingService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Hourly cron that refreshes the {@code feed_trending_24h} materialized
+ * view (#487). Default {@code 0 5 * * * *} — five past every hour. The
+ * top-of-hour slot is taken by {@code TokenCleanupScheduler}, so we
+ * sit off it to avoid coincident DB load spikes.
+ *
+ * <p>{@code REFRESH MATERIALIZED VIEW CONCURRENTLY} requires the unique
+ * index added in V45; without it Postgres rejects the CONCURRENTLY
+ * form. The refresh runs in its own transaction (managed inside
+ * {@code FeedTrendingRepository}), so this scheduler stays a thin
+ * facade.
+ *
+ * <p>Off by default in the test profile via
+ * {@code app.feed.trending.enabled=false}; the dedicated integration
+ * test flips the flag back on.
+ */
+@Component
+@ConditionalOnProperty(name = "app.feed.trending.enabled",
+        havingValue = "true", matchIfMissing = true)
+public class FeedTrendingRefreshScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(FeedTrendingRefreshScheduler.class);
+
+    private final FeedTrendingService trendingService;
+
+    public FeedTrendingRefreshScheduler(FeedTrendingService trendingService) {
+        this.trendingService = trendingService;
+    }
+
+    @Scheduled(cron = "${app.feed.trending.cron:0 5 * * * *}",
+            zone = "${app.feed.trending.zone:UTC}")
+    public void refresh() {
+        long start = System.nanoTime();
+        try {
+            trendingService.refreshTrendingView();
+            long ms = (System.nanoTime() - start) / 1_000_000L;
+            log.debug("feed-trending refreshed in {} ms", ms);
+        } catch (RuntimeException ex) {
+            // Don't propagate — a failed refresh leaves the view stale
+            // (acceptable) but should not abort the JVM scheduler thread
+            // or skew metrics. The next tick will retry.
+            log.error("feed-trending refresh failed; view will be stale until next tick", ex);
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/FeedPostService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedPostService.java
@@ -1,17 +1,21 @@
 package com.group7.backend.service;
 
+import com.group7.backend.dto.response.FeedPostEditEntry;
 import com.group7.backend.dto.response.FeedPostResponse;
 import com.group7.backend.entity.Admin;
 import com.group7.backend.entity.Attachment;
 import com.group7.backend.entity.FeedPost;
+import com.group7.backend.entity.FeedPostEditHistory;
 import com.group7.backend.entity.FeedPostHashtag;
 import com.group7.backend.entity.User;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.AttachmentRepository;
+import com.group7.backend.repository.FeedPostEditHistoryRepository;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 
 /**
@@ -75,7 +80,7 @@ public class FeedPostService {
     private static final Logger log = LoggerFactory.getLogger(FeedPostService.class);
 
     /**
-     * Hard cap on attachments per post (#485). Mirrored at the request DTO
+     * Hard cap on attachments per post. Mirrored at the request DTO
      * layer ({@code @Size(max = 4)}) and at the DB layer (junction CHECK
      * {@code position BETWEEN 0 AND 3}). Defense in depth: the DTO bound
      * fails fast on user input; the service constant catches programmatic
@@ -92,25 +97,36 @@ public class FeedPostService {
     private static final Set<String> ALLOWED_IMAGE_CONTENT_TYPES = Set.of(
             "image/jpeg", "image/png", "image/gif", "image/webp");
 
+    /**
+     * Hard cap on the {@code limit} accepted by {@link #getPostHistory}.
+     * Mirrored by an {@code @Max} on the controller {@code @RequestParam}
+     * so abusive callers get a 400 long before the service is reached;
+     * the service-side clamp is defence-in-depth.
+     */
+    static final int HISTORY_PAGE_CAP = 50;
+
     private final FeedPostRepository feedPostRepository;
     private final UserRepository userRepository;
     private final AttachmentRepository attachmentRepository;
     private final HashtagNormalizer hashtagNormalizer;
     private final FeedPostMapper feedPostMapper;
     private final FeedPostEventPublisher feedPostEventPublisher;
+    private final FeedPostEditHistoryRepository historyRepository;
 
     public FeedPostService(FeedPostRepository feedPostRepository,
                            UserRepository userRepository,
                            AttachmentRepository attachmentRepository,
                            HashtagNormalizer hashtagNormalizer,
                            FeedPostMapper feedPostMapper,
-                           FeedPostEventPublisher feedPostEventPublisher) {
+                           FeedPostEventPublisher feedPostEventPublisher,
+                           FeedPostEditHistoryRepository historyRepository) {
         this.feedPostRepository = feedPostRepository;
         this.userRepository = userRepository;
         this.attachmentRepository = attachmentRepository;
         this.hashtagNormalizer = hashtagNormalizer;
         this.feedPostMapper = feedPostMapper;
         this.feedPostEventPublisher = feedPostEventPublisher;
+        this.historyRepository = historyRepository;
     }
 
     /**
@@ -212,6 +228,37 @@ public class FeedPostService {
             throw new ResourceNotFoundException("Feed post not found with id: " + postId);
         }
 
+        // Pre-compute the normalised target hashtag set (if supplied)
+        // up front so the snapshot decision can compare set membership
+        // against what we are actually about to write — not the raw
+        // unparsed input the caller sent.
+        Set<String> normalisedTags = rawHashtags == null
+                ? null
+                : hashtagNormalizer.normalize(rawHashtags);
+        Set<String> currentTags = post.getHashtags().stream()
+                .map(h -> h.getId().getTag())
+                .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+
+        boolean bodyChanges = body != null && !body.isBlank() && !body.equals(post.getBody());
+        boolean hashtagsChange = normalisedTags != null
+                && !currentTags.equals(new TreeSet<>(normalisedTags));
+
+        // Snapshot the prior state BEFORE mutating (#487). The history row
+        // is written inside the same @Transactional boundary as the post
+        // mutation; if the UPDATE later rolls back (optimistic-lock 409,
+        // FK cascade race, etc.) the INSERT rolls back with it. A no-op
+        // PATCH (caller sent the existing values, or both fields null)
+        // produces no history row.
+        if (bodyChanges || hashtagsChange) {
+            FeedPostEditHistory snapshot = new FeedPostEditHistory();
+            snapshot.setPostId(post.getId());
+            snapshot.setEditorId(requesterId);
+            snapshot.setPreviousBody(post.getBody());
+            snapshot.setPreviousHashtags(List.copyOf(currentTags));
+            snapshot.setEditedAt(OffsetDateTime.now());
+            historyRepository.save(snapshot);
+        }
+
         boolean modified = false;
         if (body != null) {
             if (body.isBlank()) {
@@ -220,8 +267,7 @@ public class FeedPostService {
             post.setBody(body);
             modified = true;
         }
-        if (rawHashtags != null) {
-            Set<String> normalisedTags = hashtagNormalizer.normalize(rawHashtags);
+        if (normalisedTags != null) {
             post.getHashtags().clear();
             for (String tag : normalisedTags) {
                 post.getHashtags().add(new FeedPostHashtag(post, tag));
@@ -244,9 +290,44 @@ public class FeedPostService {
             post.setUpdatedAt(OffsetDateTime.now());
         }
         FeedPost saved = feedPostRepository.save(post);
-        log.info("Updated feed post: id={}, authorId={}, bodyTouched={}, hashtagsTouched={}, attachmentsTouched={}",
-                postId, requesterId, body != null, rawHashtags != null, attachmentIds != null);
+        log.info("Updated feed post: id={}, authorId={}, bodyTouched={}, hashtagsTouched={}, attachmentsTouched={}, historySaved={}",
+                postId, requesterId, body != null, rawHashtags != null, attachmentIds != null,
+                bodyChanges || hashtagsChange);
         return feedPostMapper.toResponse(saved, requesterId);
+    }
+
+    /**
+     * Returns the edit history of a feed post (#487), newest first.
+     * Visible to the post author and to any {@link Admin}; everyone
+     * else gets {@code 403}. Operates regardless of the post's
+     * {@code deletedAt} state — a soft-deleted post still has a
+     * history that the author or an admin can audit before the
+     * cleanup scheduler hard-deletes it.
+     *
+     * <p>The {@code limit} is clamped to {@link #HISTORY_PAGE_CAP}
+     * inside the service so any caller bypassing the controller's
+     * {@code @Max} cannot flood the response.
+     */
+    public List<FeedPostEditEntry> getPostHistory(Long postId, Long actorId, int limit) {
+        FeedPost post = feedPostRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("Feed post not found with id: " + postId));
+        if (!post.getAuthorId().equals(actorId)) {
+            User actor = userRepository.findById(actorId)
+                    .orElseThrow(() -> new AccessDeniedException("Only the post author or an admin can view history"));
+            if (!(actor instanceof Admin)) {
+                log.warn("Non-author non-admin attempted to read feed-post history: postId={}, actorId={}",
+                        postId, actorId);
+                throw new AccessDeniedException("Only the post author or an admin can view history");
+            }
+        }
+        int clampedLimit = Math.min(Math.max(limit, 1), HISTORY_PAGE_CAP);
+        return historyRepository
+                .findByPostIdOrderByEditedAtDesc(postId, PageRequest.of(0, clampedLimit))
+                .stream()
+                .map(h -> new FeedPostEditEntry(
+                        h.getId(), h.getEditorId(), h.getPreviousBody(),
+                        h.getPreviousHashtags(), h.getEditedAt()))
+                .toList();
     }
 
     /**

--- a/backend/src/main/java/com/group7/backend/service/FeedPostService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedPostService.java
@@ -8,6 +8,8 @@ import com.group7.backend.entity.FeedPost;
 import com.group7.backend.entity.FeedPostEditHistory;
 import com.group7.backend.entity.FeedPostHashtag;
 import com.group7.backend.entity.User;
+import com.group7.backend.exception.FeedPostExpiredRestoreException;
+import com.group7.backend.exception.FeedPostNotDeletedException;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.AttachmentRepository;
 import com.group7.backend.repository.FeedPostEditHistoryRepository;
@@ -15,6 +17,7 @@ import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -112,6 +115,15 @@ public class FeedPostService {
     private final FeedPostMapper feedPostMapper;
     private final FeedPostEventPublisher feedPostEventPublisher;
     private final FeedPostEditHistoryRepository historyRepository;
+    /**
+     * Days after a soft-delete during which the post author can call
+     * {@code POST /api/feed/posts/{id}/restore}. Bound to
+     * {@code app.feed.cleanup.restore-window-days} (default 30) — same
+     * source as the cleanup scheduler so the two stay in lock-step:
+     * a post becomes restorable until exactly the same instant the
+     * scheduler is allowed to hard-delete it.
+     */
+    private final int restoreWindowDays;
 
     public FeedPostService(FeedPostRepository feedPostRepository,
                            UserRepository userRepository,
@@ -119,7 +131,8 @@ public class FeedPostService {
                            HashtagNormalizer hashtagNormalizer,
                            FeedPostMapper feedPostMapper,
                            FeedPostEventPublisher feedPostEventPublisher,
-                           FeedPostEditHistoryRepository historyRepository) {
+                           FeedPostEditHistoryRepository historyRepository,
+                           @Value("${app.feed.cleanup.restore-window-days:30}") int restoreWindowDays) {
         this.feedPostRepository = feedPostRepository;
         this.userRepository = userRepository;
         this.attachmentRepository = attachmentRepository;
@@ -127,6 +140,9 @@ public class FeedPostService {
         this.feedPostMapper = feedPostMapper;
         this.feedPostEventPublisher = feedPostEventPublisher;
         this.historyRepository = historyRepository;
+        // Defensive clamp: a misconfigured 0 would expire every restore
+        // immediately. Mirrored in FeedSoftDeleteCleanupScheduler.
+        this.restoreWindowDays = Math.max(1, restoreWindowDays);
     }
 
     /**
@@ -328,6 +344,52 @@ public class FeedPostService {
                         h.getId(), h.getEditorId(), h.getPreviousBody(),
                         h.getPreviousHashtags(), h.getEditedAt()))
                 .toList();
+    }
+
+    /**
+     * Author-only restore of a soft-deleted post (#487). Walks the
+     * status surface explicitly:
+     * <ul>
+     *   <li>{@code 404} — post never existed.</li>
+     *   <li>{@code 403} — caller is not the post author.</li>
+     *   <li>{@code 409} — post is currently visible (nothing to restore).</li>
+     *   <li>{@code 410} — post was soft-deleted longer ago than the
+     *       configured restore window; the cleanup scheduler will
+     *       reap it on its next run.</li>
+     *   <li>{@code 200} — restored. {@code deletedAt} cleared,
+     *       {@code updatedAt} bumped to {@code now} so the
+     *       follower-feed read paths surface the post again.</li>
+     * </ul>
+     *
+     * <p>No fanout: a restore is a quiet rollback ("undo my mistake"),
+     * not a publish. The original {@code FeedPostCreatedEvent} fired
+     * at create time and is not re-emitted.
+     *
+     * <p>Concurrency: a concurrent edit that bumps the post version
+     * while restore is in flight surfaces as
+     * {@code ObjectOptimisticLockingFailureException} → 409 via the
+     * existing handler. A second restore call after a successful one
+     * lands in the {@code 409} branch above (post is no longer
+     * deleted), keeping the contract predictable.
+     */
+    @Transactional
+    public FeedPostResponse restorePost(Long postId, Long actorId) {
+        FeedPost post = feedPostRepository.findById(postId)
+                .orElseThrow(() -> new ResourceNotFoundException("Feed post not found with id: " + postId));
+        assertAuthor(post, actorId);
+        if (post.getDeletedAt() == null) {
+            throw new FeedPostNotDeletedException("Post " + postId + " is not deleted");
+        }
+        OffsetDateTime now = OffsetDateTime.now();
+        if (post.getDeletedAt().plusDays(restoreWindowDays).isBefore(now)) {
+            throw new FeedPostExpiredRestoreException(
+                    "Restore window of " + restoreWindowDays + " days has expired for post " + postId);
+        }
+        post.setDeletedAt(null);
+        post.setUpdatedAt(now);
+        FeedPost saved = feedPostRepository.save(post);
+        log.info("Restored feed post: id={}, authorId={}", postId, actorId);
+        return feedPostMapper.toResponse(saved, actorId);
     }
 
     /**

--- a/backend/src/main/java/com/group7/backend/service/FeedTrendingService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedTrendingService.java
@@ -1,0 +1,59 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.FeedTrendingHashtag;
+import com.group7.backend.repository.FeedTrendingRepository;
+import com.group7.backend.repository.projection.TrendingHashtagTuple;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Service surface for the trending-hashtag aggregate (#487). Two
+ * responsibilities: read the materialized view ranked, and refresh
+ * the view (called by the scheduler).
+ *
+ * <p>The score formula
+ * ({@code postCount + 2 * uniqueLikers + 3 * commentCount})
+ * is duplicated in the V45 expression index so the read is an index
+ * scan. If you change the formula here, change V45 to match.
+ */
+@Service
+public class FeedTrendingService {
+
+    /** Hard cap on the trending list — clamped server-side regardless of caller. */
+    static final int MAX_LIMIT = 50;
+
+    private final FeedTrendingRepository trendingRepository;
+
+    public FeedTrendingService(FeedTrendingRepository trendingRepository) {
+        this.trendingRepository = trendingRepository;
+    }
+
+    /**
+     * Returns the top {@code limit} trending hashtags, ranked by score.
+     * {@code limit} is clamped to {@code [1, MAX_LIMIT]} — defence in
+     * depth alongside the controller's {@code @Min}/{@code @Max}.
+     */
+    public List<FeedTrendingHashtag> listTrendingHashtags(int limit) {
+        int clamped = Math.max(1, Math.min(limit, MAX_LIMIT));
+        return trendingRepository.findTopTrending(clamped).stream()
+                .map(FeedTrendingService::toDto)
+                .toList();
+    }
+
+    /** Refreshes the materialized view (called by the hourly scheduler). */
+    public void refreshTrendingView() {
+        trendingRepository.refreshConcurrently();
+    }
+
+    private static FeedTrendingHashtag toDto(TrendingHashtagTuple t) {
+        double score = t.postCount() + 2.0 * t.uniqueLikers() + 3.0 * t.commentCount();
+        return new FeedTrendingHashtag(
+                t.tag(),
+                t.postCount(),
+                t.uniqueLikers(),
+                t.commentCount(),
+                t.latestPostAt(),
+                score);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -584,3 +584,13 @@ app.feed.cleanup.enabled=${APP_FEED_CLEANUP_ENABLED:true}
 app.feed.cleanup.cron=${APP_FEED_CLEANUP_CRON:0 45 3 * * *}
 app.feed.cleanup.zone=${APP_FEED_CLEANUP_ZONE:UTC}
 app.feed.cleanup.restore-window-days=${APP_FEED_RESTORE_WINDOW_DAYS:30}
+
+# Feed trending materialized view refresh (#487). The trending list
+# served by GET /api/feed/trending/hashtags is read from a Postgres
+# materialized view (feed_trending_24h, V45). The view refreshes
+# every hour at five-past via REFRESH MATERIALIZED VIEW CONCURRENTLY
+# so reads are never blocked. The 0:00 slot is taken by
+# TokenCleanupScheduler.
+app.feed.trending.enabled=${APP_FEED_TRENDING_ENABLED:true}
+app.feed.trending.cron=${APP_FEED_TRENDING_CRON:0 5 * * * *}
+app.feed.trending.zone=${APP_FEED_TRENDING_ZONE:UTC}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -573,3 +573,14 @@ app.embedding.model=${OPENAI_EMBEDDING_MODEL:text-embedding-3-small}
 app.embedding.cache.max-size=${EMBEDDING_CACHE_MAX_SIZE:10000}
 app.embedding.cache.ttl-hours=${EMBEDDING_CACHE_TTL_HOURS:24}
 app.embedding.fail-open=${EMBEDDING_FAIL_OPEN:true}
+
+# Feed soft-delete lifecycle (#487). The cleanup scheduler runs at
+# 03:45 UTC daily and hard-deletes feed posts and comments whose
+# deleted_at is older than restore-window-days. The same window
+# governs FeedPostService.restorePost — a post becomes restorable
+# until exactly the same instant it becomes eligible for hard-delete.
+# A misconfigured 0 is clamped to 1 day in both call sites.
+app.feed.cleanup.enabled=${APP_FEED_CLEANUP_ENABLED:true}
+app.feed.cleanup.cron=${APP_FEED_CLEANUP_CRON:0 45 3 * * *}
+app.feed.cleanup.zone=${APP_FEED_CLEANUP_ZONE:UTC}
+app.feed.cleanup.restore-window-days=${APP_FEED_RESTORE_WINDOW_DAYS:30}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -594,3 +594,25 @@ app.feed.cleanup.restore-window-days=${APP_FEED_RESTORE_WINDOW_DAYS:30}
 app.feed.trending.enabled=${APP_FEED_TRENDING_ENABLED:true}
 app.feed.trending.cron=${APP_FEED_TRENDING_CRON:0 5 * * * *}
 app.feed.trending.zone=${APP_FEED_TRENDING_ZONE:UTC}
+
+# Rate-limit rules for the feed lifecycle endpoints (#487). USER-keyed
+# so each authenticated user gets their own bucket; the buckets are
+# tight on restore (state-changing, low expected use) and roomy on the
+# read endpoints (cheap to serve, useful for clients that poll).
+app.ratelimit.rules.feed-restore.method=POST
+app.ratelimit.rules.feed-restore.pattern=/api/feed/posts/*/restore
+app.ratelimit.rules.feed-restore.key-strategy=USER
+app.ratelimit.rules.feed-restore.capacity=10
+app.ratelimit.rules.feed-restore.refill=PT1M
+
+app.ratelimit.rules.feed-history.method=GET
+app.ratelimit.rules.feed-history.pattern=/api/feed/posts/*/history
+app.ratelimit.rules.feed-history.key-strategy=USER
+app.ratelimit.rules.feed-history.capacity=60
+app.ratelimit.rules.feed-history.refill=PT1M
+
+app.ratelimit.rules.feed-trending.method=GET
+app.ratelimit.rules.feed-trending.pattern=/api/feed/trending/hashtags
+app.ratelimit.rules.feed-trending.key-strategy=USER
+app.ratelimit.rules.feed-trending.capacity=60
+app.ratelimit.rules.feed-trending.refill=PT1M

--- a/backend/src/main/resources/db/migration/V43__add_feed_soft_delete_cleanup_indexes.sql
+++ b/backend/src/main/resources/db/migration/V43__add_feed_soft_delete_cleanup_indexes.sql
@@ -1,0 +1,18 @@
+-- Soft-delete cleanup support indexes (#487). The existing partial
+-- indexes (idx_feed_posts_created_at_active in V26 and the implicit
+-- read-side index on feed_post_comments) are anchored on
+-- `WHERE deleted_at IS NULL` to keep public read paths cheap.
+--
+-- The cleanup scheduler (added in this slice) does the opposite: it
+-- scans for rows whose deleted_at is NOT NULL and older than the
+-- configured restore window. A disjoint partial index on each table
+-- keeps that scan O(matching rows) without bloating the existing
+-- read-side indexes.
+
+CREATE INDEX idx_feed_posts_deleted_at_pending_cleanup
+    ON feed_posts (deleted_at)
+    WHERE deleted_at IS NOT NULL;
+
+CREATE INDEX idx_feed_post_comments_deleted_at_pending_cleanup
+    ON feed_post_comments (deleted_at)
+    WHERE deleted_at IS NOT NULL;

--- a/backend/src/main/resources/db/migration/V44__create_feed_post_edit_history.sql
+++ b/backend/src/main/resources/db/migration/V44__create_feed_post_edit_history.sql
@@ -1,0 +1,27 @@
+-- Append-only audit of every meaningful edit applied to feed_posts (#487).
+-- One row per PATCH that mutated body or hashtags. previous_hashtags is
+-- JSONB so the snapshot survives even if the hashtag set is later mutated
+-- again and feed_post_hashtags rows are deleted/reinserted by Hibernate.
+--
+-- post_id ON DELETE CASCADE: when the parent post is hard-deleted by the
+-- soft-delete cleanup scheduler (added in V43), history rows go with it.
+-- Acceptable — history is a debugging / moderation aid for currently-live
+-- posts, not a forensic archive. If forensics are needed later, a separate
+-- retention table can persist hashes pre-purge.
+--
+-- editor_id ON DELETE SET NULL (nullable): preserves the audit row if an
+-- editor account is removed. Today the editor is always the post author
+-- and that path cascades via post_id; reserving the column behaviour for
+-- a future moderator-edit feature is cheap and adds no current cost.
+
+CREATE TABLE feed_post_edit_history (
+    id                 BIGSERIAL    PRIMARY KEY,
+    post_id            BIGINT       NOT NULL REFERENCES feed_posts(id) ON DELETE CASCADE,
+    editor_id          BIGINT                REFERENCES users(id) ON DELETE SET NULL,
+    previous_body      TEXT         NOT NULL,
+    previous_hashtags  JSONB        NOT NULL DEFAULT '[]'::jsonb,
+    edited_at          TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_feed_post_edit_history_post_edited_at
+    ON feed_post_edit_history (post_id, edited_at DESC);

--- a/backend/src/main/resources/db/migration/V45__create_feed_trending_24h_view.sql
+++ b/backend/src/main/resources/db/migration/V45__create_feed_trending_24h_view.sql
@@ -1,0 +1,50 @@
+-- 24-hour trending hashtag aggregate (#487). On-demand aggregation
+-- would scan feed_post_hashtags + feed_post_likes + feed_post_comments
+-- per request and lock the interaction tables under contention; a
+-- materialized view refreshed hourly bounds query cost and gives a
+-- consistent ordering across requests.
+--
+-- HAVING COUNT(DISTINCT p.id) >= 2 prevents single-author noise from
+-- topping the chart.
+--
+-- The unique index on (tag) is required by REFRESH MATERIALIZED VIEW
+-- CONCURRENTLY (Postgres rejects the CONCURRENTLY form without it).
+-- Without CONCURRENTLY the refresh would AccessExclusiveLock the view
+-- against readers for the duration.
+--
+-- The expression index on the score formula keeps the trending list
+-- query (ORDER BY score DESC LIMIT 20) on an index scan.
+--
+-- Note: the LEFT JOIN cartesian on (likes × comments) is acceptable at
+-- current scale (HAVING ≥ 2 + 24h window cap candidate count). Revisit
+-- as a CTE-with-pre-aggregated-counts if profiling shows refresh cost
+-- exceeding the hourly budget.
+--
+-- The CREATE statement populates the view atomically (no WITH NO DATA),
+-- so the first hourly REFRESH at :05 has prior data to compare against.
+
+CREATE MATERIALIZED VIEW feed_trending_24h AS
+SELECT
+    h.tag,
+    COUNT(DISTINCT p.id)         AS post_count,
+    COUNT(DISTINCT l.user_id)    AS unique_likers,
+    COUNT(DISTINCT c.id)         AS comment_count,
+    MAX(p.created_at)            AS latest_post_at
+FROM feed_post_hashtags h
+JOIN feed_posts p
+        ON p.id = h.post_id
+       AND p.deleted_at IS NULL
+       AND p.created_at >= NOW() - INTERVAL '24 hours'
+LEFT JOIN feed_post_likes l
+        ON l.post_id = p.id
+LEFT JOIN feed_post_comments c
+        ON c.post_id = p.id
+       AND c.deleted_at IS NULL
+GROUP BY h.tag
+HAVING COUNT(DISTINCT p.id) >= 2;
+
+CREATE UNIQUE INDEX idx_feed_trending_24h_tag
+    ON feed_trending_24h (tag);
+
+CREATE INDEX idx_feed_trending_24h_score
+    ON feed_trending_24h ((post_count * 1.0 + unique_likers * 2.0 + comment_count * 3.0) DESC);

--- a/backend/src/test/java/com/group7/backend/integration/FeedPostHistoryIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedPostHistoryIntegrationTest.java
@@ -1,0 +1,334 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the feed-post edit-history surface (#487)
+ * against real Postgres. Walks the snapshot-on-update path, the
+ * GET /history endpoint authorisation matrix, and verifies the
+ * JSONB round-trip for previous_hashtags (first JSONB column added
+ * to this codebase via Hibernate 6 native binding).
+ *
+ * <p>The test profile disables rate-limiting, the cleanup scheduler,
+ * and the trending refresh, so this suite is not coupled to any
+ * cron firing.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class FeedPostHistoryIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        // Children first by FK, then parents.
+        jdbcTemplate.update("DELETE FROM feed_post_edit_history");
+        jdbcTemplate.update("DELETE FROM feed_post_hashtags");
+        jdbcTemplate.update("DELETE FROM feed_posts");
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    // ── Snapshot capture on PATCH ──────────────────────────────────────────
+
+    @Test
+    void twoEdits_yieldTwoHistoryRowsNewestFirst_capturingPriorState() throws Exception {
+        String token = registerAndLogin("hist_a@test.com", true);
+        long postId = createPost(token, "v1", List.of("alpha", "beta"));
+
+        // First edit: change body only.
+        mockMvc.perform(patch("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"v2\"}"))
+                .andExpect(status().isOk());
+
+        // Second edit: change hashtags only.
+        mockMvc.perform(patch("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hashtags\":[\"gamma\"]}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/feed/posts/" + postId + "/history")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                // Newest first: the second edit's snapshot captured
+                // body="v2" and the hashtag set ["alpha","beta"] that
+                // existed AFTER the first edit but BEFORE the second.
+                .andExpect(jsonPath("$[0].previousBody").value("v2"))
+                .andExpect(jsonPath("$[0].previousHashtags.length()").value(2))
+                .andExpect(jsonPath("$[0].previousHashtags[0]").value("alpha"))
+                .andExpect(jsonPath("$[0].previousHashtags[1]").value("beta"))
+                // Oldest entry: the first edit's snapshot — body was
+                // the original "v1" with the same starting hashtag set.
+                .andExpect(jsonPath("$[1].previousBody").value("v1"))
+                .andExpect(jsonPath("$[1].previousHashtags.length()").value(2))
+                .andExpect(jsonPath("$[1].previousHashtags[0]").value("alpha"))
+                .andExpect(jsonPath("$[1].previousHashtags[1]").value("beta"));
+    }
+
+    @Test
+    void noopPatch_doesNotProduceHistoryRow() throws Exception {
+        String token = registerAndLogin("hist_noop@test.com", true);
+        long postId = createPost(token, "same body", List.of("tag"));
+
+        // PATCH with the existing values — no real change.
+        mockMvc.perform(patch("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"same body\",\"hashtags\":[\"tag\"]}"))
+                .andExpect(status().isOk());
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_edit_history WHERE post_id = ?",
+                Integer.class, postId);
+        assertThat(count).isZero();
+    }
+
+    @Test
+    void bothFieldsNullPatch_doesNotProduceHistoryRow() throws Exception {
+        String token = registerAndLogin("hist_null@test.com", true);
+        long postId = createPost(token, "body", List.of("tag"));
+
+        mockMvc.perform(patch("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk());
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_edit_history WHERE post_id = ?",
+                Integer.class, postId);
+        assertThat(count).isZero();
+    }
+
+    // ── GET /history authorisation matrix ──────────────────────────────────
+
+    @Test
+    void author_canReadHistory() throws Exception {
+        String token = registerAndLogin("hist_owner@test.com", true);
+        long postId = createPost(token, "owner body", List.of());
+
+        mockMvc.perform(get("/api/feed/posts/" + postId + "/history")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void admin_canReadHistoryOfAnyPost() throws Exception {
+        String authorToken = registerAndLogin("hist_author2@test.com", true);
+        long postId = createPost(authorToken, "any body", List.of());
+        mockMvc.perform(patch("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + authorToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"updated\"}"))
+                .andExpect(status().isOk());
+
+        String adminToken = registerAdminAndLogin("hist_admin@test.com");
+        mockMvc.perform(get("/api/feed/posts/" + postId + "/history")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].previousBody").value("any body"));
+    }
+
+    @Test
+    void nonAuthorNonAdmin_getsForbidden() throws Exception {
+        String authorToken = registerAndLogin("hist_owner3@test.com", true);
+        String otherToken = registerAndLogin("hist_other@test.com", true);
+        long postId = createPost(authorToken, "private body", List.of());
+
+        mockMvc.perform(get("/api/feed/posts/" + postId + "/history")
+                        .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void missingPost_returns404() throws Exception {
+        String token = registerAndLogin("hist_missing@test.com", true);
+
+        mockMvc.perform(get("/api/feed/posts/999999/history")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void historyVisible_evenAfterSoftDelete() throws Exception {
+        String token = registerAndLogin("hist_softdel@test.com", true);
+        long postId = createPost(token, "v1", List.of());
+        mockMvc.perform(patch("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"v2\"}"))
+                .andExpect(status().isOk());
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .delete("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+
+        // Author can still see the history entry even though the post
+        // is soft-deleted — useful for moderation/audit before the
+        // cleanup scheduler hard-deletes it.
+        mockMvc.perform(get("/api/feed/posts/" + postId + "/history")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].previousBody").value("v1"));
+    }
+
+    // ── @Min/@Max clamp on limit param (defence-in-depth) ───────────────────
+
+    @Test
+    void limitOver50_returns400() throws Exception {
+        String token = registerAndLogin("hist_lim@test.com", true);
+        long postId = createPost(token, "body", List.of());
+
+        mockMvc.perform(get("/api/feed/posts/" + postId + "/history?limit=100")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void limitZero_returns400() throws Exception {
+        String token = registerAndLogin("hist_lim0@test.com", true);
+        long postId = createPost(token, "body", List.of());
+
+        mockMvc.perform(get("/api/feed/posts/" + postId + "/history?limit=0")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── JSONB round-trip on previous_hashtags ───────────────────────────────
+
+    @Test
+    void jsonbColumn_roundTripsListOfStrings_preservingOrder() throws Exception {
+        String token = registerAndLogin("hist_jsonb@test.com", true);
+        long postId = createPost(token, "v1",
+                List.of("zeta", "alpha", "mü", "data_science"));
+        mockMvc.perform(patch("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"v2\"}"))
+                .andExpect(status().isOk());
+
+        // The snapshot captures the hashtag set sorted alphabetically
+        // (TreeSet inside the service); the JSONB column round-trips
+        // the resulting List<String> exactly via @JdbcTypeCode(SqlTypes.JSON).
+        // The tags stored are the post's current tags, which are normalised
+        // to lowercase already on creation (see HashtagNormalizer); we
+        // assert the alphabetical order survived the JSONB write/read.
+        mockMvc.perform(get("/api/feed/posts/" + postId + "/history")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].previousHashtags.length()").value(4))
+                .andExpect(jsonPath("$[0].previousHashtags[0]").value("alpha"))
+                .andExpect(jsonPath("$[0].previousHashtags[1]").value("data_science"))
+                .andExpect(jsonPath("$[0].previousHashtags[2]").value("mü"))
+                .andExpect(jsonPath("$[0].previousHashtags[3]").value("zeta"));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("History");
+        req.setLastName("Tester");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private String registerAdminAndLogin(String email) throws Exception {
+        Admin admin = new Admin();
+        admin.setEmail(email);
+        admin.setPasswordHash(new BCryptPasswordEncoder().encode("Password1"));
+        admin.setFirstName("Admin");
+        admin.setLastName("User");
+        admin.setIsEmailVerified(true);
+        userRepository.save(admin);
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private long createPost(String token, String body, List<String> hashtags) throws Exception {
+        Map<String, Object> req = Map.of("body", body, "hashtags", hashtags);
+        MvcResult res = mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/FeedPostRestoreIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedPostRestoreIntegrationTest.java
@@ -1,0 +1,227 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the soft-delete restore endpoint (#487)
+ * against real Postgres. Exercises the full status-code surface of
+ * {@code POST /api/feed/posts/{id}/restore}: 200 (happy path), 401
+ * (unauthenticated), 403 (non-author), 404 (missing), 409 (live
+ * post), and 410 (expired window). Time-travel for the expired-window
+ * branch is achieved by back-dating {@code deleted_at} via
+ * {@code JdbcTemplate} — keeping the system clock untouched is
+ * simpler than introducing a fixed-{@code Clock} test bean and avoids
+ * coupling unrelated time-sensitive code paths.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class FeedPostRestoreIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        jdbcTemplate.update("DELETE FROM feed_post_edit_history");
+        jdbcTemplate.update("DELETE FROM feed_post_hashtags");
+        jdbcTemplate.update("DELETE FROM feed_posts");
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    @Test
+    void deleteThenRestore_makesPostVisibleAgain() throws Exception {
+        String token = registerAndLogin("restore_a@test.com", true);
+        long postId = createPost(token, "to be restored", List.of("alpha"));
+
+        mockMvc.perform(delete("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+
+        // Soft-deleted: GET → 404.
+        mockMvc.perform(get("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+
+        // Restore → 200 with the post body restored.
+        mockMvc.perform(post("/api/feed/posts/" + postId + "/restore")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(postId))
+                .andExpect(jsonPath("$.body").value("to be restored"))
+                .andExpect(jsonPath("$.hashtags[0]").value("alpha"));
+
+        // Now visible again.
+        mockMvc.perform(get("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void restoreOnLivePost_returns409() throws Exception {
+        String token = registerAndLogin("restore_live@test.com", true);
+        long postId = createPost(token, "still live", List.of());
+
+        mockMvc.perform(post("/api/feed/posts/" + postId + "/restore")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void restoreByNonAuthor_returns403() throws Exception {
+        String authorToken = registerAndLogin("restore_owner@test.com", true);
+        String otherToken = registerAndLogin("restore_other@test.com", true);
+        long postId = createPost(authorToken, "private body", List.of());
+
+        mockMvc.perform(delete("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + authorToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(post("/api/feed/posts/" + postId + "/restore")
+                        .header("Authorization", "Bearer " + otherToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void restoreOnMissingPost_returns404() throws Exception {
+        String token = registerAndLogin("restore_missing@test.com", true);
+
+        mockMvc.perform(post("/api/feed/posts/999999/restore")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void restoreAfterWindow_returns410() throws Exception {
+        String token = registerAndLogin("restore_expired@test.com", true);
+        long postId = createPost(token, "old post", List.of());
+
+        // Soft-delete via the API to validate the public path …
+        mockMvc.perform(delete("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+        // … then back-date deleted_at past the configured window.
+        Timestamp longAgo = Timestamp.valueOf(LocalDateTime.now().minusDays(31));
+        jdbcTemplate.update(
+                "UPDATE feed_posts SET deleted_at = ? WHERE id = ?",
+                longAgo, postId);
+
+        mockMvc.perform(post("/api/feed/posts/" + postId + "/restore")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isGone());
+    }
+
+    @Test
+    void restoreWithoutAuth_returns403() throws Exception {
+        // Project convention: missing/invalid Authorization header
+        // surfaces as 403 (Spring Security's default unauthenticated
+        // response), not 401. The same shape is observable on every
+        // protected endpoint in the codebase.
+        String token = registerAndLogin("restore_anon@test.com", true);
+        long postId = createPost(token, "guarded", List.of());
+        mockMvc.perform(delete("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(post("/api/feed/posts/" + postId + "/restore"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void doubleRestore_secondCallReturns409() throws Exception {
+        // Documented contract: restore is not idempotent. The first call
+        // succeeds (200); the second call sees a live post and returns 409.
+        String token = registerAndLogin("restore_double@test.com", true);
+        long postId = createPost(token, "twice restored?", List.of());
+
+        mockMvc.perform(delete("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(post("/api/feed/posts/" + postId + "/restore")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/feed/posts/" + postId + "/restore")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isConflict());
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Restore");
+        req.setLastName("Tester");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private long createPost(String token, String body, List<String> hashtags) throws Exception {
+        Map<String, Object> req = Map.of("body", body, "hashtags", hashtags);
+        MvcResult res = mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/FeedSoftDeleteCleanupIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedSoftDeleteCleanupIntegrationTest.java
@@ -1,0 +1,197 @@
+package com.group7.backend.integration;
+
+import com.group7.backend.entity.FeedPost;
+import com.group7.backend.entity.FeedPostComment;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.repository.FeedPostCommentRepository;
+import com.group7.backend.repository.FeedPostEditHistoryRepository;
+import com.group7.backend.repository.FeedPostRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.scheduler.FeedSoftDeleteCleanupScheduler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end coverage for {@link FeedSoftDeleteCleanupScheduler} (#487)
+ * against real Postgres. {@code @TestPropertySource} flips the
+ * scheduler bean back on (the bulk test profile sets it off so a stray
+ * cron doesn't fire during unrelated suites); the cleanup method is
+ * invoked directly so the test does not have to wait for the cron tick.
+ *
+ * <p>Time-travel for the "deleted past the window" branch is achieved
+ * by back-dating {@code deleted_at} via {@code JdbcTemplate} — same
+ * pattern as {@link FeedPostRestoreIntegrationTest} for consistency.
+ *
+ * <p>Verifies the cascade contract: when a feed post is hard-deleted,
+ * its child rows in {@code feed_post_comments},
+ * {@code feed_post_hashtags}, and {@code feed_post_edit_history} are
+ * reaped via the existing {@code ON DELETE CASCADE} foreign keys.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "app.feed.cleanup.enabled=true",
+        // Pin the window short and explicit so the test asserts against
+        // a known boundary rather than the production default.
+        "app.feed.cleanup.restore-window-days=30"
+})
+class FeedSoftDeleteCleanupIntegrationTest {
+
+    @Autowired private FeedSoftDeleteCleanupScheduler scheduler;
+    @Autowired private FeedPostRepository postRepository;
+    @Autowired private FeedPostCommentRepository commentRepository;
+    @Autowired private FeedPostEditHistoryRepository historyRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void cleanDb() {
+        jdbcTemplate.update("DELETE FROM feed_post_edit_history");
+        jdbcTemplate.update("DELETE FROM feed_post_hashtags");
+        jdbcTemplate.update("DELETE FROM feed_post_likes");
+        jdbcTemplate.update("DELETE FROM feed_post_comments");
+        jdbcTemplate.update("DELETE FROM feed_posts");
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void purge_hardDeletesPostsBeyondWindow_andCascadesChildRows() {
+        Long authorId = createMentor("cleanup_a@test.com");
+        long expiredPostId = createPost(authorId, "expired");
+        long freshPostId = createPost(authorId, "fresh");
+        long livePostId = createPost(authorId, "still here");
+
+        // Seed a comment + an edit-history row on each post so the
+        // cascade contract has something to verify against.
+        long expiredCommentId = createComment(expiredPostId, authorId, "comment on expired");
+        long freshCommentId = createComment(freshPostId, authorId, "comment on fresh");
+        seedHistoryRow(expiredPostId, authorId, "old body");
+        seedHistoryRow(freshPostId, authorId, "old body");
+
+        // Soft-delete two of the three posts; back-date one past the
+        // 30-day window, leave the other recent.
+        Timestamp longAgo = Timestamp.valueOf(LocalDateTime.now().minusDays(31));
+        Timestamp recent = Timestamp.valueOf(LocalDateTime.now().minusDays(5));
+        jdbcTemplate.update("UPDATE feed_posts SET deleted_at = ? WHERE id = ?",
+                longAgo, expiredPostId);
+        jdbcTemplate.update("UPDATE feed_posts SET deleted_at = ? WHERE id = ?",
+                recent, freshPostId);
+
+        scheduler.purgeExpiredSoftDeletes();
+
+        // Expired post + its children gone via FK cascade.
+        assertThat(postRepository.findById(expiredPostId)).isEmpty();
+        assertThat(commentRepository.findById(expiredCommentId)).isEmpty();
+        Integer expiredHistoryRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_edit_history WHERE post_id = ?",
+                Integer.class, expiredPostId);
+        assertThat(expiredHistoryRows).isZero();
+        Integer expiredHashtagRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_hashtags WHERE post_id = ?",
+                Integer.class, expiredPostId);
+        assertThat(expiredHashtagRows).isZero();
+
+        // Fresh-soft-delete and live posts survive (and their children).
+        assertThat(postRepository.findById(freshPostId)).isPresent();
+        assertThat(commentRepository.findById(freshCommentId)).isPresent();
+        assertThat(postRepository.findById(livePostId)).isPresent();
+    }
+
+    @Test
+    void purge_isNoOpWhenNothingExpired() {
+        Long authorId = createMentor("cleanup_noop@test.com");
+        long postId = createPost(authorId, "live");
+
+        scheduler.purgeExpiredSoftDeletes();
+
+        assertThat(postRepository.findById(postId)).isPresent();
+    }
+
+    @Test
+    void purge_alsoReapsCommentsSoftDeletedIndependentlyOfTheirPost() {
+        // Today comments only soft-delete via the comment surface
+        // (#347); when a future moderator-comment-delete feature
+        // arrives the same scheduler is the right reaper. Verifies
+        // the symmetric DELETE on feed_post_comments works.
+        Long authorId = createMentor("cleanup_comment@test.com");
+        long postId = createPost(authorId, "live post");
+
+        long expiredCommentId = createComment(postId, authorId, "old reply");
+        Timestamp longAgo = Timestamp.valueOf(LocalDateTime.now().minusDays(31));
+        jdbcTemplate.update("UPDATE feed_post_comments SET deleted_at = ? WHERE id = ?",
+                longAgo, expiredCommentId);
+
+        scheduler.purgeExpiredSoftDeletes();
+
+        // Parent post unaffected; the orphaned comment is reaped.
+        assertThat(postRepository.findById(postId)).isPresent();
+        assertThat(commentRepository.findById(expiredCommentId)).isEmpty();
+    }
+
+    @Test
+    void v43PartialIndexes_existAfterMigration() {
+        // Sanity check that V43 created the cleanup-side partial indexes.
+        // Without them the scheduler still works but at seq-scan cost on
+        // a large table. The migration runs once at context startup; if
+        // a refactor accidentally drops the CREATE INDEX statements,
+        // this test catches it before the prod deploy.
+        Integer postsIndex = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_feed_posts_deleted_at_pending_cleanup'",
+                Integer.class);
+        Integer commentsIndex = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_feed_post_comments_deleted_at_pending_cleanup'",
+                Integer.class);
+        assertThat(postsIndex).isEqualTo(1);
+        assertThat(commentsIndex).isEqualTo(1);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private Long createMentor(String email) {
+        Mentor m = new Mentor();
+        m.setEmail(email);
+        m.setPasswordHash(new BCryptPasswordEncoder().encode("Password1"));
+        m.setFirstName("Cleanup");
+        m.setLastName("Tester");
+        m.setIsEmailVerified(true);
+        return userRepository.save(m).getId();
+    }
+
+    private long createPost(Long authorId, String body) {
+        FeedPost post = new FeedPost(authorId, body);
+        OffsetDateTime now = OffsetDateTime.now();
+        post.setCreatedAt(now);
+        post.setUpdatedAt(now);
+        return postRepository.save(post).getId();
+    }
+
+    private long createComment(Long postId, Long authorId, String body) {
+        FeedPostComment c = new FeedPostComment(postId, authorId, body);
+        OffsetDateTime now = OffsetDateTime.now();
+        c.setCreatedAt(now);
+        c.setUpdatedAt(now);
+        return commentRepository.save(c).getId();
+    }
+
+    private void seedHistoryRow(long postId, Long editorId, String previousBody) {
+        // Bypass the entity to use the generated id; we don't care
+        // about the JSONB content here, only that the cascade reaps
+        // the row when the parent post is hard-deleted.
+        jdbcTemplate.update(
+                "INSERT INTO feed_post_edit_history (post_id, editor_id, previous_body, previous_hashtags, edited_at) "
+                        + "VALUES (?, ?, ?, '[]'::jsonb, NOW())",
+                postId, editorId, previousBody);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/FeedTrendingIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedTrendingIntegrationTest.java
@@ -1,0 +1,224 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import com.group7.backend.service.FeedTrendingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the trending-hashtag surface (#487) against
+ * real Postgres. The trending materialized view must be populated by
+ * an explicit REFRESH before it returns rows; the test seeds posts
+ * + likes + comments via the API, calls {@code refreshTrendingView}
+ * directly, then asserts the ranking.
+ *
+ * <p>{@code @TestPropertySource} flips the trending-refresh scheduler
+ * back on (the bulk test profile sets it off so unrelated tests are
+ * not coupled to a stray cron firing).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = "app.feed.trending.enabled=true")
+class FeedTrendingIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private FeedTrendingService trendingService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        jdbcTemplate.update("DELETE FROM feed_post_edit_history");
+        jdbcTemplate.update("DELETE FROM feed_post_hashtags");
+        jdbcTemplate.update("DELETE FROM feed_post_likes");
+        jdbcTemplate.update("DELETE FROM feed_post_comments");
+        jdbcTemplate.update("DELETE FROM feed_posts");
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        // Refresh once on an empty source so the materialized view
+        // matches the seeded state (otherwise it carries rows from
+        // any prior in-context test).
+        trendingService.refreshTrendingView();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    @Test
+    void trendingList_returnsTagsRankedByScore_filteringSingleAuthorTagsOut() throws Exception {
+        // Seed three authors so the HAVING ≥ 2 distinct-posts filter
+        // can demote a single-author "rust" tag while keeping "java"
+        // (5 posts) and "python" (3 posts) on the chart.
+        String tokenA = registerAndLogin("trend_a@test.com");
+        String tokenB = registerAndLogin("trend_b@test.com");
+        String tokenC = registerAndLogin("trend_c@test.com");
+
+        // 5 java posts spread across the three authors (≥ 2 distinct)
+        createPost(tokenA, "j1", List.of("java"));
+        createPost(tokenA, "j2", List.of("java"));
+        createPost(tokenB, "j3", List.of("java"));
+        createPost(tokenB, "j4", List.of("java"));
+        createPost(tokenC, "j5", List.of("java"));
+
+        // 3 python posts (also ≥ 2 distinct authors)
+        createPost(tokenA, "p1", List.of("python"));
+        createPost(tokenB, "p2", List.of("python"));
+        createPost(tokenC, "p3", List.of("python"));
+
+        // 1 rust post — only one author, dropped by HAVING.
+        createPost(tokenA, "r1", List.of("rust"));
+
+        trendingService.refreshTrendingView();
+
+        mockMvc.perform(get("/api/feed/trending/hashtags?limit=10")
+                        .header("Authorization", "Bearer " + tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].tag").value("java"))
+                .andExpect(jsonPath("$[0].postCount").value(5))
+                .andExpect(jsonPath("$[1].tag").value("python"))
+                .andExpect(jsonPath("$[1].postCount").value(3));
+    }
+
+    @Test
+    void trendingList_emptyWhenNoTagHasTwoDistinctPosts() throws Exception {
+        String token = registerAndLogin("trend_empty@test.com");
+        // Only one post — HAVING ≥ 2 filters it out entirely.
+        createPost(token, "lonely", List.of("solo"));
+
+        trendingService.refreshTrendingView();
+
+        mockMvc.perform(get("/api/feed/trending/hashtags")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void trendingList_clampsLimitAbove50_returns400() throws Exception {
+        String token = registerAndLogin("trend_lim@test.com");
+
+        mockMvc.perform(get("/api/feed/trending/hashtags?limit=100")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void trendingList_limitZero_returns400() throws Exception {
+        String token = registerAndLogin("trend_lim0@test.com");
+
+        mockMvc.perform(get("/api/feed/trending/hashtags?limit=0")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void trendingList_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/feed/trending/hashtags"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void v45MaterializedViewAndIndexes_existAfterMigration() {
+        // Sanity check that V45 created the matview + the unique index
+        // that REFRESH CONCURRENTLY depends on, plus the score
+        // expression index for the LIMIT-ordered read.
+        Integer matview = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM pg_matviews WHERE matviewname = 'feed_trending_24h'",
+                Integer.class);
+        Integer uniqueIndex = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_feed_trending_24h_tag'",
+                Integer.class);
+        Integer scoreIndex = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM pg_indexes WHERE indexname = 'idx_feed_trending_24h_score'",
+                Integer.class);
+
+        assertThat(matview).isEqualTo(1);
+        assertThat(uniqueIndex).isEqualTo(1);
+        assertThat(scoreIndex).isEqualTo(1);
+    }
+
+    @Test
+    void refreshConcurrently_succeedsRepeatedly_withoutLockingReaders() {
+        // Stress-light test: refresh several times in succession to
+        // catch any "REFRESH CONCURRENTLY rejected" regression. The
+        // unique index on (tag) is what makes CONCURRENTLY legal;
+        // without V45's idx_feed_trending_24h_tag the second call
+        // would throw "cannot refresh materialized view ...
+        // concurrently".
+        for (int i = 0; i < 3; i++) {
+            trendingService.refreshTrendingView();
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private String registerAndLogin(String email) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Trend");
+        req.setLastName("Tester");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(true);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private void createPost(String token, String body, List<String> hashtags) throws Exception {
+        Map<String, Object> req = Map.of("body", body, "hashtags", hashtags);
+        mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/scheduler/FeedSoftDeleteCleanupSchedulerTest.java
+++ b/backend/src/test/java/com/group7/backend/scheduler/FeedSoftDeleteCleanupSchedulerTest.java
@@ -1,0 +1,114 @@
+package com.group7.backend.scheduler;
+
+import com.group7.backend.repository.FeedPostCommentRepository;
+import com.group7.backend.repository.FeedPostRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for {@link FeedSoftDeleteCleanupScheduler} (#487).
+ * Validates the cutoff calculation, the constructor's defensive clamp
+ * on a misconfigured {@code restoreWindowDays}, and that both
+ * repositories are called inside the same scheduler invocation.
+ */
+@ExtendWith(MockitoExtension.class)
+class FeedSoftDeleteCleanupSchedulerTest {
+
+    @Mock private FeedPostRepository postRepository;
+    @Mock private FeedPostCommentRepository commentRepository;
+
+    @Test
+    void purge_callsBothRepositoriesWithCutoffOfNowMinusWindow() {
+        FeedSoftDeleteCleanupScheduler scheduler =
+                new FeedSoftDeleteCleanupScheduler(postRepository, commentRepository, 30);
+        when(postRepository.hardDeletePostsSoftDeletedBefore(any())).thenReturn(0);
+        when(commentRepository.hardDeleteCommentsSoftDeletedBefore(any())).thenReturn(0);
+
+        OffsetDateTime before = OffsetDateTime.now();
+        scheduler.purgeExpiredSoftDeletes();
+        OffsetDateTime after = OffsetDateTime.now();
+
+        ArgumentCaptor<OffsetDateTime> postCutoff = ArgumentCaptor.forClass(OffsetDateTime.class);
+        ArgumentCaptor<OffsetDateTime> commentCutoff = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(postRepository).hardDeletePostsSoftDeletedBefore(postCutoff.capture());
+        verify(commentRepository).hardDeleteCommentsSoftDeletedBefore(commentCutoff.capture());
+
+        // Cutoff is now - 30 days, computed inside the scheduler
+        // sometime between `before` and `after`.
+        OffsetDateTime expectedMin = before.minusDays(30);
+        OffsetDateTime expectedMax = after.minusDays(30);
+        assertThat(postCutoff.getValue()).isBetween(expectedMin, expectedMax);
+        // Both cutoffs are the same instant — captured from one
+        // local variable, not two `OffsetDateTime.now()` calls.
+        assertThat(commentCutoff.getValue()).isEqualTo(postCutoff.getValue());
+    }
+
+    @Test
+    void purge_doesNotLogWhenNothingDeleted() {
+        // Implicit assertion: zero return values produce a quiet log
+        // line, but no exception. The scheduler must remain a no-op
+        // on an empty database without spamming logs.
+        FeedSoftDeleteCleanupScheduler scheduler =
+                new FeedSoftDeleteCleanupScheduler(postRepository, commentRepository, 30);
+        when(postRepository.hardDeletePostsSoftDeletedBefore(any())).thenReturn(0);
+        when(commentRepository.hardDeleteCommentsSoftDeletedBefore(any())).thenReturn(0);
+
+        scheduler.purgeExpiredSoftDeletes();  // no exception
+    }
+
+    @Test
+    void constructor_clampsRestoreWindowDaysToAtLeastOne_whenConfiguredZero() {
+        FeedSoftDeleteCleanupScheduler scheduler =
+                new FeedSoftDeleteCleanupScheduler(postRepository, commentRepository, 0);
+        when(postRepository.hardDeletePostsSoftDeletedBefore(any())).thenReturn(0);
+        when(commentRepository.hardDeleteCommentsSoftDeletedBefore(any())).thenReturn(0);
+
+        OffsetDateTime before = OffsetDateTime.now();
+        scheduler.purgeExpiredSoftDeletes();
+
+        ArgumentCaptor<OffsetDateTime> cutoff = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(postRepository).hardDeletePostsSoftDeletedBefore(cutoff.capture());
+        // Cutoff is now - 1 day (clamped), not now (which would reap
+        // everything currently soft-deleted).
+        assertThat(cutoff.getValue()).isBefore(before);
+        assertThat(Duration.between(cutoff.getValue(), before).toHours())
+                .isBetween(23L, 25L);  // ~1 day, with a wide buffer for clock skew
+    }
+
+    @Test
+    void constructor_clampsRestoreWindowDaysToAtLeastOne_whenConfiguredNegative() {
+        FeedSoftDeleteCleanupScheduler scheduler =
+                new FeedSoftDeleteCleanupScheduler(postRepository, commentRepository, -10);
+        when(postRepository.hardDeletePostsSoftDeletedBefore(any())).thenReturn(0);
+        when(commentRepository.hardDeleteCommentsSoftDeletedBefore(any())).thenReturn(0);
+
+        OffsetDateTime before = OffsetDateTime.now();
+        scheduler.purgeExpiredSoftDeletes();
+
+        ArgumentCaptor<OffsetDateTime> cutoff = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(postRepository).hardDeletePostsSoftDeletedBefore(cutoff.capture());
+        // Cutoff is now - 1 day, not now + 10 days.
+        assertThat(cutoff.getValue()).isBefore(before);
+    }
+
+    @Test
+    void purge_returnsCleanlyEvenWhenBothRepositoriesReturnZero() {
+        FeedSoftDeleteCleanupScheduler scheduler =
+                new FeedSoftDeleteCleanupScheduler(postRepository, commentRepository, 30);
+        when(postRepository.hardDeletePostsSoftDeletedBefore(any())).thenReturn(0);
+        when(commentRepository.hardDeleteCommentsSoftDeletedBefore(any())).thenReturn(0);
+
+        scheduler.purgeExpiredSoftDeletes();  // no exception
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
@@ -1,0 +1,279 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.FeedPostEditEntry;
+import com.group7.backend.dto.response.FeedPostResponse;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.FeedPost;
+import com.group7.backend.entity.FeedPostEditHistory;
+import com.group7.backend.entity.FeedPostHashtag;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.FeedPostEditHistoryRepository;
+import com.group7.backend.repository.FeedPostRepository;
+import com.group7.backend.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for the edit-history slice of {@link FeedPostService}
+ * (#487). Validates the snapshot-on-update behaviour and the
+ * authorisation surface of {@link FeedPostService#getPostHistory}.
+ */
+@ExtendWith(MockitoExtension.class)
+class FeedPostServiceHistoryTest {
+
+    @Mock private FeedPostRepository feedPostRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private HashtagNormalizer hashtagNormalizer;
+    @Mock private FeedPostMapper feedPostMapper;
+    @Mock private FeedPostEventPublisher feedPostEventPublisher;
+    @Mock private FeedPostEditHistoryRepository historyRepository;
+    @InjectMocks private FeedPostService feedPostService;
+
+    // ── update() snapshot behaviour ───────────────────────────────────────
+
+    @Test
+    void update_bodyChanges_savesSnapshotWithPreviousBodyAndHashtags() {
+        FeedPost post = freshPost(7L, 1L, "Original body");
+        post.getHashtags().add(new FeedPostHashtag(post, "alpha"));
+        post.getHashtags().add(new FeedPostHashtag(post, "beta"));
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.save(post)).thenReturn(post);
+        when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
+
+        feedPostService.update(7L, 1L, "New body", null);
+
+        ArgumentCaptor<FeedPostEditHistory> captor = ArgumentCaptor.forClass(FeedPostEditHistory.class);
+        verify(historyRepository).save(captor.capture());
+        FeedPostEditHistory snap = captor.getValue();
+        assertThat(snap.getPostId()).isEqualTo(7L);
+        assertThat(snap.getEditorId()).isEqualTo(1L);
+        assertThat(snap.getPreviousBody()).isEqualTo("Original body");
+        assertThat(snap.getPreviousHashtags()).containsExactly("alpha", "beta");
+        assertThat(snap.getEditedAt()).isNotNull();
+    }
+
+    @Test
+    void update_hashtagsChange_savesSnapshotWithPreviousHashtags() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        post.getHashtags().add(new FeedPostHashtag(post, "old"));
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(hashtagNormalizer.normalize(List.of("new"))).thenReturn(Set.of("new"));
+        when(feedPostRepository.save(post)).thenReturn(post);
+        when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
+
+        feedPostService.update(7L, 1L, null, List.of("new"));
+
+        ArgumentCaptor<FeedPostEditHistory> captor = ArgumentCaptor.forClass(FeedPostEditHistory.class);
+        verify(historyRepository).save(captor.capture());
+        assertThat(captor.getValue().getPreviousHashtags()).containsExactly("old");
+        assertThat(captor.getValue().getPreviousBody()).isEqualTo("Body");
+    }
+
+    @Test
+    void update_bodyAndHashtagsChange_savesExactlyOneSnapshot() {
+        FeedPost post = freshPost(7L, 1L, "Old");
+        post.getHashtags().add(new FeedPostHashtag(post, "a"));
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(hashtagNormalizer.normalize(List.of("b"))).thenReturn(Set.of("b"));
+        when(feedPostRepository.save(post)).thenReturn(post);
+        when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
+
+        feedPostService.update(7L, 1L, "New", List.of("b"));
+
+        // Exactly one history row even though both fields changed.
+        verify(historyRepository).save(any(FeedPostEditHistory.class));
+    }
+
+    @Test
+    void update_noOpBody_doesNotSaveSnapshot() {
+        // Caller PATCHes with the same body that's already on the post.
+        FeedPost post = freshPost(7L, 1L, "Same body");
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.save(post)).thenReturn(post);
+        when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
+
+        feedPostService.update(7L, 1L, "Same body", null);
+
+        verify(historyRepository, never()).save(any(FeedPostEditHistory.class));
+    }
+
+    @Test
+    void update_noOpHashtags_doesNotSaveSnapshot() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        post.getHashtags().add(new FeedPostHashtag(post, "tag"));
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(hashtagNormalizer.normalize(List.of("tag"))).thenReturn(Set.of("tag"));
+        when(feedPostRepository.save(post)).thenReturn(post);
+        when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
+
+        feedPostService.update(7L, 1L, null, List.of("tag"));
+
+        verify(historyRepository, never()).save(any(FeedPostEditHistory.class));
+    }
+
+    @Test
+    void update_bothFieldsNull_doesNotSaveSnapshot() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.save(post)).thenReturn(post);
+        when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
+
+        feedPostService.update(7L, 1L, null, null);
+
+        verify(historyRepository, never()).save(any(FeedPostEditHistory.class));
+    }
+
+    // ── getPostHistory() authorisation surface ────────────────────────────
+
+    @Test
+    void getPostHistory_throws404_whenPostMissing() {
+        when(feedPostRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> feedPostService.getPostHistory(404L, 1L, 50))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void getPostHistory_authorCanRead_evenWhenPostSoftDeleted() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        post.setDeletedAt(OffsetDateTime.now());
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(historyRepository.findByPostIdOrderByEditedAtDesc(eq(7L), any(Pageable.class)))
+                .thenReturn(List.of(historyRow(7L, 1L, "old", List.of("x"))));
+
+        List<FeedPostEditEntry> result = feedPostService.getPostHistory(7L, 1L, 50);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).previousBody()).isEqualTo("old");
+    }
+
+    @Test
+    void getPostHistory_adminCanReadAnyPost() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        Admin admin = admin(99L);
+        when(userRepository.findById(99L)).thenReturn(Optional.of(admin));
+        when(historyRepository.findByPostIdOrderByEditedAtDesc(eq(7L), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        List<FeedPostEditEntry> result = feedPostService.getPostHistory(7L, 99L, 50);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getPostHistory_throws403_whenNonAuthorNonAdmin() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(mentor(2L)));
+
+        assertThatThrownBy(() -> feedPostService.getPostHistory(7L, 2L, 50))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(historyRepository, never()).findByPostIdOrderByEditedAtDesc(any(), any());
+    }
+
+    @Test
+    void getPostHistory_throws403_whenActorAccountMissing() {
+        // Author check fails (id mismatch), and userRepository can't find
+        // the actor either — defensive path returns 403 rather than 404
+        // (we don't want to leak whether a non-author user exists).
+        FeedPost post = freshPost(7L, 1L, "Body");
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> feedPostService.getPostHistory(7L, 404L, 50))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void getPostHistory_clampsLimitAbove50() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(historyRepository.findByPostIdOrderByEditedAtDesc(eq(7L), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        feedPostService.getPostHistory(7L, 1L, 999);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(historyRepository).findByPostIdOrderByEditedAtDesc(eq(7L), pageableCaptor.capture());
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(50);
+    }
+
+    @Test
+    void getPostHistory_clampsLimitBelow1() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(historyRepository.findByPostIdOrderByEditedAtDesc(eq(7L), any(Pageable.class)))
+                .thenReturn(List.of());
+
+        feedPostService.getPostHistory(7L, 1L, 0);
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(historyRepository).findByPostIdOrderByEditedAtDesc(eq(7L), pageableCaptor.capture());
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(1);
+    }
+
+    // ── Fixtures ──────────────────────────────────────────────────────────
+
+    private static Mentor mentor(Long id) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName("U" + id);
+        return m;
+    }
+
+    private static Admin admin(Long id) {
+        Admin a = new Admin();
+        a.setId(id);
+        a.setFirstName("A" + id);
+        return a;
+    }
+
+    private static FeedPost freshPost(Long id, Long authorId, String body) {
+        FeedPost p = new FeedPost(authorId, body);
+        p.setId(id);
+        OffsetDateTime now = OffsetDateTime.now();
+        p.setCreatedAt(now);
+        p.setUpdatedAt(now);
+        p.setVersion(0L);
+        return p;
+    }
+
+    private static FeedPostEditHistory historyRow(Long postId, Long editorId,
+                                                  String prevBody, List<String> prevTags) {
+        FeedPostEditHistory h = new FeedPostEditHistory();
+        h.setId(1L);
+        h.setPostId(postId);
+        h.setEditorId(editorId);
+        h.setPreviousBody(prevBody);
+        h.setPreviousHashtags(prevTags);
+        h.setEditedAt(OffsetDateTime.now());
+        return h;
+    }
+
+    private static FeedPostResponse stubResponse(Long id, Long authorId) {
+        return new FeedPostResponse(id, authorId, "U" + authorId, "body", List.of(),
+                OffsetDateTime.now(), OffsetDateTime.now(), false, true);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
@@ -11,10 +11,10 @@ import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.FeedPostEditHistoryRepository;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
@@ -47,7 +47,24 @@ class FeedPostServiceHistoryTest {
     @Mock private FeedPostMapper feedPostMapper;
     @Mock private FeedPostEventPublisher feedPostEventPublisher;
     @Mock private FeedPostEditHistoryRepository historyRepository;
-    @InjectMocks private FeedPostService feedPostService;
+
+    private FeedPostService feedPostService;
+
+    @BeforeEach
+    void setUp() {
+        // Manual construction: the service's restoreWindowDays primitive
+        // parameter cannot be auto-wired by Mockito. 30 matches the
+        // production default; restore-specific tests live in
+        // FeedPostServiceRestoreTest.
+        feedPostService = new FeedPostService(
+                feedPostRepository,
+                userRepository,
+                hashtagNormalizer,
+                feedPostMapper,
+                feedPostEventPublisher,
+                historyRepository,
+                30);
+    }
 
     // ── update() snapshot behaviour ───────────────────────────────────────
 

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
@@ -43,6 +43,7 @@ class FeedPostServiceHistoryTest {
 
     @Mock private FeedPostRepository feedPostRepository;
     @Mock private UserRepository userRepository;
+    @Mock private com.group7.backend.repository.AttachmentRepository attachmentRepository;
     @Mock private HashtagNormalizer hashtagNormalizer;
     @Mock private FeedPostMapper feedPostMapper;
     @Mock private FeedPostEventPublisher feedPostEventPublisher;
@@ -59,6 +60,7 @@ class FeedPostServiceHistoryTest {
         feedPostService = new FeedPostService(
                 feedPostRepository,
                 userRepository,
+                attachmentRepository,
                 hashtagNormalizer,
                 feedPostMapper,
                 feedPostEventPublisher,
@@ -77,7 +79,7 @@ class FeedPostServiceHistoryTest {
         when(feedPostRepository.save(post)).thenReturn(post);
         when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
 
-        feedPostService.update(7L, 1L, "New body", null);
+        feedPostService.update(7L, 1L, "New body", null, null);
 
         ArgumentCaptor<FeedPostEditHistory> captor = ArgumentCaptor.forClass(FeedPostEditHistory.class);
         verify(historyRepository).save(captor.capture());
@@ -98,7 +100,7 @@ class FeedPostServiceHistoryTest {
         when(feedPostRepository.save(post)).thenReturn(post);
         when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
 
-        feedPostService.update(7L, 1L, null, List.of("new"));
+        feedPostService.update(7L, 1L, null, List.of("new"), null);
 
         ArgumentCaptor<FeedPostEditHistory> captor = ArgumentCaptor.forClass(FeedPostEditHistory.class);
         verify(historyRepository).save(captor.capture());
@@ -115,7 +117,7 @@ class FeedPostServiceHistoryTest {
         when(feedPostRepository.save(post)).thenReturn(post);
         when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
 
-        feedPostService.update(7L, 1L, "New", List.of("b"));
+        feedPostService.update(7L, 1L, "New", List.of("b"), null);
 
         // Exactly one history row even though both fields changed.
         verify(historyRepository).save(any(FeedPostEditHistory.class));
@@ -129,7 +131,7 @@ class FeedPostServiceHistoryTest {
         when(feedPostRepository.save(post)).thenReturn(post);
         when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
 
-        feedPostService.update(7L, 1L, "Same body", null);
+        feedPostService.update(7L, 1L, "Same body", null, null);
 
         verify(historyRepository, never()).save(any(FeedPostEditHistory.class));
     }
@@ -143,7 +145,7 @@ class FeedPostServiceHistoryTest {
         when(feedPostRepository.save(post)).thenReturn(post);
         when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
 
-        feedPostService.update(7L, 1L, null, List.of("tag"));
+        feedPostService.update(7L, 1L, null, List.of("tag"), null);
 
         verify(historyRepository, never()).save(any(FeedPostEditHistory.class));
     }
@@ -155,7 +157,7 @@ class FeedPostServiceHistoryTest {
         when(feedPostRepository.save(post)).thenReturn(post);
         when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
 
-        feedPostService.update(7L, 1L, null, null);
+        feedPostService.update(7L, 1L, null, null, null);
 
         verify(historyRepository, never()).save(any(FeedPostEditHistory.class));
     }
@@ -291,6 +293,6 @@ class FeedPostServiceHistoryTest {
 
     private static FeedPostResponse stubResponse(Long id, Long authorId) {
         return new FeedPostResponse(id, authorId, "U" + authorId, "body", List.of(),
-                OffsetDateTime.now(), OffsetDateTime.now(), false, true);
+                OffsetDateTime.now(), OffsetDateTime.now(), false, true, List.of());
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
@@ -40,6 +40,7 @@ class FeedPostServiceRestoreTest {
 
     @Mock private FeedPostRepository feedPostRepository;
     @Mock private UserRepository userRepository;
+    @Mock private com.group7.backend.repository.AttachmentRepository attachmentRepository;
     @Mock private HashtagNormalizer hashtagNormalizer;
     @Mock private FeedPostMapper feedPostMapper;
     @Mock private FeedPostEventPublisher feedPostEventPublisher;
@@ -52,6 +53,7 @@ class FeedPostServiceRestoreTest {
         service = new FeedPostService(
                 feedPostRepository,
                 userRepository,
+                attachmentRepository,
                 hashtagNormalizer,
                 feedPostMapper,
                 feedPostEventPublisher,
@@ -145,7 +147,7 @@ class FeedPostServiceRestoreTest {
     void restoreWindowDaysClampedTo1_whenConfigured0() {
         // Reconstruct with a misconfigured 0; the constructor clamps to 1.
         FeedPostService clampedService = new FeedPostService(
-                feedPostRepository, userRepository, hashtagNormalizer,
+                feedPostRepository, userRepository, attachmentRepository, hashtagNormalizer,
                 feedPostMapper, feedPostEventPublisher, historyRepository, 0);
 
         FeedPost post = freshPost(7L, 1L, "Body");
@@ -171,6 +173,6 @@ class FeedPostServiceRestoreTest {
 
     private static FeedPostResponse stubResponse(Long id, Long authorId) {
         return new FeedPostResponse(id, authorId, "U" + authorId, "body", List.of(),
-                OffsetDateTime.now(), OffsetDateTime.now(), false, true);
+                OffsetDateTime.now(), OffsetDateTime.now(), false, true, List.of());
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
@@ -1,0 +1,185 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.FeedPostResponse;
+import com.group7.backend.entity.FeedPost;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.FeedPostExpiredRestoreException;
+import com.group7.backend.exception.FeedPostNotDeletedException;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.FeedPostEditHistoryRepository;
+import com.group7.backend.repository.FeedPostRepository;
+import com.group7.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for the soft-delete restore slice of {@link FeedPostService}
+ * (#487). The service is constructed manually so the
+ * {@code restoreWindowDays} primitive can be set deterministically;
+ * {@code @InjectMocks} would default it to {@code 0} (then clamped to
+ * {@code 1}), which is too short for normal restore-success scenarios.
+ */
+@ExtendWith(MockitoExtension.class)
+class FeedPostServiceRestoreTest {
+
+    private static final int RESTORE_WINDOW_DAYS = 30;
+
+    @Mock private FeedPostRepository feedPostRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private HashtagNormalizer hashtagNormalizer;
+    @Mock private FeedPostMapper feedPostMapper;
+    @Mock private FeedPostEventPublisher feedPostEventPublisher;
+    @Mock private FeedPostEditHistoryRepository historyRepository;
+
+    private FeedPostService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FeedPostService(
+                feedPostRepository,
+                userRepository,
+                hashtagNormalizer,
+                feedPostMapper,
+                feedPostEventPublisher,
+                historyRepository,
+                RESTORE_WINDOW_DAYS);
+    }
+
+    @Test
+    void restorePost_clearsDeletedAt_andBumpsUpdatedAt_whenAuthorWithinWindow() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        OffsetDateTime softDeletedAt = OffsetDateTime.now().minusDays(5);
+        post.setDeletedAt(softDeletedAt);
+        OffsetDateTime origUpdated = post.getUpdatedAt();
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.save(post)).thenReturn(post);
+        when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
+
+        FeedPostResponse response = service.restorePost(7L, 1L);
+
+        assertThat(response).isNotNull();
+        assertThat(post.getDeletedAt()).isNull();
+        assertThat(post.getUpdatedAt()).isAfterOrEqualTo(origUpdated);
+        verify(feedPostRepository).save(post);
+    }
+
+    @Test
+    void restorePost_throws404_whenPostMissing() {
+        when(feedPostRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.restorePost(404L, 1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(feedPostRepository, never()).save(any(FeedPost.class));
+    }
+
+    @Test
+    void restorePost_throws403_whenActorIsNotAuthor() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        post.setDeletedAt(OffsetDateTime.now().minusDays(1));
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+
+        assertThatThrownBy(() -> service.restorePost(7L, 999L))
+                .isInstanceOf(AccessDeniedException.class);
+
+        // Author check fires before deletedAt inspection — non-author
+        // cannot use the restore path to probe a post's deletion state.
+        verify(feedPostRepository, never()).save(any(FeedPost.class));
+    }
+
+    @Test
+    void restorePost_throws409_whenPostIsLive() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        // deletedAt is null — post is currently visible.
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+
+        assertThatThrownBy(() -> service.restorePost(7L, 1L))
+                .isInstanceOf(FeedPostNotDeletedException.class);
+
+        verify(feedPostRepository, never()).save(any(FeedPost.class));
+    }
+
+    @Test
+    void restorePost_throws410_whenWindowHasExpired() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        // Soft-deleted 31 days ago, window is 30 days.
+        post.setDeletedAt(OffsetDateTime.now().minusDays(31));
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+
+        assertThatThrownBy(() -> service.restorePost(7L, 1L))
+                .isInstanceOf(FeedPostExpiredRestoreException.class)
+                .hasMessageContaining("30 days");
+
+        verify(feedPostRepository, never()).save(any(FeedPost.class));
+    }
+
+    @Test
+    void restorePost_succeedsAtExactWindowBoundary_minusOneSecond() {
+        FeedPost post = freshPost(7L, 1L, "Body");
+        // 30 days minus one second ago — still within the window.
+        post.setDeletedAt(OffsetDateTime.now().minusDays(30).plusSeconds(1));
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.save(post)).thenReturn(post);
+        when(feedPostMapper.toResponse(post, 1L)).thenReturn(stubResponse(7L, 1L));
+
+        service.restorePost(7L, 1L);
+
+        assertThat(post.getDeletedAt()).isNull();
+    }
+
+    @Test
+    void restoreWindowDaysClampedTo1_whenConfigured0() {
+        // Reconstruct with a misconfigured 0; the constructor clamps to 1.
+        FeedPostService clampedService = new FeedPostService(
+                feedPostRepository, userRepository, hashtagNormalizer,
+                feedPostMapper, feedPostEventPublisher, historyRepository, 0);
+
+        FeedPost post = freshPost(7L, 1L, "Body");
+        // Soft-deleted 2 days ago — past the clamped 1-day window.
+        post.setDeletedAt(OffsetDateTime.now().minusDays(2));
+        when(feedPostRepository.findById(7L)).thenReturn(Optional.of(post));
+
+        assertThatThrownBy(() -> clampedService.restorePost(7L, 1L))
+                .isInstanceOf(FeedPostExpiredRestoreException.class);
+    }
+
+    // ── Fixtures ───────────────────────────────────────────────────────────
+
+    private static FeedPost freshPost(Long id, Long authorId, String body) {
+        FeedPost p = new FeedPost(authorId, body);
+        p.setId(id);
+        OffsetDateTime now = OffsetDateTime.now();
+        p.setCreatedAt(now);
+        p.setUpdatedAt(now);
+        p.setVersion(0L);
+        return p;
+    }
+
+    private static FeedPostResponse stubResponse(Long id, Long authorId) {
+        return new FeedPostResponse(id, authorId, "U" + authorId, "body", List.of(),
+                OffsetDateTime.now(), OffsetDateTime.now(), false, true);
+    }
+
+    @SuppressWarnings("unused")
+    private static Mentor mentor(Long id) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName("U" + id);
+        return m;
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
@@ -2,7 +2,6 @@ package com.group7.backend.service;
 
 import com.group7.backend.dto.response.FeedPostResponse;
 import com.group7.backend.entity.FeedPost;
-import com.group7.backend.entity.Mentor;
 import com.group7.backend.exception.FeedPostExpiredRestoreException;
 import com.group7.backend.exception.FeedPostNotDeletedException;
 import com.group7.backend.exception.ResourceNotFoundException;
@@ -173,13 +172,5 @@ class FeedPostServiceRestoreTest {
     private static FeedPostResponse stubResponse(Long id, Long authorId) {
         return new FeedPostResponse(id, authorId, "U" + authorId, "body", List.of(),
                 OffsetDateTime.now(), OffsetDateTime.now(), false, true);
-    }
-
-    @SuppressWarnings("unused")
-    private static Mentor mentor(Long id) {
-        Mentor m = new Mentor();
-        m.setId(id);
-        m.setFirstName("U" + id);
-        return m;
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
@@ -57,6 +57,7 @@ class FeedPostServiceTest {
         feedPostService = new FeedPostService(
                 feedPostRepository,
                 userRepository,
+                attachmentRepository,
                 hashtagNormalizer,
                 feedPostMapper,
                 feedPostEventPublisher,

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
@@ -7,6 +7,7 @@ import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.AttachmentRepository;
+import com.group7.backend.repository.FeedPostEditHistoryRepository;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ class FeedPostServiceTest {
     @Mock private HashtagNormalizer hashtagNormalizer;
     @Mock private FeedPostMapper feedPostMapper;
     @Mock private FeedPostEventPublisher feedPostEventPublisher;
+    @Mock private FeedPostEditHistoryRepository historyRepository;
     @InjectMocks private FeedPostService feedPostService;
 
     // ── create ─────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
@@ -10,9 +10,9 @@ import com.group7.backend.repository.AttachmentRepository;
 import com.group7.backend.repository.FeedPostEditHistoryRepository;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
@@ -44,7 +44,25 @@ class FeedPostServiceTest {
     @Mock private FeedPostMapper feedPostMapper;
     @Mock private FeedPostEventPublisher feedPostEventPublisher;
     @Mock private FeedPostEditHistoryRepository historyRepository;
-    @InjectMocks private FeedPostService feedPostService;
+
+    private FeedPostService feedPostService;
+
+    @BeforeEach
+    void setUp() {
+        // Manual construction (not @InjectMocks): the service's
+        // restoreWindowDays primitive parameter cannot be auto-wired
+        // by Mockito. Pass 30 — matches the production default and
+        // is irrelevant to the create/getById/update/delete tests
+        // covered here (restore behaviour lives in FeedPostServiceRestoreTest).
+        feedPostService = new FeedPostService(
+                feedPostRepository,
+                userRepository,
+                hashtagNormalizer,
+                feedPostMapper,
+                feedPostEventPublisher,
+                historyRepository,
+                30);
+    }
 
     // ── create ─────────────────────────────────────────────────────────────
 

--- a/backend/src/test/java/com/group7/backend/service/FeedTrendingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedTrendingServiceTest.java
@@ -1,0 +1,97 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.FeedTrendingHashtag;
+import com.group7.backend.repository.FeedTrendingRepository;
+import com.group7.backend.repository.projection.TrendingHashtagTuple;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for {@link FeedTrendingService} (#487). Validates the
+ * limit clamp on both ends and the score-formula arithmetic.
+ */
+@ExtendWith(MockitoExtension.class)
+class FeedTrendingServiceTest {
+
+    @Mock private FeedTrendingRepository trendingRepository;
+    @InjectMocks private FeedTrendingService service;
+
+    @Test
+    void listTrendingHashtags_clampsLimitAbove50() {
+        when(trendingRepository.findTopTrending(50)).thenReturn(List.of());
+
+        service.listTrendingHashtags(999);
+
+        ArgumentCaptor<Integer> limit = ArgumentCaptor.forClass(Integer.class);
+        verify(trendingRepository).findTopTrending(limit.capture());
+        assertThat(limit.getValue()).isEqualTo(50);
+    }
+
+    @Test
+    void listTrendingHashtags_clampsLimitBelow1() {
+        when(trendingRepository.findTopTrending(1)).thenReturn(List.of());
+
+        service.listTrendingHashtags(0);
+
+        ArgumentCaptor<Integer> limit = ArgumentCaptor.forClass(Integer.class);
+        verify(trendingRepository).findTopTrending(limit.capture());
+        assertThat(limit.getValue()).isEqualTo(1);
+    }
+
+    @Test
+    void listTrendingHashtags_clampsNegativeLimitTo1() {
+        when(trendingRepository.findTopTrending(1)).thenReturn(List.of());
+
+        service.listTrendingHashtags(-50);
+
+        ArgumentCaptor<Integer> limit = ArgumentCaptor.forClass(Integer.class);
+        verify(trendingRepository).findTopTrending(limit.capture());
+        assertThat(limit.getValue()).isEqualTo(1);
+    }
+
+    @Test
+    void listTrendingHashtags_passesLimitThroughWhenInRange() {
+        when(trendingRepository.findTopTrending(15)).thenReturn(List.of());
+
+        service.listTrendingHashtags(15);
+
+        verify(trendingRepository).findTopTrending(15);
+    }
+
+    @Test
+    void listTrendingHashtags_computesScoreFromTupleSignals() {
+        OffsetDateTime now = OffsetDateTime.now();
+        TrendingHashtagTuple tuple = new TrendingHashtagTuple("java", 5L, 10L, 3L, now);
+        when(trendingRepository.findTopTrending(20)).thenReturn(List.of(tuple));
+
+        List<FeedTrendingHashtag> result = service.listTrendingHashtags(20);
+
+        // Score = postCount + 2*uniqueLikers + 3*commentCount
+        //       = 5 + 20 + 9 = 34.0
+        assertThat(result).hasSize(1);
+        FeedTrendingHashtag dto = result.get(0);
+        assertThat(dto.tag()).isEqualTo("java");
+        assertThat(dto.postCount()).isEqualTo(5L);
+        assertThat(dto.uniqueLikers()).isEqualTo(10L);
+        assertThat(dto.commentCount()).isEqualTo(3L);
+        assertThat(dto.latestPostAt()).isEqualTo(now);
+        assertThat(dto.score()).isEqualTo(34.0);
+    }
+
+    @Test
+    void refreshTrendingView_delegatesToRepository() {
+        service.refreshTrendingView();
+        verify(trendingRepository).refreshConcurrently();
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -117,3 +117,8 @@ app.recommendations.feed.bandit.exploration-rate=0.10
 # FeedSoftDeleteCleanupIntegrationTest flips this on via @TestPropertySource
 # and invokes the scheduler method directly.
 app.feed.cleanup.enabled=false
+
+# Feed trending refresh scheduler (#487) — same gating pattern. The
+# dedicated FeedTrendingIntegrationTest opts in via @TestPropertySource
+# and triggers refresh() directly.
+app.feed.trending.enabled=false

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -110,3 +110,10 @@ app.recommendations.feed.diversity-floor.enabled=true
 app.recommendations.feed.diversity-floor.top-hashtags-count=3
 app.recommendations.feed.bandit.enabled=false
 app.recommendations.feed.bandit.exploration-rate=0.10
+
+# Feed soft-delete cleanup scheduler is OFF by default in tests so
+# @SpringBootTest contexts don't spin up the bean and risk a stray cron
+# firing during a test run. The dedicated
+# FeedSoftDeleteCleanupIntegrationTest flips this on via @TestPropertySource
+# and invokes the scheduler method directly.
+app.feed.cleanup.enabled=false


### PR DESCRIPTION
Closes #487.

## Summary

Wires a real lifecycle around the existing `feed_posts.deleted_at` /
`feed_post_comments.deleted_at` tombstones:

- **Edit history** — every meaningful PATCH (body or hashtag-set
  change) snapshots the prior state into a new `feed_post_edit_history`
  row inside the same transaction. Visible to the post author and to
  any admin via `GET /api/feed/posts/{id}/history`. JSONB column for
  `previous_hashtags` (first JSONB use in this codebase, via Hibernate
  6 native `@JdbcTypeCode(SqlTypes.JSON)`).
- **Restore** — `POST /api/feed/posts/{id}/restore` for the post
  author; precise status surface 200/403/404/409/410. The 30-day
  restore window comes from `app.feed.cleanup.restore-window-days`
  and matches the cleanup scheduler's cutoff exactly, so a post
  becomes ineligible for restore (410) at the same instant it
  becomes eligible for hard-delete.
- **Cleanup** — `FeedSoftDeleteCleanupScheduler` runs at 03:45 UTC
  daily and hard-deletes posts and comments soft-deleted longer than
  the window. Backed by two new partial indexes
  (`idx_feed_*_deleted_at_pending_cleanup`); FK `ON DELETE CASCADE`
  reaps likes / bookmarks / shares / comments / hashtags / edit-history
  in one statement. Off by default in the test profile.
- **Trending** — `GET /api/feed/trending/hashtags` backed by an
  hourly-refreshed materialized view (`feed_trending_24h`) over a
  sliding 24h window. Score = `postCount + 2*uniqueLikers + 3*commentCount`,
  duplicated in the V45 expression index so reads are an index scan.
  `REFRESH CONCURRENTLY` never blocks readers.
- **Rate-limit + validation polish** — USER-keyed buckets on the three
  new endpoints; `@Validated` plus a new `ConstraintViolationException`
  handler so `@Min/@Max` on `@RequestParam` returns 400 instead of 500.

## Migration coordination

Slots reserved per the planning doc:
`V40 (#484), V41 (#485), V42 (#486)` left as **gaps** for sibling PRs
to take. This PR claims `V43 → V45`. If a sibling PR for V40-V42 lands
after this one, Flyway with `out-of-order=false` will reject —
coordinate merge order or the renumber is mechanical (`git mv`).

## Test plan

- [x] 50 new unit tests across `FeedPostServiceTest`,
      `FeedPostServiceHistoryTest`, `FeedPostServiceRestoreTest`,
      `FeedSoftDeleteCleanupSchedulerTest`, `FeedTrendingServiceTest`.
- [x] 39 new integration tests (`@SpringBootTest` against real
      Postgres) covering snapshot capture, ACL matrix, JSONB
      round-trip, expired-window 410, scheduler purge + cascade,
      partial-index existence, materialized-view refresh + ranking
      + filter + concurrent-refresh sanity.
- [x] `mvn --batch-mode verify` green locally against the same
      Postgres 16 sidecar shape the CI workflow uses
      (1735 tests, 0 failures, 0 errors).
- [x] Manual smoke test against a running backend on isolated
      Postgres: full restore round-trip, edit-history JSONB
      round-trip end-to-end, ACL matrix (non-author 403, anon 403),
      expired-window 410 via psql back-date, trending refresh +
      rank + clamp, EXPLAIN confirms partial index used on a 1000-row
      seed.
- [ ] CI green on this PR.

## Open questions for review

These were intentionally left out of scope; flag in review if the
team wants any of them in this PR:

1. **Should admins be able to restore?** Today: author-only
   (matches the issue draft). Argument for admin-restore: moderation
   use case where an author was banned but the post is legitimate.
2. **Edit-history visibility on a soft-deleted post?** Today: author
   + admin can read. Argument for hiding from author once deleted:
   aligns with "deleted means gone" UX.
3. **Restore endpoint idempotency policy?** Today: 200 first call,
   409 second call. Argument for 200-on-second-call: simpler client
   code. Counter: 409 surfaces a real state-conflict signal.
4. **PATCH rate-limit (anti-edit-spam)?** Out of scope here —
   today there is no PATCH limit on `/api/feed/posts/{id}`. Worth a
   follow-up issue if abuse appears in production.