### PR TITLE
feat(web): notification renderer for feed engagement types (#508)

### DIFF
--- a/frontend/src/components/NotificationBell.jsx
+++ b/frontend/src/components/NotificationBell.jsx
@@ -39,6 +39,37 @@ function TypeIcon({ type }) {
           <line x1="4" y1="22" x2="4" y2="15" />
         </svg>
       )
+    case 'FEED_LIKE':
+      return (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+          <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+        </svg>
+      )
+    case 'FEED_COMMENT':
+      return (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+      )
+    case 'FEED_SHARE':
+      return (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+          <circle cx="18" cy="5" r="3" />
+          <circle cx="6" cy="12" r="3" />
+          <circle cx="18" cy="19" r="3" />
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+        </svg>
+      )
+    case 'NEW_FOLLOWER':
+      return (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+          <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+          <circle cx="8.5" cy="7" r="4" />
+          <line x1="20" y1="8" x2="20" y2="14" />
+          <line x1="23" y1="11" x2="17" y2="11" />
+        </svg>
+      )
     default:
       // Default bell icon for unknown types
       return (
@@ -56,6 +87,10 @@ function typeColorClass(type) {
     case 'REQUEST_REJECTED': return 'notif-icon--red'
     case 'TASK_DEADLINE_REMINDER': return 'notif-icon--orange'
     case 'MILESTONE_REMINDER': return 'notif-icon--purple'
+    case 'FEED_LIKE': return 'notif-icon--red'
+    case 'FEED_COMMENT': return 'notif-icon--blue'
+    case 'FEED_SHARE': return 'notif-icon--green'
+    case 'NEW_FOLLOWER': return 'notif-icon--purple'
     default: return 'notif-icon--blue'
   }
 }
@@ -201,6 +236,16 @@ export default function NotificationBell() {
                   if (!n.read) handleMarkRead(n.id)
                   setOpen(false)
                   const rid = n.relatedId || n.entityId
+                  switch (n.type) {
+                    case 'FEED_LIKE':
+                    case 'FEED_COMMENT':
+                    case 'FEED_SHARE':
+                      navigate(rid ? `/feed/${rid}` : '/feed')
+                      return
+                    case 'NEW_FOLLOWER':
+                      navigate(rid ? `/users/${rid}` : '/explore')
+                      return
+                  }
                   if (!rid) return
                   switch (n.type) {
                     case 'REQUEST_SUBMITTED':
@@ -215,7 +260,6 @@ export default function NotificationBell() {
                       navigate(`/mentorships/${rid}#milestones`)
                       break
                     default:
-                      // Fallback: No navigation for unknown types unless we want a default
                       break
                   }
                 }}

--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -22,10 +22,38 @@ const TYPE_ICON = {
   MEETING_REMINDER: '📅',
   TASK_DEADLINE_REMINDER: '⏰',
   MILESTONE_REMINDER: '🚩',
+  FEED_LIKE: '❤️',
+  FEED_COMMENT: '💬',
+  FEED_SHARE: '🔁',
+  NEW_FOLLOWER: '👤',
 }
 
 function iconFor(type) {
   return TYPE_ICON[type] || '🔔'
+}
+
+function routeForNotification(type, rid) {
+  switch (type) {
+    case 'FEED_LIKE':
+    case 'FEED_COMMENT':
+    case 'FEED_SHARE':
+      return rid ? `/feed/${rid}` : '/feed'
+    case 'NEW_FOLLOWER':
+      return rid ? `/users/${rid}` : '/explore'
+  }
+  if (!rid) return null
+  switch (type) {
+    case 'REQUEST_SUBMITTED':
+    case 'REQUEST_ACCEPTED':
+    case 'REQUEST_RECEIVED':
+      return `/mentorships/${rid}`
+    case 'TASK_DEADLINE_REMINDER':
+      return `/tasks?mentorshipId=${rid}`
+    case 'MILESTONE_REMINDER':
+      return `/mentorships/${rid}#milestones`
+    default:
+      return null
+  }
 }
 
 export default function NotificationsPage() {
@@ -129,23 +157,8 @@ export default function NotificationsPage() {
                   className={`notif-page-item${!n.read ? ' notif-page-item--unread' : ''}`}
                   onClick={() => {
                     if (!n.read) handleMarkRead(n.id)
-                    const rid = n.relatedId || n.entityId
-                    if (!rid) return
-                    switch (n.type) {
-                      case 'REQUEST_SUBMITTED':
-                      case 'REQUEST_ACCEPTED':
-                      case 'REQUEST_RECEIVED':
-                        navigate(`/mentorships/${rid}`)
-                        break
-                      case 'TASK_DEADLINE_REMINDER':
-                        navigate(`/tasks?mentorshipId=${rid}`)
-                        break
-                      case 'MILESTONE_REMINDER':
-                        navigate(`/mentorships/${rid}#milestones`)
-                        break
-                      default:
-                        break
-                    }
+                    const route = routeForNotification(n.type, n.relatedId || n.entityId)
+                    if (route) navigate(route)
                   }}
                   role="button"
                   tabIndex={0}
@@ -153,23 +166,8 @@ export default function NotificationsPage() {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault()
                       if (!n.read) handleMarkRead(n.id)
-                      const rid = n.relatedId || n.entityId
-                      if (!rid) return
-                      switch (n.type) {
-                        case 'REQUEST_SUBMITTED':
-                        case 'REQUEST_ACCEPTED':
-                        case 'REQUEST_RECEIVED':
-                          navigate(`/mentorships/${rid}`)
-                          break
-                        case 'TASK_DEADLINE_REMINDER':
-                          navigate(`/tasks?mentorshipId=${rid}`)
-                          break
-                        case 'MILESTONE_REMINDER':
-                          navigate(`/mentorships/${rid}#milestones`)
-                          break
-                        default:
-                          break
-                      }
+                      const route = routeForNotification(n.type, n.relatedId || n.entityId)
+                      if (route) navigate(route)
                     }
                   }}
                   data-testid={`notifications-item-${n.id}`}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1704,9 +1704,11 @@
   display: flex; align-items: center; justify-content: center;
   flex-shrink: 0; margin-top: 1px;
 }
-.notif-icon--green { background: #d1fae5; color: #059669; }
-.notif-icon--red   { background: #fee2e2; color: #dc2626; }
-.notif-icon--blue  { background: #dbeafe; color: #2563eb; }
+.notif-icon--green  { background: #d1fae5; color: #059669; }
+.notif-icon--red    { background: #fee2e2; color: #dc2626; }
+.notif-icon--blue   { background: #dbeafe; color: #2563eb; }
+.notif-icon--orange { background: #ffedd5; color: #c2410c; }
+.notif-icon--purple { background: #ede9fe; color: #7c3aed; }
 
 .notif-body { flex: 1; min-width: 0; }
 .notif-item-title {


### PR DESCRIPTION

  Closes #508.                                                                                                                                                                          
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Adds rendering + click-through for the four new social-feed notification types backend started publishing in #495: FEED_LIKE, FEED_COMMENT, FEED_SHARE, NEW_FOLLOWER. Before this PR
  they fell through to the generic bell icon and clicking did nothing.                                                                                                                  
                                                                                             
  Changes                                                       
                                                               
  - NotificationBell.jsx — added 4 SVG icon cases (heart / chat-bubble / share-arrows / user-plus) to TypeIcon and matching color-class entries in typeColorClass. Added a navigation   
  switch that runs before the existing if (!rid) return guard so the feed/follower routes still navigate to a sensible fallback (/feed, /explore) when the backend payload doesn't carry
   a relatedId.                                                                                                                                                                         
  - NotificationsPage.jsx — added 4 emoji entries to TYPE_ICON (❤️  / 💬 / 🔁 / 👤). Extracted the previously-duplicated click + keyboard handlers into a single                         
  routeForNotification(type, rid) helper so both invocations stay in sync.                   
  - main.css — added .notif-icon--orange and .notif-icon--purple. PR #459 already references these classes for TASK_DEADLINE_REMINDER / MILESTONE_REMINDER but never defined them, so
  this also fixes a latent visual gap on dev.                                                                                                                                           
                                            