### PR TITLE
Feature/issue 357 follow UI (#357)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import ResetPasswordPage from './pages/ResetPasswordPage'
 import VerifyEmailPage from './pages/VerifyEmailPage'
 import ProtectedRoute from './components/ProtectedRoute'
 import UserProfilePage from './pages/UserProfilePage'
+import UserFollowListPage from './pages/UserFollowListPage'
 import MentorshipDetailPage from './pages/MentorshipDetailPage'
 import MessagesPage from './pages/MessagesPage'
 import TasksPage from './pages/TasksPage'
@@ -37,6 +38,8 @@ export default function App() {
           <Route path="/explore" element={<ExplorePage />} />
           <Route path="/availability" element={<AvailabilityPage />} />
           <Route path="/users/:id" element={<UserProfilePage />} />
+          <Route path="/users/:id/followers" element={<UserFollowListPage mode="followers" />} />
+          <Route path="/users/:id/following" element={<UserFollowListPage mode="following" />} />
           <Route path="/mentorships/:id" element={<MentorshipDetailPage />} />
           <Route path="/messages" element={<MessagesPage />} />
           <Route path="/tasks" element={<TasksPage />} />

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import MainLayout from '../components/MainLayout'
 import FeedPostCard from '../components/FeedPostCard'
+import Avatar from '../components/Avatar'
 import {
   getForYouFeed,
   getFollowingFeed,
@@ -9,6 +10,8 @@ import {
   createFeedPost,
   updateFeedPost,
   deleteFeedPost,
+  getFollowRecommendations,
+  followUser,
 } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import '../styles/main.css'
@@ -17,6 +20,36 @@ const TABS = [
   { key: 'for-you', label: 'For you' },
   { key: 'following', label: 'Following' },
 ]
+
+function displayUserName(user) {
+  if (!user) return 'User'
+  if (user.role === 'MENTOR') {
+    return [user.firstName, user.lastName].filter(Boolean).join(' ')
+  }
+  return user.firstName || 'User'
+}
+
+function userInitials(user) {
+  if (!user) return '?'
+  const parts = user.role === 'MENTOR'
+    ? [user.firstName, user.lastName]
+    : [user.firstName]
+  const initials = parts.filter(Boolean).map(w => w[0]).join('')
+  return initials ? initials.toUpperCase().slice(0, 2) : '?'
+}
+
+function formatFollowFactor(factor) {
+  if (!factor) return ''
+  if (factor.startsWith('shared-interest:')) {
+    const label = factor.replace('shared-interest:', '')
+    return `Shared interest: ${label}`
+  }
+  if (factor.startsWith('followed-by-')) {
+    const match = factor.match(/followed-by-(\d+)-of-your-follows/)
+    if (match) return `Followed by ${match[1]} of your follows`
+  }
+  return factor
+}
 
 export default function FeedPage() {
   const [params, setParams] = useSearchParams()
@@ -27,6 +60,10 @@ export default function FeedPage() {
   const [posts, setPosts] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+
+  const [recommendations, setRecommendations] = useState([])
+  const [recLoading, setRecLoading] = useState(false)
+  const [recError, setRecError] = useState(null)
 
   const [searchQuery, setSearchQuery] = useState('')
   const [activeSearch, setActiveSearch] = useState(null) // { q?, hashtag? } or null
@@ -67,6 +104,26 @@ export default function FeedPage() {
   }, [tab, activeSearch])
 
   useEffect(() => { reload() }, [reload])
+
+  const loadRecommendations = useCallback(async () => {
+    setRecLoading(true)
+    setRecError(null)
+    try {
+      const page = await getFollowRecommendations(0, 8)
+      const list = (page?.content || []).map(r => ({ ...r, isFollowing: false, busy: false }))
+      setRecommendations(list)
+    } catch (err) {
+      setRecError(err?.message || 'Failed to load suggestions')
+      setRecommendations([])
+    } finally {
+      setRecLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (tab !== 'following' || activeSearch || loading || posts.length > 0) return
+    loadRecommendations()
+  }, [tab, activeSearch, loading, posts.length, loadRecommendations])
 
   // ── Tab nav ───────────────────────────────────────────────────────────
   function changeTab(next) {
@@ -164,6 +221,19 @@ export default function FeedPage() {
     }
   }
 
+  async function handleFollowSuggestion(userId) {
+    setRecommendations(prev => prev.map(r => r.id === userId ? { ...r, busy: true } : r))
+    try {
+      await followUser(userId)
+      setRecommendations(prev => prev.map(r => r.id === userId
+        ? { ...r, busy: false, isFollowing: true }
+        : r))
+    } catch (err) {
+      setRecommendations(prev => prev.map(r => r.id === userId ? { ...r, busy: false } : r))
+      window.alert(err?.message || 'Failed to follow user')
+    }
+  }
+
   // ── Render ────────────────────────────────────────────────────────────
   return (
     <MainLayout>
@@ -249,13 +319,75 @@ export default function FeedPage() {
             <div className="md-error-sub">{error}</div>
           </div>
         ) : posts.length === 0 ? (
-          <div className="empty-state">
-            {activeSearch
-              ? 'No posts match this search.'
-              : tab === 'following'
-                ? 'You don\'t follow anyone yet — switch to For you to discover posts.'
-                : 'No posts yet — be the first to share something.'}
-          </div>
+          activeSearch ? (
+            <div className="empty-state">No posts match this search.</div>
+          ) : tab === 'following' ? (
+            <div className="empty-following">
+              <div className="empty-state">
+                You do not follow anyone yet. Find people to follow to populate your feed.
+              </div>
+
+              <div className="follow-suggested">
+                <div className="follow-suggested-header">
+                  <div className="follow-suggested-title">Suggested to follow</div>
+                  {recLoading && <div className="follow-suggested-sub">Loading…</div>}
+                  {!recLoading && recError && <div className="follow-suggested-sub">{recError}</div>}
+                </div>
+
+                {recLoading ? (
+                  <div className="md-loading">Loading suggestions…</div>
+                ) : recError ? null : recommendations.length === 0 ? (
+                  <div className="empty-state">No suggestions available right now.</div>
+                ) : (
+                  <div className="follow-suggested-rail">
+                    {recommendations.map(rec => (
+                      <div className="follow-suggested-card" key={rec.id}>
+                        <div className="follow-suggested-main">
+                          <Avatar
+                            src={rec.profilePhoto}
+                            initials={userInitials(rec)}
+                            size="md"
+                          />
+                          <div>
+                            <div className="follow-suggested-name">{displayUserName(rec)}</div>
+                            <div className="follow-suggested-role">{rec.role === 'MENTOR' ? 'Mentor' : 'Mentee'}</div>
+                          </div>
+                        </div>
+                        {Array.isArray(rec.factors) && rec.factors.length > 0 && (
+                          <div className="follow-suggested-factors">
+                            {rec.factors.slice(0, 2).map((f, i) => (
+                              <span className="follow-suggested-factor" key={`${rec.id}-f-${i}`}>
+                                {formatFollowFactor(f)}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                        <div className="follow-suggested-actions">
+                          <button
+                            className="view-profile-btn"
+                            type="button"
+                            onClick={() => navigate(`/users/${rec.id}`)}
+                          >
+                            View Profile
+                          </button>
+                          <button
+                            className={`follow-btn${rec.isFollowing ? ' follow-btn--active' : ''}`}
+                            type="button"
+                            onClick={() => !rec.isFollowing && !rec.busy && handleFollowSuggestion(rec.id)}
+                            disabled={rec.busy || rec.isFollowing}
+                          >
+                            {rec.busy ? 'Updating...' : rec.isFollowing ? 'Following' : 'Follow'}
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="empty-state">No posts yet — be the first to share something.</div>
+          )
         ) : (
           <div className="feed-list">
             {posts.map(p => (

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -376,7 +376,7 @@ export default function FeedPage() {
                             onClick={() => !rec.isFollowing && !rec.busy && handleFollowSuggestion(rec.id)}
                             disabled={rec.busy || rec.isFollowing}
                           >
-                            {rec.busy ? 'Updating...' : rec.isFollowing ? 'Following' : 'Follow'}
+                            {rec.busy ? 'Updating...' : rec.isFollowing ? 'Unfollow' : 'Follow'}
                           </button>
                         </div>
                       </div>

--- a/frontend/src/pages/UserFollowListPage.jsx
+++ b/frontend/src/pages/UserFollowListPage.jsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import MainLayout from '../components/MainLayout'
+import Avatar from '../components/Avatar'
+import { getUserById, getFollowers, getFollowing } from '../services/api'
+import '../styles/main.css'
+
+const PAGE_SIZE = 12
+
+function displayProfileName(profile) {
+  if (!profile) return 'User'
+  if (profile.role === 'MENTOR') {
+    return [profile.firstName, profile.lastName].filter(Boolean).join(' ')
+  }
+  return profile.firstName || 'User'
+}
+
+function displayUserName(user) {
+  if (!user) return 'User'
+  if (user.role === 'MENTOR') {
+    return [user.firstName, user.lastName].filter(Boolean).join(' ')
+  }
+  return user.firstName || 'User'
+}
+
+function userInitials(user) {
+  if (!user) return '?'
+  const parts = user.role === 'MENTOR'
+    ? [user.firstName, user.lastName]
+    : [user.firstName]
+  const initials = parts.filter(Boolean).map(w => w[0]).join('')
+  return initials ? initials.toUpperCase().slice(0, 2) : '?'
+}
+
+export default function UserFollowListPage({ mode }) {
+  const { id } = useParams()
+  const navigate = useNavigate()
+
+  const [profile, setProfile] = useState(null)
+  const [profileLoading, setProfileLoading] = useState(true)
+  const [profileError, setProfileError] = useState('')
+
+  const [list, setList] = useState([])
+  const [listLoading, setListLoading] = useState(true)
+  const [listError, setListError] = useState('')
+  const [page, setPage] = useState(0)
+  const [totalPages, setTotalPages] = useState(1)
+
+  const title = mode === 'following' ? 'Following' : 'Followers'
+
+  useEffect(() => {
+    let ignore = false
+    setProfileLoading(true)
+    setProfileError('')
+    getUserById(id)
+      .then(data => {
+        if (!ignore) setProfile(data)
+      })
+      .catch(err => {
+        if (!ignore) setProfileError(err?.message || 'Failed to load profile.')
+      })
+      .finally(() => {
+        if (!ignore) setProfileLoading(false)
+      })
+    return () => { ignore = true }
+  }, [id])
+
+  useEffect(() => {
+    let ignore = false
+    setListLoading(true)
+    setListError('')
+    async function loadList() {
+      try {
+        const res = mode === 'following'
+          ? await getFollowing(id, page, PAGE_SIZE)
+          : await getFollowers(id, page, PAGE_SIZE)
+        if (ignore) return
+        setList(res?.content || [])
+        setTotalPages(Math.max(res?.totalPages ?? 1, 1))
+      } catch (err) {
+        if (ignore) return
+        setList([])
+        setTotalPages(1)
+        setListError(err?.message || `Could not load ${title.toLowerCase()}.`)
+      } finally {
+        if (!ignore) setListLoading(false)
+      }
+    }
+    loadList()
+    return () => { ignore = true }
+  }, [id, page, mode, title])
+
+  const subtitle = profileLoading
+    ? ''
+    : profileError
+      ? ''
+      : `for ${displayProfileName(profile)}`
+
+  return (
+    <MainLayout>
+      <div className="page-header">
+        <div>
+          <button
+            onClick={() => navigate(-1)}
+            style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: '13px', padding: 0, marginBottom: '8px' }}
+          >
+            ← Back
+          </button>
+          <div className="page-title">{title}</div>
+          {subtitle && <div className="page-sub">{subtitle}</div>}
+        </div>
+      </div>
+
+      <div className="follow-page">
+        {profileError && (
+          <div className="md-error-card">
+            <div className="md-error-title">Profile unavailable</div>
+            <div className="md-error-sub">{profileError}</div>
+          </div>
+        )}
+
+        {listLoading ? (
+          <div className="md-loading">Loading {title.toLowerCase()}…</div>
+        ) : listError ? (
+          <div className="md-error-card">
+            <div className="md-error-title">Couldn’t load {title.toLowerCase()}</div>
+            <div className="md-error-sub">{listError}</div>
+          </div>
+        ) : list.length === 0 ? (
+          <div className="empty-state">
+            {mode === 'following'
+              ? 'Not following anyone yet.'
+              : 'No followers yet.'}
+          </div>
+        ) : (
+          <>
+            <div className="follow-list">
+              {list.map(user => (
+                <div className="follow-card" key={user.id}>
+                  <div className="follow-card-main">
+                    <Avatar
+                      src={user.profilePhoto}
+                      initials={userInitials(user)}
+                      size="md"
+                    />
+                    <div className="follow-card-meta">
+                      <div className="follow-card-name">{displayUserName(user)}</div>
+                      <div className="follow-card-role">{user.role === 'MENTOR' ? 'Mentor' : 'Mentee'}</div>
+                    </div>
+                  </div>
+                  <button
+                    className="view-profile-btn"
+                    type="button"
+                    onClick={() => navigate(`/users/${user.id}`)}
+                  >
+                    View Profile
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="follow-pagination">
+                <button
+                  className="action-btn"
+                  type="button"
+                  onClick={() => setPage(p => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                >
+                  Previous
+                </button>
+                <div className="follow-page-indicator">
+                  Page {page + 1} of {totalPages}
+                </div>
+                <button
+                  className="action-btn"
+                  type="button"
+                  onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                  disabled={page >= totalPages - 1}
+                >
+                  Next
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </MainLayout>
+  )
+}

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -3,7 +3,16 @@ import { useParams, useNavigate } from 'react-router-dom'
 import MainLayout from '../components/MainLayout'
 import Avatar from '../components/Avatar'
 import RequestMentorshipModal from '../components/RequestMentorshipModal'
-import { getUserById, createMentorshipRequest, getSentMentorshipRequests, getActiveMentorships, getMentorAvailability } from '../services/api'
+import {
+  getUserById,
+  createMentorshipRequest,
+  getSentMentorshipRequests,
+  getActiveMentorships,
+  getMentorAvailability,
+  followUser,
+  unfollowUser,
+  getFollowing,
+} from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import '../styles/main.css'
 
@@ -51,6 +60,9 @@ export default function UserProfilePage() {
   const [requestError, setRequestError] = useState('')
   const [requestSent, setRequestSent] = useState(false)
 
+  const [isFollowing, setIsFollowing] = useState(false)
+  const [followLoading, setFollowLoading] = useState(false)
+
   useEffect(() => {
     getUserById(id)
       .then(data => {
@@ -89,6 +101,26 @@ export default function UserProfilePage() {
     }
   }, [id, isMentee])
 
+  useEffect(() => {
+    if (!userId || !id || !profile) return
+    if (String(userId) === String(id)) return
+    if (role === 'MENTEE' && profile.role === 'MENTEE') return
+    let ignore = false
+    async function loadFollowState() {
+      try {
+        const page = await getFollowing(userId, 0, 200)
+        const list = page?.content || []
+        if (!ignore) {
+          setIsFollowing(list.some(u => String(u.id) === String(id)))
+        }
+      } catch {
+        // ignore follow-state failures; toggle will still work
+      }
+    }
+    loadFollowState()
+    return () => { ignore = true }
+  }, [userId, id, profile, role])
+
   async function handleSubmitRequest(message) {
     setRequestLoading(true)
     setRequestError('')
@@ -100,6 +132,26 @@ export default function UserProfilePage() {
       setRequestError(err.message || 'Failed to send request.')
     } finally {
       setRequestLoading(false)
+    }
+  }
+
+  async function toggleFollow() {
+    if (followLoading) return
+    setFollowLoading(true)
+    try {
+      if (isFollowing) {
+        await unfollowUser(id)
+        setIsFollowing(false)
+        setProfile(prev => prev ? { ...prev, followerCount: Math.max(0, (prev.followerCount ?? 0) - 1) } : prev)
+      } else {
+        await followUser(id)
+        setIsFollowing(true)
+        setProfile(prev => prev ? { ...prev, followerCount: (prev.followerCount ?? 0) + 1 } : prev)
+      }
+    } catch (err) {
+      window.alert(err?.message || 'Failed to update follow status')
+    } finally {
+      setFollowLoading(false)
     }
   }
 
@@ -141,6 +193,11 @@ export default function UserProfilePage() {
     ? profile.profilePhoto
     : (canSeePhoto ? profile.profilePhoto : null)
 
+  const followerCount = profile.followerCount ?? 0
+  const followingCount = profile.followingCount ?? 0
+  const canFollow = !isOwnProfile && !(role === 'MENTEE' && profile.role === 'MENTEE')
+  const canViewFollowGraph = !(role === 'MENTEE' && profile.role === 'MENTEE' && !isOwnProfile)
+
   return (
     <MainLayout>
       <div className="page-header">
@@ -168,6 +225,38 @@ export default function UserProfilePage() {
               </span>
             )}
           </div>
+
+          <div className="profile-follow-stats">
+            <button
+              type="button"
+              className="profile-follow-stat"
+              onClick={() => canViewFollowGraph && navigate(`/users/${id}/followers`)}
+              disabled={!canViewFollowGraph}
+            >
+              <div className="profile-follow-num">{followerCount}</div>
+              <div className="profile-follow-label">Followers</div>
+            </button>
+            <button
+              type="button"
+              className="profile-follow-stat"
+              onClick={() => canViewFollowGraph && navigate(`/users/${id}/following`)}
+              disabled={!canViewFollowGraph}
+            >
+              <div className="profile-follow-num">{followingCount}</div>
+              <div className="profile-follow-label">Following</div>
+            </button>
+          </div>
+
+          {canFollow && (
+            <button
+              type="button"
+              className={`follow-btn${isFollowing ? ' follow-btn--active' : ''}`}
+              onClick={toggleFollow}
+              disabled={followLoading}
+            >
+              {followLoading ? 'Updating...' : isFollowing ? 'Following' : 'Follow'}
+            </button>
+          )}
 
           {isMentorProfile && (
             <div className="profile-stats-row">

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -254,7 +254,7 @@ export default function UserProfilePage() {
               onClick={toggleFollow}
               disabled={followLoading}
             >
-              {followLoading ? 'Updating...' : isFollowing ? 'Following' : 'Follow'}
+              {followLoading ? 'Updating...' : isFollowing ? 'Unfollow' : 'Follow'}
             </button>
           )}
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -157,6 +157,47 @@ export async function getUserById(id) {
   return handleResponse(res)
 }
 
+// ── Follow graph (#343) ─────────────────────────────────────────────────
+
+export async function followUser(id) {
+  const res = await fetch(`${BASE_URL}/users/${id}/follow`, {
+    method: 'POST',
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function unfollowUser(id) {
+  const res = await fetch(`${BASE_URL}/users/${id}/follow`, {
+    method: 'DELETE',
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function getFollowers(id, page = 0, size = 20) {
+  const res = await fetch(`${BASE_URL}/users/${id}/followers?page=${page}&size=${size}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function getFollowing(id, page = 0, size = 20) {
+  const res = await fetch(`${BASE_URL}/users/${id}/following?page=${page}&size=${size}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+// ── Follow recommendations (#344) ───────────────────────────────────────
+
+export async function getFollowRecommendations(page = 0, size = 12) {
+  const res = await fetch(`${BASE_URL}/users/me/follow-recommendations?page=${page}&size=${size}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
 export async function getNotifications(unreadOnly = false) {
   const res = await fetch(`${BASE_URL}/notifications?unreadOnly=${unreadOnly}`, {
     headers: authHeaders(),

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -901,6 +901,58 @@
 .psr-item + .psr-item { border-left: 1px solid var(--border); }
 .psr-num { font-size: 22px; font-weight: 700; color: var(--green-dark); }
 .psr-lbl { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
+.profile-follow-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+.profile-follow-stat {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 12px;
+  text-align: center;
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+.profile-follow-stat:hover:not(:disabled) {
+  box-shadow: var(--shadow-card);
+  transform: translateY(-1px);
+}
+.profile-follow-stat:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.profile-follow-num { font-size: 18px; font-weight: 700; color: var(--green-dark); }
+.profile-follow-label { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
+.follow-btn {
+  width: 100%;
+  height: 40px;
+  border-radius: 999px;
+  border: 1px solid var(--green-dark);
+  background: var(--green-dark);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  transition: filter 0.15s ease, transform 0.15s ease;
+  margin-bottom: 16px;
+}
+.follow-btn:hover:not(:disabled) { filter: brightness(0.92); }
+.follow-btn:active:not(:disabled) { transform: scale(0.98); }
+.follow-btn--active {
+  background: #fff;
+  color: var(--green-dark);
+  border-color: var(--green-mid);
+}
+.follow-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
 /* Chip tags for profile field values */
 .profile-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 4px; }
 .profile-chip {
@@ -950,6 +1002,32 @@
   white-space: nowrap;
 }
 .view-profile-btn:hover { background: var(--green-pale); color: var(--green-dark); border-color: var(--green-mid); }
+
+/* ── FOLLOW LISTS ── */
+.follow-page { max-width: 720px; margin: 0 auto; padding: 8px 16px 48px; }
+.follow-list { display: flex; flex-direction: column; gap: 12px; }
+.follow-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.follow-card-main { display: flex; align-items: center; gap: 12px; }
+.follow-card-meta { display: flex; flex-direction: column; gap: 4px; }
+.follow-card-name { font-size: 14px; font-weight: 600; color: var(--text-dark); }
+.follow-card-role { font-size: 12px; color: var(--text-muted); }
+.follow-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 16px;
+}
+.follow-page-indicator { font-size: 12px; color: var(--text-muted); }
 
 /* ── MESSAGES PAGE ── */
 .messages-layout {
@@ -1352,6 +1430,49 @@
 .feed-card-action-btn--active {
   color: var(--green-dark);
 }
+.empty-following { display: flex; flex-direction: column; gap: 24px; }
+.follow-suggested {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  box-shadow: var(--shadow-card);
+}
+.follow-suggested-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  gap: 12px;
+}
+.follow-suggested-title { font-size: 14px; font-weight: 700; color: var(--text-dark); }
+.follow-suggested-sub { font-size: 12px; color: var(--text-muted); }
+.follow-suggested-rail {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+}
+.follow-suggested-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.follow-suggested-main { display: flex; align-items: center; gap: 10px; }
+.follow-suggested-name { font-size: 14px; font-weight: 600; color: var(--text-dark); }
+.follow-suggested-role { font-size: 12px; color: var(--text-muted); }
+.follow-suggested-factors { display: flex; flex-wrap: wrap; gap: 6px; }
+.follow-suggested-factor {
+  font-size: 11px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--green-bg);
+  color: var(--green-dark);
+  border: 1px solid var(--green-pale);
+}
+.follow-suggested-actions { display: flex; gap: 8px; align-items: center; }
 .day-row {
   display: flex; align-items: center; gap: 16px;
   padding: 14px 12px; border-radius: var(--radius-sm);


### PR DESCRIPTION
### 📝 Description
This PR implements the frontend UI for the Follow/Unfollow system, which is a prerequisite for the Following feed. It introduces profile interactions, dedicated network list pages, and recommendation empty states while strictly enforcing role-based privacy rules.

### 🛠 Changes Made
- **Profile UI:** Added a Follow/Unfollow toggle on public user profiles reflecting the current follow state.
- **Network Stats:** Displayed Follower and Following counts on user profiles, linking to their respective list pages.
- **List Pages:** Created `/users/:id/followers` and `/users/:id/following` routes rendering paginated user cards.
- **Empty State:** Added a "Suggested to follow" rail (driven by the recommendation system) when the Following feed is empty.
- **Privacy Enforcement:** Implemented UI logic to completely hide the Follow toggle when a Mentee is viewing another Mentee's profile (per requirement 1.1.2.6).

### 🧪 Testing Instructions
1. **Toggle & Stats:** Log in as a Mentor. Visit another user's profile, click the Follow/Unfollow toggle, and verify the state updates.
2. **List Navigation:** Click on the "Followers" or "Following" numbers on the profile and verify it routes correctly and displays paginated user cards.
3. **Empty State:** Navigate to your Following feed (while not following anyone) and verify the "Suggested to follow" rail appears.
4. **Privacy Rule:** Log in as a Mentee. Navigate to another Mentee's profile and verify that the Follow toggle is completely hidden.