### PR TITLE
feat(mobile): blog posts, feed images, like/comment, trending hashtags

### DIFF
--- a/mobile-app/app/(tabs)/index.tsx
+++ b/mobile-app/app/(tabs)/index.tsx
@@ -272,25 +272,6 @@ export default function HomeScreen() {
         </TouchableOpacity>
 
         <Text style={styles.sectionTitle}>{sectionTitle}</Text>
-        <View style={styles.tabRow}>
-          <TouchableOpacity
-            style={[styles.tabChip, selectedTab === 'active' && styles.tabChipActive]}
-            onPress={() => setSelectedTab('active')}
-          >
-            <Text style={[styles.tabChipText, selectedTab === 'active' && styles.tabChipTextActive]}>
-              Active ({activeConnections.length})
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.tabChip, selectedTab === 'past' && styles.tabChipActive]}
-            onPress={() => setSelectedTab('past')}
-          >
-            <Text style={[styles.tabChipText, selectedTab === 'past' && styles.tabChipTextActive]}>
-              Past ({pastConnections.length})
-            </Text>
-          </TouchableOpacity>
-        </View>
-
         <View style={{ flexDirection: 'row', gap: 10, marginBottom: 16 }}>
           {(['active', 'past'] as const).map((tab) => (
             <TouchableOpacity

--- a/mobile-app/app/(tabs)/messages.tsx
+++ b/mobile-app/app/(tabs)/messages.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Image,
   KeyboardAvoidingView,
   Linking,
   Platform,
@@ -22,6 +23,7 @@ import * as Sharing from 'expo-sharing';
 import apiClient from '../../api/client';
 import { useRole } from '../../components/RoleContext';
 import { useProtectedSession } from '../../components/useProtectedSession';
+import AuthImage from '../../components/AuthImage';
 
 type ConversationListTab = 'mentorships' | 'mentorPeers';
 
@@ -846,30 +848,37 @@ export default function MessagesScreen() {
                       </Text>
 
                       {message.attachment ? (
-                        <TouchableOpacity
-                          style={styles.attachmentPill}
-                          onPress={() => openAttachment(message.attachment!)}
-                          disabled={openingAttachmentId === message.attachment.id}
-                          accessibilityRole="button"
-                          accessibilityLabel={`Open attachment ${message.attachment.name}`}
-                          accessibilityHint={
-                            openingAttachmentId === message.attachment.id
-                              ? 'Attachment is opening'
-                              : 'Opens the shared attachment'
-                          }
-                        >
-                          <Text style={styles.attachmentIcon}>
-                            {message.attachment.contentType?.includes('image') ? '🖼️' : '📄'}
-                          </Text>
-                          <View style={styles.attachmentTextWrap}>
-                            <Text style={styles.attachmentTitle}>{message.attachment.name}</Text>
-                            <Text style={styles.attachmentMeta}>
-                              {openingAttachmentId === message.attachment.id
-                                ? 'Opening...'
-                                : message.attachment.meta}
-                            </Text>
-                          </View>
-                        </TouchableOpacity>
+                        message.attachment.contentType?.includes('image') && message.attachment.downloadUrl ? (
+                          <AuthImage
+                            downloadUrl={message.attachment.downloadUrl}
+                            filename={message.attachment.name}
+                            style={{ width: 220, height: 160 }}
+                            onPress={() => openAttachment(message.attachment!)}
+                          />
+                        ) : (
+                          <TouchableOpacity
+                            style={styles.attachmentPill}
+                            onPress={() => openAttachment(message.attachment!)}
+                            disabled={openingAttachmentId === message.attachment.id}
+                            accessibilityRole="button"
+                            accessibilityLabel={`Open attachment ${message.attachment.name}`}
+                            accessibilityHint={
+                              openingAttachmentId === message.attachment.id
+                                ? 'Attachment is opening'
+                                : 'Opens the shared attachment'
+                            }
+                          >
+                            <Text style={styles.attachmentIcon}>📄</Text>
+                            <View style={styles.attachmentTextWrap}>
+                              <Text style={styles.attachmentTitle}>{message.attachment.name}</Text>
+                              <Text style={styles.attachmentMeta}>
+                                {openingAttachmentId === message.attachment.id
+                                  ? 'Opening...'
+                                  : message.attachment.meta}
+                              </Text>
+                            </View>
+                          </TouchableOpacity>
+                        )
                       ) : null}
                     </View>
 
@@ -892,6 +901,13 @@ export default function MessagesScreen() {
 
         {pendingAttachment ? (
           <View style={styles.pendingAttachmentBar}>
+            {pendingAttachment.type?.includes('image') ? (
+              <Image
+                source={{ uri: pendingAttachment.uri }}
+                style={{ width: 44, height: 44, borderRadius: 8, marginRight: 10 }}
+                resizeMode="cover"
+              />
+            ) : null}
             <View style={styles.pendingAttachmentInfo}>
               <Text style={styles.pendingAttachmentTitle}>{pendingAttachment.name}</Text>
               <Text style={styles.pendingAttachmentMeta}>

--- a/mobile-app/app/(tabs)/profile.tsx
+++ b/mobile-app/app/(tabs)/profile.tsx
@@ -633,6 +633,15 @@ function MenteeProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
               <Text style={styles.quickActionIcon}>📅</Text>
               <Text style={styles.quickActionText}>Availability</Text>
             </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.quickActionButton}
+              onPress={() => router.push({ pathname: '/my-blog', params: { authorId: sessionUserId } } as any)}
+              accessibilityRole="button"
+              accessibilityLabel="Blog"
+            >
+              <Text style={styles.quickActionIcon}>📝</Text>
+              <Text style={styles.quickActionText}>Blog</Text>
+            </TouchableOpacity>
           </View>
 
           <View style={styles.formCardMentee}>
@@ -865,6 +874,15 @@ function MentorProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
               <Text style={styles.quickActionIcon}>📅</Text>
               <Text style={styles.quickActionText}>Availability</Text>
             </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.quickActionButton}
+              onPress={() => router.push({ pathname: '/my-blog', params: { authorId: sessionUserId } } as any)}
+              accessibilityRole="button"
+              accessibilityLabel="Blog"
+            >
+              <Text style={styles.quickActionIcon}>📝</Text>
+              <Text style={styles.quickActionText}>Blog</Text>
+            </TouchableOpacity>
           </View>
 
           <View style={styles.formCardMentor}>
@@ -927,6 +945,7 @@ function MentorProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
           >
             <Text style={styles.saveButtonText}>Save Changes</Text>
           </TouchableOpacity>
+
           <TouchableOpacity
             style={styles.logoutButton}
             onPress={onLogout}

--- a/mobile-app/app/my-blog.tsx
+++ b/mobile-app/app/my-blog.tsx
@@ -1,0 +1,185 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { router, useLocalSearchParams } from 'expo-router';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
+import apiClient from '../api/client';
+import AuthImage from '../components/AuthImage';
+
+type PostAttachment = {
+  id: string;
+  downloadUrl: string;
+  filename: string;
+  contentType: string;
+};
+
+type BlogPost = {
+  id: number;
+  body: string;
+  hashtags: string[];
+  createdAt: string;
+  likeCount: number;
+  commentCount: number;
+  attachments: PostAttachment[];
+};
+
+function parseString(v: string | string[] | undefined) {
+  return Array.isArray(v) ? v[0] : v ?? '';
+}
+
+function formatRelativeLabel(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const diffMinutes = Math.max(1, Math.round((Date.now() - date.getTime()) / 60000));
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${Math.round(diffHours / 24)}d ago`;
+}
+
+export default function MyBlogScreen() {
+  const params = useLocalSearchParams();
+  const authorId = parseString(params.authorId);
+
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const fetchPosts = useCallback(async (p = 0) => {
+    if (!authorId) return;
+    try {
+      if (p === 0) setLoading(true);
+      else setLoadingMore(true);
+      const res = await apiClient.get(`/feed/users/${authorId}/posts?page=${p}&size=10`);
+      const data = res.data;
+      const items: BlogPost[] = data.content ?? data ?? [];
+      setPosts((prev) => (p === 0 ? items : [...prev, ...items]));
+      setHasMore(!data.last);
+      setPage(p);
+    } catch {
+      // silently ignore
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [authorId]);
+
+  useEffect(() => {
+    fetchPosts(0);
+  }, [fetchPosts]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backText}>‹ Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.title}>My Blog</Text>
+      </View>
+
+      {loading ? (
+        <ActivityIndicator size="large" color="#456B50" style={{ marginTop: 60 }} />
+      ) : (
+        <ScrollView
+          contentContainerStyle={styles.content}
+          showsVerticalScrollIndicator={false}
+        >
+          {posts.length === 0 ? (
+            <View style={styles.empty}>
+              <Text style={styles.emptyText}>No posts yet.</Text>
+              <Text style={styles.emptySubText}>Posts you create in the feed will appear here.</Text>
+            </View>
+          ) : (
+            <>
+              {posts.map((post) => (
+                <View key={post.id} style={styles.postCard}>
+                  <Text style={styles.postBody}>{post.body}</Text>
+                  {post.attachments?.length > 0 && post.attachments.map((att) => (
+                    <AuthImage key={att.id} downloadUrl={att.downloadUrl} filename={att.filename} />
+                  ))}
+                  {post.hashtags.length > 0 && (
+                    <View style={styles.hashtagRow}>
+                      {post.hashtags.map((h) => (
+                        <Text key={h} style={styles.hashtag}>#{h}</Text>
+                      ))}
+                    </View>
+                  )}
+                  <View style={styles.postFooter}>
+                    <Text style={styles.postMeta}>{formatRelativeLabel(post.createdAt)}</Text>
+                    <Text style={styles.postMeta}>♥ {post.likeCount}  💬 {post.commentCount}</Text>
+                  </View>
+                </View>
+              ))}
+              {hasMore && (
+                <TouchableOpacity
+                  style={styles.loadMoreBtn}
+                  onPress={() => fetchPosts(page + 1)}
+                  disabled={loadingMore}
+                >
+                  {loadingMore ? (
+                    <ActivityIndicator size="small" color="#456B50" />
+                  ) : (
+                    <Text style={styles.loadMoreText}>Load more</Text>
+                  )}
+                </TouchableOpacity>
+              )}
+            </>
+          )}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#ECE8E1' },
+  header: {
+    backgroundColor: '#456B50',
+    paddingTop: 54,
+    paddingHorizontal: 24,
+    paddingBottom: 24,
+  },
+  backButton: {
+    backgroundColor: 'rgba(255,255,255,0.12)',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.18)',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 16,
+    alignSelf: 'flex-start',
+    marginBottom: 16,
+  },
+  backText: { color: '#F7F4EE', fontSize: 14, fontWeight: '700' },
+  title: { color: '#F7F4EE', fontSize: 28, fontWeight: '700' },
+  content: { padding: 24, paddingBottom: 48 },
+  empty: { paddingTop: 60, alignItems: 'center' },
+  emptyText: { color: '#6F6459', fontSize: 18, fontWeight: '700', marginBottom: 8 },
+  emptySubText: { color: '#9A8F82', fontSize: 14, textAlign: 'center' },
+  postCard: {
+    backgroundColor: '#F8F6F2',
+    borderRadius: 22,
+    padding: 20,
+    marginBottom: 14,
+  },
+  postBody: { fontSize: 15, color: '#2D2D2D', lineHeight: 23, marginBottom: 12 },
+  hashtagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginBottom: 12 },
+  hashtag: { fontSize: 13, color: '#456B50', fontWeight: '600' },
+  postFooter: { flexDirection: 'row', justifyContent: 'space-between' },
+  postMeta: { fontSize: 12, color: '#A0A0A0', fontWeight: '500' },
+  loadMoreBtn: {
+    alignSelf: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 28,
+    borderRadius: 16,
+    backgroundColor: '#EDE8E1',
+    marginTop: 8,
+  },
+  loadMoreText: { fontSize: 14, fontWeight: '700', color: '#456B50' },
+});

--- a/mobile-app/app/social-feed.tsx
+++ b/mobile-app/app/social-feed.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { router } from 'expo-router';
 import {
   ActivityIndicator,
@@ -6,12 +6,21 @@ import {
   ScrollView,
   StyleSheet,
   Text,
+  TextInput,
   TouchableOpacity,
   View,
 } from 'react-native';
 import apiClient from '../api/client';
+import AuthImage from '../components/AuthImage';
 
 type FeedTab = 'forYou' | 'following';
+
+type PostAttachment = {
+  id: string;
+  downloadUrl: string;
+  filename: string;
+  contentType: string;
+};
 
 type FeedPostListItem = {
   id: number;
@@ -22,6 +31,7 @@ type FeedPostListItem = {
   createdAt: string;
   likeCount: number;
   commentCount: number;
+  attachments: PostAttachment[];
 };
 
 type FeedUnreadCountResponse = {
@@ -29,16 +39,31 @@ type FeedUnreadCountResponse = {
   cappedAtMax: boolean;
 };
 
+type TrendingHashtag = {
+  tag: string;
+  postCount: number;
+  score: number;
+};
+
+type FeedComment = {
+  id: number;
+  authorId: number | null;
+  authorFirstName: string | null;
+  body: string | null;
+  createdAt: string;
+  isEdited: boolean;
+  isAuthor: boolean;
+  isDeleted: boolean;
+};
+
 function formatRelativeLabel(value: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return '';
-
   const diffMinutes = Math.max(1, Math.round((Date.now() - date.getTime()) / 60000));
   if (diffMinutes < 60) return `${diffMinutes}m ago`;
   const diffHours = Math.round(diffMinutes / 60);
   if (diffHours < 24) return `${diffHours}h ago`;
-  const diffDays = Math.round(diffHours / 24);
-  return `${diffDays}d ago`;
+  return `${Math.round(diffHours / 24)}d ago`;
 }
 
 export default function SocialFeedScreen() {
@@ -51,9 +76,34 @@ export default function SocialFeedScreen() {
   const [markingRead, setMarkingRead] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
+  // Trending
+  const [trendingHashtags, setTrendingHashtags] = useState<TrendingHashtag[]>([]);
+
+  // Like state per post: { liked, count }
+  const [likeState, setLikeState] = useState<Record<number, { liked: boolean; count: number }>>({});
+  const [likingPostId, setLikingPostId] = useState<number | null>(null);
+
+  // Comments
+  const [expandedPostId, setExpandedPostId] = useState<number | null>(null);
+  const [comments, setComments] = useState<Record<number, FeedComment[]>>({});
+  const [commentsLoading, setCommentsLoading] = useState<Record<number, boolean>>({});
+  const [commentInput, setCommentInput] = useState('');
+  const [submittingComment, setSubmittingComment] = useState(false);
+
+  const commentInputRef = useRef<TextInput>(null);
+
   const loadUnreadCount = useCallback(async () => {
     const res = await apiClient.get('/feed/unread-count');
     setUnreadCount(res.data);
+  }, []);
+
+  const loadTrending = useCallback(async () => {
+    try {
+      const res = await apiClient.get('/feed/trending/hashtags?limit=10');
+      setTrendingHashtags(res.data ?? []);
+    } catch {
+      // silently ignore
+    }
   }, []);
 
   const loadFeeds = useCallback(async () => {
@@ -64,10 +114,18 @@ export default function SocialFeedScreen() {
         apiClient.get('/feed/following?page=0&size=20'),
         apiClient.get('/feed/unread-count'),
       ]);
-
-      setForYouPosts(forYouRes.data.content ?? []);
-      setFollowingPosts(followingRes.data.content ?? []);
+      const forYou: FeedPostListItem[] = forYouRes.data.content ?? [];
+      const following: FeedPostListItem[] = followingRes.data.content ?? [];
+      setForYouPosts(forYou);
+      setFollowingPosts(following);
       setUnreadCount(unreadRes.data);
+
+      // Seed like state from posts
+      const seed: Record<number, { liked: boolean; count: number }> = {};
+      [...forYou, ...following].forEach((p) => {
+        if (!(p.id in seed)) seed[p.id] = { liked: false, count: p.likeCount };
+      });
+      setLikeState((prev) => ({ ...seed, ...prev }));
     } catch {
       setErrorMessage('Could not load the social feed right now.');
     } finally {
@@ -78,7 +136,8 @@ export default function SocialFeedScreen() {
 
   useEffect(() => {
     loadFeeds();
-  }, [loadFeeds]);
+    loadTrending();
+  }, [loadFeeds, loadTrending]);
 
   const activePosts = useMemo(
     () => (activeTab === 'forYou' ? forYouPosts : followingPosts),
@@ -88,6 +147,7 @@ export default function SocialFeedScreen() {
   const onRefresh = () => {
     setRefreshing(true);
     loadFeeds();
+    loadTrending();
   };
 
   const markFeedRead = async () => {
@@ -100,6 +160,75 @@ export default function SocialFeedScreen() {
     } finally {
       setMarkingRead(false);
     }
+  };
+
+  const toggleLike = async (postId: number) => {
+    if (likingPostId !== null) return;
+    const prev = likeState[postId] ?? { liked: false, count: 0 };
+    // Optimistic update
+    setLikeState((s) => ({
+      ...s,
+      [postId]: { liked: !prev.liked, count: prev.liked ? prev.count - 1 : prev.count + 1 },
+    }));
+    setLikingPostId(postId);
+    try {
+      const res = await apiClient.post(`/feed/posts/${postId}/like`);
+      setLikeState((s) => ({
+        ...s,
+        [postId]: { liked: res.data.viewerHasLiked, count: res.data.likeCount },
+      }));
+    } catch {
+      // Revert optimistic
+      setLikeState((s) => ({ ...s, [postId]: prev }));
+    } finally {
+      setLikingPostId(null);
+    }
+  };
+
+  const toggleComments = async (postId: number) => {
+    if (expandedPostId === postId) {
+      setExpandedPostId(null);
+      setCommentInput('');
+      return;
+    }
+    setExpandedPostId(postId);
+    setCommentInput('');
+    if (comments[postId]) return;
+    setCommentsLoading((s) => ({ ...s, [postId]: true }));
+    try {
+      const res = await apiClient.get(`/feed/posts/${postId}/comments?page=0&size=20`);
+      setComments((s) => ({ ...s, [postId]: res.data.content ?? res.data ?? [] }));
+    } catch {
+      setComments((s) => ({ ...s, [postId]: [] }));
+    } finally {
+      setCommentsLoading((s) => ({ ...s, [postId]: false }));
+    }
+  };
+
+  const submitComment = async (postId: number) => {
+    if (!commentInput.trim() || submittingComment) return;
+    setSubmittingComment(true);
+    try {
+      const res = await apiClient.post(`/feed/posts/${postId}/comments`, { body: commentInput.trim() });
+      setComments((s) => ({ ...s, [postId]: [res.data, ...(s[postId] ?? [])] }));
+      setCommentInput('');
+      // Update comment count on post
+      setLikeState((s) => s); // no-op, comment count on the post object is separate
+      setForYouPosts((posts) =>
+        posts.map((p) => p.id === postId ? { ...p, commentCount: p.commentCount + 1 } : p)
+      );
+      setFollowingPosts((posts) =>
+        posts.map((p) => p.id === postId ? { ...p, commentCount: p.commentCount + 1 } : p)
+      );
+    } catch {
+      // silently ignore
+    } finally {
+      setSubmittingComment(false);
+    }
+  };
+
+  const navigateToUserProfile = (authorId: number) => {
+    router.push({ pathname: '/user-profile', params: { userId: String(authorId) } } as any);
   };
 
   return (
@@ -127,6 +256,21 @@ export default function SocialFeedScreen() {
           </View>
         </View>
 
+        {/* Trending hashtags */}
+        {trendingHashtags.length > 0 && (
+          <View style={styles.trendingCard}>
+            <Text style={styles.trendingLabel}>TRENDING</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.trendingScroll}>
+              {trendingHashtags.map((h) => (
+                <View key={h.tag} style={styles.trendingChip}>
+                  <Text style={styles.trendingChipText}>#{h.tag}</Text>
+                  <Text style={styles.trendingChipCount}>{h.postCount}</Text>
+                </View>
+              ))}
+            </ScrollView>
+          </View>
+        )}
+
         <View style={styles.summaryCard}>
           <View style={styles.summaryHeader}>
             <View>
@@ -145,9 +289,6 @@ export default function SocialFeedScreen() {
               </Text>
             </TouchableOpacity>
           </View>
-          <Text style={styles.summaryText}>
-            Switch between `For You` and `Following` to browse the mobile feed.
-          </Text>
         </View>
 
         <View style={styles.tabRow}>
@@ -188,41 +329,128 @@ export default function SocialFeedScreen() {
             </Text>
           </View>
         ) : (
-          activePosts.map((post) => (
-            <View key={post.id} style={styles.postCard}>
-              <View style={styles.postHeader}>
-                <View style={styles.avatar}>
-                  <Text style={styles.avatarText}>{post.authorFirstName.substring(0, 2).toUpperCase()}</Text>
-                </View>
-                <View style={styles.postHeaderCopy}>
-                  <Text style={styles.authorName}>{post.authorFirstName}</Text>
-                  <Text style={styles.postMeta}>{formatRelativeLabel(post.createdAt)}</Text>
-                </View>
-                <View style={styles.feedSourceBadge}>
-                  <Text style={styles.feedSourceBadgeText}>
-                    {activeTab === 'forYou' ? 'For You' : 'Following'}
-                  </Text>
-                </View>
-              </View>
+          activePosts.map((post) => {
+            const like = likeState[post.id] ?? { liked: false, count: post.likeCount };
+            const isExpanded = expandedPostId === post.id;
+            const postComments = comments[post.id] ?? [];
+            const loadingCmts = commentsLoading[post.id] ?? false;
 
-              <Text style={styles.postBody}>{post.body}</Text>
-
-              {post.hashtags.length > 0 && (
-                <View style={styles.hashtagRow}>
-                  {post.hashtags.map((hashtag) => (
-                    <View key={`${post.id}-${hashtag}`} style={styles.hashtagChip}>
-                      <Text style={styles.hashtagText}>#{hashtag}</Text>
+            return (
+              <View key={post.id} style={styles.postCard}>
+                <View style={styles.postHeader}>
+                  <TouchableOpacity onPress={() => navigateToUserProfile(post.authorId)}>
+                    <View style={styles.avatar}>
+                      <Text style={styles.avatarText}>{post.authorFirstName.substring(0, 2).toUpperCase()}</Text>
                     </View>
-                  ))}
+                  </TouchableOpacity>
+                  <TouchableOpacity style={styles.postHeaderCopy} onPress={() => navigateToUserProfile(post.authorId)}>
+                    <Text style={styles.authorName}>{post.authorFirstName}</Text>
+                    <Text style={styles.postMeta}>{formatRelativeLabel(post.createdAt)}</Text>
+                  </TouchableOpacity>
+                  <View style={styles.feedSourceBadge}>
+                    <Text style={styles.feedSourceBadgeText}>
+                      {activeTab === 'forYou' ? 'For You' : 'Following'}
+                    </Text>
+                  </View>
                 </View>
-              )}
 
-              <View style={styles.postFooter}>
-                <Text style={styles.footerStat}>{post.likeCount} likes</Text>
-                <Text style={styles.footerStat}>{post.commentCount} comments</Text>
+                <Text style={styles.postBody}>{post.body}</Text>
+
+                {post.attachments?.length > 0 && post.attachments.map((att) => (
+                  <AuthImage key={att.id} downloadUrl={att.downloadUrl} filename={att.filename} />
+                ))}
+
+                {post.hashtags.length > 0 && (
+                  <View style={styles.hashtagRow}>
+                    {post.hashtags.map((hashtag) => (
+                      <View key={`${post.id}-${hashtag}`} style={styles.hashtagChip}>
+                        <Text style={styles.hashtagText}>#{hashtag}</Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+
+                {/* Actions */}
+                <View style={styles.postActions}>
+                  <TouchableOpacity
+                    style={styles.actionBtn}
+                    onPress={() => toggleLike(post.id)}
+                    disabled={likingPostId === post.id}
+                  >
+                    <Text style={[styles.actionIcon, like.liked && styles.actionIconActive]}>
+                      {like.liked ? '♥' : '♡'}
+                    </Text>
+                    <Text style={[styles.actionCount, like.liked && styles.actionCountActive]}>
+                      {like.count}
+                    </Text>
+                  </TouchableOpacity>
+
+                  <TouchableOpacity
+                    style={styles.actionBtn}
+                    onPress={() => toggleComments(post.id)}
+                  >
+                    <Text style={[styles.actionIcon, isExpanded && styles.actionIconActive]}>💬</Text>
+                    <Text style={[styles.actionCount, isExpanded && styles.actionCountActive]}>
+                      {post.commentCount}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+
+                {/* Comments section */}
+                {isExpanded && (
+                  <View style={styles.commentsSection}>
+                    <View style={styles.commentInputRow}>
+                      <TextInput
+                        ref={commentInputRef}
+                        style={styles.commentInput}
+                        value={commentInput}
+                        onChangeText={setCommentInput}
+                        placeholder="Write a comment..."
+                        placeholderTextColor="#B5ADA3"
+                        multiline
+                      />
+                      <TouchableOpacity
+                        style={[styles.commentSendBtn, (!commentInput.trim() || submittingComment) && { opacity: 0.4 }]}
+                        onPress={() => submitComment(post.id)}
+                        disabled={!commentInput.trim() || submittingComment}
+                      >
+                        {submittingComment ? (
+                          <ActivityIndicator size="small" color="#fff" />
+                        ) : (
+                          <Text style={styles.commentSendText}>Send</Text>
+                        )}
+                      </TouchableOpacity>
+                    </View>
+
+                    {loadingCmts ? (
+                      <ActivityIndicator color="#456B50" style={{ marginTop: 12 }} />
+                    ) : postComments.length === 0 ? (
+                      <Text style={styles.noComments}>No comments yet.</Text>
+                    ) : (
+                      postComments.map((c) => (
+                        <View key={c.id} style={styles.commentItem}>
+                          <View style={styles.commentAvatar}>
+                            <Text style={styles.commentAvatarText}>
+                              {c.authorFirstName ? c.authorFirstName.substring(0, 1).toUpperCase() : '?'}
+                            </Text>
+                          </View>
+                          <View style={styles.commentBody}>
+                            <Text style={styles.commentAuthor}>
+                              {c.authorFirstName ?? 'Deleted user'}
+                              {c.isEdited ? <Text style={styles.editedTag}> · edited</Text> : null}
+                            </Text>
+                            <Text style={styles.commentText}>
+                              {c.isDeleted ? '[comment removed]' : c.body}
+                            </Text>
+                          </View>
+                        </View>
+                      ))
+                    )}
+                  </View>
+                )}
               </View>
-            </View>
-          ))
+            );
+          })
         )}
       </ScrollView>
     </View>
@@ -230,52 +458,26 @@ export default function SocialFeedScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#ECE8E1',
-  },
-  scrollArea: {
-    flex: 1,
-  },
-  content: {
-    paddingHorizontal: 24,
-    paddingTop: 54,
-    paddingBottom: 40,
-  },
+  container: { flex: 1, backgroundColor: '#ECE8E1' },
+  scrollArea: { flex: 1 },
+  content: { paddingHorizontal: 24, paddingTop: 54, paddingBottom: 40 },
   statusRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 24,
   },
-  statusText: {
-    color: '#2E2A24',
-    fontSize: 16,
-    fontWeight: '700',
-  },
-  statusIcons: {
-    color: '#5D554C',
-    fontSize: 18,
-    fontWeight: '700',
-  },
+  statusText: { color: '#2E2A24', fontSize: 16, fontWeight: '700' },
+  statusIcons: { color: '#5D554C', fontSize: 18, fontWeight: '700' },
   headerRow: {
     flexDirection: 'row',
     alignItems: 'flex-start',
     gap: 14,
-    marginBottom: 22,
+    marginBottom: 18,
   },
-  backButton: {
-    paddingTop: 2,
-    paddingRight: 8,
-  },
-  backText: {
-    color: '#23372B',
-    fontSize: 32,
-    fontWeight: '500',
-  },
-  headerCopy: {
-    flex: 1,
-  },
+  backButton: { paddingTop: 2, paddingRight: 8 },
+  backText: { color: '#23372B', fontSize: 32, fontWeight: '500' },
+  headerCopy: { flex: 1 },
   eyebrow: {
     color: '#8B8176',
     fontSize: 12,
@@ -283,12 +485,35 @@ const styles = StyleSheet.create({
     letterSpacing: 1.8,
     marginBottom: 8,
   },
-  title: {
-    color: '#23372B',
-    fontSize: 30,
-    lineHeight: 36,
-    fontWeight: '700',
+  title: { color: '#23372B', fontSize: 30, lineHeight: 36, fontWeight: '700' },
+  trendingCard: {
+    backgroundColor: '#F8F6F2',
+    borderRadius: 20,
+    padding: 16,
+    marginBottom: 14,
+    borderWidth: 1,
+    borderColor: '#DDD5CA',
   },
+  trendingLabel: {
+    color: '#8B8176',
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    marginBottom: 10,
+  },
+  trendingScroll: { flexDirection: 'row' },
+  trendingChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#EEF3EE',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+    marginRight: 8,
+    gap: 6,
+  },
+  trendingChipText: { color: '#2F563C', fontSize: 13, fontWeight: '700' },
+  trendingChipCount: { color: '#5D8D66', fontSize: 11, fontWeight: '600' },
   summaryCard: {
     backgroundColor: '#F8F6F2',
     borderRadius: 24,
@@ -303,39 +528,16 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
     gap: 12,
   },
-  summaryLabel: {
-    color: '#8B8176',
-    fontSize: 12,
-    fontWeight: '700',
-    marginBottom: 6,
-  },
-  summaryCount: {
-    color: '#23372B',
-    fontSize: 30,
-    fontWeight: '700',
-  },
-  summaryText: {
-    color: '#6F6459',
-    fontSize: 14,
-    lineHeight: 21,
-    marginTop: 12,
-  },
+  summaryLabel: { color: '#8B8176', fontSize: 12, fontWeight: '700', marginBottom: 6 },
+  summaryCount: { color: '#23372B', fontSize: 30, fontWeight: '700' },
   markReadButton: {
     backgroundColor: '#456B50',
     borderRadius: 16,
     paddingHorizontal: 14,
     paddingVertical: 10,
   },
-  markReadButtonText: {
-    color: '#F8F6F2',
-    fontSize: 13,
-    fontWeight: '700',
-  },
-  tabRow: {
-    flexDirection: 'row',
-    gap: 10,
-    marginBottom: 18,
-  },
+  markReadButtonText: { color: '#F8F6F2', fontSize: 13, fontWeight: '700' },
+  tabRow: { flexDirection: 'row', gap: 10, marginBottom: 18 },
   tabButton: {
     flex: 1,
     backgroundColor: '#F8F6F2',
@@ -345,21 +547,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#DDD5CA',
   },
-  tabButtonActive: {
-    backgroundColor: '#456B50',
-    borderColor: '#456B50',
-  },
-  tabButtonText: {
-    color: '#5F5449',
-    fontSize: 15,
-    fontWeight: '700',
-  },
-  tabButtonTextActive: {
-    color: '#F8F6F2',
-  },
-  loader: {
-    marginTop: 36,
-  },
+  tabButtonActive: { backgroundColor: '#456B50', borderColor: '#456B50' },
+  tabButtonText: { color: '#5F5449', fontSize: 15, fontWeight: '700' },
+  tabButtonTextActive: { color: '#F8F6F2' },
+  loader: { marginTop: 36 },
   emptyCard: {
     backgroundColor: '#F8F6F2',
     borderRadius: 22,
@@ -367,17 +558,8 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#DDD5CA',
   },
-  emptyTitle: {
-    color: '#23372B',
-    fontSize: 18,
-    fontWeight: '700',
-    marginBottom: 8,
-  },
-  emptyText: {
-    color: '#6F6459',
-    fontSize: 14,
-    lineHeight: 21,
-  },
+  emptyTitle: { color: '#23372B', fontSize: 18, fontWeight: '700', marginBottom: 8 },
+  emptyText: { color: '#6F6459', fontSize: 14, lineHeight: 21 },
   postCard: {
     backgroundColor: '#F8F6F2',
     borderRadius: 24,
@@ -386,11 +568,7 @@ const styles = StyleSheet.create({
     borderColor: '#DDD5CA',
     marginBottom: 14,
   },
-  postHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 14,
-  },
+  postHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 14 },
   avatar: {
     width: 44,
     height: 44,
@@ -400,66 +578,74 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     marginRight: 12,
   },
-  avatarText: {
-    color: '#2F563C',
-    fontSize: 14,
-    fontWeight: '700',
-  },
-  postHeaderCopy: {
-    flex: 1,
-  },
-  authorName: {
-    color: '#23372B',
-    fontSize: 15,
-    fontWeight: '700',
-    marginBottom: 2,
-  },
-  postMeta: {
-    color: '#8B8176',
-    fontSize: 12,
-    fontWeight: '500',
-  },
+  avatarText: { color: '#2F563C', fontSize: 14, fontWeight: '700' },
+  postHeaderCopy: { flex: 1 },
+  authorName: { color: '#23372B', fontSize: 15, fontWeight: '700', marginBottom: 2 },
+  postMeta: { color: '#8B8176', fontSize: 12, fontWeight: '500' },
   feedSourceBadge: {
     backgroundColor: '#EEF3EE',
     borderRadius: 999,
     paddingHorizontal: 10,
     paddingVertical: 6,
   },
-  feedSourceBadgeText: {
-    color: '#2F563C',
-    fontSize: 11,
-    fontWeight: '700',
-  },
-  postBody: {
-    color: '#3E352C',
-    fontSize: 15,
-    lineHeight: 22,
-  },
-  hashtagRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 8,
-    marginTop: 14,
-  },
+  feedSourceBadgeText: { color: '#2F563C', fontSize: 11, fontWeight: '700' },
+  postBody: { color: '#3E352C', fontSize: 15, lineHeight: 22 },
+  hashtagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 14 },
   hashtagChip: {
     backgroundColor: '#EEF3EE',
     borderRadius: 999,
     paddingHorizontal: 10,
     paddingVertical: 6,
   },
-  hashtagText: {
-    color: '#2F563C',
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  postFooter: {
+  hashtagText: { color: '#2F563C', fontSize: 12, fontWeight: '700' },
+  postActions: {
     flexDirection: 'row',
-    gap: 16,
+    gap: 20,
     marginTop: 16,
+    paddingTop: 14,
+    borderTopWidth: 1,
+    borderTopColor: '#EDE8E1',
   },
-  footerStat: {
-    color: '#8B8176',
-    fontSize: 12,
-    fontWeight: '600',
+  actionBtn: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  actionIcon: { fontSize: 18, color: '#8B8176' },
+  actionIconActive: { color: '#E05C5C' },
+  actionCount: { fontSize: 13, fontWeight: '600', color: '#8B8176' },
+  actionCountActive: { color: '#E05C5C' },
+  commentsSection: { marginTop: 14 },
+  commentInputRow: { flexDirection: 'row', gap: 8, marginBottom: 12, alignItems: 'flex-end' },
+  commentInput: {
+    flex: 1,
+    borderWidth: 1.5,
+    borderColor: '#D8CEC0',
+    borderRadius: 16,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 14,
+    color: '#3E352C',
+    backgroundColor: '#FCFBF8',
+    maxHeight: 80,
   },
+  commentSendBtn: {
+    backgroundColor: '#456B50',
+    borderRadius: 14,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    justifyContent: 'center',
+  },
+  commentSendText: { color: '#fff', fontSize: 13, fontWeight: '700' },
+  noComments: { color: '#9A8F82', fontSize: 13, textAlign: 'center', marginVertical: 8 },
+  commentItem: { flexDirection: 'row', gap: 10, marginBottom: 12 },
+  commentAvatar: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: '#D7E8DA',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  commentAvatarText: { color: '#2F563C', fontSize: 12, fontWeight: '700' },
+  commentBody: { flex: 1, backgroundColor: '#EDE8E1', borderRadius: 12, padding: 10 },
+  commentAuthor: { color: '#23372B', fontSize: 12, fontWeight: '700', marginBottom: 4 },
+  commentText: { color: '#3E352C', fontSize: 13, lineHeight: 18 },
+  editedTag: { color: '#9A8F82', fontSize: 11, fontWeight: '400' },
 });

--- a/mobile-app/app/user-profile.tsx
+++ b/mobile-app/app/user-profile.tsx
@@ -12,6 +12,34 @@ import {
 import * as SecureStore from 'expo-secure-store';
 import apiClient from '../api/client';
 import ActionModal from '../components/ActionModal';
+import AuthImage from '../components/AuthImage';
+
+type PostAttachment = {
+  id: string;
+  downloadUrl: string;
+  filename: string;
+  contentType: string;
+};
+
+type BlogPost = {
+  id: number;
+  body: string;
+  hashtags: string[];
+  createdAt: string;
+  likeCount: number;
+  commentCount: number;
+  attachments: PostAttachment[];
+};
+
+function formatRelativeLabel(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const diffMinutes = Math.max(1, Math.round((Date.now() - date.getTime()) / 60000));
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${Math.round(diffHours / 24)}d ago`;
+}
 
 function parseString(v: string | string[] | undefined) {
   return Array.isArray(v) ? v[0] : v ?? '';
@@ -86,6 +114,32 @@ export default function UserProfileScreen() {
 
   const [reportModalVisible, setReportModalVisible] = useState(false);
   const [reportReason, setReportReason] = useState('');
+
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+  const [postsLoading, setPostsLoading] = useState(true);
+  const [postsPage, setPostsPage] = useState(0);
+  const [postsHasMore, setPostsHasMore] = useState(false);
+
+  const fetchPosts = useCallback(async (p = 0) => {
+    if (!userId) return;
+    try {
+      if (p === 0) setPostsLoading(true);
+      const res = await apiClient.get(`/feed/users/${userId}/posts?page=${p}&size=10`);
+      const data = res.data;
+      const items: BlogPost[] = data.content ?? data ?? [];
+      setPosts((prev) => (p === 0 ? items : [...prev, ...items]));
+      setPostsHasMore(!data.last);
+      setPostsPage(p);
+    } catch {
+      // silently ignore
+    } finally {
+      setPostsLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchPosts(0);
+  }, [fetchPosts]);
 
   const confirmReport = () => {
     if (!reportReason.trim()) return;
@@ -178,6 +232,44 @@ export default function UserProfileScreen() {
               <Text style={styles.bioText}>{bio}</Text>
             </View>
           ) : null}
+
+          <View style={{ width: '100%', marginTop: 24 }}>
+            <Text style={styles.postsLabel}>POSTS</Text>
+            {postsLoading ? (
+              <ActivityIndicator color="#456B50" style={{ marginTop: 16 }} />
+            ) : posts.length === 0 ? (
+              <View style={styles.emptyPosts}>
+                <Text style={styles.emptyPostsText}>No posts yet.</Text>
+              </View>
+            ) : (
+              <>
+                {posts.map((post) => (
+                  <View key={post.id} style={styles.postCard}>
+                    <Text style={styles.postBody}>{post.body}</Text>
+                    {post.attachments?.length > 0 && post.attachments.map((att) => (
+                      <AuthImage key={att.id} downloadUrl={att.downloadUrl} filename={att.filename} />
+                    ))}
+                    {post.hashtags.length > 0 && (
+                      <View style={styles.hashtagRow}>
+                        {post.hashtags.map((h) => (
+                          <Text key={h} style={styles.hashtag}>#{h}</Text>
+                        ))}
+                      </View>
+                    )}
+                    <View style={styles.postFooter}>
+                      <Text style={styles.postMeta}>{formatRelativeLabel(post.createdAt)}</Text>
+                      <Text style={styles.postMeta}>♥ {post.likeCount}  💬 {post.commentCount}</Text>
+                    </View>
+                  </View>
+                ))}
+                {postsHasMore && (
+                  <TouchableOpacity style={styles.loadMoreBtn} onPress={() => fetchPosts(postsPage + 1)}>
+                    <Text style={styles.loadMoreText}>Load more</Text>
+                  </TouchableOpacity>
+                )}
+              </>
+            )}
+          </View>
 
           {!isOwnProfile && (
             <TouchableOpacity style={styles.reportBtn} onPress={() => setReportModalVisible(true)}>
@@ -276,4 +368,29 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   reportBtnText: { fontSize: 14, fontWeight: '600', color: '#D9534F' },
+  postsLabel: { fontSize: 11, fontWeight: '700', letterSpacing: 1.5, color: '#A0A0A0', marginBottom: 12 },
+  emptyPosts: { paddingVertical: 24, alignItems: 'center' },
+  emptyPostsText: { color: '#9A8F82', fontSize: 14 },
+  postCard: {
+    backgroundColor: '#F8F8F7',
+    borderRadius: 20,
+    padding: 18,
+    marginBottom: 12,
+    width: '100%',
+  },
+  postBody: { fontSize: 15, color: '#2D2D2D', lineHeight: 22, marginBottom: 10 },
+  hashtagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginBottom: 10 },
+  hashtag: { fontSize: 13, color: '#456B50', fontWeight: '600' },
+  postFooter: { flexDirection: 'row', justifyContent: 'space-between' },
+  postMeta: { fontSize: 12, color: '#A0A0A0', fontWeight: '500' },
+  loadMoreBtn: {
+    alignSelf: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    borderRadius: 16,
+    backgroundColor: '#EDE8E1',
+    marginTop: 4,
+    marginBottom: 8,
+  },
+  loadMoreText: { fontSize: 13, fontWeight: '700', color: '#456B50' },
 });

--- a/mobile-app/components/AuthImage.tsx
+++ b/mobile-app/components/AuthImage.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, Image, TouchableOpacity } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
+import * as FileSystem from 'expo-file-system/legacy';
+
+type Props = {
+  downloadUrl: string;
+  filename: string;
+  style?: object;
+  onPress?: () => void;
+};
+
+export default function AuthImage({ downloadUrl, filename, style, onPress }: Props) {
+  const [localUri, setLocalUri] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = await SecureStore.getItemAsync('userToken');
+        if (!token || cancelled) return;
+        const targetPath = `${FileSystem.cacheDirectory}${filename}`;
+        const info = await FileSystem.getInfoAsync(targetPath);
+        if (info.exists) {
+          if (!cancelled) setLocalUri(targetPath);
+          return;
+        }
+        const result = await FileSystem.downloadAsync(downloadUrl, targetPath, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!cancelled) setLocalUri(result.uri);
+      } catch {
+        // silently ignore
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [downloadUrl, filename]);
+
+  if (loading && !localUri) {
+    return <ActivityIndicator color="#456B50" style={{ margin: 8 }} />;
+  }
+  if (!localUri) return null;
+
+  const img = (
+    <Image
+      source={{ uri: localUri }}
+      style={[{ width: '100%', height: 200, borderRadius: 12, marginTop: 10 }, style]}
+      resizeMode="cover"
+    />
+  );
+
+  if (onPress) {
+    return (
+      <TouchableOpacity onPress={onPress} activeOpacity={0.85}>
+        {img}
+      </TouchableOpacity>
+    );
+  }
+  return img;
+}


### PR DESCRIPTION
## Summary

- **Blog screen** (`/my-blog`): Users can view their own posts in a dedicated screen, accessible via the "Blog" quick-action button on the profile tab. Posts are paginated with a "Load more" button.

- **User profile posts**: Visiting another user's profile from the feed now shows their posts below the bio section, alongside the existing follow/unfollow button.

- **Feed image attachments**: Post images are fetched with Bearer auth, cached locally, and rendered inline (full-width) in the social feed, user profile posts, and blog screen. Uses the new `GET /api/uploads/feed-media/{uuid}` endpoint from #485.

- **AuthImage component** (`components/AuthImage.tsx`): Shared reusable component that downloads any auth-gated image to local cache and renders it. Used across feed, blog, and profile screens.

- **Interactive likes**: Each feed post now has a tappable like button with optimistic UI update, synced with `POST /api/feed/posts/{id}/like`.

- **Inline comments**: Tapping the comment icon on a feed post expands an inline comment section. Users can read existing comments and submit new ones via `GET/POST /api/feed/posts/{id}/comments`.

- **Trending hashtags**: A horizontally scrollable strip of trending hashtags (with post counts) appears at the top of the social feed, powered by `GET /api/feed/trending/hashtags`.

- **WhatsApp-style chat images**: In the messages screen, image attachments now render as inline photos instead of file name pills. Non-image files keep the existing pill format.

- **Home screen fix**: Removed duplicate Active/Past tab buttons that were appearing twice.

## Test plan
- [x] Profile tab → Blog button → own posts are listed
- [x] Tap a user in the feed → their posts and images appear on their profile
- [ ] Feed posts with images render attachments inline
- [ ] Tap like button → count updates instantly, synced with server
- [x] Tap comment icon → comments expand, new comment can be submitted
- [ ] Trending hashtags strip appears at the top of the social feed on load
- [x] Image attachments in chat render inline; PDFs/docs keep pill format

