### PR TITLE
Fix/feedpostresponse test arity

### DIFF
--- a/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
@@ -190,7 +190,7 @@ class FeedPostControllerTest {
         // Fixed timestamps so the assertion is deterministic.
         OffsetDateTime t0 = OffsetDateTime.parse("2026-05-09T10:15:00Z");
         FeedPostResponse fixed = new FeedPostResponse(42L, 1L, "Alice", "Hello",
-                List.of("data"), t0, t0, false, true);
+                List.of("data"), t0, t0, false, true, List.of());
         when(feedPostService.getById(42L, 1L)).thenReturn(fixed);
 
         mockMvc.perform(get("/api/feed/posts/42").header("Authorization", "Bearer " + TOKEN))
@@ -205,7 +205,7 @@ class FeedPostControllerTest {
         mockMenteeJwt(TOKEN, 1L);
         OffsetDateTime t0 = OffsetDateTime.parse("2026-05-09T10:15:00Z");
         FeedPostResponse fixed = new FeedPostResponse(42L, 1L, "Alice", "Hello",
-                List.of("data"), t0, t0, false, true);
+                List.of("data"), t0, t0, false, true, List.of());
         when(feedPostService.getById(42L, 1L)).thenReturn(fixed);
 
         // First fetch — capture the ETag.
@@ -229,9 +229,9 @@ class FeedPostControllerTest {
         OffsetDateTime created = OffsetDateTime.parse("2026-05-09T10:15:00Z");
         OffsetDateTime edited = OffsetDateTime.parse("2026-05-09T11:02:34Z");
         FeedPostResponse before = new FeedPostResponse(42L, 1L, "Alice", "Hello",
-                List.of("data"), created, created, false, true);
+                List.of("data"), created, created, false, true, List.of());
         FeedPostResponse after = new FeedPostResponse(42L, 1L, "Alice", "Hello edited",
-                List.of("data"), created, edited, true, true);
+                List.of("data"), created, edited, true, true, List.of());
         when(feedPostService.getById(42L, 1L)).thenReturn(before, after);
 
         String etagBefore = mockMvc.perform(get("/api/feed/posts/42")


### PR DESCRIPTION
## Summary

Fixes a semantic merge conflict on dev that broke the test build.

PR #498 (image attachments) added a 10th component to the
`FeedPostResponse` record — `List<AttachmentSummary> attachments`.
PR #499 (API ergonomics) added new tests in `FeedPostControllerTest`
that constructed `FeedPostResponse` with the old 9-arg signature and
was merged without rebasing onto #498. Each branch's CI was green in
isolation (the conflicting changes never lived on the same tree
during their own CI run), but on dev the compiler now rejects four
call sites.

Adds `List.of()` for the new `attachments` slot at the four affected
constructor calls in `FeedPostControllerTest` so the test build
matches the production record shape.

## Why CI didn't catch this

GitHub's "mergeable: clean" check is a textual merge — the two PRs
touched different lines, so no conflict markers appeared. The
contract change (record arity) is invisible to a textual diff but
fatal at compile time. The standard guard against this is requiring
branches to be up-to-date with the base before merge, which would
have triggered a real CI run with both changes in place.

## Test plan

- [x] `mvn -DskipTests test-compile` passes locally on the fix branch
- [ ] Backend CI green on this branch
- [ ] Merge to dev unblocks the broken test build
