### PR TITLE
feat(web): feed image attachments — compose, edit, render (#507)

### DIFF
--- a/frontend/src/components/FeedAttachmentGrid.jsx
+++ b/frontend/src/components/FeedAttachmentGrid.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Renders a feed post's image attachments (#507) as a 1-4 image grid.
+ *
+ * Backend serves each attachment via the authenticated download endpoint
+ * `GET /api/uploads/feed-media/{id}` (FeedMediaDownloadController), so we
+ * cannot bind `attachment.downloadUrl` directly to <img src>. Same pattern
+ * as MessageAttachment.ImagePreview: fetch with the bearer header, build a
+ * blob URL, revoke on unmount.
+ */
+export default function FeedAttachmentGrid({ attachments }) {
+  if (!Array.isArray(attachments) || attachments.length === 0) return null
+  const layout = layoutClassFor(attachments.length)
+  return (
+    <div className={`feed-attach-grid ${layout}`} onClick={(e) => e.stopPropagation()}>
+      {attachments.map((att, i) => (
+        <AuthImage key={att.id || `${att.filename}-${i}`} attachment={att} />
+      ))}
+    </div>
+  )
+}
+
+function layoutClassFor(n) {
+  switch (n) {
+    case 1: return 'feed-attach-grid--1'
+    case 2: return 'feed-attach-grid--2'
+    case 3: return 'feed-attach-grid--3'
+    default: return 'feed-attach-grid--4'
+  }
+}
+
+function AuthImage({ attachment }) {
+  const [blobUrl, setBlobUrl] = useState(null)
+  const [error, setError] = useState(false)
+  useEffect(() => {
+    let revoked = false
+    let createdUrl = null
+    setBlobUrl(null)
+    setError(false)
+    const token = localStorage.getItem('auth_token')
+    fetch(attachment.downloadUrl, { headers: token ? { Authorization: `Bearer ${token}` } : {} })
+      .then(r => r.ok ? r.blob() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then(blob => {
+        if (revoked) return
+        createdUrl = URL.createObjectURL(blob)
+        setBlobUrl(createdUrl)
+      })
+      .catch(() => { if (!revoked) setError(true) })
+    return () => {
+      revoked = true
+      if (createdUrl) URL.revokeObjectURL(createdUrl)
+    }
+  }, [attachment.downloadUrl])
+
+  if (error) {
+    return <div className="feed-attach-cell feed-attach-cell--err">Image unavailable</div>
+  }
+  if (!blobUrl) {
+    return <div className="feed-attach-cell feed-attach-cell--loading" />
+  }
+  return (
+    <a
+      href={blobUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="feed-attach-cell"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <img src={blobUrl} alt={attachment.filename} loading="lazy" />
+    </a>
+  )
+}

--- a/frontend/src/components/FeedImageUploader.jsx
+++ b/frontend/src/components/FeedImageUploader.jsx
@@ -1,0 +1,158 @@
+import { useEffect, useRef, useState } from 'react'
+import { ImagePlus, X } from 'lucide-react'
+import { uploadMessageAttachment, MAX_ATTACHMENT_BYTES } from '../services/attachmentService'
+
+const MAX_IMAGES = 4
+const ALLOWED_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp'])
+
+/**
+ * File picker + thumb strip for feed-post image attachments (#507).
+ *
+ * Owns its own per-file upload state. Files are uploaded as they're picked
+ * (POST /api/messages/attachments — the universal upload endpoint), so by
+ * the time the user clicks Publish/Save we already have UUIDs to send as
+ * `attachmentIds`.
+ *
+ * Props:
+ *   value: AttachmentSummary[] — current attachment list (empty array on compose)
+ *   onChange(next: AttachmentSummary[]): called when items are added/removed
+ *   disabled: boolean — disable the picker button while parent is busy publishing
+ */
+export default function FeedImageUploader({ value = [], onChange, disabled = false }) {
+  const inputRef = useRef(null)
+  const [pending, setPending] = useState([]) // [{ tempId, name, previewUrl }]
+  const [error, setError] = useState(null)
+
+  // Revoke object URLs when pending entries leave the list, to avoid leaks.
+  useEffect(() => {
+    return () => pending.forEach(p => URL.revokeObjectURL(p.previewUrl))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const remaining = MAX_IMAGES - value.length - pending.length
+  const canAdd = remaining > 0 && !disabled
+
+  async function handleFiles(files) {
+    setError(null)
+    const arr = Array.from(files || [])
+    if (arr.length === 0) return
+    if (arr.length > remaining) {
+      setError(`You can attach at most ${MAX_IMAGES} images per post.`)
+      return
+    }
+    for (const file of arr) {
+      if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+        setError('Only JPEG, PNG, GIF, or WebP images are allowed.')
+        continue
+      }
+      if (file.size > MAX_ATTACHMENT_BYTES) {
+        setError('Images must be 5 MB or smaller.')
+        continue
+      }
+      const tempId = `${file.name}-${file.size}-${Date.now()}-${Math.random()}`
+      const previewUrl = URL.createObjectURL(file)
+      setPending(prev => [...prev, { tempId, name: file.name, previewUrl }])
+      try {
+        const summary = await uploadMessageAttachment(file)
+        setPending(prev => prev.filter(p => p.tempId !== tempId))
+        URL.revokeObjectURL(previewUrl)
+        onChange?.([...value, summary])
+      } catch (err) {
+        setPending(prev => prev.filter(p => p.tempId !== tempId))
+        URL.revokeObjectURL(previewUrl)
+        setError(err?.message || 'Upload failed')
+      }
+    }
+  }
+
+  function removeAt(index) {
+    if (disabled) return
+    const next = value.slice(0, index).concat(value.slice(index + 1))
+    onChange?.(next)
+  }
+
+  return (
+    <div className="feed-uploader">
+      <div className="feed-uploader-thumbs">
+        {value.map((att, i) => (
+          <UploadedThumb
+            key={att.id || `${att.filename}-${i}`}
+            attachment={att}
+            onRemove={() => removeAt(i)}
+            disabled={disabled}
+          />
+        ))}
+        {pending.map(p => (
+          <div key={p.tempId} className="feed-uploader-thumb feed-uploader-thumb--pending">
+            <img src={p.previewUrl} alt={p.name} />
+            <div className="feed-uploader-thumb-spinner" aria-label="Uploading" />
+          </div>
+        ))}
+        {canAdd && (
+          <button
+            type="button"
+            className="feed-uploader-add"
+            onClick={() => inputRef.current?.click()}
+            aria-label="Add images"
+            title={`Add images (${remaining} remaining)`}
+          >
+            <ImagePlus size={18} strokeWidth={1.75} />
+            <span>Add image</span>
+          </button>
+        )}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/gif,image/webp"
+        multiple
+        hidden
+        onChange={(e) => {
+          handleFiles(e.target.files)
+          e.target.value = ''
+        }}
+      />
+      {error && <div className="feed-uploader-error">{error}</div>}
+    </div>
+  )
+}
+
+function UploadedThumb({ attachment, onRemove, disabled }) {
+  const [blobUrl, setBlobUrl] = useState(null)
+  useEffect(() => {
+    let revoked = false
+    let createdUrl = null
+    const token = localStorage.getItem('auth_token')
+    fetch(attachment.downloadUrl, { headers: token ? { Authorization: `Bearer ${token}` } : {} })
+      .then(r => r.ok ? r.blob() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then(blob => {
+        if (revoked) return
+        createdUrl = URL.createObjectURL(blob)
+        setBlobUrl(createdUrl)
+      })
+      .catch(() => {})
+    return () => {
+      revoked = true
+      if (createdUrl) URL.revokeObjectURL(createdUrl)
+    }
+  }, [attachment.downloadUrl])
+
+  return (
+    <div className="feed-uploader-thumb">
+      {blobUrl
+        ? <img src={blobUrl} alt={attachment.filename} />
+        : <div className="feed-uploader-thumb-placeholder" />}
+      {!disabled && (
+        <button
+          type="button"
+          className="feed-uploader-thumb-remove"
+          onClick={onRemove}
+          aria-label={`Remove ${attachment.filename}`}
+          title="Remove"
+        >
+          <X size={14} strokeWidth={2} />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/FeedPostCard.jsx
+++ b/frontend/src/components/FeedPostCard.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { MoreHorizontal, Pencil, Trash2, Share2, Bookmark, Heart, MessageCircle } from 'lucide-react'
 import Avatar from './Avatar'
+import FeedAttachmentGrid from './FeedAttachmentGrid'
 import { linkify } from '../utils/linkify'
 import {
   toggleBookmarkOnPost,
@@ -326,6 +327,8 @@ export default function FeedPostCard({
       </div>
 
       <div className="feed-card-body">{renderBody(post.body)}</div>
+
+      <FeedAttachmentGrid attachments={post.attachments} />
 
       {Array.isArray(post.hashtags) && post.hashtags.length > 0 && (
         <div className="feed-card-tags">

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import MainLayout from '../components/MainLayout'
 import FeedPostCard from '../components/FeedPostCard'
+import FeedImageUploader from '../components/FeedImageUploader'
 import Avatar from '../components/Avatar'
 import {
   getForYouFeed,
@@ -71,6 +72,7 @@ export default function FeedPage() {
   // Minimal compose — full UI lands in #353
   const [composeOpen, setComposeOpen] = useState(false)
   const [composeBody, setComposeBody] = useState('')
+  const [composeAttachments, setComposeAttachments] = useState([]) // AttachmentSummary[]
   const [composeBusy, setComposeBusy] = useState(false)
   const [composeError, setComposeError] = useState(null)
 
@@ -78,6 +80,7 @@ export default function FeedPage() {
   const [editing, setEditing] = useState(null) // post object or null
   const [editBody, setEditBody] = useState('')
   const [editHashtags, setEditHashtags] = useState('')
+  const [editAttachments, setEditAttachments] = useState([])
   const [editBusy, setEditBusy] = useState(false)
   const [editError, setEditError] = useState(null)
 
@@ -162,8 +165,13 @@ export default function FeedPage() {
     setComposeBusy(true)
     setComposeError(null)
     try {
-      const created = await createFeedPost({ body, hashtags: extractHashtags(body) })
+      const created = await createFeedPost({
+        body,
+        hashtags: extractHashtags(body),
+        attachmentIds: composeAttachments.map(a => a.id),
+      })
       setComposeBody('')
+      setComposeAttachments([])
       setComposeOpen(false)
       // Optimistically prepend for visibility; reload picks up the canonical state
       setPosts(prev => [created, ...prev])
@@ -179,6 +187,7 @@ export default function FeedPage() {
     setEditing(post)
     setEditBody(post.body || '')
     setEditHashtags((post.hashtags || []).join(' '))
+    setEditAttachments(Array.isArray(post.attachments) ? post.attachments : [])
     setEditError(null)
   }
 
@@ -196,9 +205,13 @@ export default function FeedPage() {
         .split(/\s+/)
         .map(t => t.replace(/^#/, '').trim())
         .filter(Boolean)
-      const updated = await updateFeedPost(editing.id, { body, hashtags: tags })
+      const updated = await updateFeedPost(editing.id, {
+        body,
+        hashtags: tags,
+        attachmentIds: editAttachments.map(a => a.id),
+      })
       setPosts(prev => prev.map(p => p.id === updated.id
-        ? { ...p, body: updated.body, hashtags: updated.hashtags, isEdited: true }
+        ? { ...p, body: updated.body, hashtags: updated.hashtags, attachments: updated.attachments, isEdited: true }
         : p))
       setEditing(null)
     } catch (err) {
@@ -270,6 +283,11 @@ export default function FeedPage() {
               onChange={(e) => setComposeBody(e.target.value)}
               disabled={composeBusy}
               style={{ width: '100%', maxHeight: 'none', resize: 'vertical' }}
+            />
+            <FeedImageUploader
+              value={composeAttachments}
+              onChange={setComposeAttachments}
+              disabled={composeBusy}
             />
             {composeError && <div className="md-composer-error">{composeError}</div>}
             <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: '8px' }}>
@@ -423,6 +441,12 @@ export default function FeedPage() {
               placeholder="design react ux"
               disabled={editBusy}
               style={{ minHeight: 'auto', height: '40px' }}
+            />
+            <label className="section-label" style={{ marginTop: '12px', display: 'block' }}>Images</label>
+            <FeedImageUploader
+              value={editAttachments}
+              onChange={setEditAttachments}
+              disabled={editBusy}
             />
             {editError && <div className="md-composer-error" style={{ marginTop: '8px' }}>{editError}</div>}
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '16px' }}>

--- a/frontend/src/pages/FeedPostDetailPage.jsx
+++ b/frontend/src/pages/FeedPostDetailPage.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import MainLayout from '../components/MainLayout'
 import FeedPostCard from '../components/FeedPostCard'
+import FeedImageUploader from '../components/FeedImageUploader'
 import { getFeedPostById, updateFeedPost, deleteFeedPost } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import '../styles/main.css'
@@ -20,6 +21,7 @@ export default function FeedPostDetailPage() {
   const [editing, setEditing] = useState(null)
   const [editBody, setEditBody] = useState('')
   const [editHashtags, setEditHashtags] = useState('')
+  const [editAttachments, setEditAttachments] = useState([])
   const [editBusy, setEditBusy] = useState(false)
   const [editError, setEditError] = useState(null)
 
@@ -38,6 +40,7 @@ export default function FeedPostDetailPage() {
     setEditing(p)
     setEditBody(p.body || '')
     setEditHashtags((p.hashtags || []).join(' '))
+    setEditAttachments(Array.isArray(p.attachments) ? p.attachments : [])
     setEditError(null)
   }
 
@@ -52,7 +55,11 @@ export default function FeedPostDetailPage() {
         .split(/\s+/)
         .map(t => t.replace(/^#/, '').trim())
         .filter(Boolean)
-      const updated = await updateFeedPost(editing.id, { body, hashtags: tags })
+      const updated = await updateFeedPost(editing.id, {
+        body,
+        hashtags: tags,
+        attachmentIds: editAttachments.map(a => a.id),
+      })
       setPost(updated)
       setEditing(null)
     } catch (err) {
@@ -127,6 +134,12 @@ export default function FeedPostDetailPage() {
               placeholder="design react ux"
               disabled={editBusy}
               style={{ minHeight: 'auto', height: '40px' }}
+            />
+            <label className="section-label" style={{ marginTop: '12px', display: 'block' }}>Images</label>
+            <FeedImageUploader
+              value={editAttachments}
+              onChange={setEditAttachments}
+              disabled={editBusy}
             />
             {editError && <div className="md-composer-error" style={{ marginTop: '8px' }}>{editError}</div>}
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '16px' }}>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -653,11 +653,13 @@ export async function markMentorPairMessagesRead(otherMentorId) {
 // ── Social feed ───────────────────────────────────────────────────────────
 // Backend: FeedPostController + FeedReadController (+ FeedInteractionController in #340)
 
-export async function createFeedPost({ body, hashtags = [] }) {
+export async function createFeedPost({ body, hashtags = [], attachmentIds = [] }) {
+  const payload = { body, hashtags }
+  if (attachmentIds.length > 0) payload.attachmentIds = attachmentIds
   const res = await fetch(`${BASE_URL}/feed/posts`, {
     method: 'POST',
     headers: authJsonHeaders(),
-    body: JSON.stringify({ body, hashtags }),
+    body: JSON.stringify(payload),
   })
   return handleResponse(res)
 }
@@ -669,10 +671,13 @@ export async function getFeedPostById(id) {
   return handleResponse(res)
 }
 
-export async function updateFeedPost(id, { body, hashtags }) {
+export async function updateFeedPost(id, { body, hashtags, attachmentIds }) {
   const payload = {}
   if (body !== undefined) payload.body = body
   if (hashtags !== undefined) payload.hashtags = hashtags
+  // attachmentIds: omit to leave attachments untouched; pass [] to clear them;
+  // pass an array to replace the post's attachment list (backend semantics).
+  if (attachmentIds !== undefined) payload.attachmentIds = attachmentIds
   const res = await fetch(`${BASE_URL}/feed/posts/${id}`, {
     method: 'PATCH',
     headers: authJsonHeaders(),

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1473,6 +1473,138 @@
   border: 1px solid var(--green-pale);
 }
 .follow-suggested-actions { display: flex; gap: 8px; align-items: center; }
+
+/* ── FEED IMAGE ATTACHMENTS (#507) ── */
+.feed-attach-grid {
+  margin-top: 10px;
+  display: grid;
+  gap: 4px;
+  border-radius: 12px;
+  overflow: hidden;
+  max-height: 420px;
+}
+.feed-attach-grid--1 { grid-template-columns: 1fr; grid-template-rows: 1fr; }
+.feed-attach-grid--2 { grid-template-columns: 1fr 1fr; grid-template-rows: 1fr; }
+.feed-attach-grid--3 { grid-template-columns: 1fr 1fr; grid-template-rows: 1fr 1fr; }
+.feed-attach-grid--3 .feed-attach-cell:first-child { grid-row: span 2; }
+.feed-attach-grid--4 { grid-template-columns: 1fr 1fr; grid-template-rows: 1fr 1fr; }
+
+.feed-attach-cell {
+  position: relative;
+  display: block;
+  background: #f3f4f6;
+  overflow: hidden;
+  min-height: 120px;
+}
+.feed-attach-cell img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.feed-attach-cell--loading {
+  background: linear-gradient(90deg, #f3f4f6 0%, #e5e7eb 50%, #f3f4f6 100%);
+  background-size: 200% 100%;
+  animation: feed-attach-shimmer 1.4s ease-in-out infinite;
+}
+@keyframes feed-attach-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+.feed-attach-cell--err {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 16px;
+}
+
+/* ── FEED IMAGE UPLOADER (compose / edit) ── */
+.feed-uploader { margin-top: 10px; }
+.feed-uploader-thumbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.feed-uploader-thumb {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #f3f4f6;
+  border: 1px solid var(--border);
+}
+.feed-uploader-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.feed-uploader-thumb-placeholder {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, #f3f4f6 0%, #e5e7eb 50%, #f3f4f6 100%);
+  background-size: 200% 100%;
+  animation: feed-attach-shimmer 1.4s ease-in-out infinite;
+}
+.feed-uploader-thumb--pending img { opacity: 0.55; }
+.feed-uploader-thumb-spinner {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 22px;
+  height: 22px;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-top-color: var(--green-dark);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+.feed-uploader-thumb-remove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+.feed-uploader-thumb-remove:hover { background: rgba(0, 0, 0, 0.8); }
+.feed-uploader-add {
+  width: 80px;
+  height: 80px;
+  border-radius: 10px;
+  border: 1px dashed var(--border);
+  background: #fff;
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  font-family: 'DM Sans', sans-serif;
+  transition: border-color 0.15s ease, color 0.15s ease;
+}
+.feed-uploader-add:hover {
+  border-color: var(--green-mid);
+  color: var(--green-dark);
+}
+.feed-uploader-error {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--red, #dc2626);
+}
+
 .feed-card-comments {
   margin-top: 12px;
   padding-top: 12px;


### PR DESCRIPTION
Closes #507.                                                                                                                                                                          
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Wires the feed UI to the image-attachment data flow backend shipped in PR #498 / commit d30f1bc. Previously the compose modal had no file picker, the API wrappers didn't send        
  attachmentIds, and the post card didn't render the attachments field. After this PR you can attach 1–4 images to a new post, edit a post's image set, and any reader sees them        
  rendered through the authenticated /api/uploads/feed-media/{id} endpoint.                                                                                                             
                                                                                                                                                                                        
  Changes                                                                                                                                                                               
                                                                                                                                                                                        
  - services/api.js — createFeedPost and updateFeedPost now accept attachmentIds. On updateFeedPost, omitting the field leaves attachments untouched (matches the backend's             
  UpdateFeedPostRequest semantics: omit-or-replace).                                                                                                                                    
  - components/FeedImageUploader.jsx (new) — file picker + thumb strip. Uploads each picked file immediately via the universal POST /api/messages/attachments endpoint (returns an      
  AttachmentSummary with a UUID), so by the time the user clicks Publish/Save we already have the IDs. Enforces 4-image cap, image-only types (jpeg/png/gif/webp), and the existing 5MB 
  cap. Per-file pending state and remove buttons.
  - components/FeedAttachmentGrid.jsx (new) — 1/2/3/4-cell layouts that render a post's attachments. Uses the same auth-blob pattern as MessageAttachment.ImagePreview (fetch with      
  bearer header → URL.createObjectURL → revoke on unmount), since /api/uploads/feed-media/{id} rejects unauthenticated <img src> loads.                                                 
  - FeedPostCard.jsx — renders the grid between body and hashtags.
  - FeedPage.jsx + FeedPostDetailPage.jsx — added composeAttachments / editAttachments state, hooked the uploader into the compose card and both edit modals, threaded attachmentIds    
  through to the API calls, and updated optimistic state to carry the returned attachments array.                                                                                       
  - styles/main.css — grid layouts, thumb styles, shimmer placeholder while blobs load.                                                                                                 
                                                                                                                                                                                        
  Test plan                                                 
                                                                                                                                                                                        
  - npm run build clean.                                                                                                                                                                
  - npm test — 64/64 unit tests pass.
  - Manual: compose a post with 1, 2, 3, and 4 images — each layout renders correctly on the for-you feed and on /feed/:id.                                                             
  - Manual: edit a post to add and remove images — confirm the post displays the new set after save.                                                                                    
  - Manual: try to attach a 5th image — uploader shows "max 4" error and the picker hides the Add button.                                                                               
  - Manual: try to attach a non-image file via the picker (it shouldn't be selectable, but if drag-drop later) — error surfaces from the validator.