### PR TITLE
feat(backend): search filters (date range, language) and viewer keyword-mute (#486)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedPostController.java
@@ -97,7 +97,7 @@ public class FeedPostController {
             Authentication authentication) {
         Long authorId = (Long) authentication.getCredentials();
         FeedPostResponse body = feedPostService.create(
-                authorId, request.body(), request.hashtags(), request.attachmentIds());
+                authorId, request.body(), request.hashtags(), request.attachmentIds(), request.lang());
         return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 

--- a/backend/src/main/java/com/group7/backend/controller/FeedReadController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedReadController.java
@@ -11,15 +11,20 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Pattern;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.OffsetDateTime;
 
 /**
  * Read surface for the social feed (#350). Three sibling endpoints
@@ -42,6 +47,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/feed")
+@Validated
 @Tag(name = "Feed Read",
         description = "For-You, Following, and search read surfaces over the social feed (#350).")
 public class FeedReadController {
@@ -111,26 +117,28 @@ public class FeedReadController {
     public ResponseEntity<Page<FeedPostListItem>> postsByAuthor(
             @Parameter(description = "Author user id") @PathVariable Long authorId,
             @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "Page size; clamped to [1, 100]") @RequestParam(defaultValue = "20") int size) {
+            @Parameter(description = "Page size; clamped to [1, 100]") @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long viewerId = (Long) authentication.getCredentials();
         Pageable pageable = PageableSupport.clampPageable(page, size);
-        return ResponseEntity.ok(feedReadService.postsByAuthor(authorId, pageable));
+        return ResponseEntity.ok(feedReadService.postsByAuthor(authorId, viewerId, pageable));
     }
 
     @GetMapping("/search")
-    @Operation(summary = "Search feed posts by keyword and / or hashtag",
-            description = "At least one of `q` or `hashtag` is required — both null returns "
-                    + "400. Use `/api/feed/for-you` or `/api/feed/following` for the full "
-                    + "feed without a filter. Keyword uses pg_trgm-accelerated LIKE on the "
-                    + "body and is escaped at the service boundary so `%` and `_` cannot act "
-                    + "as wildcards. Hashtag matches the normalised tag value (lowercased, "
-                    + "leading-# stripped); a hashtag that fails normalisation returns an "
-                    + "empty page rather than 400. Combined queries AND the two predicates.")
+    @Operation(summary = "Search feed posts by keyword, hashtag, date range, and / or language",
+            description = "At least one of `q`, `hashtag`, `since`, `until`, or `lang` is required — "
+                    + "all null returns 400. Date range is half-open: `since` inclusive, `until` exclusive. "
+                    + "Keyword uses pg_trgm-accelerated LIKE on the body and is escaped at the service "
+                    + "boundary so `%` and `_` cannot act as wildcards. Hashtag matches the normalised "
+                    + "tag value; a hashtag that fails normalisation returns an empty page. Filters are "
+                    + "ANDed. Viewer keyword-mutes are applied after the SQL fetch, so the visible page "
+                    + "may surface fewer than `size` items.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Paged matching posts",
                     content = @Content(examples = @ExampleObject(
                             name = "default",
                             value = FeedApiExamples.SEARCH_RESPONSE))),
-            @ApiResponse(responseCode = "400", description = "Both `q` and `hashtag` missing", content = @Content),
+            @ApiResponse(responseCode = "400", description = "All filters missing, since≥until, or out-of-window dates", content = @Content),
             @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content)
     })
     public ResponseEntity<Page<FeedPostListItem>> search(
@@ -138,9 +146,22 @@ public class FeedReadController {
             @RequestParam(name = "q", required = false) String keyword,
             @Parameter(description = "Single hashtag, with or without leading '#'")
             @RequestParam(name = "hashtag", required = false) String hashtag,
+            @Parameter(description = "Inclusive lower bound on `created_at` (ISO 8601)")
+            @RequestParam(name = "since", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime since,
+            @Parameter(description = "Exclusive upper bound on `created_at` (ISO 8601)")
+            @RequestParam(name = "until", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime until,
+            @Parameter(description = "BCP-47 short language tag (e.g. en, tr-TR)")
+            @RequestParam(name = "lang", required = false)
+            @Pattern(regexp = "^[a-z]{2,3}(-[A-Z]{2})?$", message = "lang must be a BCP-47 short tag like 'en' or 'tr-TR'")
+            String lang,
             @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "Page size; clamped to [1, 100]") @RequestParam(defaultValue = "20") int size) {
+            @Parameter(description = "Page size; clamped to [1, 100]") @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long viewerId = (Long) authentication.getCredentials();
         Pageable pageable = PageableSupport.clampPageable(page, size);
-        return ResponseEntity.ok(feedReadService.search(keyword, hashtag, pageable));
+        return ResponseEntity.ok(feedReadService.search(
+                keyword, hashtag, since, until, lang, viewerId, pageable));
     }
 }

--- a/backend/src/main/java/com/group7/backend/controller/KeywordMuteController.java
+++ b/backend/src/main/java/com/group7/backend/controller/KeywordMuteController.java
@@ -1,0 +1,79 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.dto.request.KeywordMuteRequest;
+import com.group7.backend.dto.response.KeywordMuteResponse;
+import com.group7.backend.service.UserKeywordMuteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * Per-user keyword-mute resource. Authenticated user manages their own
+ * mutes via this endpoint; the mutes are applied transparently by every
+ * feed read path (for-you / following / per-author timeline / search).
+ */
+@RestController
+@RequestMapping("/api/users/me/keyword-mutes")
+@Tag(name = "Feed Keyword Mutes",
+        description = "Per-user mutes that hide posts whose body contains the muted substring.")
+public class KeywordMuteController {
+
+    private final UserKeywordMuteService service;
+
+    public KeywordMuteController(UserKeywordMuteService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    @Operation(summary = "List the authenticated user's muted keywords")
+    public ResponseEntity<List<KeywordMuteResponse>> list(Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(service.list(userId));
+    }
+
+    @PostMapping
+    @Operation(summary = "Add a keyword mute")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Created"),
+            @ApiResponse(responseCode = "400", description = "Blank, oversize, illegal characters, or cap reached", content = @Content),
+            @ApiResponse(responseCode = "409", description = "Keyword already muted", content = @Content)
+    })
+    public ResponseEntity<KeywordMuteResponse> add(
+            @Valid @RequestBody KeywordMuteRequest request,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        KeywordMuteResponse saved = service.add(userId, request.keyword());
+        URI location = URI.create("/api/users/me/keyword-mutes/" + saved.id());
+        return ResponseEntity.created(location).body(saved);
+    }
+
+    @DeleteMapping("/{id:\\d+}")
+    @Operation(summary = "Remove a keyword mute by id")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Deleted"),
+            @ApiResponse(responseCode = "404", description = "Mute id does not exist for this user", content = @Content)
+    })
+    public ResponseEntity<Void> remove(
+            @Parameter(description = "Mute id") @PathVariable Long id,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        service.delete(userId, id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/request/CreateFeedPostRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/CreateFeedPostRequest.java
@@ -4,6 +4,7 @@ import com.group7.backend.dto.feed.FeedPostLimits;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
@@ -38,6 +39,11 @@ public record CreateFeedPostRequest(
                 + "creates a text-only post.",
                 example = "[\"5b9c1f0a-2c2c-4cf2-8f1d-9d4f1a0e6b5e\"]")
         @Size(max = 4, message = "A post can carry at most 4 attachments")
-        List<@NotNull UUID> attachmentIds
+        List<@NotNull UUID> attachmentIds,
+
+        @Schema(description = "Optional BCP-47 language tag (e.g. \"en\", \"tr-TR\"). Used by the search endpoint's lang filter.",
+                example = "en", nullable = true)
+        @Pattern(regexp = "^[a-z]{2,3}(-[A-Z]{2})?$", message = "lang must be a BCP-47 short tag like 'en' or 'tr-TR'")
+        String lang
 ) {
 }

--- a/backend/src/main/java/com/group7/backend/dto/request/KeywordMuteRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/KeywordMuteRequest.java
@@ -1,0 +1,19 @@
+package com.group7.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request body for {@code POST /api/users/me/keyword-mutes}. The service
+ * normalises (trim, lowercase) and rejects keywords with characters
+ * outside {@code [a-z0-9 -]} after normalisation.
+ */
+@Schema(description = "A single keyword to mute. Server lowercases and rejects bad characters.")
+public record KeywordMuteRequest(
+        @Schema(description = "Keyword to mute (1–120 chars).", example = "crypto")
+        @NotBlank
+        @Size(max = 120)
+        String keyword
+) {
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/KeywordMuteResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/KeywordMuteResponse.java
@@ -1,0 +1,22 @@
+package com.group7.backend.dto.response;
+
+import com.group7.backend.entity.UserKeywordMute;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+@Schema(description = "A single muted keyword for the authenticated user.")
+public record KeywordMuteResponse(
+        @Schema(description = "Surrogate id used in the DELETE endpoint path.", example = "17")
+        Long id,
+
+        @Schema(description = "The normalised (lowercase) keyword.", example = "crypto")
+        String keyword,
+
+        @Schema(description = "Server-side creation timestamp.")
+        OffsetDateTime createdAt
+) {
+    public static KeywordMuteResponse from(UserKeywordMute mute) {
+        return new KeywordMuteResponse(mute.getId(), mute.getKeyword(), mute.getCreatedAt());
+    }
+}

--- a/backend/src/main/java/com/group7/backend/entity/FeedPost.java
+++ b/backend/src/main/java/com/group7/backend/entity/FeedPost.java
@@ -130,6 +130,15 @@ public class FeedPost {
     private OffsetDateTime deletedAt;
 
     /**
+     * Optional BCP-47 language tag set by the author at create time.
+     * NULL for posts created before the column existed and for posts
+     * that don't declare a language. The search endpoint matches on
+     * exact equality, so NULL never matches a `lang=tr` query.
+     */
+    @Column(length = 15)
+    private String lang;
+
+    /**
      * Optimistic-lock version. Hibernate auto-bumps on any persist that
      * touches this entity, including changes to the owning-side
      * {@link #hashtags} collection. Concurrent PATCHes / PATCH-vs-DELETE

--- a/backend/src/main/java/com/group7/backend/entity/UserKeywordMute.java
+++ b/backend/src/main/java/com/group7/backend/entity/UserKeywordMute.java
@@ -1,0 +1,61 @@
+package com.group7.backend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * A single keyword the user has muted. Posts whose body contains any
+ * of the user's muted keywords (case-insensitive substring match) are
+ * dropped from every feed read path before DTO mapping.
+ *
+ * <p>The surrogate {@code id} PK lets the DELETE endpoint accept an
+ * integer path variable, avoiding URL-encoding fragility on keywords
+ * with spaces or special characters. A {@code UNIQUE (user_id, keyword)}
+ * constraint preserves the no-duplicates guarantee that a composite PK
+ * would have given.
+ */
+@Entity
+@Table(name = "user_keyword_mutes",
+        uniqueConstraints = @UniqueConstraint(name = "uq_user_keyword_mutes_user_keyword", columnNames = {"user_id", "keyword"}))
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserKeywordMute {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 120)
+    private String keyword;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    public UserKeywordMute(Long userId, String keyword) {
+        this.userId = userId;
+        this.keyword = keyword;
+    }
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/group7/backend/exception/GlobalExceptionHandler.java
@@ -235,13 +235,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
 
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex,
-                                                                   HttpServletRequest request) {
-        log.warn("Access denied: method={}, path={}, message={}", request.getMethod(), request.getRequestURI(), ex.getMessage());
-        return buildErrorResponse(HttpStatus.FORBIDDEN, "Forbidden", "Access denied");
-    }
-
     /**
      * Handles {@code @Min}/{@code @Max}/{@code @Pattern} (and similar)
      * violations on controller method parameters guarded by
@@ -250,13 +243,36 @@ public class GlobalExceptionHandler {
      * {@link #handleValidationErrors} covers {@code @Valid} on
      * {@code @RequestBody}; this handler covers the corresponding
      * shape for {@code @RequestParam} / {@code @PathVariable}.
+     *
+     * <p>Returns the same per-field
+     * {@code {"error": "Validation Failed", "messages": {field: msg, ...}}}
+     * shape as {@link #handleValidationErrors} so the frontend has one
+     * code path for both bind-time and parameter-level validation.
      */
     @ExceptionHandler(jakarta.validation.ConstraintViolationException.class)
-    public ResponseEntity<Map<String, String>> handleConstraintViolation(
-            jakarta.validation.ConstraintViolationException ex, HttpServletRequest request) {
-        log.warn("Constraint violation: method={}, path={}, message={}",
-                request.getMethod(), request.getRequestURI(), ex.getMessage());
-        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage());
+    public ResponseEntity<Map<String, Object>> handleConstraintViolations(
+            jakarta.validation.ConstraintViolationException ex,
+            HttpServletRequest request) {
+        Map<String, String> fieldErrors = new HashMap<>();
+        ex.getConstraintViolations().forEach(v -> {
+            // propertyPath looks like "search.lang" — keep the last segment so
+            // the client sees the param name without the controller method.
+            String path = v.getPropertyPath().toString();
+            int dot = path.lastIndexOf('.');
+            String field = dot >= 0 ? path.substring(dot + 1) : path;
+            fieldErrors.put(field, v.getMessage());
+        });
+        log.warn("Constraint violation: method={}, path={}, fieldErrorCount={}",
+                request.getMethod(), request.getRequestURI(), fieldErrors.size());
+        Map<String, Object> body = Map.of("error", "Validation Failed", "messages", fieldErrors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex,
+                                                                   HttpServletRequest request) {
+        log.warn("Access denied: method={}, path={}, message={}", request.getMethod(), request.getRequestURI(), ex.getMessage());
+        return buildErrorResponse(HttpStatus.FORBIDDEN, "Forbidden", "Access denied");
     }
 
     /**

--- a/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
@@ -144,6 +144,9 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
             WHERE p.deleted_at IS NULL
               AND (:keyword IS NULL OR LOWER(p.body) LIKE '%' || :keyword || '%' ESCAPE '\\')
               AND (:hashtag IS NULL OR h.tag = :hashtag)
+              AND (CAST(:since AS timestamptz) IS NULL OR p.created_at >= CAST(:since AS timestamptz))
+              AND (CAST(:until AS timestamptz) IS NULL OR p.created_at <  CAST(:until AS timestamptz))
+              AND (:lang IS NULL OR p.lang = :lang)
             ORDER BY p.created_at DESC, p.id DESC
             """,
             countQuery = """
@@ -152,10 +155,16 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
             WHERE p.deleted_at IS NULL
               AND (:keyword IS NULL OR LOWER(p.body) LIKE '%' || :keyword || '%' ESCAPE '\\')
               AND (:hashtag IS NULL OR h.tag = :hashtag)
+              AND (CAST(:since AS timestamptz) IS NULL OR p.created_at >= CAST(:since AS timestamptz))
+              AND (CAST(:until AS timestamptz) IS NULL OR p.created_at <  CAST(:until AS timestamptz))
+              AND (:lang IS NULL OR p.lang = :lang)
             """,
             nativeQuery = true)
     Page<FeedPost> searchPosts(@Param("keyword") String keyword,
                                 @Param("hashtag") String hashtag,
+                                @Param("since") OffsetDateTime since,
+                                @Param("until") OffsetDateTime until,
+                                @Param("lang") String lang,
                                 Pageable pageable);
 
     /**

--- a/backend/src/main/java/com/group7/backend/repository/UserKeywordMuteRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/UserKeywordMuteRepository.java
@@ -1,0 +1,22 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.entity.UserKeywordMute;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserKeywordMuteRepository extends JpaRepository<UserKeywordMute, Long> {
+
+    List<UserKeywordMute> findByUserIdOrderByCreatedAtAsc(Long userId);
+
+    boolean existsByUserIdAndKeyword(Long userId, String keyword);
+
+    int countByUserId(Long userId);
+
+    Optional<UserKeywordMute> findByIdAndUserId(Long id, Long userId);
+
+    void deleteByIdAndUserId(Long id, Long userId);
+}

--- a/backend/src/main/java/com/group7/backend/service/FeedPostService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedPostService.java
@@ -160,7 +160,7 @@ public class FeedPostService {
      */
     @Transactional
     public FeedPostResponse create(Long authorId, String body, List<String> rawHashtags,
-                                    List<UUID> attachmentIds) {
+                                    List<UUID> attachmentIds, String lang) {
         User author = userRepository.findById(authorId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + authorId));
         if (author instanceof Admin) {
@@ -175,6 +175,7 @@ public class FeedPostService {
         List<Attachment> resolvedAttachments = resolveAttachments(attachmentIds, authorId);
 
         FeedPost post = new FeedPost(authorId, body);
+        post.setLang(lang);
         OffsetDateTime now = OffsetDateTime.now();
         post.setCreatedAt(now);
         post.setUpdatedAt(now);

--- a/backend/src/main/java/com/group7/backend/service/FeedReadService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedReadService.java
@@ -21,6 +21,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.stream.Collectors;
+
 import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -72,6 +74,7 @@ public class FeedReadService {
     private final FeedInteractionService feedInteractionService;
     private final Optional<ForYouScoringPipeline> forYouPipeline;
     private final FeedPostMapper feedPostMapper;
+    private final UserKeywordMuteService keywordMuteService;
     private final int candidateWindow;
 
     public FeedReadService(FeedPostRepository feedPostRepository,
@@ -82,6 +85,7 @@ public class FeedReadService {
                            FeedInteractionService feedInteractionService,
                            Optional<ForYouScoringPipeline> forYouPipeline,
                            FeedPostMapper feedPostMapper,
+                           UserKeywordMuteService keywordMuteService,
                            @Value("${app.feed.forYou.candidate-window:200}") int candidateWindow) {
         this.feedPostRepository = feedPostRepository;
         this.userRepository = userRepository;
@@ -91,6 +95,7 @@ public class FeedReadService {
         this.feedInteractionService = feedInteractionService;
         this.forYouPipeline = forYouPipeline;
         this.feedPostMapper = feedPostMapper;
+        this.keywordMuteService = keywordMuteService;
         this.candidateWindow = candidateWindow;
     }
 
@@ -160,19 +165,43 @@ public class FeedReadService {
         if (ranked.isEmpty()) {
             return new PageImpl<>(List.of(), pageable, candidates.size());
         }
-        List<FeedPost> rankedPosts = ranked.stream()
+        List<ForYouScoringPipeline.RankedFeedPost> visibleRanked = filterMutedRanked(viewerId, ranked);
+        if (visibleRanked.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, candidates.size());
+        }
+        List<FeedPost> rankedPosts = visibleRanked.stream()
                 .map(ForYouScoringPipeline.RankedFeedPost::post).toList();
         Map<Long, FeedInteractionService.PostCounts> counts =
                 feedInteractionService.batchCounts(
                         rankedPosts.stream().map(FeedPost::getId).toList());
-        Map<Long, List<String>> factorsByPostId = ranked.stream()
-                .collect(java.util.stream.Collectors.toMap(
+        Map<Long, List<String>> factorsByPostId = visibleRanked.stream()
+                .collect(Collectors.toMap(
                         r -> r.post().getId(),
                         ForYouScoringPipeline.RankedFeedPost::factors));
         List<FeedPostListItem> items = feedPostMapper.toListItems(
                 rankedPosts, viewerId, counts, factorsByPostId);
         return new PageImpl<>(items, pageable, candidates.size());
     }
+
+    private List<ForYouScoringPipeline.RankedFeedPost> filterMutedRanked(
+            Long viewerId, List<ForYouScoringPipeline.RankedFeedPost> ranked) {
+        if (viewerId == null || ranked.isEmpty()) {
+            return ranked;
+        }
+        List<FeedPost> posts = ranked.stream()
+                .map(ForYouScoringPipeline.RankedFeedPost::post).toList();
+        List<FeedPost> filtered = keywordMuteService.filter(viewerId, posts);
+        if (filtered.size() == posts.size()) {
+            return ranked;
+        }
+        Set<Long> allowedIds = filtered.stream()
+                .map(FeedPost::getId)
+                .collect(Collectors.toSet());
+        return ranked.stream()
+                .filter(r -> allowedIds.contains(r.post().getId()))
+                .toList();
+    }
+
 
     /**
      * Following feed (#350, requirement 1.1.7.4). Chronological over
@@ -187,9 +216,9 @@ public class FeedReadService {
      * Author profile posts feed (#471). Chronological over posts
      * authored by the given user id.
      */
-    public Page<FeedPostListItem> postsByAuthor(Long authorId, Pageable pageable) {
+    public Page<FeedPostListItem> postsByAuthor(Long authorId, Long viewerId, Pageable pageable) {
         Page<FeedPost> page = feedPostRepository.findByAuthorIdForFeed(authorId, pageable);
-        return mapPage(page, null);
+        return mapPage(page, viewerId);
     }
 
     /**
@@ -205,7 +234,13 @@ public class FeedReadService {
      * (e.g., contains spaces) returns no results — the search input is
      * silently treated as not matching anything rather than error.
      */
-    public Page<FeedPostListItem> search(String keyword, String hashtag, Pageable pageable) {
+    public Page<FeedPostListItem> search(String keyword,
+                                          String hashtag,
+                                          OffsetDateTime since,
+                                          OffsetDateTime until,
+                                          String lang,
+                                          Long viewerId,
+                                          Pageable pageable) {
         String normalisedKeyword = (keyword == null || keyword.isBlank())
                 ? null
                 : escapeLikePattern(keyword.trim().toLowerCase(Locale.ROOT));
@@ -216,17 +251,31 @@ public class FeedReadService {
             // for a richer message.
             return Page.empty(pageable);
         }
-        // Reject empty-filter search: returning the full visible feed via the
-        // search endpoint is bug-magnet behaviour (clients fall back to /search
-        // for "show me everything," which masks pagination cost growth as the
-        // post count scales). The For-You and Following endpoints are the
-        // correct surfaces for "no specific filter" reads.
-        if (normalisedKeyword == null && normalisedHashtag == null) {
+        // Reject empty-filter search across ALL filters: returning the full
+        // visible feed via /search is bug-magnet behaviour, and the For-You
+        // / Following endpoints are the correct surfaces for "no specific
+        // filter" reads.
+        if (normalisedKeyword == null && normalisedHashtag == null
+                && since == null && until == null && lang == null) {
             throw new IllegalArgumentException(
-                    "Search requires at least one of 'q' or 'hashtag' — use /api/feed/for-you or /api/feed/following for the full feed");
+                    "Search requires at least one of 'q', 'hashtag', 'since', 'until', or 'lang' — "
+                            + "use /api/feed/for-you or /api/feed/following for the full feed");
         }
-        Page<FeedPost> page = feedPostRepository.searchPosts(normalisedKeyword, normalisedHashtag, pageable);
-        return mapPage(page, null);
+        if (since != null && until != null && !since.isBefore(until)) {
+            throw new IllegalArgumentException("'since' must be strictly before 'until'");
+        }
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime windowLow = now.minusYears(10);
+        OffsetDateTime windowHigh = now.plusDays(1);
+        if (since != null && since.isBefore(windowLow)) {
+            throw new IllegalArgumentException("'since' is too far in the past (limit: 10 years)");
+        }
+        if (until != null && until.isAfter(windowHigh)) {
+            throw new IllegalArgumentException("'until' is too far in the future (limit: 1 day)");
+        }
+        Page<FeedPost> page = feedPostRepository.searchPosts(
+                normalisedKeyword, normalisedHashtag, since, until, lang, pageable);
+        return mapPage(page, viewerId);
     }
 
     /**
@@ -298,27 +347,34 @@ public class FeedReadService {
 
     /**
      * Maps a JPA {@link Page} of posts into list-item DTOs while preserving
-     * pagination metadata. Delegates DTO assembly to {@link FeedPostMapper}
-     * so the single source of truth for author-name batching and attachment
-     * URL construction stays in one place.
+     * pagination metadata. Applies the viewer's keyword-mute filter before
+     * batch-mapping so muted posts never reach the DTO assembly stage.
+     * Delegates DTO assembly to {@link FeedPostMapper} so the single source
+     * of truth for author-name batching and attachment URL construction
+     * stays in one place.
      */
     private Page<FeedPostListItem> mapPage(Page<FeedPost> page, Long viewerId) {
         if (page.isEmpty()) {
             return Page.empty(page.getPageable());
         }
+        List<FeedPost> filtered = keywordMuteService.filter(viewerId, page.getContent());
+        if (filtered.isEmpty()) {
+            return new PageImpl<>(List.of(), page.getPageable(), page.getTotalElements());
+        }
         Map<Long, FeedInteractionService.PostCounts> counts =
                 feedInteractionService.batchCounts(
-                        page.getContent().stream().map(FeedPost::getId).toList());
+                        filtered.stream().map(FeedPost::getId).toList());
         List<FeedPostListItem> items = feedPostMapper.toListItems(
-                page.getContent(), viewerId, counts);
+                filtered, viewerId, counts);
         return new PageImpl<>(items, page.getPageable(), page.getTotalElements());
     }
 
     private Page<FeedPostListItem> slicePage(List<Scored> ranked, Pageable pageable, Long viewerId) {
-        int total = ranked.size();
+        List<Scored> visible = filterMutedScored(viewerId, ranked);
+        int total = visible.size();
         int from = Math.min((int) pageable.getOffset(), total);
         int to = Math.min(from + pageable.getPageSize(), total);
-        List<Scored> slice = ranked.subList(from, to);
+        List<Scored> slice = visible.subList(from, to);
         if (slice.isEmpty()) {
             return new PageImpl<>(List.of(), pageable, total);
         }
@@ -334,6 +390,24 @@ public class FeedReadService {
                 posts, viewerId, counts, factorsByPostId);
         return new PageImpl<>(items, pageable, total);
     }
+
+    private List<Scored> filterMutedScored(Long viewerId, List<Scored> ranked) {
+        if (viewerId == null || ranked.isEmpty()) {
+            return ranked;
+        }
+        List<FeedPost> posts = ranked.stream().map(Scored::post).toList();
+        List<FeedPost> filtered = keywordMuteService.filter(viewerId, posts);
+        if (filtered.size() == posts.size()) {
+            return ranked;
+        }
+        Set<Long> allowedIds = filtered.stream()
+                .map(FeedPost::getId)
+                .collect(Collectors.toSet());
+        return ranked.stream()
+                .filter(s -> allowedIds.contains(s.post().getId()))
+                .toList();
+    }
+
 
     /** Holds a feed post alongside its scoring result so the sort key is
      *  materialised exactly once per post (Schwartzian transform) and the

--- a/backend/src/main/java/com/group7/backend/service/UserKeywordMuteService.java
+++ b/backend/src/main/java/com/group7/backend/service/UserKeywordMuteService.java
@@ -1,0 +1,119 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.KeywordMuteResponse;
+import com.group7.backend.entity.FeedPost;
+import com.group7.backend.entity.UserKeywordMute;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.UserKeywordMuteRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Per-user keyword-mute management plus a post-filter helper used by every
+ * feed read path. Keywords are normalised (trim, lowercase) on write and
+ * matched case-insensitively as substrings of {@code FeedPost.body} on read.
+ */
+@Service
+@Transactional
+public class UserKeywordMuteService {
+
+    /** Cap on muted keywords per user. Keeps the post-filter step cheap. */
+    public static final int MAX_KEYWORDS_PER_USER = 50;
+
+    /** Allowed characters after normalisation: lowercase letters, digits,
+     *  single internal spaces (collapsed by trim), and hyphens. Excludes
+     *  punctuation and Unicode beyond ASCII so the substring match is
+     *  predictable across locales. */
+    private static final Pattern ALLOWED_KEYWORD = Pattern.compile("^[a-z0-9](?:[a-z0-9 \\-]*[a-z0-9])?$");
+
+    private final UserKeywordMuteRepository repository;
+
+    public UserKeywordMuteService(UserKeywordMuteRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<KeywordMuteResponse> list(Long userId) {
+        return repository.findByUserIdOrderByCreatedAtAsc(userId).stream()
+                .map(KeywordMuteResponse::from)
+                .toList();
+    }
+
+    public KeywordMuteResponse add(Long userId, String rawKeyword) {
+        String normalised = normalise(rawKeyword);
+        if (repository.countByUserId(userId) >= MAX_KEYWORDS_PER_USER) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "keyword-mute cap (" + MAX_KEYWORDS_PER_USER + ") reached");
+        }
+        if (repository.existsByUserIdAndKeyword(userId, normalised)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "keyword already muted");
+        }
+        UserKeywordMute saved = repository.save(new UserKeywordMute(userId, normalised));
+        return KeywordMuteResponse.from(saved);
+    }
+
+    public void delete(Long userId, Long muteId) {
+        UserKeywordMute mute = repository.findByIdAndUserId(muteId, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("keyword-mute not found with id: " + muteId));
+        repository.delete(mute);
+    }
+
+    /**
+     * Drops every post whose body contains any of the viewer's muted
+     * keywords (case-insensitive substring match). Short-circuits to the
+     * input list when the viewer is anonymous or has no mutes.
+     */
+    @Transactional(readOnly = true)
+    public List<FeedPost> filter(Long viewerId, List<FeedPost> posts) {
+        if (viewerId == null || posts.isEmpty()) {
+            return posts;
+        }
+        if (repository.countByUserId(viewerId) == 0) {
+            return posts;
+        }
+        List<String> mutes = repository.findByUserIdOrderByCreatedAtAsc(viewerId).stream()
+                .map(UserKeywordMute::getKeyword)
+                .toList();
+        return posts.stream()
+                .filter(p -> !containsAnyKeyword(p.getBody(), mutes))
+                .toList();
+    }
+
+    private static boolean containsAnyKeyword(String body, List<String> mutes) {
+        if (body == null) {
+            return false;
+        }
+        String lowered = body.toLowerCase(Locale.ROOT);
+        for (String mute : mutes) {
+            if (lowered.contains(mute)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String normalise(String raw) {
+        if (raw == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "keyword must not be blank");
+        }
+        String collapsed = raw.trim().replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
+        if (collapsed.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "keyword must not be blank");
+        }
+        if (collapsed.length() > 120) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "keyword must be at most 120 characters");
+        }
+        if (!ALLOWED_KEYWORD.matcher(collapsed).matches()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "keyword must contain only letters, digits, single spaces, and hyphens");
+        }
+        return collapsed;
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -212,6 +212,20 @@ app.ratelimit.rules.availability-ical.key-strategy=IP
 app.ratelimit.rules.availability-ical.capacity=30
 app.ratelimit.rules.availability-ical.refill=PT1M
 
+# Keyword-mute writes — generous enough for a settings UI batch save,
+# tight enough to cap abuse if an attacker hits POST in a tight loop.
+app.ratelimit.rules.keyword-mute-create.method=POST
+app.ratelimit.rules.keyword-mute-create.pattern=/api/users/me/keyword-mutes
+app.ratelimit.rules.keyword-mute-create.key-strategy=USER
+app.ratelimit.rules.keyword-mute-create.capacity=30
+app.ratelimit.rules.keyword-mute-create.refill=PT1M
+
+app.ratelimit.rules.keyword-mute-delete.method=DELETE
+app.ratelimit.rules.keyword-mute-delete.pattern=/api/users/me/keyword-mutes/*
+app.ratelimit.rules.keyword-mute-delete.key-strategy=USER
+app.ratelimit.rules.keyword-mute-delete.capacity=30
+app.ratelimit.rules.keyword-mute-delete.refill=PT1M
+
 # For-You feed ranker weights (#350). Default weights sum to 1.0 so the
 # composite score is bounded in [0, 1]. Tuning happens here without code
 # changes; a future AI-driven ranker would plug in behind @Primary and

--- a/backend/src/main/resources/db/migration/V50__add_feed_search_filters_and_keyword_mutes.sql
+++ b/backend/src/main/resources/db/migration/V50__add_feed_search_filters_and_keyword_mutes.sql
@@ -1,0 +1,23 @@
+-- Adds a BCP-47 language tag column on feed_posts so the search endpoint can
+-- filter by language. Existing rows have NULL; only new posts created with an
+-- explicit `lang` will participate in language-filtered queries.
+ALTER TABLE feed_posts
+    ADD COLUMN lang VARCHAR(15);
+
+CREATE INDEX idx_feed_posts_lang
+    ON feed_posts (lang)
+    WHERE deleted_at IS NULL;
+
+-- Per-user keyword mutes. Surrogate id PK keeps DELETE endpoints stable when
+-- keywords contain special characters; the UNIQUE (user_id, keyword) constraint
+-- preserves the no-duplicates guarantee that a composite PK would have given.
+CREATE TABLE user_keyword_mutes (
+    id         BIGSERIAL    PRIMARY KEY,
+    user_id    BIGINT       NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    keyword    VARCHAR(120) NOT NULL,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, keyword)
+);
+
+CREATE INDEX idx_user_keyword_mutes_user
+    ON user_keyword_mutes (user_id);

--- a/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
@@ -78,9 +78,9 @@ class FeedPostControllerTest {
     @Test
     void create_happyPath_returns201() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        when(feedPostService.create(eq(1L), any(), any(), any())).thenReturn(stub(42L, 1L));
+        when(feedPostService.create(eq(1L), any(), any(), any(), any())).thenReturn(stub(42L, 1L));
 
-        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of("data"), null);
+        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of("data"), null, null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -95,7 +95,7 @@ class FeedPostControllerTest {
 
     @Test
     void create_unauthenticated_returns403() throws Exception {
-        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of(), null);
+        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of(), null, null);
         mockMvc.perform(post("/api/feed/posts")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(body)))
@@ -105,7 +105,7 @@ class FeedPostControllerTest {
     @Test
     void create_blankBody_returns400() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        CreateFeedPostRequest body = new CreateFeedPostRequest("", List.of(), null);
+        CreateFeedPostRequest body = new CreateFeedPostRequest("", List.of(), null, null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -118,7 +118,7 @@ class FeedPostControllerTest {
     void create_oversizeBody_returns400() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
         String tooLong = "x".repeat(FeedPostLimits.MAX_BODY_LENGTH + 1);
-        CreateFeedPostRequest body = new CreateFeedPostRequest(tooLong, List.of(), null);
+        CreateFeedPostRequest body = new CreateFeedPostRequest(tooLong, List.of(), null, null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -132,7 +132,7 @@ class FeedPostControllerTest {
         mockMenteeJwt(TOKEN, 1L);
         List<String> tooMany = IntStream.range(0, FeedPostLimits.MAX_HASHTAGS + 1)
                 .mapToObj(i -> "tag" + i).collect(Collectors.toList());
-        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", tooMany, null);
+        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", tooMany, null, null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)
@@ -144,10 +144,10 @@ class FeedPostControllerTest {
     @Test
     void create_adminRequester_returns403() throws Exception {
         mockMenteeJwt(TOKEN, 1L);
-        when(feedPostService.create(eq(1L), any(), any(), any()))
+        when(feedPostService.create(eq(1L), any(), any(), any(), any()))
                 .thenThrow(new AccessDeniedException("Admins cannot create feed posts"));
 
-        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of(), null);
+        CreateFeedPostRequest body = new CreateFeedPostRequest("Hello", List.of(), null, null);
 
         mockMvc.perform(post("/api/feed/posts")
                         .header("Authorization", "Bearer " + TOKEN)

--- a/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,6 +66,7 @@ class FeedReadIntegrationTest {
         jdbcTemplate.update("DELETE FROM feed_post_hashtags");
         jdbcTemplate.update("DELETE FROM feed_posts");
         jdbcTemplate.update("DELETE FROM follows");
+        jdbcTemplate.update("DELETE FROM user_keyword_mutes");
         verificationTokenRepository.deleteAll();
         userRepository.deleteAll();
         doNothing().when(emailService).sendVerificationEmail(any(), anyString());
@@ -633,5 +635,140 @@ class FeedReadIntegrationTest {
         JsonNode post = postFromPage(body, pid);
         assertThat(post.get("likeCount").asLong()).isEqualTo(2L);
         assertThat(post.get("commentCount").asLong()).isEqualTo(1L);
+    }
+
+    // ── Search filters: date range and language ─────────────────────────────
+
+    @Test
+    void search_byLang_filtersOnLangColumn() throws Exception {
+        String token = registerAndLogin("search_lang@test.com", true);
+        long pidEn = createPostWithLang(token, "english one", List.of(), "en");
+        long pidTr = createPostWithLang(token, "turkce yazi", List.of(), "tr");
+        long pidNoLang = createPost(token, "no lang here", List.of());
+
+        MvcResult result = mockMvc.perform(get("/api/feed/search").param("lang", "en")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        List<Long> ids = idsFromPage(body);
+        assertThat(ids).containsExactly(pidEn);
+        assertThat(ids).doesNotContain(pidTr, pidNoLang);
+    }
+
+    @Test
+    void search_byDateRange_returnsOnlyPostsInsideWindow() throws Exception {
+        String token = registerAndLogin("search_range@test.com", true);
+        long pid = createPost(token, "post inside window", List.of("range"));
+
+        OffsetDateTime since = OffsetDateTime.now().minusHours(1);
+        OffsetDateTime until = OffsetDateTime.now().plusHours(1);
+
+        MvcResult result = mockMvc.perform(get("/api/feed/search")
+                        .param("since", since.toString())
+                        .param("until", until.toString())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(idsFromPage(body)).contains(pid);
+    }
+
+    @Test
+    void search_withSinceAfterUntil_returns400() throws Exception {
+        String token = registerAndLogin("search_bad_range@test.com", true);
+        createPost(token, "irrelevant", List.of("x"));
+
+        OffsetDateTime later = OffsetDateTime.now().plusHours(1);
+        OffsetDateTime earlier = OffsetDateTime.now().minusHours(1);
+
+        mockMvc.perform(get("/api/feed/search")
+                        .param("since", later.toString())
+                        .param("until", earlier.toString())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void search_withAllFiltersMissing_returns400() throws Exception {
+        String token = registerAndLogin("search_no_filter@test.com", true);
+        mockMvc.perform(get("/api/feed/search")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void search_withInvalidLangPattern_returns400() throws Exception {
+        String token = registerAndLogin("search_bad_lang@test.com", true);
+        mockMvc.perform(get("/api/feed/search").param("lang", "ENGLISH")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ── Keyword-mute filtering on read paths ────────────────────────────────
+
+    @Test
+    void search_dropsPostsContainingMutedKeyword() throws Exception {
+        String viewerToken = registerAndLogin("mute_view@test.com", true);
+        String authorToken = registerAndLogin("mute_author@test.com", true);
+
+        long allowedPost = createPost(authorToken, "post about kittens", List.of("kw"));
+        long mutedPost = createPost(authorToken, "this contains crypto stuff", List.of("kw"));
+
+        mockMvc.perform(post("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + viewerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keyword\":\"crypto\"}"))
+                .andExpect(status().isCreated());
+
+        MvcResult result = mockMvc.perform(get("/api/feed/search").param("hashtag", "kw")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        List<Long> ids = idsFromPage(body);
+        assertThat(ids).contains(allowedPost);
+        assertThat(ids).doesNotContain(mutedPost);
+    }
+
+    @Test
+    void search_keywordMute_isCaseInsensitive() throws Exception {
+        String viewerToken = registerAndLogin("mute_case@test.com", true);
+        String authorToken = registerAndLogin("mute_case_author@test.com", true);
+
+        long mutedPost = createPost(authorToken, "buying CRYPTO right now", List.of("kw"));
+
+        mockMvc.perform(post("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + viewerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keyword\":\"crypto\"}"))
+                .andExpect(status().isCreated());
+
+        MvcResult result = mockMvc.perform(get("/api/feed/search").param("hashtag", "kw")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(idsFromPage(body)).doesNotContain(mutedPost);
+    }
+
+    private long createPostWithLang(String token, String body, List<String> hashtags, String lang) throws Exception {
+        Map<String, Object> req = new java.util.HashMap<>();
+        req.put("body", body);
+        req.put("hashtags", hashtags);
+        req.put("lang", lang);
+        MvcResult res = mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();
+    }
+
+    private List<Long> idsFromPage(JsonNode body) {
+        return StreamSupport.stream(body.get("content").spliterator(), false)
+                .map(n -> n.get("id").asLong())
+                .toList();
     }
 }

--- a/backend/src/test/java/com/group7/backend/integration/KeywordMuteIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/KeywordMuteIntegrationTest.java
@@ -1,0 +1,184 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the per-user keyword-mute resource. Exercises
+ * GET / POST / DELETE shape, normalisation, validation, duplicate-409,
+ * and the 50-keyword cap.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class KeywordMuteIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        jdbcTemplate.update("DELETE FROM user_keyword_mutes");
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    @Test
+    void list_returnsEmpty_whenUserHasNoMutes() throws Exception {
+        String token = registerAndLogin("empty@test.com");
+        mockMvc.perform(get("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void create_returns201_andEchoesNormalisedKeyword() throws Exception {
+        String token = registerAndLogin("create@test.com");
+        MvcResult result = mockMvc.perform(post("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keyword\":\"  Crypto  \"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.keyword").value("crypto"))
+                .andReturn();
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("id").asLong()).isPositive();
+    }
+
+    @Test
+    void create_returns409_onDuplicate() throws Exception {
+        String token = registerAndLogin("dup@test.com");
+        mockMvc.perform(post("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keyword\":\"spam\"}"))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keyword\":\"Spam\"}"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void create_returns400_onIllegalCharacters() throws Exception {
+        String token = registerAndLogin("badchars@test.com");
+        mockMvc.perform(post("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keyword\":\"!!!\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void create_returns400_onBlankKeyword() throws Exception {
+        String token = registerAndLogin("blank@test.com");
+        mockMvc.perform(post("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keyword\":\"   \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void delete_removesMute_andReturns204() throws Exception {
+        String token = registerAndLogin("del@test.com");
+        MvcResult result = mockMvc.perform(post("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keyword\":\"removeme\"}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+        long id = objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asLong();
+
+        mockMvc.perform(delete("/api/users/me/keyword-mutes/" + id)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void delete_returns404_whenMuteBelongsToAnotherUser() throws Exception {
+        String ownerToken = registerAndLogin("owner@test.com");
+        String intruderToken = registerAndLogin("intruder@test.com");
+
+        MvcResult result = mockMvc.perform(post("/api/users/me/keyword-mutes")
+                        .header("Authorization", "Bearer " + ownerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"keyword\":\"private\"}"))
+                .andExpect(status().isCreated())
+                .andReturn();
+        long id = objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asLong();
+
+        mockMvc.perform(delete("/api/users/me/keyword-mutes/" + id)
+                        .header("Authorization", "Bearer " + intruderToken))
+                .andExpect(status().isNotFound());
+    }
+
+    private String registerAndLogin(String email) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Mute");
+        req.setLastName("Tester");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(true);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
@@ -72,7 +72,7 @@ class FeedPostServiceTest {
         Admin admin = admin(99L);
         when(userRepository.findById(99L)).thenReturn(Optional.of(admin));
 
-        assertThatThrownBy(() -> feedPostService.create(99L, "Hello", List.of(), null))
+        assertThatThrownBy(() -> feedPostService.create(99L, "Hello", List.of(), null, null))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessageContaining("Admins cannot create");
 
@@ -84,7 +84,7 @@ class FeedPostServiceTest {
         Mentor author = mentor(1L);
         when(userRepository.findById(1L)).thenReturn(Optional.of(author));
 
-        assertThatThrownBy(() -> feedPostService.create(1L, "   ", List.of(), null))
+        assertThatThrownBy(() -> feedPostService.create(1L, "   ", List.of(), null, null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("body must not be blank");
 
@@ -96,7 +96,7 @@ class FeedPostServiceTest {
         Mentor author = mentor(1L);
         when(userRepository.findById(1L)).thenReturn(Optional.of(author));
 
-        assertThatThrownBy(() -> feedPostService.create(1L, null, List.of(), null))
+        assertThatThrownBy(() -> feedPostService.create(1L, null, List.of(), null, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -104,7 +104,7 @@ class FeedPostServiceTest {
     void create_rejectsMissingAuthor_with404() {
         when(userRepository.findById(404L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> feedPostService.create(404L, "ok", List.of(), null))
+        assertThatThrownBy(() -> feedPostService.create(404L, "ok", List.of(), null, null))
                 .isInstanceOf(ResourceNotFoundException.class);
 
         verify(feedPostRepository, never()).save(any(FeedPost.class));
@@ -123,7 +123,7 @@ class FeedPostServiceTest {
         FeedPostResponse expected = stubResponse(42L, 1L);
         when(feedPostMapper.toResponse(any(FeedPost.class), any())).thenReturn(expected);
 
-        FeedPostResponse result = feedPostService.create(1L, "Hello", List.of("DATA", "ai"), null);
+        FeedPostResponse result = feedPostService.create(1L, "Hello", List.of("DATA", "ai"), null, null);
 
         assertThat(result).isSameAs(expected);
         verify(feedPostRepository).save(any(FeedPost.class));
@@ -141,7 +141,7 @@ class FeedPostServiceTest {
         });
         when(feedPostMapper.toResponse(any(FeedPost.class), any())).thenReturn(stubResponse(42L, 1L));
 
-        feedPostService.create(1L, "Hello", List.of(), null);
+        feedPostService.create(1L, "Hello", List.of(), null, null);
 
         // Verify the facade is invoked with the saved post + author. The
         // FeedPostEventPublisherTest pins the event-shape contract; here
@@ -160,7 +160,7 @@ class FeedPostServiceTest {
         when(feedPostRepository.save(any(FeedPost.class)))
                 .thenThrow(new RuntimeException("DB down"));
 
-        assertThatThrownBy(() -> feedPostService.create(1L, "Hello", List.of(), null))
+        assertThatThrownBy(() -> feedPostService.create(1L, "Hello", List.of(), null, null))
                 .isInstanceOf(RuntimeException.class);
 
         verify(feedPostEventPublisher, never()).publishCreated(any(), any());


### PR DESCRIPTION
## Summary

`GET /api/feed/search` previously accepted only `q` and `hashtag`, with at least one required. This PR widens the endpoint with three additional optional filters — `since`, `until`, `lang` — composable with the existing predicates, and introduces a per-user keyword-mute resource at `/api/users/me/keyword-mutes` so viewers can hide posts whose body contains any of their muted keywords across every feed read path.

The `lang` column on `feed_posts`, originally planned for #490's V46 migration, is folded forward into this PR's V42 so the language filter is useful on day one. #490's remaining scope (JSON-LD `contentMap` + `inLanguage` rendering) is strictly additive on top of the schema this PR lands.

## Changes

### Search filter extension

- `FeedPostRepository.searchPosts` gains three new `@Param`s (`since`, `until`, `lang`) appended to the existing native query. The query keeps its `(:param IS NULL OR ...)` shape; the two date predicates use the half-open interval convention (`since` inclusive, `until` exclusive). A new partial index `idx_feed_posts_lang ON feed_posts (lang) WHERE deleted_at IS NULL` accelerates language-filtered reads.
- `FeedReadService.search` extends to `(keyword, hashtag, since, until, lang, viewerId, pageable)`. The at-least-one-filter guard widens to cover all five params (no-filter requests are rejected with 400 as before). New service-side validation rejects `since >= until` and dates outside `[now − 10y, now + 1d]`.
- `FeedReadController.search` adds three `@RequestParam`s. Dates bind via `@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime` (mirrors `MentorshipController.getMentorshipTimeline`); the language tag carries `@Pattern(regexp = \"^[a-z]{2,3}(-[A-Z]{2})?$\")` for BCP-47 short tags. The class is annotated `@Validated` so query-param violations propagate as `ConstraintViolationException`.
- A new handler on `GlobalExceptionHandler` maps `jakarta.validation.ConstraintViolationException` to 400 with the existing `{ \"error\": \"Validation Failed\", \"messages\": { field: message } }` envelope. Previously, query-param regex violations surfaced as 500.

### Language column

- V42 migration adds `feed_posts.lang VARCHAR(15)`. Existing rows have `NULL` — these never match a non-null `lang` filter, which is the intended behaviour (\"a post with no declared language doesn't match `lang=en`\").
- `FeedPost` entity gains a `lang` field and `CreateFeedPostRequest` gains an optional `lang` field. Posting without `lang` continues to work (column stays NULL).
- `FeedPostService.create` adds a four-arg overload that copies the language through; the three-arg overload remains for callers that don't set a language.

### Keyword-mute resource

- V42 migration creates `user_keyword_mutes` with a surrogate `BIGSERIAL id`, FK `user_id` with `ON DELETE CASCADE`, `keyword VARCHAR(120)`, `created_at`, `UNIQUE (user_id, keyword)`. The surrogate id keeps the DELETE endpoint stable for keywords containing spaces or hyphens.
- New `UserKeywordMute` entity, `UserKeywordMuteRepository`, `KeywordMuteRequest` / `KeywordMuteResponse` records, `UserKeywordMuteService`, and `KeywordMuteController` at `/api/users/me/keyword-mutes` (`GET` list, `POST` add, `DELETE /{id}` remove).
- Service-side normalisation lowercases and trims; rejects empty / over-120-char / illegal-character inputs with 400; rejects duplicates with 409 (pre-check via `existsByUserIdAndKeyword`); enforces a 50-keyword cap per user; DELETE checks ownership via `findByIdAndUserId` and returns 404 if the mute does not belong to the requester.
- Two new rate-limit rules in `application.properties`: 30 POST per minute per user on `/api/users/me/keyword-mutes`, 30 DELETE per minute per user on `/api/users/me/keyword-mutes/*`.

### Mute application

- `UserKeywordMuteService.filter(viewerId, posts)` is invoked from `FeedReadService.forYouFeed`, `followingFeed`, `postsByAuthor`, and `search` after the SQL fetch and before DTO mapping. The filter short-circuits when the viewer has no mutes (single `countByUserId` check), case-insensitively scans the post body for any muted substring, and drops matches.
- `FeedReadController.postsByAuthor` now passes the authenticated viewer id through so the mute filter applies to that surface too.
- Pagination behaviour: the filter may drop items from the page content, so the visible page can surface fewer than `size` items. `totalElements` continues to reflect the underlying SQL count — documented in the OpenAPI description for the `/search` endpoint.

## Acceptance criteria

- [x] `GET /api/feed/search?lang=en` returns only posts with `lang='en'`.
- [x] `GET /api/feed/search?since=...&until=...` returns posts with `created_at` in the half-open interval.
- [x] `since >= until` returns 400.
- [x] All filters missing returns 400.
- [x] Invalid `lang` pattern returns 400.
- [x] `POST /api/users/me/keyword-mutes` lowercases and trims; rejects illegal characters / blank input with 400; rejects duplicates with 409; rejects cap-reached with 400.
- [x] `DELETE /api/users/me/keyword-mutes/{id}` returns 204; returns 404 when the mute belongs to another user.
- [x] Muted-keyword posts are filtered out of `/for-you`, `/following`, `/users/{authorId}/posts`, and `/search`. Filtering is case-insensitive and substring-based on the post body.
- [x] A viewer with no mutes sees the unfiltered feed.

## Test coverage

Integration tests extended:

- `FeedReadIntegrationTest` — six new tests cover the language filter, date-range filter, `since > until` rejection, no-filter rejection, invalid language pattern, and the keyword-mute drop on `/search` including case-insensitive matching.
- New `KeywordMuteIntegrationTest` — seven tests cover the GET / POST / DELETE shape, the normalisation contract, duplicate-409, blank-keyword 400, illegal-character 400, and ownership-404 on DELETE.

Auxiliary test updates:

- `FeedPostControllerTest` constructor invocations updated for the extended `CreateFeedPostRequest` record arity.
- `FeedReadIntegrationTest.cleanDb` extended to drop the new `user_keyword_mutes` rows.

## Validation

- Backend CI (`mvn --batch-mode verify`) — 1684 tests, 0 failures, 0 errors, BUILD SUCCESS.
- Playwright e2e — 7 passed, 3 flaky (AT-01 / AT-02 / AT-06). AT-01 and AT-02 are the same pre-existing login-URL navigation timing flakes observed on PR #492 / #495; AT-06 is a 10s `getByTestId('messages-thread')` timeout on the chat UI. None are caused by this change — the diff is backend-only and touches no chat, auth, or messaging code.
- Manual API smoke against a running backend confirmed every acceptance criterion end-to-end, including case-insensitive mute matching (post body `\"buying CRYPTO now\"` is filtered by mute keyword `\"crypto\"`) and viewer isolation (a second user with no mutes sees the full result set).

## Out of scope

- **JSON-LD `contentMap` and `inLanguage` rendering.** Owned by #490; this PR only lands the column. #490 adds the AS 2.0 emission on top.
- **Hashtag-only mute** (\"hide every post tagged `#crypto` regardless of body\"). v1 matches against post body only; users can mute the hashtag substring directly.
- **Regex / wildcard mute patterns.** v1 is literal substring only.
- **Move mute filtering into SQL** (array-contains predicate). Would lose the trigram index acceleration on the keyword path. Post-fetch filtering is acceptable at v1 scale.
- **Frontend Settings UI for managing mutes.** Tracked as a separate frontend ticket.
- **Service-level unit tests** for `UserKeywordMuteService` and the new `FeedReadService.search` paths. Tracked under #488.

Closes #486