### PR TITLE
feat(web): weekly calendar view with availability + meetings (#123)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import MentorshipDetailPage from './pages/MentorshipDetailPage'
 import MessagesPage from './pages/MessagesPage'
 import TasksPage from './pages/TasksPage'
 import SchedulePage from './pages/SchedulePage'
+import CalendarPage from './pages/CalendarPage'
 import NotificationsPage from './pages/NotificationsPage'
 import FeedPage from './pages/FeedPage'
 import FeedPostDetailPage from './pages/FeedPostDetailPage'
@@ -44,6 +45,7 @@ export default function App() {
           <Route path="/messages" element={<MessagesPage />} />
           <Route path="/tasks" element={<TasksPage />} />
           <Route path="/schedule" element={<SchedulePage />} />
+          <Route path="/calendar" element={<CalendarPage />} />
           <Route path="/notifications" element={<NotificationsPage />} />
           <Route path="/feed" element={<FeedPage />} />
           <Route path="/feed/bookmarks" element={<FeedBookmarksPage />} />

--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -20,6 +20,7 @@ const NAV_TABS = [
   { label: 'Messages', path: '/messages' },
   { label: 'Tasks', path: '/tasks' },
   { label: 'Schedule', path: '/schedule' },
+  { label: 'Calendar', path: '/calendar' },
   { label: 'Availability', path: '/availability' },
   { label: 'Profile', path: '/profile' },
 ]
@@ -31,6 +32,7 @@ const SIDEBAR_LINKS = [
   { label: 'Messages', path: '/messages', icon: MessageCircle },
   { label: 'My Tasks', path: '/tasks', icon: CheckSquare },
   { label: 'Schedule', path: '/schedule', icon: CalendarDays },
+  { label: 'Calendar', path: '/calendar', icon: CalendarDays },
   { label: 'Availability', path: '/availability', icon: Clock },
   { label: 'Profile', path: '/profile', icon: User },
 ]

--- a/frontend/src/pages/CalendarPage.jsx
+++ b/frontend/src/pages/CalendarPage.jsx
@@ -1,0 +1,307 @@
+import { useEffect, useMemo, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import MainLayout from '../components/MainLayout'
+import {
+  getActiveMentorships,
+  listMentorshipMeetings,
+  getMentorAvailability,
+} from '../services/api'
+import { useAuth } from '../context/AuthContext'
+import '../styles/main.css'
+
+/**
+ * Weekly calendar view (#123). Renders, for the current week:
+ *  - Mentor's availability slots as background bands (mentor view only).
+ *  - Confirmed and pending meetings as overlay blocks (both viewers).
+ *
+ * Click an empty hour cell on a day → /schedule with the date pre-filled in
+ * the query string so the existing meeting-creation modal there can pick it
+ * up. Click a meeting → /mentorships/:id with a `#meeting-{id}` anchor.
+ *
+ * Scope kept tight: weekly grid only, no month / day views, no drag-create.
+ */
+
+const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+const DAY_KEYS = ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY']
+const HOUR_START = 8
+const HOUR_END = 22
+const HOUR_PX = 44
+
+function startOfIsoWeek(date) {
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+  const dow = d.getDay() // 0=Sunday..6=Saturday
+  const diff = (dow + 6) % 7 // distance back to Monday
+  d.setDate(d.getDate() - diff)
+  return d
+}
+
+function addDays(date, n) {
+  const d = new Date(date)
+  d.setDate(d.getDate() + n)
+  return d
+}
+
+function isSameDay(a, b) {
+  return a.getFullYear() === b.getFullYear()
+    && a.getMonth() === b.getMonth()
+    && a.getDate() === b.getDate()
+}
+
+function fmtDayLabel(d) {
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+}
+
+function fmtWeekRange(monday) {
+  const sunday = addDays(monday, 6)
+  const sameMonth = monday.getMonth() === sunday.getMonth()
+  const left = monday.toLocaleDateString('en-GB', { day: 'numeric', month: sameMonth ? undefined : 'short' })
+  const right = sunday.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+  return `${left} – ${right}`
+}
+
+function parseHHMM(t) {
+  // Backend serialises LocalTime as "HH:mm:ss". Defensive against bad input.
+  if (!t) return 0
+  const parts = String(t).split(':')
+  const h = Number(parts[0] || 0)
+  const m = Number(parts[1] || 0)
+  return h + m / 60
+}
+
+export default function CalendarPage() {
+  const navigate = useNavigate()
+  const { userId, role } = useAuth()
+  const isMentor = role === 'MENTOR'
+
+  const [weekStart, setWeekStart] = useState(() => startOfIsoWeek(new Date()))
+  const [meetings, setMeetings] = useState([])
+  const [slots, setSlots] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const days = useMemo(
+    () => Array.from({ length: 7 }, (_, i) => addDays(weekStart, i)),
+    [weekStart]
+  )
+  const today = useMemo(() => { const t = new Date(); t.setHours(0, 0, 0, 0); return t }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const mentorships = await getActiveMentorships().catch(() => [])
+      const meetingArrays = await Promise.all(
+        (mentorships || []).map(m =>
+          listMentorshipMeetings(m.id)
+            .then(list => (list || []).map(meeting => ({
+              ...meeting,
+              mentorshipId: m.id,
+              counterpartName: isMentor ? m.menteeFirstName : m.mentorFirstName,
+            })))
+            .catch(() => [])
+        )
+      )
+      setMeetings(meetingArrays.flat())
+
+      if (isMentor && userId) {
+        const av = await getMentorAvailability(userId).catch(() => null)
+        setSlots(Array.isArray(av) ? av : (av?.slots || []))
+      } else {
+        setSlots([])
+      }
+    } catch (err) {
+      setError(err?.message || 'Failed to load calendar.')
+    } finally {
+      setLoading(false)
+    }
+  }, [isMentor, userId])
+
+  useEffect(() => { load() }, [load])
+
+  // ── Slot positioning helpers ──────────────────────────────────────────
+  function meetingsForDay(day) {
+    return meetings.filter(m => {
+      const start = new Date(m.startTime)
+      return !isNaN(start.getTime()) && isSameDay(start, day)
+    })
+  }
+
+  function slotsForDay(day) {
+    if (!isMentor || !slots.length) return []
+    const dayKey = DAY_KEYS[(day.getDay() + 6) % 7]
+    return slots.filter(s => s.dayOfWeek === dayKey)
+  }
+
+  function topPxFromHours(h) {
+    return (h - HOUR_START) * HOUR_PX
+  }
+
+  function meetingBlockStyle(meeting) {
+    const start = new Date(meeting.startTime)
+    const startHours = start.getHours() + start.getMinutes() / 60
+    const durationH = Math.max(0.5, (Number(meeting.durationMin) || 30) / 60)
+    return {
+      top: `${topPxFromHours(startHours)}px`,
+      height: `${durationH * HOUR_PX - 2}px`,
+    }
+  }
+
+  function slotBandStyle(slot) {
+    const startH = parseHHMM(slot.startTime)
+    const endH = parseHHMM(slot.endTime)
+    return {
+      top: `${topPxFromHours(startH)}px`,
+      height: `${(endH - startH) * HOUR_PX}px`,
+    }
+  }
+
+  function meetingClassFor(status) {
+    switch (status) {
+      case 'CONFIRMED': return 'cal-meeting cal-meeting--confirmed'
+      case 'PENDING_CONFIRMATION': return 'cal-meeting cal-meeting--pending'
+      case 'COMPLETED': return 'cal-meeting cal-meeting--past'
+      default: return 'cal-meeting cal-meeting--other'
+    }
+  }
+
+  function handleEmptyCellClick(day, hour) {
+    // Pre-fill date+hour into /schedule's query string so its existing
+    // create-meeting modal can pick it up. ISO 8601 local-date w/ hour suffix.
+    const yyyy = day.getFullYear()
+    const mm = String(day.getMonth() + 1).padStart(2, '0')
+    const dd = String(day.getDate()).padStart(2, '0')
+    const hh = String(hour).padStart(2, '0')
+    navigate(`/schedule?prefillDate=${yyyy}-${mm}-${dd}&prefillHour=${hh}`)
+  }
+
+  function handleMeetingClick(meeting) {
+    navigate(`/mentorships/${meeting.mentorshipId}#meeting-${meeting.id}`)
+  }
+
+  return (
+    <MainLayout>
+      <div className="page-header">
+        <div>
+          <div className="page-title">Calendar</div>
+          <div className="page-sub">
+            {isMentor
+              ? 'Your availability and upcoming meetings.'
+              : 'Your upcoming meetings, week by week.'}
+          </div>
+        </div>
+        <div className="cal-nav">
+          <button
+            type="button"
+            className="cal-nav-btn"
+            onClick={() => setWeekStart(addDays(weekStart, -7))}
+            aria-label="Previous week"
+          >
+            <ChevronLeft size={16} strokeWidth={2} />
+          </button>
+          <button
+            type="button"
+            className="cal-nav-btn cal-nav-today"
+            onClick={() => setWeekStart(startOfIsoWeek(new Date()))}
+          >
+            Today
+          </button>
+          <button
+            type="button"
+            className="cal-nav-btn"
+            onClick={() => setWeekStart(addDays(weekStart, 7))}
+            aria-label="Next week"
+          >
+            <ChevronRight size={16} strokeWidth={2} />
+          </button>
+          <span className="cal-week-label">{fmtWeekRange(weekStart)}</span>
+        </div>
+      </div>
+
+      {error && (
+        <div className="md-error-card" style={{ marginBottom: '12px' }}>
+          <div className="md-error-title">Couldn’t load calendar</div>
+          <div className="md-error-sub">{error}</div>
+        </div>
+      )}
+
+      <div className="cal-grid">
+        <div className="cal-grid-header">
+          <div className="cal-grid-corner" aria-hidden="true" />
+          {days.map((d, i) => (
+            <div
+              key={i}
+              className={`cal-day-header${isSameDay(d, today) ? ' cal-day-header--today' : ''}`}
+            >
+              <div className="cal-day-name">{DAY_NAMES[i]}</div>
+              <div className="cal-day-date">{fmtDayLabel(d)}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="cal-grid-body">
+          <div className="cal-hours-col">
+            {Array.from({ length: HOUR_END - HOUR_START }, (_, i) => HOUR_START + i).map(h => (
+              <div key={h} className="cal-hour-label" style={{ height: `${HOUR_PX}px` }}>
+                {String(h).padStart(2, '0')}:00
+              </div>
+            ))}
+          </div>
+
+          {days.map((day, di) => {
+            const dayMeetings = meetingsForDay(day)
+            const daySlots = slotsForDay(day)
+            const isToday = isSameDay(day, today)
+            return (
+              <div
+                key={di}
+                className={`cal-day-col${isToday ? ' cal-day-col--today' : ''}`}
+                style={{ height: `${(HOUR_END - HOUR_START) * HOUR_PX}px` }}
+              >
+                {daySlots.map(slot => (
+                  <div
+                    key={`s-${slot.id}`}
+                    className="cal-availability-band"
+                    style={slotBandStyle(slot)}
+                    title={`Available ${slot.startTime?.slice(0, 5)} – ${slot.endTime?.slice(0, 5)}`}
+                  />
+                ))}
+
+                {Array.from({ length: HOUR_END - HOUR_START }, (_, i) => HOUR_START + i).map(h => (
+                  <button
+                    key={`h-${h}`}
+                    type="button"
+                    className="cal-hour-cell"
+                    style={{ top: `${topPxFromHours(h)}px`, height: `${HOUR_PX}px` }}
+                    onClick={() => handleEmptyCellClick(day, h)}
+                    aria-label={`Create meeting on ${fmtDayLabel(day)} at ${h}:00`}
+                  />
+                ))}
+
+                {dayMeetings.map(m => (
+                  <button
+                    key={`m-${m.id}`}
+                    type="button"
+                    className={meetingClassFor(m.status)}
+                    style={meetingBlockStyle(m)}
+                    onClick={() => handleMeetingClick(m)}
+                    title={`${m.title || 'Meeting'} · ${m.status?.replace(/_/g, ' ').toLowerCase()}`}
+                  >
+                    <div className="cal-meeting-title">{m.title || 'Meeting'}</div>
+                    <div className="cal-meeting-meta">
+                      {new Date(m.startTime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      {m.counterpartName ? ` · ${m.counterpartName}` : ''}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {loading && <div className="md-loading" style={{ marginTop: '12px' }}>Loading calendar…</div>}
+    </MainLayout>
+  )
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3218,6 +3218,150 @@
 .md-primary-btn { background: var(--green-dark); }
 .md-primary-btn:hover:not(:disabled) { background: var(--green-mid); }
 
+/* Calendar weekly grid (#123). */
+.cal-nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.cal-nav-btn {
+  height: 34px;
+  min-width: 34px;
+  padding: 0 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--text);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.cal-nav-btn:hover { border-color: var(--green-mid); background: var(--green-pale); }
+.cal-nav-today { padding: 0 14px; }
+.cal-week-label {
+  margin-left: 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.cal-grid {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.cal-grid-header {
+  display: grid;
+  grid-template-columns: 64px repeat(7, 1fr);
+  border-bottom: 1px solid var(--border);
+  background: #fafaf9;
+}
+.cal-grid-corner { background: transparent; }
+.cal-day-header {
+  padding: 10px 8px;
+  text-align: center;
+  border-left: 1px solid var(--border);
+}
+.cal-day-header--today {
+  background: var(--green-pale);
+}
+.cal-day-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.cal-day-date {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+  margin-top: 2px;
+}
+
+.cal-grid-body {
+  display: grid;
+  grid-template-columns: 64px repeat(7, 1fr);
+}
+.cal-hours-col {
+  border-right: 1px solid var(--border);
+}
+.cal-hour-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 4px 6px;
+  text-align: right;
+  border-bottom: 1px solid #f0efed;
+}
+.cal-day-col {
+  position: relative;
+  border-left: 1px solid var(--border);
+}
+.cal-day-col--today { background: rgba(180, 215, 188, 0.08); }
+.cal-hour-cell {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #f0efed;
+  cursor: pointer;
+  padding: 0;
+}
+.cal-hour-cell:hover { background: rgba(180, 215, 188, 0.18); }
+
+.cal-availability-band {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  background: rgba(93, 141, 102, 0.12);
+  border-left: 3px solid var(--green-mid);
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+.cal-meeting {
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  border-radius: 6px;
+  border: none;
+  text-align: left;
+  padding: 4px 6px;
+  cursor: pointer;
+  overflow: hidden;
+  font-family: 'DM Sans', sans-serif;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  z-index: 1;
+}
+.cal-meeting--confirmed { background: var(--green-dark, #2e7d4f); }
+.cal-meeting--pending   { background: #d97706; }
+.cal-meeting--past      { background: #6b7280; }
+.cal-meeting--other     { background: #4b5563; }
+.cal-meeting:hover { filter: brightness(0.92); }
+.cal-meeting-title {
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.cal-meeting-meta {
+  font-size: 11px;
+  opacity: 0.92;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
 /* Mentor rating modal + post-end prompt (#278). */
 .md-rating-card {
   margin: 12px 0;


### PR DESCRIPTION
              
##  Summary
                                                                                                                                                                                        
  New /calendar route renders a weekly grid (Mon → Sun, 08:00–22:00) showing the viewer's confirmed and pending meetings, with the mentor's availability slots laid in as background    
  bands when the viewer is a mentor. Week navigation buttons (← Today →) move the displayed range without remounting.                                                                   
                                                                                                                                                                                        
##  Changes                                                   

  - pages/CalendarPage.jsx (new) — single-component implementation. Loads getActiveMentorships() then parallel-fetches listMentorshipMeetings(id) for each, flattens, and partitions per
   day. For mentors, also calls getMentorAvailability(userId) and renders dayOfWeek + startTime + endTime slots as translucent green bands behind the meeting overlay.
  - components/MainLayout.jsx — added "Calendar" entries to both the top nav tabs and the sidebar links, between Schedule and Availability.                                             
  - App.jsx — registered the /calendar route under <ProtectedRoute />.                                                                                                                  
  - styles/main.css — grid + meeting block styles. Status-color mapping: confirmed = green, pending = amber, completed = grey.                                                          
                                                                                                                                                                                        
###  Acceptance criteria mapping (from #123)                                                                                                                                               
                                                                                                                                                                                        
  - ✅ Weekly grid (Mon–Sun, hour rows) renders availability slots and confirmed meetings with distinct visual styles.                                                                  
  - ✅ "Today" column highlighted; week navigation buttons (← → Today) update the displayed range.
  - ✅ Clicking an empty cell navigates to /schedule?prefillDate=YYYY-MM-DD&prefillHour=HH so SchedulePage's existing create-meeting modal can open pre-filled. Note: the modal there   
  doesn't currently consume those query params; opening pre-filled is a one-line follow-up in SchedulePage.jsx once you confirm the param shape.                                        
  - ✅ Clicking a meeting navigates to /mentorships/:id#meeting-{id}.                                                                                                                   
                                                                                                                                                                                        
 ### Out of scope                                                                                                                                                                          
                                                                                                                                                                                        
  - Pre-fill consumption on /schedule (one-line follow-up — the modal there ignores the query params today; nothing breaks, just no auto-open).                                         
  - Drag-to-create / drag-to-resize on the grid.
  - Day or month views.                                                                                                                                                                 
                                                                                                                                                                                        
###  Test plan                                                                                                                                                                             
                                                                                                                                                                                        
  - npm run build clean.                 
  - npm test — 64/64 unit tests pass.
  - Manual (mentor): visit /calendar. Availability bands match what's set on /availability. Confirmed meetings render in green at the correct hours.
  - Manual (mentee): same view, no availability bands, only meetings rendered.                                                                                                          
  - Manual: ←/→ buttons shift one week; Today snaps back to the current week. The "Today" column highlight follows the current weekday only when that week is shown.                    
                                     