### PR TITLE
fix(backend): bake Neo4j GDS plugin into a custom Docker image

### DIFF
--- a/backend/docker/neo4j-gds/Dockerfile
+++ b/backend/docker/neo4j-gds/Dockerfile
@@ -1,0 +1,39 @@
+# Neo4j 5 + Graph Data Science (Community) 2.13.4. The GDS jar is fetched
+# in a small builder stage and copied into the final image so that when a
+# container started from this image opens its Bolt port, the plugin is
+# already on disk under /plugins — Testcontainers' default readiness probe
+# waits for Bolt and is therefore sufficient.
+#
+# Why not NEO4J_PLUGINS=["graph-data-science"]? That env var triggers a
+# runtime download from the Neo4j plugin marketplace during container
+# start, and GitHub Actions runners observe intermittent failures: Bolt
+# opens before the download completes, the test starts, and
+# CALL gds.graph.drop(...) hits a "procedure not found" error. Baking the
+# JAR into an image layer removes that race entirely.
+
+# ---- builder: pull + verify the JAR -----------------------------------------
+FROM alpine:3.20 AS gds-fetcher
+
+ARG GDS_VERSION=2.13.4
+# Pinned checksum — an upstream re-publish or supply-chain swap fails the
+# build loudly rather than silently shipping a different binary. Refresh
+# alongside any GDS_VERSION bump:
+#   curl -fsSL <jar-url> | sha256sum
+ARG GDS_SHA256=10e072f73992224f1159f246c9d6a89da5f3b3434aeffa5be42647edda13a8d8
+
+RUN apk add --no-cache curl ca-certificates \
+ && curl -fsSL -o /tmp/neo4j-graph-data-science.jar \
+        "https://github.com/neo4j/graph-data-science/releases/download/${GDS_VERSION}/neo4j-graph-data-science-${GDS_VERSION}.jar" \
+ && echo "${GDS_SHA256}  /tmp/neo4j-graph-data-science.jar" | sha256sum -c -
+
+# ---- runtime: stock neo4j + the verified JAR --------------------------------
+FROM neo4j:5-community
+
+COPY --from=gds-fetcher /tmp/neo4j-graph-data-science.jar \
+                        /var/lib/neo4j/plugins/neo4j-graph-data-science.jar
+
+# GDS procedures need explicit allow-listing under Neo4j 5. Baking the
+# config in the image keeps every consumer honest (tests, compose, future
+# prod) without duplicating env-vars at the call site.
+ENV NEO4J_dbms_security_procedures_unrestricted="gds.*"
+ENV NEO4J_dbms_security_procedures_allowlist="gds.*"

--- a/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
@@ -190,7 +190,7 @@ class FeedPostControllerTest {
         // Fixed timestamps so the assertion is deterministic.
         OffsetDateTime t0 = OffsetDateTime.parse("2026-05-09T10:15:00Z");
         FeedPostResponse fixed = new FeedPostResponse(42L, 1L, "Alice", "Hello",
-                List.of("data"), t0, t0, false, true);
+                List.of("data"), t0, t0, false, true, List.of());
         when(feedPostService.getById(42L, 1L)).thenReturn(fixed);
 
         mockMvc.perform(get("/api/feed/posts/42").header("Authorization", "Bearer " + TOKEN))
@@ -205,7 +205,7 @@ class FeedPostControllerTest {
         mockMenteeJwt(TOKEN, 1L);
         OffsetDateTime t0 = OffsetDateTime.parse("2026-05-09T10:15:00Z");
         FeedPostResponse fixed = new FeedPostResponse(42L, 1L, "Alice", "Hello",
-                List.of("data"), t0, t0, false, true);
+                List.of("data"), t0, t0, false, true, List.of());
         when(feedPostService.getById(42L, 1L)).thenReturn(fixed);
 
         // First fetch — capture the ETag.
@@ -229,9 +229,9 @@ class FeedPostControllerTest {
         OffsetDateTime created = OffsetDateTime.parse("2026-05-09T10:15:00Z");
         OffsetDateTime edited = OffsetDateTime.parse("2026-05-09T11:02:34Z");
         FeedPostResponse before = new FeedPostResponse(42L, 1L, "Alice", "Hello",
-                List.of("data"), created, created, false, true);
+                List.of("data"), created, created, false, true, List.of());
         FeedPostResponse after = new FeedPostResponse(42L, 1L, "Alice", "Hello edited",
-                List.of("data"), created, edited, true, true);
+                List.of("data"), created, edited, true, true, List.of());
         when(feedPostService.getById(42L, 1L)).thenReturn(before, after);
 
         String etagBefore = mockMvc.perform(get("/api/feed/posts/42")

--- a/backend/src/test/java/com/group7/backend/service/ranking/graph/FollowGraphProjectionServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ranking/graph/FollowGraphProjectionServiceTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
 
@@ -42,13 +41,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import(FollowGraphProjectionService.class)
 class FollowGraphProjectionServiceTest {
 
+    // Uses the shared neo4j+GDS image (see Neo4jGdsTestImage). The image is
+    // built from backend/docker/neo4j-gds/Dockerfile, baking the GDS jar
+    // into a layer at build time so the runtime NEO4J_PLUGINS download race
+    // that made CI flaky is gone.
     @Container
-    static final Neo4jContainer<?> NEO4J = new Neo4jContainer<>(
-            DockerImageName.parse("neo4j:5-community"))
+    static final Neo4jContainer<?> NEO4J = new Neo4jContainer<>(Neo4jGdsTestImage.IMAGE)
             .withoutAuthentication()
-            .withEnv("NEO4J_PLUGINS", "[\"graph-data-science\"]")
-            .withEnv("NEO4J_dbms_security_procedures_unrestricted", "gds.*")
-            .withEnv("NEO4J_dbms_security_procedures_allowlist", "gds.*")
             .withReuse(false);
 
     @DynamicPropertySource

--- a/backend/src/test/java/com/group7/backend/service/ranking/graph/Neo4jGdsTestImage.java
+++ b/backend/src/test/java/com/group7/backend/service/ranking/graph/Neo4jGdsTestImage.java
@@ -1,0 +1,33 @@
+package com.group7.backend.service.ranking.graph;
+
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.file.Path;
+
+/**
+ * Shared Neo4j 5 + GDS Community image used by every integration test that
+ * needs the {@code gds.*} procedure surface. The image is built from
+ * {@code backend/docker/neo4j-gds/Dockerfile} the first time any test class
+ * touches {@link #IMAGE} in a JVM, and Testcontainers' content-hash cache
+ * (combined with the fixed tag below + {@code deleteOnExit=false}) ensures
+ * later test classes in the same Maven run resolve to the same image
+ * without rebuilding — important because the apk/curl fetch inside the
+ * builder stage is the one network step we can't guarantee on first try.
+ *
+ * <p>Path is relative to Maven's working directory ({@code backend/}).
+ */
+final class Neo4jGdsTestImage {
+
+    private static final ImageFromDockerfile IMAGE_FROM_DOCKERFILE =
+            new ImageFromDockerfile("group7-neo4j-gds-test", false)
+                    .withDockerfile(Path.of("docker/neo4j-gds/Dockerfile"));
+
+    /** Resolved image name (triggers the build on first reference). */
+    static final DockerImageName IMAGE = DockerImageName
+            .parse(IMAGE_FROM_DOCKERFILE.get())
+            .asCompatibleSubstituteFor("neo4j");
+
+    private Neo4jGdsTestImage() {
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/ranking/graph/PersonalizedPageRankIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ranking/graph/PersonalizedPageRankIntegrationTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
 
@@ -52,16 +51,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataNeo4jTest
 class PersonalizedPageRankIntegrationTest {
 
+    // Uses the shared neo4j+GDS image (see Neo4jGdsTestImage). The image is
+    // built from backend/docker/neo4j-gds/Dockerfile, baking the GDS jar
+    // into a layer at build time so the runtime NEO4J_PLUGINS download race
+    // that made CI flaky is gone.
     @Container
-    static final Neo4jContainer<?> NEO4J = new Neo4jContainer<>(
-            DockerImageName.parse("neo4j:5-community"))
+    static final Neo4jContainer<?> NEO4J = new Neo4jContainer<>(Neo4jGdsTestImage.IMAGE)
             .withoutAuthentication()
-            // The newer Testcontainers Neo4j module dropped Neo4jLabsPlugin
-            // enum in favour of plain env vars — match what docker-compose
-            // does for the prod image.
-            .withEnv("NEO4J_PLUGINS", "[\"graph-data-science\"]")
-            .withEnv("NEO4J_dbms_security_procedures_unrestricted", "gds.*")
-            .withEnv("NEO4J_dbms_security_procedures_allowlist", "gds.*")
             .withReuse(false);
 
     @DynamicPropertySource

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,15 @@ services:
       - group7_net
 
   neo4j:
-    image: neo4j:5-community
+    # Custom image that bakes the GDS plugin jar in at build time. The
+    # upstream NEO4J_PLUGINS=["graph-data-science"] approach downloaded the
+    # JAR from the Neo4j plugin marketplace during container start, which
+    # was unreliable on CI runners (Bolt opened before the download
+    # completed; gds.* procedures returned "procedure not found"). Baking
+    # the JAR into an image layer removes that race for every consumer.
+    build: ./backend/docker/neo4j-gds
     environment:
       NEO4J_AUTH: ${NEO4J_USERNAME:-neo4j}/${NEO4J_PASSWORD:-group7pass}
-      NEO4J_PLUGINS: '["graph-data-science"]'
-      NEO4J_dbms_security_procedures_unrestricted: gds.*
-      NEO4J_dbms_security_procedures_allowlist: gds.*
     ports:
       - "${NEO4J_HTTP_PORT:-7474}:7474"
       - "${NEO4J_BOLT_PORT:-7687}:7687"


### PR DESCRIPTION
## Summary

Dev's backend CI and E2E CI have both been red since the Neo4j follow-ranker tests landed, with eight test errors per run and a backend-jar compile failure that prevented the Playwright suite from even starting. Both failures share a single underlying cause: dependencies that were assumed to be available at runtime (the GDS plugin) or already aligned with sibling changes (the `FeedPostResponse` arity) are not, on the actual dev tree.

This change makes the GDS plugin a property of the image layer rather than a runtime fetch, and aligns the four orphaned test stubs in `FeedPostControllerTest` with the `attachments`-aware `FeedPostResponse` shape that landed via the image-attachments work.

## Why this is needed

`FollowGraphProjectionServiceTest` and `PersonalizedPageRankIntegrationTest` configure their Testcontainers Neo4j with `NEO4J_PLUGINS=["graph-data-science"]`, which triggers a download from the Neo4j plugin marketplace at container start. On GitHub Actions runners the container's Bolt port opens before the download completes; Testcontainers' default wait strategy reports the container ready; the test's `@BeforeEach` calls `CALL gds.graph.drop(...)` and fails with `Neo.ClientError.Procedure.ProcedureNotFound`. The result is eight errors per backend CI run and a downstream e2e CI failure (the jar build is part of the e2e job, but the e2e job ran into the unrelated `FeedPostResponse` arity compile error before it could even probe Neo4j).

Production is not affected — `app.recommendations.follow.sync.enabled` defaults to `false` and the prod compose file declares no Neo4j service.

## What changed

- **`backend/docker/neo4j-gds/Dockerfile`** — new. Two-stage build: an alpine fetcher pulls the GDS Community 2.13.4 jar, verifies a pinned SHA-256, and copies the verified jar into a final image built on `neo4j:5-community`. The GDS allow-list env vars are baked in so call sites never have to repeat them.
- **`backend/src/test/.../graph/Neo4jGdsTestImage.java`** — new. A small shared image holder. `ImageFromDockerfile` is constructed once per JVM with a fixed tag (`group7-neo4j-gds-test`) and `deleteOnExit=false`; the second test class in the same Maven run resolves the cached image instead of attempting a fresh apk fetch from inside Testcontainers.
- **`FollowGraphProjectionServiceTest` / `PersonalizedPageRankIntegrationTest`** — drop the three `withEnv(...)` calls that mirrored the runtime plugin install (now baked in) and route both `@Container` instances at the shared image.
- **`docker-compose.yml`** — the local-dev `neo4j` service is switched from `image: neo4j:5-community` (which inherited the same plugin-marketplace race) to `build: ./backend/docker/neo4j-gds`. `docker-compose.prod.yml` is intentionally unchanged.
- **`FeedPostControllerTest`** — three call-site stubs that constructed `FeedPostResponse` with nine arguments are bumped to ten by appending `, List.of()` for the `attachments` field. This is the same fix that PR #504 is shipping for `main`; without it, dev's `mvn test-compile` step fails before any test runs.

## Verification

- `docker build -t neo4j-gds:smoke backend/docker/neo4j-gds/` succeeds end-to-end and the resulting image's SHA-256 check passes.
- Booting a container from the image and querying `SHOW PROCEDURES YIELD name WHERE name STARTS WITH 'gds.graph.drop' RETURN name` returns the procedure (previously missing).
- `mvn -B test -Dtest=FollowGraphProjectionServiceTest,PersonalizedPageRankIntegrationTest` -> 8/8 pass (previously 8/8 errors).
- `mvn -B test-compile` -> clean (the `FeedPostResponse` arity fix unblocks compilation).

## Cost considerations

The first run on a fresh CI runner pays roughly 30 seconds for the apk install and the GDS jar download during image build. The download is then cached in a Docker layer for the rest of the job; subsequent test classes in the same Maven invocation pick up the cached image and skip the build.

## Out of scope

- Adding Neo4j to `docker-compose.prod.yml` — production has not opted into the follow-graph feature.
- Refactoring the tests away from Testcontainers toward a workflow service container — the existing `@DataNeo4jTest` + `@DynamicPropertySource` shape works against the new image and matches the only Testcontainers pattern currently in the project.

## Test plan

- [x] Image builds cleanly and `gds.*` procedures register on the running container.
- [x] Both Neo4j integration test classes pass locally (8/8).
- [x] Backend `mvn test-compile` is green.
- [x] CI: Backend CI/CD test job runs to completion and reports zero GDS-related errors.
- [x] CI: E2E CI Playwright job builds the backend jar and proceeds to the spec suite (previously blocked at compile).