### PR TITLE
feat(web): mentor extend-mentorship modal with 1/3/6 month picker (#276)

### DIFF
--- a/frontend/src/pages/MentorshipDetailPage.jsx
+++ b/frontend/src/pages/MentorshipDetailPage.jsx
@@ -11,6 +11,7 @@ import {
   updateSharedGoal,
   cancelMentorship,
   endMentorship,
+  extendMentorship,
   listMentorshipMeetings,
 } from '../services/api'
 import { useAuth } from '../context/AuthContext'
@@ -156,6 +157,95 @@ function EndMentorshipModal({ open, onClose, onConfirm, loading, otherName }) {
             disabled={loading}
           >
             {loading ? 'Ending…' : 'End Mentorship'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Mentor-side extension modal (#276 / 1.1.1.2.13). Backend requires
+ * additionalMonths ∈ {1, 3, 6}; we render the choice as a 3-up segmented
+ * picker rather than a free-form input so we never send an invalid value.
+ */
+function ExtendMentorshipModal({ open, onClose, onConfirm, loading, otherName, currentEndDate }) {
+  const overlayRef = useRef(null)
+  const [months, setMonths] = useState(3)
+
+  useEffect(() => {
+    if (open) setMonths(3)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onKey = e => { if (e.key === 'Escape' && !loading) onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose, loading])
+
+  if (!open) return null
+
+  const projectedEnd = currentEndDate
+    ? (() => {
+        const d = new Date(currentEndDate)
+        if (isNaN(d.getTime())) return null
+        d.setMonth(d.getMonth() + months)
+        return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+      })()
+    : null
+
+  return (
+    <div
+      className="modal-overlay"
+      ref={overlayRef}
+      onMouseDown={e => { if (e.target === overlayRef.current && !loading) onClose() }}
+    >
+      <div className="modal-card" role="dialog" aria-modal="true" aria-labelledby="extendMentorshipTitle">
+        <div className="modal-header">
+          <div>
+            <h2 id="extendMentorshipTitle">Extend mentorship?</h2>
+            <p className="modal-subtitle">
+              Push the end date of your mentorship with {otherName || 'this mentee'} forward.
+              Your mentee will be notified.
+            </p>
+          </div>
+          <button type="button" className="modal-close" onClick={onClose} aria-label="Close modal">×</button>
+        </div>
+
+        <label className="section-label" style={{ marginTop: '12px', display: 'block' }}>
+          Add to current end date
+        </label>
+        <div className="md-extend-options">
+          {[1, 3, 6].map(m => (
+            <button
+              key={m}
+              type="button"
+              className={`md-extend-option${months === m ? ' md-extend-option--active' : ''}`}
+              onClick={() => setMonths(m)}
+              disabled={loading}
+              aria-pressed={months === m}
+            >
+              +{m} month{m !== 1 ? 's' : ''}
+            </button>
+          ))}
+        </div>
+
+        {projectedEnd && (
+          <div style={{ fontSize: '13px', color: 'var(--text-muted)', marginTop: '12px' }}>
+            New end date: <strong style={{ color: 'var(--text)' }}>{projectedEnd}</strong>
+          </div>
+        )}
+
+        <div className="modal-actions" style={{ marginTop: '16px' }}>
+          <button type="button" className="modal-btn-secondary" onClick={onClose} disabled={loading}>Cancel</button>
+          <button
+            type="button"
+            className="modal-btn-primary"
+            onClick={() => onConfirm(months)}
+            disabled={loading}
+          >
+            {loading ? 'Extending…' : `Extend by ${months} month${months !== 1 ? 's' : ''}`}
           </button>
         </div>
       </div>
@@ -355,6 +445,9 @@ export default function MentorshipDetailPage() {
   const [endOpen, setEndOpen] = useState(false)
   const [endLoading, setEndLoading] = useState(false)
   const [endError, setEndError] = useState(null)
+  const [extendOpen, setExtendOpen] = useState(false)
+  const [extendLoading, setExtendLoading] = useState(false)
+  const [extendError, setExtendError] = useState(null)
 
   const [cancelOpen, setCancelOpen] = useState(false)
   const [cancelLoading, setCancelLoading] = useState(false)
@@ -422,6 +515,21 @@ export default function MentorshipDetailPage() {
       setEndError(err?.message || 'Failed to end mentorship')
     } finally {
       setEndLoading(false)
+    }
+  }
+
+  async function handleExtendConfirm(additionalMonths) {
+    setExtendLoading(true)
+    setExtendError(null)
+    try {
+      const updated = await extendMentorship(mentorship.id, additionalMonths)
+      setMentorship(updated)
+      setExtendOpen(false)
+      refresh()
+    } catch (err) {
+      setExtendError(err?.message || 'Failed to extend mentorship')
+    } finally {
+      setExtendLoading(false)
     }
   }
 
@@ -725,6 +833,16 @@ export default function MentorshipDetailPage() {
         >
           My Tasks
         </button>
+        {viewerIsMentor && (
+          <button
+            className="md-action-btn"
+            onClick={() => setExtendOpen(true)}
+            disabled={!isActive}
+            title={isActive ? 'Add 1, 3, or 6 months to the end date' : 'This mentorship has already ended'}
+          >
+            Extend Duration
+          </button>
+        )}
         {viewerIsMentor ? (
           <button
             className="md-action-btn md-action-danger"
@@ -759,6 +877,22 @@ export default function MentorshipDetailPage() {
           <div className="md-error-sub">{endError}</div>
         </div>
       )}
+
+      {extendError && (
+        <div className="md-error-card" style={{ marginTop: '12px' }}>
+          <div className="md-error-title">Couldn’t extend mentorship</div>
+          <div className="md-error-sub">{extendError}</div>
+        </div>
+      )}
+
+      <ExtendMentorshipModal
+        open={extendOpen}
+        onClose={() => !extendLoading && setExtendOpen(false)}
+        onConfirm={handleExtendConfirm}
+        loading={extendLoading}
+        otherName={displayName || otherFirstName}
+        currentEndDate={mentorship.endDate}
+      />
 
       <EndMentorshipModal
         open={endOpen}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -300,6 +300,17 @@ export async function endMentorship(id, reason) {
   return handleResponse(res)
 }
 
+// Mentor-only extend (#276 / 1.1.1.2.13). additionalMonths must be 1, 3, or 6
+// per backend ExtendMentorshipRequest validator. Returns the updated mentorship.
+export async function extendMentorship(id, additionalMonths) {
+  const res = await fetch(`${BASE_URL}/mentorships/${id}/extend`, {
+    method: 'PATCH',
+    headers: authJsonHeaders(),
+    body: JSON.stringify({ additionalMonths }),
+  })
+  return handleResponse(res)
+}
+
 // ── Mentorship tasks (#125) ───────────────────────────────────────────────
 // Backend: TaskController. Status enum: PENDING, SUBMITTED, REVISION_REQUESTED, COMPLETED.
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3218,6 +3218,35 @@
 .md-primary-btn { background: var(--green-dark); }
 .md-primary-btn:hover:not(:disabled) { background: var(--green-mid); }
 
+/* Extend-mentorship 1/3/6 month picker (#276). */
+.md-extend-options {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-top: 6px;
+}
+.md-extend-option {
+  padding: 12px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #fff;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.md-extend-option:hover:not(:disabled) {
+  border-color: var(--green-mid);
+}
+.md-extend-option--active {
+  border-color: var(--green-dark);
+  background: var(--green-pale);
+  color: var(--green-dark);
+}
+.md-extend-option:disabled { opacity: 0.5; cursor: not-allowed; }
+
 @media (max-width: 720px) {
   .md-stats-row { grid-template-columns: repeat(2, 1fr); }
   .md-hero { flex-wrap: wrap; }


### PR DESCRIPTION
Closes the Extend half of #276 (the End half shipped earlier in PR #127).                                                                                                             
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Mentor-only "Extend Duration" button on /mentorships/:id opens a modal with a +1 / +3 / +6 month picker (matching the backend's ExtendMentorshipRequest validator: additionalMonths ∈ 
  {1, 3, 6}). Submitting calls PATCH /api/mentorships/{id}/extend, replaces local state with the returned MentorshipResponse, and refreshes the global mentorship counts. The mentee is 
  notified server-side via the existing MENTORSHIP_EXTENDED notification path.                                                                                                          
                                                                                                                                                                                      
  Changes                                                                                                                                                                               
   
  - services/api.js — added extendMentorship(id, additionalMonths).                                                                                                                     
  - pages/MentorshipDetailPage.jsx:                                                                                                                                                   
    - New ExtendMentorshipModal component (sibling to EndMentorshipModal). Shows a 3-up segmented picker, a live preview of the projected new end date, and disables both close paths   
  while the request is in flight.                                                                                                                                                       
    - extendOpen / extendLoading / extendError state + handleExtendConfirm handler, mirroring the End / Cancel patterns.                                                                
    - "Extend Duration" button rendered next to "End Mentorship" — mentor-only, gated to isActive.                                                                                      
    - Error banner above the modal mount, same shape as the existing end/cancel banners.                                                                                                
  - styles/main.css — added .md-extend-options + .md-extend-option styles for the segmented picker.                                                                                     
                                                                                                                                                                                        
  Acceptance criteria mapping (from #276)                                                                                                                                               
   
  - ✅ "Extend duration" button visible to mentor on /mentorships/:id while ACTIVE.                                                                                                     
  - ✅ Modal lets mentor pick the extension from predefined options (1 / 3 / 6 months — matching backend).
  - ✅ End button (already shipped) untouched.                                                                                                                                          
  - ✅ After action, status / endDate update without page reload (setMentorship(updated)).                                                                                              
  - ✅ Mentee notification handled by backend (no client work).                                                                                                                         
                                                                                                                                                                                        
  Test plan                                                                                                                                                                             
                                                                                                                                                                                        
  - npm run build clean.                                    
  - npm test — 64/64 unit tests pass.
  - Manual: mentor on an ACTIVE mentorship clicks "Extend Duration" → picks +3 months → confirms → end date on the page updates immediately and the mentee receives a                   
  MENTORSHIP_EXTENDED notification.                                                                                                                                                     
  - Manual: mentee viewing the same page does not see the button.                                                                                                                       
  - Manual: completed/cancelled mentorship — button disabled with the "already ended" tooltip.