### PR TITLE
feat(web): mentee mentor-rating prompt after mentorship ends + avg on…

### DIFF
--- a/frontend/src/pages/MentorshipDetailPage.jsx
+++ b/frontend/src/pages/MentorshipDetailPage.jsx
@@ -12,6 +12,7 @@ import {
   cancelMentorship,
   endMentorship,
   extendMentorship,
+  rateMentor,
   listMentorshipMeetings,
 } from '../services/api'
 import { useAuth } from '../context/AuthContext'
@@ -254,6 +255,116 @@ function ExtendMentorshipModal({ open, onClose, onConfirm, loading, otherName, c
 }
 
 /**
+ * Mentee-side mentor rating modal (#278 / 1.1.1.1.11). Backend caps the
+ * score at 1..5 and the optional comment at 1000 chars. One-shot per
+ * mentorship — duplicate POST returns 409, surfaced here as an error.
+ */
+function RateMentorModal({ open, onClose, onConfirm, loading, mentorName }) {
+  const overlayRef = useRef(null)
+  const [score, setScore] = useState(0)
+  const [hoverScore, setHoverScore] = useState(0)
+  const [comment, setComment] = useState('')
+
+  useEffect(() => {
+    if (open) { setScore(0); setHoverScore(0); setComment('') }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onKey = e => { if (e.key === 'Escape' && !loading) onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose, loading])
+
+  if (!open) return null
+
+  const displayScore = hoverScore || score
+
+  return (
+    <div
+      className="modal-overlay"
+      ref={overlayRef}
+      onMouseDown={e => { if (e.target === overlayRef.current && !loading) onClose() }}
+    >
+      <div className="modal-card" role="dialog" aria-modal="true" aria-labelledby="rateMentorTitle">
+        <div className="modal-header">
+          <div>
+            <h2 id="rateMentorTitle">Rate {mentorName || 'your mentor'}</h2>
+            <p className="modal-subtitle">
+              Your rating helps other mentees find a great match. Only the average and rating
+              count are shown publicly — your comment may appear without your name attached.
+            </p>
+          </div>
+          <button type="button" className="modal-close" onClick={onClose} aria-label="Close modal">×</button>
+        </div>
+
+        <label className="section-label" style={{ marginTop: '12px', display: 'block' }}>
+          Score (required)
+        </label>
+        <div
+          className="md-rating-stars"
+          role="radiogroup"
+          aria-label="Score from 1 to 5 stars"
+          onMouseLeave={() => setHoverScore(0)}
+        >
+          {[1, 2, 3, 4, 5].map(n => (
+            <button
+              key={n}
+              type="button"
+              role="radio"
+              aria-checked={score === n}
+              aria-label={`${n} star${n !== 1 ? 's' : ''}`}
+              className={`md-rating-star${displayScore >= n ? ' md-rating-star--filled' : ''}`}
+              onClick={() => setScore(n)}
+              onMouseEnter={() => setHoverScore(n)}
+              onFocus={() => setHoverScore(n)}
+              onBlur={() => setHoverScore(0)}
+              disabled={loading}
+            >
+              ★
+            </button>
+          ))}
+          <span className="md-rating-value">
+            {displayScore > 0 ? `${displayScore} / 5` : 'Pick a score'}
+          </span>
+        </div>
+
+        <label className="section-label" style={{ marginTop: '14px', display: 'block' }} htmlFor="rateComment">
+          Comment (optional)
+        </label>
+        <textarea
+          id="rateComment"
+          className="modal-textarea"
+          rows={4}
+          maxLength={1000}
+          value={comment}
+          onChange={e => setComment(e.target.value)}
+          placeholder="Tell future mentees what made working with this mentor valuable."
+          disabled={loading}
+        />
+        <div style={{ fontSize: '12px', color: 'var(--text-muted)', textAlign: 'right' }}>
+          {comment.length}/1000
+        </div>
+
+        <div className="modal-actions" style={{ marginTop: '16px' }}>
+          <button type="button" className="modal-btn-secondary" onClick={onClose} disabled={loading}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="modal-btn-primary"
+            onClick={() => onConfirm(score, comment.trim() || undefined)}
+            disabled={loading || score < 1}
+          >
+            {loading ? 'Submitting…' : 'Submit rating'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
  * Mentee-side cancellation modal (#127). Reason is required by the backend
  * (CancelMentorshipRequest @NotBlank); the warning copy is intentionally
  * loud because frequent cancellations escalate into a temporary ban via
@@ -448,10 +559,28 @@ export default function MentorshipDetailPage() {
   const [extendOpen, setExtendOpen] = useState(false)
   const [extendLoading, setExtendLoading] = useState(false)
   const [extendError, setExtendError] = useState(null)
+  const [rateOpen, setRateOpen] = useState(false)
+  const [rateLoading, setRateLoading] = useState(false)
+  const [rateError, setRateError] = useState(null)
+  // Backend doesn't expose a GET-rating endpoint today, so we mirror successful
+  // submissions in localStorage to suppress the prompt on subsequent visits.
+  // The 409-on-duplicate-POST path also flips this so cross-device
+  // resubmission is caught.
+  const [submittedRating, setSubmittedRating] = useState(null)
 
   const [cancelOpen, setCancelOpen] = useState(false)
   const [cancelLoading, setCancelLoading] = useState(false)
   const [cancelError, setCancelError] = useState(null)
+
+  // Hydrate already-submitted rating from localStorage so the prompt doesn't
+  // reappear on revisit. Backend has no GET-rating endpoint today (#278 follow-up).
+  useEffect(() => {
+    if (!id) return
+    try {
+      const raw = localStorage.getItem(`rated_mentorship_${id}`)
+      if (raw) setSubmittedRating(JSON.parse(raw))
+    } catch { /* malformed entry — ignore */ }
+  }, [id])
 
   useEffect(() => {
     let cancelled = false
@@ -515,6 +644,40 @@ export default function MentorshipDetailPage() {
       setEndError(err?.message || 'Failed to end mentorship')
     } finally {
       setEndLoading(false)
+    }
+  }
+
+  async function handleRateConfirm(score, comment) {
+    setRateLoading(true)
+    setRateError(null)
+    try {
+      const created = await rateMentor(mentorship.id, score, comment)
+      setSubmittedRating(created)
+      try {
+        localStorage.setItem(`rated_mentorship_${mentorship.id}`, JSON.stringify({
+          score: created.score,
+          comment: created.comment,
+          createdAt: created.createdAt,
+        }))
+      } catch { /* localStorage disabled — fall back to in-memory state */ }
+      setRateOpen(false)
+    } catch (err) {
+      const msg = err?.message || ''
+      // Duplicate-rating path: backend returns 409 with "already rated" wording.
+      // Treat as success-ish — flip to the read-only block so the user isn't stuck.
+      if (msg.includes('409') || /already.*rated/i.test(msg)) {
+        setSubmittedRating({ score, comment, createdAt: new Date().toISOString() })
+        try {
+          localStorage.setItem(`rated_mentorship_${mentorship.id}`, JSON.stringify({
+            score, comment, createdAt: new Date().toISOString(),
+          }))
+        } catch { /* ignore */ }
+        setRateOpen(false)
+      } else {
+        setRateError(msg || 'Failed to submit rating')
+      }
+    } finally {
+      setRateLoading(false)
     }
   }
 
@@ -628,6 +791,44 @@ export default function MentorshipDetailPage() {
           </div>
         </div>
       </div>
+
+      {!isActive && !viewerIsMentor && (
+        submittedRating ? (
+          <div className="md-rating-card md-rating-card--done" role="status">
+            <div className="md-rating-card-head">
+              <strong>You rated {otherFirstName || 'your mentor'}</strong>
+              <span className="md-rating-stars md-rating-stars--readonly" aria-hidden="true">
+                {[1, 2, 3, 4, 5].map(n => (
+                  <span
+                    key={n}
+                    className={`md-rating-star${submittedRating.score >= n ? ' md-rating-star--filled' : ''}`}
+                  >★</span>
+                ))}
+                <span className="md-rating-value">{submittedRating.score} / 5</span>
+              </span>
+            </div>
+            {submittedRating.comment && (
+              <p className="md-rating-card-comment">"{submittedRating.comment}"</p>
+            )}
+          </div>
+        ) : (
+          <div className="md-rating-card" role="region" aria-label="Rate your mentor">
+            <div className="md-rating-card-head">
+              <strong>Rate {otherFirstName || 'your mentor'}</strong>
+              <span className="md-rating-card-sub">
+                Help future mentees by sharing your experience.
+              </span>
+            </div>
+            <button
+              type="button"
+              className="md-action-btn md-action-primary"
+              onClick={() => setRateOpen(true)}
+            >
+              Rate your mentor
+            </button>
+          </div>
+        )
+      )}
 
       {!isActive && (
         <div className="md-ended-banner" role="status">
@@ -893,6 +1094,21 @@ export default function MentorshipDetailPage() {
         otherName={displayName || otherFirstName}
         currentEndDate={mentorship.endDate}
       />
+
+      <RateMentorModal
+        open={rateOpen}
+        onClose={() => !rateLoading && setRateOpen(false)}
+        onConfirm={handleRateConfirm}
+        loading={rateLoading}
+        mentorName={mentorship.mentorFirstName || otherFirstName}
+      />
+
+      {rateError && (
+        <div className="md-error-card" style={{ marginTop: '12px' }}>
+          <div className="md-error-title">Couldn’t submit rating</div>
+          <div className="md-error-sub">{rateError}</div>
+        </div>
+      )}
 
       <EndMentorshipModal
         open={endOpen}

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -269,6 +269,18 @@ export default function UserProfilePage() {
                 <div className="psr-num">{profile.currentMenteeCount ?? 0}/{profile.maxMenteeCapacity ?? '∞'}</div>
                 <div className="psr-lbl">Mentees</div>
               </div>
+              <div className="psr-item" title={profile.ratingCount ? `${profile.ratingCount} rating${profile.ratingCount === 1 ? '' : 's'}` : 'No ratings yet'}>
+                <div className="psr-num">
+                  {profile.averageRating != null
+                    ? `★ ${profile.averageRating.toFixed(1)}`
+                    : '—'}
+                </div>
+                <div className="psr-lbl">
+                  {profile.ratingCount
+                    ? `${profile.ratingCount} rating${profile.ratingCount === 1 ? '' : 's'}`
+                    : 'Rating'}
+                </div>
+              </div>
             </div>
           )}
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -311,6 +311,20 @@ export async function extendMentorship(id, additionalMonths) {
   return handleResponse(res)
 }
 
+// Mentee-only rating (#278 / 1.1.1.1.11). Backend rejects with 409 if the
+// mentorship is still ACTIVE or already rated; 403 if a mentor calls it.
+// Score must be 1..5; comment is optional and capped at 1000 chars.
+export async function rateMentor(id, score, comment) {
+  const body = { score }
+  if (comment) body.comment = comment
+  const res = await fetch(`${BASE_URL}/mentorships/${id}/rating`, {
+    method: 'POST',
+    headers: authJsonHeaders(),
+    body: JSON.stringify(body),
+  })
+  return handleResponse(res)
+}
+
 // ── Mentorship tasks (#125) ───────────────────────────────────────────────
 // Backend: TaskController. Status enum: PENDING, SUBMITTED, REVISION_REQUESTED, COMPLETED.
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3218,6 +3218,65 @@
 .md-primary-btn { background: var(--green-dark); }
 .md-primary-btn:hover:not(:disabled) { background: var(--green-mid); }
 
+/* Mentor rating modal + post-end prompt (#278). */
+.md-rating-card {
+  margin: 12px 0;
+  padding: 14px 16px;
+  background: var(--green-pale, #ecf6ee);
+  border: 1px solid var(--green-mid, #b6d8bd);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.md-rating-card--done {
+  flex-direction: column;
+  align-items: flex-start;
+}
+.md-rating-card-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.md-rating-card-sub {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+.md-rating-card-comment {
+  margin: 6px 0 0;
+  color: var(--text);
+  font-size: 14px;
+  font-style: italic;
+}
+.md-rating-stars {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.md-rating-stars--readonly { pointer-events: none; }
+.md-rating-star {
+  background: none;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
+  color: #d1d5db;
+  cursor: pointer;
+  padding: 2px 4px;
+  transition: color 0.12s ease, transform 0.12s ease;
+}
+.md-rating-star:hover:not(:disabled) { transform: scale(1.1); }
+.md-rating-star--filled { color: #f59e0b; }
+.md-rating-star:disabled { cursor: not-allowed; opacity: 0.6; }
+.md-rating-value {
+  margin-left: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
 /* Extend-mentorship 1/3/6 month picker (#276). */
 .md-extend-options {
   display: grid;


### PR DESCRIPTION
Closes the bulk of #278.                                                                                                                                                              
                                                                                                                                                                                        
##  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Mentee-side mentor rating flow. After a mentorship ends (status COMPLETED / TERMINATED / CANCELLED), the mentee sees a prompt at the top of /mentorships/:id. The modal captures a 1–5
   star rating and an optional comment, then POSTs to /api/mentorships/{id}/rating. Subsequent visits show the read-only "you rated" block instead of the prompt. The mentor's average  
  rating + count are now visible on their public profile (/users/:id).                                                                                                                  
                                                                                                                                                                                      
##  Changes

  - services/api.js — rateMentor(id, score, comment) calls POST /api/mentorships/{id}/rating.                                                                                           
  - pages/MentorshipDetailPage.jsx:
    - New RateMentorModal component with a hover-aware 1–5 star picker and optional 1000-char comment.                                                                                  
    - Rate prompt card rendered when !isActive && !viewerIsMentor. After successful submit (or 409 from a duplicate POST), the same card swaps to a read-only display with the score +  
  quoted comment.                                                                                                                                                                       
    - submittedRating state hydrated from localStorage on mount so revisiting the page doesn't re-prompt. Successful submissions are persisted there.                                   
    - 409 path is handled gracefully: if the backend says "already rated," we flip to the read-only state instead of bubbling the error.                                                
  - pages/UserProfilePage.jsx — added a ★ X.X / N ratings cell to the mentor stats row, sourced from profile.averageRating + profile.ratingCount (already on UserResponse).             
  - styles/main.css — .md-rating-card, .md-rating-stars, .md-rating-star, etc.                                                                                                          
                                                                                                                                                                                        
  Acceptance criteria mapping (from #278)                                                                                                                                               
                                                                                                                                                                                        
  - ✅ When status transitions to ENDED, mentee sees a "Rate your mentor" prompt on the detail page.                                                                                    
  - ✅ Rating UI captures 1–5 stars (required) and optional comment (1000-char cap matches backend).
  - ✅ Submission allowed at most once per mentorship (backend 409 + client-side localStorage guard); subsequent visits render read-only.                                               
  - ✅ Mentor public profile displays average rating and total rating count.                                 

### Test plan
                                                                                                                                                                                        
  - npm run build clean.                                    
  - npm test — 64/64 unit tests pass.
  - Manual: end a mentorship as mentor → mentee visits /mentorships/:id → sees "Rate your mentor" prompt → submits 4 stars + comment → page swaps to read-only "You rated …" block →
  reload → still read-only.                                                                                                                                                             
  - Manual: visit the mentor's /users/:id after rating → ★ X.X · 1 rating appears in the stats row.
  - Manual: try a 2nd POST via DevTools (or a 2nd browser) → 409 → UI flips to read-only without a scary error.                                                                         
                                      