### PR TITLE
feat(web): notification preferences toggles on profile (#289)

### DIFF
--- a/frontend/src/components/NotificationPreferences.jsx
+++ b/frontend/src/components/NotificationPreferences.jsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from 'react'
+import { getNotificationPreferences, updateNotificationPreferences } from '../services/api'
+
+/**
+ * Per-user notification toggles (#289 / req 1.1.5.8). Backed by
+ * `GET / PATCH /api/users/me/notification-preferences`. Each toggle flips
+ * optimistically and PATCHes the single field; on failure we roll back.
+ *
+ * The required-by-#289 toggles are taskDeadlineReminders + milestoneReminders.
+ * The other 7 categories the backend exposes are surfaced too, since they're
+ * the same data flow and there's no value in hiding controls the user has
+ * opinions about.
+ */
+const CATEGORIES = [
+  {
+    key: 'taskDeadlineRemindersEnabled',
+    title: 'Task deadline reminders',
+    sub: 'Notify me 24 hours before a task is due.',
+    group: 'Reminders',
+  },
+  {
+    key: 'milestoneRemindersEnabled',
+    title: 'Milestone reminders',
+    sub: 'Notify me 3 days before a milestone is due.',
+    group: 'Reminders',
+  },
+  {
+    key: 'matchesEnabled',
+    title: 'Matches',
+    sub: 'New mentor / mentee match suggestions.',
+    group: 'Mentorship',
+  },
+  {
+    key: 'requestsEnabled',
+    title: 'Mentorship requests',
+    sub: 'Incoming requests, accepts, and rejections.',
+    group: 'Mentorship',
+  },
+  {
+    key: 'meetingsEnabled',
+    title: 'Meetings',
+    sub: 'Confirmations, reschedules, cancellations, and upcoming meeting reminders.',
+    group: 'Mentorship',
+  },
+  {
+    key: 'tasksEnabled',
+    title: 'Tasks',
+    sub: 'New assignments, submissions, and reviews.',
+    group: 'Mentorship',
+  },
+  {
+    key: 'messagesEnabled',
+    title: 'Messages',
+    sub: 'New direct messages from your mentor or mentee.',
+    group: 'Messaging',
+  },
+  {
+    key: 'feedEngagementEnabled',
+    title: 'Feed engagement',
+    sub: 'Likes, comments, and shares on your posts.',
+    group: 'Social',
+  },
+  {
+    key: 'newFollowerEnabled',
+    title: 'New followers',
+    sub: 'Notify me when someone follows me.',
+    group: 'Social',
+  },
+]
+
+export default function NotificationPreferences() {
+  const [prefs, setPrefs] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [savingKey, setSavingKey] = useState(null)
+  const [savedKey, setSavedKey] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    getNotificationPreferences()
+      .then(p => { if (!cancelled) setPrefs(p) })
+      .catch(err => { if (!cancelled) setError(err?.message || 'Failed to load preferences.') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  async function handleToggle(key) {
+    if (!prefs || savingKey) return
+    const previous = prefs[key]
+    const next = !previous
+    setPrefs(p => ({ ...p, [key]: next }))
+    setSavingKey(key)
+    setSavedKey(null)
+    try {
+      const updated = await updateNotificationPreferences({ [key]: next })
+      setPrefs(updated)
+      setSavedKey(key)
+      setTimeout(() => setSavedKey(k => (k === key ? null : k)), 1500)
+    } catch (err) {
+      setPrefs(p => ({ ...p, [key]: previous }))
+      setError(err?.message || 'Failed to save preference.')
+    } finally {
+      setSavingKey(null)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="card" style={{ marginTop: '24px' }}>
+        <div className="section-label">Notification Preferences</div>
+        <p style={{ fontSize: '13px', color: 'var(--text-muted)' }}>Loading…</p>
+      </div>
+    )
+  }
+  if (error && !prefs) {
+    return (
+      <div className="card" style={{ marginTop: '24px' }}>
+        <div className="section-label">Notification Preferences</div>
+        <p style={{ fontSize: '13px', color: 'var(--red-text)' }}>{error}</p>
+      </div>
+    )
+  }
+  if (!prefs) return null
+
+  // Group categories for visual structure without changing the data model.
+  const groups = CATEGORIES.reduce((acc, cat) => {
+    if (!acc[cat.group]) acc[cat.group] = []
+    acc[cat.group].push(cat)
+    return acc
+  }, {})
+
+  return (
+    <div className="card" style={{ marginTop: '24px' }} data-testid="notification-preferences">
+      <div className="section-label">Notification Preferences</div>
+      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '4px', marginBottom: '12px' }}>
+        Toggles save automatically. Disabling a category suppresses notifications of that type
+        the next time the system would have sent one.
+      </p>
+
+      {Object.entries(groups).map(([groupName, items]) => (
+        <div key={groupName} style={{ marginTop: '16px' }}>
+          <div style={{ fontSize: '12px', fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '4px' }}>
+            {groupName}
+          </div>
+          {items.map(cat => (
+            <div
+              key={cat.key}
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 0', borderBottom: '1px solid var(--border)' }}
+              data-testid={`pref-row-${cat.key}`}
+            >
+              <div style={{ paddingRight: '16px' }}>
+                <div style={{ fontSize: '14px', fontWeight: 500 }}>{cat.title}</div>
+                <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '2px' }}>
+                  {cat.sub}
+                </div>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                {savedKey === cat.key && (
+                  <span style={{ fontSize: '11px', color: 'var(--green-dark)' }}>Saved</span>
+                )}
+                <button
+                  type="button"
+                  className={`toggle${prefs[cat.key] ? '' : ' off'}`}
+                  onClick={() => handleToggle(cat.key)}
+                  aria-label={`Toggle ${cat.title}`}
+                  aria-pressed={prefs[cat.key]}
+                  disabled={savingKey != null}
+                  data-testid={`pref-toggle-${cat.key}`}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+
+      {error && (
+        <p style={{ fontSize: '12px', color: 'var(--red-text)', marginTop: '12px' }}>{error}</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import MainLayout from '../components/MainLayout'
 import Avatar from '../components/Avatar'
+import NotificationPreferences from '../components/NotificationPreferences'
 import usePresence from '../hooks/usePresence'
 import { useAuth } from '../context/AuthContext'
 import { useMentorship } from '../context/MentorshipContext'
@@ -569,6 +570,8 @@ export default function ProfilePage() {
               {saving ? 'Saving...' : 'Save Changes'}
             </button>
           </form>
+
+          <NotificationPreferences />
         </div>
 
       </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -311,6 +311,26 @@ export async function extendMentorship(id, additionalMonths) {
   return handleResponse(res)
 }
 
+// User notification preferences (#289 / 1.1.5.8). Backend lazily creates the
+// row with all toggles enabled on first GET. PATCH is partial — omitted
+// fields keep their current value, so the client only sends the toggle
+// being flipped.
+export async function getNotificationPreferences() {
+  const res = await fetch(`${BASE_URL}/users/me/notification-preferences`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function updateNotificationPreferences(patch) {
+  const res = await fetch(`${BASE_URL}/users/me/notification-preferences`, {
+    method: 'PATCH',
+    headers: authJsonHeaders(),
+    body: JSON.stringify(patch),
+  })
+  return handleResponse(res)
+}
+
 // Mentee-only rating (#278 / 1.1.1.1.11). Backend rejects with 409 if the
 // mentorship is still ACTIVE or already rated; 403 if a mentor calls it.
 // Score must be 1..5; comment is optional and capped at 1000 chars.


### PR DESCRIPTION
Closes #289.                                                                                                                                                                          
                                                                                                                                                                                        
 ## Summary                                                                                                                                                                               
                                                                                                                                                                                        
  New "Notification Preferences" card on /profile exposes per-category push toggles, backed by GET / PATCH /api/users/me/notification-preferences (already shipped server-side per      
  #136). Toggles save individually with optimistic UI + rollback on error — no separate Save button — matching the existing Profile Visibility toggle on the same page.                 
                                                                                                                                                                                        
 ## Changes                                                                                                                                                                             

  - services/api.js — getNotificationPreferences() and updateNotificationPreferences(patch) wrappers. PATCH is partial so each toggle sends only the single flipped field.              
  - components/NotificationPreferences.jsx (new) — standalone card. Loads prefs on mount; renders 9 categories grouped into Reminders / Mentorship / Messaging / Social sections. Each
  row is a label + sub-line + the existing .toggle control. Optimistic flip + per-row "Saved" flash; rollback on PATCH failure.                                                         
  - pages/ProfilePage.jsx — mounts <NotificationPreferences /> directly under the existing profile form so the section is reachable without navigating away.
                                                                                                                                                                                        
##  Acceptance criteria mapping (from #289)                   
                                                                                                                                                                                        
  - ✅ "Notification preferences" section on /profile with toggles for task-deadline reminders (24 h) and milestone reminders (3 d) — first two rows in the Reminders group.            
  - ✅ Toggle state persists via PATCH on the preferences endpoint.
  - ✅ Disabling a toggle suppresses the corresponding notification type the next time the scheduled job fires (backend behaviour, unchanged).                                          
  - ✅ Section reachable from the navbar profile dropdown (the dropdown already links to /profile; no new route needed).                                                                
                                                                                                                                                                                        
###  Beyond #289                                                                                                                                                                           
                                                                                                                                                                                        
  The backend exposes 7 additional category toggles (matches, requests, meetings, tasks, messages, feed engagement, new followers). Surfacing them too costs almost nothing — same data 
  flow, same control — and gives users granular control they're already implicitly being charged for. If you'd rather hide everything except the two reminder categories #289 calls out,
   easy to gate with a feature flag.                                                                                                                                                    
                                                            
###  Test plan                                                                                                                                                                             
   
  - npm run build clean.                                                                                                                                                                
  - npm test — 64/64 unit tests pass.                       
  - Manual: log in, open /profile, scroll to "Notification Preferences" — toggles render with current state.
  - Manual: flip Task deadline reminders → "Saved" pill flashes → reload page → state persists.                                                                                         
  - Manual: simulate offline → flip a toggle → toggle reverts to its previous position with an error message.  