### PR TITLE
feat(mobile): mentorship progress timeline + meeting notes + UX fixes

### DIFF
--- a/mobile-app/app/(tabs)/explore.tsx
+++ b/mobile-app/app/(tabs)/explore.tsx
@@ -95,7 +95,7 @@ function MenteeExploreContent() {
     const fetchMentors = async () => {
       try {
         const [mentorsRes, myId] = await Promise.all([
-          apiClient.get('/users/mentors'),
+          apiClient.get('/users/mentors/all'),
           SecureStore.getItemAsync('userId'),
         ]);
         const data: any[] = mentorsRes.data.content ?? mentorsRes.data;
@@ -380,7 +380,7 @@ function MentorRequestsContent() {
     setDiscoverLoading(true);
     try {
       const [mentorsRes, myId] = await Promise.all([
-        apiClient.get('/users/mentors'),
+        apiClient.get('/users/mentors/all'),
         SecureStore.getItemAsync('userId'),
       ]);
       const data: any[] = mentorsRes.data.content ?? mentorsRes.data;

--- a/mobile-app/app/connection-profile.tsx
+++ b/mobile-app/app/connection-profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { router, useLocalSearchParams } from 'expo-router';
 import {
   View,
@@ -9,6 +9,7 @@ import {
   ScrollView,
   ActivityIndicator,
   Alert,
+  Modal,
 } from 'react-native';
 import { useRole } from '../components/RoleContext';
 import { useProtectedSession } from '../components/useProtectedSession';
@@ -29,6 +30,30 @@ type MilestoneSummary = {
   targetDate: string | null;
   status: MilestoneStatus;
   orderIndex: number;
+};
+
+type MeetingSummary = {
+  id: number;
+  title: string;
+  startTime: string | null;
+  status: string;
+};
+
+type TaskSummary = {
+  id: number;
+  title: string;
+  dueDate: string | null;
+  status: string;
+};
+
+type TimelineEventKind = 'start' | 'end' | 'today' | 'milestone' | 'meeting' | 'task';
+
+type TimelineEvent = {
+  kind: TimelineEventKind;
+  date: string; // YYYY-MM-DD
+  label: string;
+  refId?: number;
+  status?: string;
 };
 
 type MilestoneActionItem = {
@@ -121,8 +146,13 @@ export default function ConnectionProfileScreen() {
   const [mentorSlots, setMentorSlots] = useState<AvailabilitySlot[]>([]);
   const [availabilityLoading, setAvailabilityLoading] = useState(false);
 
-  const [sharedGoal, setSharedGoal] = useState(parseString(params.subtitle));
+  const [sharedGoal, setSharedGoal] = useState('');
   const [goalDraft, setGoalDraft] = useState('');
+  const [mentorshipStartDate, setMentorshipStartDate] = useState<string | null>(null);
+  const [mentorshipEndDate, setMentorshipEndDate] = useState<string | null>(null);
+  const [meetings, setMeetings] = useState<MeetingSummary[]>([]);
+  const [tasks, setTasks] = useState<TaskSummary[]>([]);
+  const [timelineModalEvent, setTimelineModalEvent] = useState<TimelineEvent | null>(null);
   const [goalEditing, setGoalEditing] = useState(false);
   const [goalSaving, setGoalSaving] = useState(false);
   const [milestones, setMilestones] = useState<MilestoneSummary[]>([]);
@@ -184,12 +214,32 @@ export default function ConnectionProfileScreen() {
     if (!mentorshipId) return;
     apiClient.get(`/mentorships/${mentorshipId}`).then((res) => {
       if (res.data.sharedGoal) setSharedGoal(res.data.sharedGoal);
+      if (res.data.startDate) setMentorshipStartDate(String(res.data.startDate).slice(0, 10));
+      if (res.data.endDate) setMentorshipEndDate(String(res.data.endDate).slice(0, 10));
     }).catch(() => {});
+
+    apiClient.get(`/mentorships/${mentorshipId}/meetings`)
+      .then((res) => setMeetings((res.data ?? []) as MeetingSummary[]))
+      .catch(() => setMeetings([]));
+
+    apiClient.get(`/mentorships/${mentorshipId}/tasks`)
+      .then((res) => setTasks((res.data ?? []) as TaskSummary[]))
+      .catch(() => setTasks([]));
   }, [mentorshipId, session, sessionLoading]);
 
   const fetchMilestoneDetail = async (milestoneId: number) => {
     const res = await apiClient.get(`/milestones/${milestoneId}`);
-    return res.data as MilestoneDetail;
+    const data = res.data as MilestoneDetail;
+    return {
+      ...data,
+      actionItems: (data.actionItems ?? []).map((raw) => {
+        const item = raw as MilestoneActionItem & { completed?: boolean };
+        return {
+          ...item,
+          isCompleted: item.isCompleted ?? item.completed ?? false,
+        };
+      }),
+    } as MilestoneDetail;
   };
 
   const loadMilestones = useCallback(async (keepSelection = true) => {
@@ -286,6 +336,73 @@ export default function ConnectionProfileScreen() {
 
   const isViewingMentor = type === 'mentor';
   const selectedMilestone = selectedMilestoneId ? milestoneDetails[selectedMilestoneId] : null;
+
+  const timelineEvents: TimelineEvent[] = useMemo(() => {
+    if (!mentorshipStartDate || !mentorshipEndDate) return [];
+    const list: TimelineEvent[] = [
+      { kind: 'start', date: mentorshipStartDate, label: 'Program Start' },
+      { kind: 'end', date: mentorshipEndDate, label: 'Program Completion' },
+    ];
+    const today = new Date().toISOString().slice(0, 10);
+    if (today >= mentorshipStartDate && today <= mentorshipEndDate) {
+      list.push({ kind: 'today', date: today, label: 'Today' });
+    }
+    milestones.forEach((m) => {
+      if (m.targetDate) {
+        list.push({
+          kind: 'milestone',
+          date: String(m.targetDate).slice(0, 10),
+          label: m.title,
+          refId: m.id,
+          status: m.status,
+        });
+      }
+    });
+    meetings.forEach((m) => {
+      if (m.startTime) {
+        list.push({
+          kind: 'meeting',
+          date: String(m.startTime).slice(0, 10),
+          label: m.title || 'Meeting',
+          refId: m.id,
+          status: m.status,
+        });
+      }
+    });
+    tasks.forEach((t) => {
+      if (t.dueDate) {
+        list.push({
+          kind: 'task',
+          date: String(t.dueDate).slice(0, 10),
+          label: t.title || 'Task',
+          refId: t.id,
+          status: t.status,
+        });
+      }
+    });
+    list.sort((a, b) => a.date.localeCompare(b.date));
+    return list;
+  }, [mentorshipStartDate, mentorshipEndDate, milestones, meetings, tasks]);
+
+  const handleTimelineEventPress = (event: TimelineEvent) => {
+    if (event.kind === 'milestone' && event.refId) {
+      setSelectedMilestoneId(event.refId);
+      setTimelineModalEvent(null);
+      openMilestonesScreen(event.refId);
+      return;
+    }
+    if (event.kind === 'meeting') {
+      setTimelineModalEvent(null);
+      openMeetings();
+      return;
+    }
+    if (event.kind === 'task') {
+      setTimelineModalEvent(null);
+      openTasks();
+      return;
+    }
+    setTimelineModalEvent(event);
+  };
   const totalActionItems = Object.values(milestoneDetails).reduce(
     (sum, milestone) => sum + milestone.actionItems.length,
     0
@@ -401,6 +518,19 @@ export default function ConnectionProfileScreen() {
     });
   };
 
+  const openMilestonesScreen = (milestoneId?: number) => {
+    router.push({
+      pathname: '/milestones',
+      params: {
+        connectedUserName: name,
+        connectedUserType: type,
+        mentorshipId,
+        sourceScreen: 'connection-profile',
+        ...(milestoneId ? { focusMilestoneId: String(milestoneId) } : {}),
+      },
+    });
+  };
+
   const openMessages = () => {
     console.log('[navigation] opening messages', {
       sourceScreen: 'connection-profile',
@@ -418,20 +548,30 @@ export default function ConnectionProfileScreen() {
 
   const createMilestone = async () => {
     if (!mentorshipId || !milestoneTitleDraft.trim()) return;
+    const targetDate = toIsoDateOrNull(milestoneDateDraft);
+    if (targetDate && mentorshipStartDate && mentorshipEndDate
+        && (targetDate < mentorshipStartDate || targetDate > mentorshipEndDate)) {
+      Alert.alert(
+        'Invalid date',
+        `Target date must be between ${mentorshipStartDate} and ${mentorshipEndDate}.`
+      );
+      return;
+    }
     setMilestoneCreating(true);
     try {
       await apiClient.post(`/mentorships/${mentorshipId}/milestones`, {
         title: milestoneTitleDraft.trim(),
         description: milestoneDescriptionDraft.trim() || null,
-        targetDate: toIsoDateOrNull(milestoneDateDraft),
+        targetDate,
       });
       setMilestoneTitleDraft('');
       setMilestoneDescriptionDraft('');
       setMilestoneDateDraft('');
       setMilestoneComposerOpen(false);
       await loadMilestones(false);
-    } catch {
-      Alert.alert('Error', 'Could not create the milestone.');
+    } catch (err: any) {
+      const msg = err?.response?.data?.message || 'Could not create the milestone.';
+      Alert.alert('Error', msg);
     } finally {
       setMilestoneCreating(false);
     }
@@ -633,6 +773,72 @@ export default function ConnectionProfileScreen() {
             )}
           </View>
 
+          {timelineEvents.length > 0 && (
+            <>
+              <Text style={styles.sectionTitle}>PROGRESS TIMELINE</Text>
+              <View style={styles.card}>
+                <Text style={styles.timelineSubtitle}>
+                  Program duration: {mentorshipStartDate} – {mentorshipEndDate}
+                </Text>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.timelineScroll}
+                >
+                  <View style={[styles.timelineContainer, { minWidth: Math.max(600, timelineEvents.length * 140) }]}>
+                    <View style={styles.timelineTrack} />
+                    {timelineEvents.map((event, idx) => {
+                      const total = timelineEvents.length;
+                      const left = total > 1 ? (idx / (total - 1)) * 100 : 50;
+                      const color =
+                        event.kind === 'today' ? '#E5A035'
+                        : event.kind === 'milestone' ? '#3B7DD8'
+                        : event.kind === 'meeting' ? '#2F563C'
+                        : event.kind === 'task' ? '#8A5D12'
+                        : '#23372B';
+                      const dateLabel = new Date(event.date).toLocaleDateString('en-US', {
+                        month: 'short', day: 'numeric',
+                      });
+                      return (
+                        <View key={`${event.kind}-${event.refId ?? idx}`} style={[styles.timelineSlot, { left: `${left}%` }]}>
+                          <TouchableOpacity
+                            style={[styles.timelinePill, { backgroundColor: color }]}
+                            onPress={() => handleTimelineEventPress(event)}
+                          >
+                            <Text style={styles.timelinePillText} numberOfLines={2}>{event.label}</Text>
+                          </TouchableOpacity>
+                          <Text style={styles.timelineDateLabel}>{dateLabel}</Text>
+                          <TouchableOpacity
+                            style={[styles.timelineDot, { backgroundColor: color }]}
+                            onPress={() => handleTimelineEventPress(event)}
+                          />
+                        </View>
+                      );
+                    })}
+                  </View>
+                </ScrollView>
+                <View style={styles.timelineLegend}>
+                  <View style={styles.timelineLegendItem}>
+                    <View style={[styles.timelineLegendDot, { backgroundColor: '#3B7DD8' }]} />
+                    <Text style={styles.timelineLegendText}>Milestone</Text>
+                  </View>
+                  <View style={styles.timelineLegendItem}>
+                    <View style={[styles.timelineLegendDot, { backgroundColor: '#2F563C' }]} />
+                    <Text style={styles.timelineLegendText}>Meeting</Text>
+                  </View>
+                  <View style={styles.timelineLegendItem}>
+                    <View style={[styles.timelineLegendDot, { backgroundColor: '#8A5D12' }]} />
+                    <Text style={styles.timelineLegendText}>Task</Text>
+                  </View>
+                  <View style={styles.timelineLegendItem}>
+                    <View style={[styles.timelineLegendDot, { backgroundColor: '#E5A035' }]} />
+                    <Text style={styles.timelineLegendText}>Today</Text>
+                  </View>
+                </View>
+              </View>
+            </>
+          )}
+
           <Text style={styles.sectionTitle}>SHARED GOAL</Text>
 
           <View style={styles.card}>
@@ -742,7 +948,11 @@ export default function ConnectionProfileScreen() {
                       style={styles.milestoneInput}
                       value={milestoneDateDraft}
                       onChangeText={setMilestoneDateDraft}
-                      placeholder="Target date (YYYY-MM-DD)"
+                      placeholder={
+                        mentorshipStartDate && mentorshipEndDate
+                          ? `Target date (${mentorshipStartDate} – ${mentorshipEndDate})`
+                          : 'Target date (YYYY-MM-DD)'
+                      }
                       placeholderTextColor="#B0A89E"
                       autoCapitalize="none"
                     />
@@ -1008,6 +1218,48 @@ export default function ConnectionProfileScreen() {
           </View>
         </View>
       </ScrollView>
+
+      <Modal
+        visible={timelineModalEvent !== null}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setTimelineModalEvent(null)}
+      >
+        <TouchableOpacity
+          activeOpacity={1}
+          style={styles.timelineModalBackdrop}
+          onPress={() => setTimelineModalEvent(null)}
+        >
+          <TouchableOpacity activeOpacity={1} style={styles.timelineModalSheet}>
+            <Text style={styles.timelineModalKind}>
+              {timelineModalEvent?.kind.toUpperCase()}
+            </Text>
+            <Text style={styles.timelineModalTitle}>
+              {timelineModalEvent?.label}
+            </Text>
+            <Text style={styles.timelineModalDate}>
+              {timelineModalEvent?.date}
+              {timelineModalEvent?.status ? `  ·  ${timelineModalEvent.status}` : ''}
+            </Text>
+            {timelineModalEvent?.kind === 'meeting' && (
+              <Text style={[styles.cardText, { marginBottom: 18 }]}>
+                Open the Meetings & Sessions screen to manage this meeting.
+              </Text>
+            )}
+            {timelineModalEvent?.kind === 'task' && (
+              <Text style={[styles.cardText, { marginBottom: 18 }]}>
+                Open the Task Tracker screen to manage this task.
+              </Text>
+            )}
+            <TouchableOpacity
+              style={styles.timelineModalCloseButton}
+              onPress={() => setTimelineModalEvent(null)}
+            >
+              <Text style={styles.timelineModalCloseText}>Close</Text>
+            </TouchableOpacity>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </Modal>
     </View>
   );
 }
@@ -1158,6 +1410,134 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     letterSpacing: 2,
     marginBottom: 18,
+  },
+  timelineSubtitle: {
+    color: '#7E7368',
+    fontSize: 13,
+    fontWeight: '500',
+    marginBottom: 18,
+  },
+  timelineScroll: {
+    paddingHorizontal: 8,
+    paddingTop: 50,
+    paddingBottom: 8,
+  },
+  timelineContainer: {
+    position: 'relative',
+    minWidth: 600,
+    height: 110,
+  },
+  timelineTrack: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 84,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: '#E5DDD1',
+  },
+  timelineSlot: {
+    position: 'absolute',
+    top: 0,
+    width: 130,
+    marginLeft: -65,
+    alignItems: 'center',
+  },
+  timelinePill: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 10,
+    marginBottom: 6,
+    maxWidth: 124,
+  },
+  timelinePillText: {
+    color: '#FFFFFF',
+    fontSize: 11,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  timelineDot: {
+    position: 'absolute',
+    top: 79,
+    alignSelf: 'center',
+    width: 14,
+    height: 14,
+    borderRadius: 7,
+    borderWidth: 2,
+    borderColor: '#F8F6F2',
+    zIndex: 2,
+  },
+  timelineDateLabel: {
+    color: '#9A8F82',
+    fontSize: 10,
+    fontWeight: '500',
+    marginTop: 0,
+  },
+  timelineLegend: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 14,
+    marginTop: 14,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#E5DDD1',
+  },
+  timelineLegendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  timelineLegendDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  timelineLegendText: {
+    color: '#7E7368',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  timelineModalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'flex-end',
+  },
+  timelineModalSheet: {
+    backgroundColor: '#F8F6F2',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    padding: 24,
+    paddingBottom: 36,
+  },
+  timelineModalKind: {
+    color: '#8B8176',
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 2,
+    marginBottom: 8,
+  },
+  timelineModalTitle: {
+    color: '#23372B',
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 6,
+  },
+  timelineModalDate: {
+    color: '#7E7368',
+    fontSize: 14,
+    fontWeight: '500',
+    marginBottom: 18,
+  },
+  timelineModalCloseButton: {
+    backgroundColor: '#456B50',
+    paddingVertical: 14,
+    borderRadius: 18,
+    alignItems: 'center',
+  },
+  timelineModalCloseText: {
+    color: '#F8F6F2',
+    fontSize: 15,
+    fontWeight: '700',
   },
   card: {
     backgroundColor: '#F8F6F2',

--- a/mobile-app/app/meetings-sessions.tsx
+++ b/mobile-app/app/meetings-sessions.tsx
@@ -3,12 +3,14 @@ import { router, useLocalSearchParams } from 'expo-router';
 import {
   View,
   Text,
+  TextInput,
   TouchableOpacity,
   StyleSheet,
   ScrollView,
   ActivityIndicator,
   RefreshControl,
   Linking,
+  Alert,
 } from 'react-native';
 import apiClient from '../api/client';
 
@@ -25,6 +27,7 @@ type Meeting = {
   meetingType: string;
   meetingLink?: string;
   recurring: boolean;
+  notes?: string | null;
 };
 
 function fmtDay(iso: string) {
@@ -69,6 +72,11 @@ export default function MeetingsSessionsScreen() {
   const [meetings, setMeetings] = useState<Meeting[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [notesDraft, setNotesDraft] = useState('');
+  const [notesEditing, setNotesEditing] = useState(false);
+  const [notesSaving, setNotesSaving] = useState(false);
+  const [notesLoading, setNotesLoading] = useState(false);
 
   const loadMeetings = useCallback(async () => {
     if (!mentorshipId) { setLoading(false); return; }
@@ -89,6 +97,42 @@ export default function MeetingsSessionsScreen() {
   const upcoming = [...meetings]
     .filter(m => new Date(m.startTime) > now && m.status !== 'CANCELLED' && m.status !== 'DECLINED')
     .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime())[0];
+
+  const toggleExpand = async (meeting: Meeting) => {
+    if (expandedId === meeting.id) {
+      setExpandedId(null);
+      setNotesEditing(false);
+      return;
+    }
+    setExpandedId(meeting.id);
+    setNotesEditing(false);
+    setNotesDraft('');
+    setNotesLoading(true);
+    try {
+      const res = await apiClient.get(`/meetings/${meeting.id}`);
+      const fetchedNotes = res.data?.notes ?? '';
+      setMeetings((prev) => prev.map((m) => m.id === meeting.id ? { ...m, notes: fetchedNotes } : m));
+    } catch {
+      // keep card open with whatever we have
+    } finally {
+      setNotesLoading(false);
+    }
+  };
+
+  const saveNotes = async (meetingId: number) => {
+    setNotesSaving(true);
+    try {
+      const res = await apiClient.patch(`/meetings/${meetingId}/notes`, { notes: notesDraft });
+      const saved = res.data?.notes ?? notesDraft;
+      setMeetings((prev) => prev.map((m) => m.id === meetingId ? { ...m, notes: saved } : m));
+      setNotesEditing(false);
+    } catch (err: any) {
+      const msg = err?.response?.data?.message || 'Could not save notes.';
+      Alert.alert('Error', msg);
+    } finally {
+      setNotesSaving(false);
+    }
+  };
 
   const openSchedule = () => {
     router.push({
@@ -178,28 +222,93 @@ export default function MeetingsSessionsScreen() {
             .sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime())
             .map((meeting) => {
               const meta = statusMeta(meeting.status);
+              const isExpanded = expandedId === meeting.id;
               return (
                 <View key={meeting.id} style={styles.meetingCard}>
-                  <View style={styles.timeBlock}>
-                    <Text style={styles.dayText}>{fmtDay(meeting.startTime)}</Text>
-                    <Text style={styles.timeText}>{fmtTime(meeting.startTime)}</Text>
-                  </View>
+                  <TouchableOpacity
+                    activeOpacity={0.7}
+                    onPress={() => toggleExpand(meeting)}
+                    style={styles.meetingCardHeader}
+                  >
+                    <View style={styles.timeBlock}>
+                      <Text style={styles.dayText}>{fmtDay(meeting.startTime)}</Text>
+                      <Text style={styles.timeText}>{fmtTime(meeting.startTime)}</Text>
+                    </View>
 
-                  <View style={styles.cardDivider} />
+                    <View style={styles.cardDivider} />
 
-                  <View style={styles.meetingInfo}>
-                    <Text style={styles.meetingTitle}>{meeting.title}</Text>
-                    <Text style={styles.meetingMentor}>{connectedUserName}</Text>
-                    {meeting.meetingLink ? (
-                      <TouchableOpacity onPress={() => meeting.meetingLink && Linking.openURL(meeting.meetingLink)}>
-                        <Text style={styles.meetingLinkText}>Join link ↗</Text>
-                      </TouchableOpacity>
-                    ) : null}
-                  </View>
+                    <View style={styles.meetingInfo}>
+                      <Text style={styles.meetingTitle}>{meeting.title}</Text>
+                      <Text style={styles.meetingMentor}>{connectedUserName}</Text>
+                      {meeting.meetingLink ? (
+                        <TouchableOpacity onPress={() => meeting.meetingLink && Linking.openURL(meeting.meetingLink)}>
+                          <Text style={styles.meetingLinkText}>Join link ↗</Text>
+                        </TouchableOpacity>
+                      ) : null}
+                    </View>
 
-                  <View style={[styles.statusBadge, meta.badgeStyle]}>
-                    <Text style={[styles.statusBadgeText, meta.textStyle]}>{meta.label}</Text>
-                  </View>
+                    <View style={[styles.statusBadge, meta.badgeStyle]}>
+                      <Text style={[styles.statusBadgeText, meta.textStyle]}>{meta.label}</Text>
+                    </View>
+                  </TouchableOpacity>
+
+                  {isExpanded && (
+                    <View style={styles.notesSection}>
+                      <Text style={styles.notesLabel}>NOTES</Text>
+                      {notesLoading ? (
+                        <ActivityIndicator size="small" color="#456B50" />
+                      ) : notesEditing ? (
+                        <>
+                          <TextInput
+                            style={styles.notesInput}
+                            value={notesDraft}
+                            onChangeText={setNotesDraft}
+                            placeholder="Add notes from this meeting..."
+                            placeholderTextColor="#B0A89E"
+                            multiline
+                            maxLength={2000}
+                            autoFocus
+                          />
+                          <Text style={styles.notesCharCount}>{notesDraft.length}/2000</Text>
+                          <View style={styles.notesButtonRow}>
+                            <TouchableOpacity
+                              style={styles.notesCancelButton}
+                              onPress={() => setNotesEditing(false)}
+                              disabled={notesSaving}
+                            >
+                              <Text style={styles.notesCancelText}>Cancel</Text>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                              style={[styles.notesSaveButton, notesSaving && { opacity: 0.5 }]}
+                              onPress={() => saveNotes(meeting.id)}
+                              disabled={notesSaving}
+                            >
+                              {notesSaving
+                                ? <ActivityIndicator size="small" color="#F8F6F2" />
+                                : <Text style={styles.notesSaveText}>Save</Text>}
+                            </TouchableOpacity>
+                          </View>
+                        </>
+                      ) : (
+                        <>
+                          <Text style={styles.notesText}>
+                            {meeting.notes && meeting.notes.trim().length > 0
+                              ? meeting.notes
+                              : 'No notes yet. Tap Edit to add notes from this meeting.'}
+                          </Text>
+                          <TouchableOpacity
+                            style={styles.notesEditButton}
+                            onPress={() => {
+                              setNotesDraft(meeting.notes ?? '');
+                              setNotesEditing(true);
+                            }}
+                          >
+                            <Text style={styles.notesEditText}>{meeting.notes ? 'Edit Notes' : 'Add Notes'}</Text>
+                          </TouchableOpacity>
+                        </>
+                      )}
+                    </View>
+                  )}
                 </View>
               );
             })
@@ -321,11 +430,96 @@ const styles = StyleSheet.create({
   meetingCard: {
     backgroundColor: '#F8F6F2',
     borderRadius: 26,
+    marginBottom: 18,
+    overflow: 'hidden',
+  },
+  meetingCardHeader: {
     paddingVertical: 24,
     paddingHorizontal: 20,
-    marginBottom: 18,
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  notesSection: {
+    paddingHorizontal: 20,
+    paddingTop: 4,
+    paddingBottom: 22,
+    borderTopWidth: 1,
+    borderTopColor: '#E5DDD1',
+  },
+  notesLabel: {
+    color: '#8B8176',
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 2,
+    marginTop: 14,
+    marginBottom: 12,
+  },
+  notesText: {
+    color: '#23372B',
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 12,
+  },
+  notesInput: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#E1D9CF',
+    padding: 14,
+    minHeight: 100,
+    textAlignVertical: 'top',
+    color: '#23372B',
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  notesCharCount: {
+    color: '#9A8F82',
+    fontSize: 12,
+    fontWeight: '500',
+    alignSelf: 'flex-end',
+    marginTop: 6,
+    marginBottom: 12,
+  },
+  notesButtonRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 10,
+  },
+  notesCancelButton: {
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 16,
+    borderWidth: 1.5,
+    borderColor: '#D8CEC0',
+    backgroundColor: '#F0EDE8',
+  },
+  notesCancelText: {
+    color: '#7E7368',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  notesSaveButton: {
+    paddingHorizontal: 22,
+    paddingVertical: 12,
+    borderRadius: 16,
+    backgroundColor: '#456B50',
+  },
+  notesSaveText: {
+    color: '#F8F6F2',
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  notesEditButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: 14,
+    backgroundColor: '#D7E8DA',
+  },
+  notesEditText: {
+    color: '#2F563C',
+    fontSize: 13,
+    fontWeight: '700',
   },
   timeBlock: { width: 90, alignItems: 'center', justifyContent: 'center' },
   dayText: { fontSize: 14, color: '#9A8F82', marginBottom: 6, fontWeight: '500' },


### PR DESCRIPTION
## Summary

Adds a horizontal **Progress Timeline** to the mentorship connection profile and an inline **Meeting Notes** editor on Meetings & Sessions. Folds in three smaller mobile fixes (mentor list, goal placeholder, milestone validation, action-item rendering).

## What's new

### Progress Timeline (`connection-profile.tsx`)
- New section above Shared Goal that plots program start/end, today's marker, milestones (by `targetDate`), meetings (by `startTime`) and tasks (by `dueDate`) on a single horizontally-scrollable track.
- Color-coded pills above each dot, dots sit ON the track, dates below the pills, with a legend underneath.
- Slot width scales with event count so labels never overlap on dense timelines.
- Tap routing:
  - **Milestone** → `/milestones` (with `focusMilestoneId` param)
  - **Meeting** → `/meetings-sessions`
  - **Task** → `/task-tracker`
  - **Start / End / Today** → info bottom-sheet modal

### Meeting Notes (`meetings-sessions.tsx`)
- Each meeting card is now expandable. Tap to open → `GET /meetings/{id}` populates the notes section.
- View/edit toggle: `Add Notes` / `Edit Notes` button reveals a multiline `TextInput` (2000-char limit + counter).
- Save calls `PATCH /meetings/{id}/notes`; surfaces backend error message on failure.
- Works on past / completed meetings too — backend imposes no status gate, ideal for retrospectives.

### Smaller fixes
- **Explore tab** (`(tabs)/explore.tsx`) — switched `/users/mentors` (paginated, 20-item cap) to `/users/mentors/all` so mentors past page 1 actually appear.
- **Shared goal** no longer pre-fills with the `Your Mentee` fallback subtitle. Initial state is empty until the API returns a real saved goal.
- **Milestone create** — pulls mentorship `startDate` / `endDate`, surfaces them in the date placeholder, validates the target locally before POST, and bubbles the backend's actual error message when the request still fails.
- **Action item rendering** — normalizes the API's `completed` field to `isCompleted` inside `fetchMilestoneDetail`. (Jackson serializes Java boolean `isCompleted` as `completed`, so checkboxes were always falsy.) Tapping now reflects persisted state immediately.