### PR TITLE
fix(web): remove followed user from suggested-to-follow rail (#512)

### DIFF
--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -113,7 +113,7 @@ export default function FeedPage() {
     setRecError(null)
     try {
       const page = await getFollowRecommendations(0, 8)
-      const list = (page?.content || []).map(r => ({ ...r, isFollowing: false, busy: false }))
+      const list = (page?.content || []).map(r => ({ ...r, busy: false }))
       setRecommendations(list)
     } catch (err) {
       setRecError(err?.message || 'Failed to load suggestions')
@@ -238,9 +238,12 @@ export default function FeedPage() {
     setRecommendations(prev => prev.map(r => r.id === userId ? { ...r, busy: true } : r))
     try {
       await followUser(userId)
-      setRecommendations(prev => prev.map(r => r.id === userId
-        ? { ...r, busy: false, isFollowing: true }
-        : r))
+      // #512: drop the followed user from the rail entirely. Keeping the card
+      // with the label flipped to "Unfollow" leaves a dead-looking button
+      // (the original click handler short-circuits on isFollowing=true). The
+      // recommendation no longer applies once we're following, so removal is
+      // the cleanest UX.
+      setRecommendations(prev => prev.filter(r => r.id !== userId))
     } catch (err) {
       setRecommendations(prev => prev.map(r => r.id === userId ? { ...r, busy: false } : r))
       window.alert(err?.message || 'Failed to follow user')
@@ -389,12 +392,12 @@ export default function FeedPage() {
                             View Profile
                           </button>
                           <button
-                            className={`follow-btn${rec.isFollowing ? ' follow-btn--active' : ''}`}
+                            className="follow-btn"
                             type="button"
-                            onClick={() => !rec.isFollowing && !rec.busy && handleFollowSuggestion(rec.id)}
-                            disabled={rec.busy || rec.isFollowing}
+                            onClick={() => !rec.busy && handleFollowSuggestion(rec.id)}
+                            disabled={rec.busy}
                           >
-                            {rec.busy ? 'Updating...' : rec.isFollowing ? 'Unfollow' : 'Follow'}
+                            {rec.busy ? 'Following…' : 'Follow'}
                           </button>
                         </div>
                       </div>


### PR DESCRIPTION
Closes #512.                                                                                                                                                                          
                                                                                                                                                                                        
 ## Summary                                                                                                                                                                               
                                                                                                                                                                                        
  After a successful follow on the "Suggested to follow" rail (Feed → Following tab, empty state from PR #505), the card no longer flips its button to a dead "Unfollow" — it disappears
   from the rail. The recommendation no longer applies once you're following, so removal is the cleanest UX.
                                                                                                                                                                                        
  Why removal beats wiring up an unfollow                                                                                                                                               
   
  The original code (!rec.isFollowing && !rec.busy && handleFollowSuggestion) plus disabled={rec.busy || rec.isFollowing} made the second click permanently inert. Two ways to fix:     
                                                                                                                                                                                      
  - Option A (this PR): remove the card from the rail on follow success. Card disappears, no dead button.                                                                               
  - Option B: wire the second click to unfollowUser(...) and flip isFollowing back. Costs a second API path and adds a "follow → unfollow → follow → …" loop on a suggestion rail that
  shouldn't be there anyway.                                                                                                                                                            
                                                                                                                                                                                      
  A is smaller and aligns with what other recommendation surfaces do (LinkedIn, Twitter): the suggestion vanishes once acted on.                                                        
                                                                                                                                                                                      
 ## Changes                                                                                                                                                                               
                                                            
  - pages/FeedPage.jsx:
    - handleFollowSuggestion now filters the followed user out of recommendations on success instead of setting isFollowing: true.
    - Removed the now-dead isFollowing branches in the card render (the conditional className, the short-circuit in onClick, the disabled-on-isFollowing path, and the "Unfollow"       
  label). The Follow button is now simply Follow → Following… while in-flight → card removed.                                                                                           
    - Dropped the isFollowing: false initializer when seeding recommendations — never read anymore.                                                                                     
                                                                                                                                                                                        
###  Test plan                                                 
                                                                                                                                                                                        
  - npm run build clean.                                    
  - npm test — 64/64 unit tests pass.
  - Manual: log in, navigate to /feed → Following tab while following no one → "Suggested to follow" rail appears → click Follow on a card → card disappears from the rail, follow      
  request succeeded.                                                                                                                                                                    
  - Manual: trigger a failed follow (network panel offline) → card stays put, "Updating..." reverts, error alert shows.                                                                 
                          