### PR TITLE
fix(web): home-page progress reads /progress endpoint to match detail…

### DIFF
--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -7,6 +7,7 @@ import {
   rejectMentorshipRequest,
   getActiveMentorships,
   getUserById,
+  getMentorshipProgress,
 } from '../services/api'
 import Avatar from '../components/Avatar'
 import { useAuth } from '../context/AuthContext'
@@ -41,6 +42,12 @@ export default function HomePage() {
   const [hasActiveMentor, setHasActiveMentor] = useState(false)
   const [activeMentorship, setActiveMentorship] = useState(null)
   const [activeMentorPhoto, setActiveMentorPhoto] = useState(null)
+  // #469: hero progress comes from the same /progress endpoint as the detail
+  // page so the two surfaces agree. progressRatio is the goal-completion
+  // ratio (tasks + milestones), not elapsed-time — the old date-based
+  // calculation showed 0% at the start of an active mentorship while the
+  // detail page already showed milestone-driven completion.
+  const [activeProgress, setActiveProgress] = useState(null)
   const [menteeLoading, setMenteeLoading] = useState(true)
 
   const [acceptingId, setAcceptingId] = useState(null)   // request being accepted
@@ -65,6 +72,7 @@ export default function HomePage() {
             setActiveMentorship(active)
             setHasActiveMentor(true)
             getUserById(active.mentorId).then(p => setActiveMentorPhoto(p?.profilePhoto || null)).catch(() => {})
+            getMentorshipProgress(active.id).then(setActiveProgress).catch(() => {})
           }
         }
         if (matchData.status === 'rejected') {
@@ -161,10 +169,12 @@ export default function HomePage() {
             const start = new Date(activeMentorship.startDate)
             const end = new Date(activeMentorship.endDate)
             const now = new Date()
-            const totalMs = end - start
-            const elapsedMs = Math.min(now - start, totalMs)
-            const progress = Math.round((elapsedMs / totalMs) * 100)
-            const daysLeft = Math.max(0, Math.ceil((end - now) / 86400000))
+            const progress = activeProgress
+              ? Math.round((activeProgress.progressRatio || 0) * 100)
+              : null
+            const daysLeft = activeProgress
+              ? Number(activeProgress.daysRemaining ?? 0)
+              : Math.max(0, Math.ceil((end - now) / 86400000))
             return (
               <div className="active-mentorship-hero">
                 <div className="amh-glow" />
@@ -197,9 +207,11 @@ export default function HomePage() {
                     <span>{daysLeft} day{daysLeft !== 1 ? 's' : ''} remaining</span>
                   </div>
                   <div className="amh-progress-track">
-                    <div className="amh-progress-fill" style={{ width: `${progress}%` }} />
+                    <div className="amh-progress-fill" style={{ width: `${progress ?? 0}%` }} />
                   </div>
-                  <div className="amh-progress-pct">{progress}% complete</div>
+                  <div className="amh-progress-pct">
+                    {progress == null ? 'Loading progress…' : `${progress}% complete`}
+                  </div>
                 </div>
 
                 <div className="amh-actions">


### PR DESCRIPTION
Partial fix for #469.                                                                                                                                                                 
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Closes the data-sync half of #469. The Home Page hero card showed 0% while /mentorships/:id already showed the milestone-driven percentage (e.g. 50%) for the same mentorship — the   
  detail page was reading /api/mentorships/{id}/progress while Home was computing (elapsed days / total days) * 100, which is ~0% at the start of any active mentorship.                
                                                                                                                                                                                        
  Change                                                                                                                                                                                
   
  HomePage.jsx now calls getMentorshipProgress(activeMentorship.id) after the active mentorship loads, and the hero card renders Math.round(progressRatio * 100) — same expression as   
  MentorshipProgressTimeline.jsx:108. The "days remaining" line also uses the backend's daysRemaining field for consistency, falling back to a date-based calc if the progress fetch
  hasn't returned yet.                                                                                                                                                                  
                                                            
  While the progress fetch is in flight the card shows "Loading progress…" with the bar at 0% — replacing the previous "stale 0%" with an honest loading state that the network         
  typically resolves in under a second.
                                                                                                                                                                                        
  Out of scope                                              

  - The timeline UI redesign half of #469 (the image_2.png visual upgrade). That stays open under #469 until the target screenshots are available.                                      
   
