### PR TITLE
feat(backend): isFollowing flag on UserProfileResponse (#513)

### DIFF
--- a/backend/src/main/java/com/group7/backend/dto/response/UserProfileResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/UserProfileResponse.java
@@ -1,5 +1,6 @@
 package com.group7.backend.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -40,4 +41,17 @@ public class UserProfileResponse {
 
     @Schema(description = "Number of users this profile follows", example = "17")
     private long followingCount;
+
+    // Jackson strips the "is" prefix from boolean getters Lombok generates,
+    // so without the explicit @JsonProperty the wire name collapses to
+    // "following" and collides semantically with "followingCount". The
+    // acceptance criteria call out a top-level "isFollowing" key, so we pin
+    // the JSON name and keep the Java field idiomatic.
+    @JsonProperty("isFollowing")
+    @Schema(description = "True if the authenticated viewer follows this profile. "
+            + "Always false on the viewer's own profile and for anonymous reads. "
+            + "Lets clients render Follow / Unfollow deterministically without a "
+            + "separate scan of the viewer's following list.",
+            example = "false")
+    private boolean isFollowing;
 }

--- a/backend/src/main/java/com/group7/backend/service/UserService.java
+++ b/backend/src/main/java/com/group7/backend/service/UserService.java
@@ -11,6 +11,7 @@ import com.group7.backend.dto.response.UserProfileResponse;
 import com.group7.backend.dto.response.UserRatingSummary;
 import com.group7.backend.dto.response.UserResponse;
 import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.FollowId;
 import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.entity.TaggedTermLists;
@@ -228,7 +229,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserProfileResponse getOwnUserProfile(Long userId) {
         ProfileResponse profile = getOwnProfile(userId);
-        return wrapWithCounts(profile, userId);
+        return wrapWithCounts(profile, userId, userId);
     }
 
     /**
@@ -241,21 +242,27 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserProfileResponse getUserProfile(Long targetId, Long requesterId) {
         ProfileResponse profile = getProfileById(targetId, requesterId);
-        return wrapWithCounts(profile, targetId);
+        return wrapWithCounts(profile, targetId, requesterId);
     }
 
-    private UserProfileResponse wrapWithCounts(ProfileResponse profile, Long userId) {
-        long followers = followRepository.countByIdFolloweeId(userId);
-        long following = followRepository.countByIdFollowerId(userId);
+    private UserProfileResponse wrapWithCounts(ProfileResponse profile, Long profileUserId, Long viewerId) {
+        long followers = followRepository.countByIdFolloweeId(profileUserId);
+        long following = followRepository.countByIdFollowerId(profileUserId);
         // Mentor rating summary (#237). Mentees never accumulate rows in
         // mentor_ratings, so the aggregate returns (null, 0) for them; we
         // still set the fields uniformly so the response shape is stable.
-        UserRatingSummary rating = mentorRatingService.aggregateForMentor(userId);
+        UserRatingSummary rating = mentorRatingService.aggregateForMentor(profileUserId);
         if (profile instanceof UserResponse base) {
             base.setAverageRating(rating.averageRating());
             base.setRatingCount(rating.ratingCount());
         }
-        return new UserProfileResponse(profile, followers, following);
+        // Self-view and anonymous reads never render Follow/Unfollow, so they
+        // skip the existsById probe; clients render Follow only when the
+        // boolean is true AND the viewer is somebody else.
+        boolean isFollowing = viewerId != null
+                && !viewerId.equals(profileUserId)
+                && followRepository.existsById(new FollowId(viewerId, profileUserId));
+        return new UserProfileResponse(profile, followers, following, isFollowing);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/group7/backend/controller/ProfileControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/ProfileControllerTest.java
@@ -69,11 +69,11 @@ class ProfileControllerTest {
      * the assertion JSON paths.
      */
     private UserProfileResponse wrapMentor() {
-        return new UserProfileResponse(buildMentorResponse(), 0L, 0L);
+        return new UserProfileResponse(buildMentorResponse(), 0L, 0L, false);
     }
 
     private UserProfileResponse wrapMentee() {
-        return new UserProfileResponse(buildMenteeResponse(), 0L, 0L);
+        return new UserProfileResponse(buildMenteeResponse(), 0L, 0L, false);
     }
 
     private MentorResponse buildMentorResponse() {

--- a/backend/src/test/java/com/group7/backend/integration/FollowIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FollowIntegrationTest.java
@@ -224,6 +224,53 @@ class FollowIntegrationTest {
                 .andExpect(jsonPath("$.followingCount").value(1));
     }
 
+    @Test
+    void isFollowingFlag_falseBeforeFollow_trueAfter_falseAfterUnfollow() throws Exception {
+        Pair p = registerTwo("isf_a@test.com", "isf_b@test.com");
+
+        // Before any follow edge exists, the viewer's read of B's profile
+        // reports isFollowing=false.
+        assertIsFollowing(p.tokenA, p.idB, false);
+
+        // After A follows B, the same read flips to true.
+        mockMvc.perform(post("/api/users/" + p.idB + "/follow")
+                        .header("Authorization", "Bearer " + p.tokenA))
+                .andExpect(status().isCreated());
+        assertIsFollowing(p.tokenA, p.idB, true);
+
+        // After unfollow, back to false.
+        mockMvc.perform(delete("/api/users/" + p.idB + "/follow")
+                        .header("Authorization", "Bearer " + p.tokenA))
+                .andExpect(status().isNoContent());
+        assertIsFollowing(p.tokenA, p.idB, false);
+    }
+
+    @Test
+    void isFollowingFlag_isAlwaysFalseOnOwnProfile_evenWithLargeFollowingList() throws Exception {
+        Pair p = registerTwo("isfself_a@test.com", "isfself_b@test.com");
+
+        // Establish a follow edge in the OTHER direction so the viewer is in
+        // somebody's "followers" set — this would trip a naive implementation
+        // that consults the wrong column.
+        mockMvc.perform(post("/api/users/" + p.idA + "/follow")
+                        .header("Authorization", "Bearer " + p.tokenB))
+                .andExpect(status().isCreated());
+
+        // Self-read via numeric id and via /me both report isFollowing=false.
+        assertIsFollowing(p.tokenA, p.idA, false);
+        mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + p.tokenA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isFollowing").value(false));
+    }
+
+    private void assertIsFollowing(String token, Long targetId, boolean expected) throws Exception {
+        mockMvc.perform(get("/api/users/" + targetId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isFollowing").value(expected));
+    }
+
     // ── DB-level cascade via raw JDBC delete (not userRepository.delete) ───
 
     @Test


### PR DESCRIPTION
## Summary

The user-profile read wrappers (`GET /api/users/{id}` and `GET /api/users/me`) currently expose `followerCount` and `followingCount`, but no signal for whether the *viewer* follows the profile. Web's `UserProfilePage.jsx` works around this with `GET /api/users/{viewerId}/following?page=0&size=200` and a client-side scan, which costs an extra round-trip on every profile view and silently breaks for users following more than 200 others.

This adds a derived boolean `isFollowing` to `UserProfileResponse`, populated via a single `existsById` probe against the follows table.

Closes #513.

## What changed

- `UserProfileResponse` gains `boolean isFollowing`. Composition stays — the field is appended to the wrapper, not pushed onto `UserResponse` / its sealed `ProfileResponse` siblings. The wire shape is purely additive.
- `UserService.wrapWithCounts(profile, profileUserId, viewerId)` carries the viewer id alongside the profile id. Both `getOwnUserProfile` and `getUserProfile` call sites are updated.
- The probe is short-circuited in two carve-outs:
  - Own-profile reads (`viewerId == profileUserId`) — every UI renders the Follow control only when "this is somebody else", so the field stays false rather than ambiguous.
  - Anonymous reads (`viewerId == null`) — endpoints that bypass auth cannot meaningfully ask "are you following".
- Otherwise: `followRepository.existsById(new FollowId(viewerId, profileUserId))`. One indexed PK lookup; no new queries on the repository.

## Frontend follow-up (separate, easy)

Once this lands the web workaround can be deleted:

```diff
- // In UserProfilePage.jsx — drop the useEffect that calls getFollowing(...)
- // and replace the local "isFollowing" state with profile.isFollowing.
```

The 200-cap silent break for power users disappears with it.

## Tests

- `FollowIntegrationTest.isFollowingFlag_falseBeforeFollow_trueAfter_falseAfterUnfollow` — full lifecycle: viewer probes profile, follows, probes again, unfollows, probes again.
- `FollowIntegrationTest.isFollowingFlag_isAlwaysFalseOnOwnProfile_evenWithLargeFollowingList` — establishes a *reverse* follow edge first (B follows A) so a naive implementation that consults the followee column instead of the follower column would incorrectly report true on A's self-read. Asserts false on both `/users/{id}` and `/users/me`.
- `ProfileControllerTest`'s two wrapper-builder helpers are extended with the new boolean parameter (unit tests stay passing).

## Verification

- `mvn -B compile` — clean.
- `mvn -B test-compile` — clean.
- Local `mvn test -Dtest=FollowIntegrationTest` is blocked by a shared-Postgres Flyway state pollution that bites every integration test in this repo when run after another in-flight test session; CI runs against a fresh container and is the source of truth here. The previously-merged FollowIntegrationTest cases continue to assert the existing counts behaviour unchanged.

## Test plan

- [x] Compile + test-compile clean locally.
- [x] New tests are wired and exercise the three acceptance paths (false / true / self-false).
- [ ] CI: `Backend CI/CD → test` passes the FollowIntegrationTest cases on a fresh database.