### PR TITLE
feat(backend): paginated history filter on GET /api/mentorships (#521)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
@@ -22,9 +22,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.OffsetDateTime;
@@ -32,6 +37,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/mentorships")
+@Validated  // enables MethodValidationPostProcessor for @Min/@Max on @RequestParam
 @Tag(name = "Mentorships", description = "Active mentorship management")
 public class MentorshipController {
 
@@ -53,7 +59,8 @@ public class MentorshipController {
     @GetMapping
     @Operation(
             summary = "List active mentorships",
-            description = "Returns all active mentorships for the authenticated user, whether they are a mentor or mentee."
+            description = "Returns all active mentorships for the authenticated user, whether they are a mentor or mentee. "
+                    + "For paginated history view across all statuses, use ?status=ALL (#521)."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Active mentorships",
@@ -62,6 +69,33 @@ public class MentorshipController {
     public ResponseEntity<List<MentorshipResponse>> getActiveMentorships(Authentication authentication) {
         Long userId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(mentorshipService.getActiveMentorships(userId));
+    }
+
+    @GetMapping(params = "status")
+    @Operation(
+            summary = "Paginated mentorship history filtered by status (#521)",
+            description = "Returns mentorships for the authenticated user filtered by status. "
+                    + "Use status=ALL for every state (history view powering the My Mentorships "
+                    + "page #408), or any MentorshipStatus name (ACTIVE, COMPLETED, CANCELLED, "
+                    + "TERMINATED) for a single-state view. Sorted endDate DESC NULLS LAST so "
+                    + "active mentorships appear first, then most-recently terminated. "
+                    + "Page size capped at 100; default 20."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paged mentorships",
+                    content = @Content(schema = @Schema(implementation = Page.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid status filter (not ALL or a known MentorshipStatus)",
+                    content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content)
+    })
+    public ResponseEntity<Page<MentorshipResponse>> getMentorshipsByStatus(
+            @RequestParam("status") String status,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorshipService.getMentorshipsByStatus(
+                userId, status, PageRequest.of(page, size)));
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorshipRepository.java
@@ -2,6 +2,8 @@ package com.group7.backend.repository;
 
 import com.group7.backend.entity.Mentorship;
 import com.group7.backend.entity.MentorshipStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +17,51 @@ public interface MentorshipRepository extends JpaRepository<Mentorship, Long> {
     @Query("SELECT m FROM Mentorship m JOIN FETCH m.mentor JOIN FETCH m.mentee "
             + "WHERE (m.mentor.id = :userId OR m.mentee.id = :userId) AND m.status = :status")
     List<Mentorship> findByUserIdAndStatus(Long userId, MentorshipStatus status);
+
+    /**
+     * Paginated history view across every {@link MentorshipStatus} (#521). The
+     * {@code JOIN FETCH} on {@code mentor} and {@code mentee} are to-one
+     * fetches (not collections), so {@code Pageable} stays SQL-native — no
+     * Hibernate {@code HHH000104} in-memory pagination warning.
+     *
+     * <p>Sort is hard-coded in the query rather than driven by
+     * {@link Pageable#getSort()}: ACTIVE rows float to the top
+     * (issue #521 — "active mentorships first"), then ties resolve by
+     * {@code endDate DESC, startDate DESC} (newest-terminated next).
+     * The schema has {@code endDate NOT NULL} on every mentorship
+     * (active ones carry the planned end), so a NULLS LAST sort wouldn't
+     * surface ACTIVE rows the way the issue expects — the explicit
+     * {@code CASE} does.
+     *
+     * <p>Callers should pass an unsorted {@link Pageable}
+     * ({@code PageRequest.of(page, size)}) to avoid emitting a conflicting
+     * {@code ORDER BY} appended by Spring Data.
+     */
+    @Query(value = "SELECT m FROM Mentorship m JOIN FETCH m.mentor JOIN FETCH m.mentee "
+            + "WHERE m.mentor.id = :userId OR m.mentee.id = :userId "
+            + "ORDER BY CASE WHEN m.status = com.group7.backend.entity.MentorshipStatus.ACTIVE THEN 0 ELSE 1 END, "
+            + "m.endDate DESC, m.startDate DESC",
+           countQuery = "SELECT COUNT(m) FROM Mentorship m "
+            + "WHERE m.mentor.id = :userId OR m.mentee.id = :userId")
+    Page<Mentorship> findByUserIdAllStatuses(@Param("userId") Long userId, Pageable pageable);
+
+    /**
+     * Paginated single-status view (#521). Same shape as
+     * {@link #findByUserIdAllStatuses} but filtered to one status; lets
+     * callers ask for e.g. {@code COMPLETED}-only history. Sort matches
+     * the all-statuses query — the {@code CASE} is a no-op when every
+     * row shares the same status, but keeping it identical prevents any
+     * surprise if the filter ever broadens.
+     */
+    @Query(value = "SELECT m FROM Mentorship m JOIN FETCH m.mentor JOIN FETCH m.mentee "
+            + "WHERE (m.mentor.id = :userId OR m.mentee.id = :userId) AND m.status = :status "
+            + "ORDER BY CASE WHEN m.status = com.group7.backend.entity.MentorshipStatus.ACTIVE THEN 0 ELSE 1 END, "
+            + "m.endDate DESC, m.startDate DESC",
+           countQuery = "SELECT COUNT(m) FROM Mentorship m "
+            + "WHERE (m.mentor.id = :userId OR m.mentee.id = :userId) AND m.status = :status")
+    Page<Mentorship> findByUserIdAndStatusPaged(@Param("userId") Long userId,
+                                                 @Param("status") MentorshipStatus status,
+                                                 Pageable pageable);
 
     /**
      * Looks up the mentorship by id, returning it only when {@code userId} is the mentor or

--- a/backend/src/main/java/com/group7/backend/service/MentorshipService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorshipService.java
@@ -15,6 +15,10 @@ import com.group7.backend.repository.MentorshipRepository;
 import com.group7.backend.repository.MentorshipRequestRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -137,6 +141,47 @@ public class MentorshipService {
         return mentorshipRepository.findByUserIdAndStatus(userId, MentorshipStatus.ACTIVE).stream()
                 .map(MentorshipResponse::from)
                 .toList();
+    }
+
+    /**
+     * Paginated history view for the "My Mentorships" surface (#521).
+     * {@code statusFilter} accepts the literal string {@code "ALL"} to
+     * return every state, or any {@link MentorshipStatus} name (e.g.
+     * {@code "COMPLETED"}) for a single-status view. Sort is hard-coded
+     * in the repository query: ACTIVE first, then {@code endDate DESC,
+     * startDate DESC}.
+     *
+     * <p>The Pageable is passed un-sorted on purpose — Spring Data would
+     * otherwise append its own {@code ORDER BY} after the query's,
+     * producing a conflicting (and on some dialects, syntactically
+     * invalid) compound sort.
+     *
+     * <p>Throws {@link IllegalArgumentException} for unrecognised filter
+     * strings — surfaces as 400 via the global handler.
+     */
+    @Transactional(readOnly = true)
+    public Page<MentorshipResponse> getMentorshipsByStatus(
+            Long userId, String statusFilter, Pageable requested) {
+        Pageable unsorted = PageRequest.of(
+                requested.getPageNumber(),
+                requested.getPageSize());  // sort lives in the repository query
+
+        Page<Mentorship> page;
+        if ("ALL".equalsIgnoreCase(statusFilter)) {
+            page = mentorshipRepository.findByUserIdAllStatuses(userId, unsorted);
+        } else {
+            MentorshipStatus status;
+            try {
+                status = MentorshipStatus.valueOf(statusFilter.toUpperCase());
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException(
+                        "Invalid status filter: '" + statusFilter
+                                + "'. Expected ALL or one of "
+                                + java.util.Arrays.toString(MentorshipStatus.values()));
+            }
+            page = mentorshipRepository.findByUserIdAndStatusPaged(userId, status, unsorted);
+        }
+        return page.map(MentorshipResponse::from);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MentorshipControllerTest.java
@@ -212,6 +212,88 @@ class MentorshipControllerTest {
                 .andExpect(status().isOk());
     }
 
+    // ── Paginated history (#521) ────────────────────────────────────────────
+
+    @Test
+    void getMentorshipsByStatus_ALL_returnsPagedAcrossEveryState() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        MentorshipResponse active = sampleMentorship();
+        MentorshipResponse completed = sampleMentorship();
+        completed.setId(101L);
+        completed.setStatus("COMPLETED");
+        org.springframework.data.domain.Page<MentorshipResponse> page =
+                new org.springframework.data.domain.PageImpl<>(
+                        List.of(active, completed),
+                        org.springframework.data.domain.PageRequest.of(0, 20),
+                        2);
+        when(mentorshipService.getMentorshipsByStatus(
+                org.mockito.ArgumentMatchers.eq(1L),
+                org.mockito.ArgumentMatchers.eq("ALL"),
+                any())).thenReturn(page);
+
+        mockMvc.perform(get("/api/mentorships?status=ALL")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].status").value("ACTIVE"))
+                .andExpect(jsonPath("$.content[1].status").value("COMPLETED"))
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    void getMentorshipsByStatus_specificStatus_filtersAccordingly() throws Exception {
+        mockMenteeJwt("mentee-token", 2L);
+        MentorshipResponse completed = sampleMentorship();
+        completed.setStatus("COMPLETED");
+        org.springframework.data.domain.Page<MentorshipResponse> page =
+                new org.springframework.data.domain.PageImpl<>(
+                        List.of(completed),
+                        org.springframework.data.domain.PageRequest.of(0, 20),
+                        1);
+        when(mentorshipService.getMentorshipsByStatus(
+                org.mockito.ArgumentMatchers.eq(2L),
+                org.mockito.ArgumentMatchers.eq("COMPLETED"),
+                any())).thenReturn(page);
+
+        mockMvc.perform(get("/api/mentorships?status=COMPLETED")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].status").value("COMPLETED"));
+    }
+
+    @Test
+    void getMentorshipsByStatus_invalidStatusString_returns400() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+        when(mentorshipService.getMentorshipsByStatus(
+                org.mockito.ArgumentMatchers.eq(1L),
+                org.mockito.ArgumentMatchers.eq("BANANA"),
+                any()))
+                .thenThrow(new IllegalArgumentException(
+                        "Invalid status filter: 'BANANA'. Expected ALL or one of [ACTIVE, COMPLETED, TERMINATED, CANCELLED]"));
+
+        mockMvc.perform(get("/api/mentorships?status=BANANA")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getMentorshipsByStatus_pageSizeOver100_returns400() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+
+        mockMvc.perform(get("/api/mentorships?status=ALL&size=200")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getMentorshipsByStatus_negativePage_returns400() throws Exception {
+        mockMentorJwt("mentor-token", 1L);
+
+        mockMvc.perform(get("/api/mentorships?status=ALL&page=-1")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isBadRequest());
+    }
+
     // ── Shared goal ─────────────────────────────────────────────────────────
 
     @Test

--- a/backend/src/test/java/com/group7/backend/integration/MentorshipHistoryFilterIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorshipHistoryFilterIntegrationTest.java
@@ -1,0 +1,261 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipRequest;
+import com.group7.backend.entity.MentorshipRequestStatus;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.repository.MentorshipRepository;
+import com.group7.backend.repository.MentorshipRequestRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the paginated history filter on
+ * {@code GET /api/mentorships?status=...} (#521) against real Postgres.
+ * Validates the SQL-side {@code endDate DESC NULLS LAST} sort + the
+ * pagination contract; mock-based controller-slice coverage in
+ * {@code MentorshipControllerTest} pins the validation surface.
+ *
+ * <p>Backward compat: confirms the no-param call path still returns a
+ * plain {@code List} (ACTIVE-only) so the dashboard's existing
+ * {@code getActiveMentorships()} consumers don't break.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MentorshipHistoryFilterIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private MentorshipRepository mentorshipRepository;
+    @Autowired private MentorshipRequestRepository mentorshipRequestRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @MockitoBean private EmailService emailService;
+
+    private Long mentorId;
+    private Long menteeId;
+    private String mentorToken;
+    private Long mentorship1Id;  // ACTIVE — endDate null → first via NULLS LAST
+    private Long mentorship2Id;  // COMPLETED — most recent endDate
+    private Long mentorship3Id;  // CANCELLED — older endDate
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Children before parents; the test creates fresh users + mentorships
+        // each run so no leakage from prior cases.
+        jdbcTemplate.update("DELETE FROM mentorship_audit_log");
+        jdbcTemplate.update("DELETE FROM mentorships");
+        jdbcTemplate.update("DELETE FROM mentorship_requests");
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+
+        mentorToken = registerAndLogin("hist_mentor@test.com", true);
+        registerAndLogin("hist_mentee@test.com", false);
+
+        mentorId = userRepository.findByEmail("hist_mentor@test.com").orElseThrow().getId();
+        menteeId = userRepository.findByEmail("hist_mentee@test.com").orElseThrow().getId();
+
+        Mentor mentor = mentorRepository.findById(mentorId).orElseThrow();
+        Mentee mentee = menteeRepository.findById(menteeId).orElseThrow();
+
+        // Three mentorships at known timestamps so the sort is deterministic.
+        // endDate is NOT NULL on every mentorship (active ones carry the
+        // planned end). Sort: ACTIVE first (via CASE), then endDate DESC.
+        mentorship1Id = seedMentorship(mentor, mentee, MentorshipStatus.ACTIVE,
+                OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2026, 8, 1, 10, 0, 0, 0, ZoneOffset.UTC));  // ACTIVE planned end (future)
+        mentorship2Id = seedMentorship(mentor, mentee, MentorshipStatus.COMPLETED,
+                OffsetDateTime.of(2026, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2026, 4, 1, 10, 0, 0, 0, ZoneOffset.UTC));  // most recent termination
+        mentorship3Id = seedMentorship(mentor, mentee, MentorshipStatus.CANCELLED,
+                OffsetDateTime.of(2025, 10, 1, 10, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2026, 1, 15, 10, 0, 0, 0, ZoneOffset.UTC));  // older termination
+    }
+
+    @Test
+    void noStatusParam_returnsActiveOnlyAsListUnchanged() throws Exception {
+        mockMvc.perform(get("/api/mentorships")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(mentorship1Id))
+                .andExpect(jsonPath("$[0].status").value("ACTIVE"));
+    }
+
+    @Test
+    void statusAll_returnsAllThreeSortedActiveFirstThenByEndDateDesc() throws Exception {
+        mockMvc.perform(get("/api/mentorships?status=ALL")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.content.length()").value(3))
+                // ACTIVE (null endDate) first via NULLS LAST
+                .andExpect(jsonPath("$.content[0].id").value(mentorship1Id))
+                .andExpect(jsonPath("$.content[0].status").value("ACTIVE"))
+                // COMPLETED next (more recent endDate 2026-04-01)
+                .andExpect(jsonPath("$.content[1].id").value(mentorship2Id))
+                .andExpect(jsonPath("$.content[1].status").value("COMPLETED"))
+                // CANCELLED last (older endDate 2026-01-15)
+                .andExpect(jsonPath("$.content[2].id").value(mentorship3Id))
+                .andExpect(jsonPath("$.content[2].status").value("CANCELLED"));
+    }
+
+    @Test
+    void statusCompleted_returnsOnlyCompleted() throws Exception {
+        mockMvc.perform(get("/api/mentorships?status=COMPLETED")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(mentorship2Id))
+                .andExpect(jsonPath("$.content[0].status").value("COMPLETED"));
+    }
+
+    @Test
+    void statusCancelled_returnsOnlyCancelled() throws Exception {
+        mockMvc.perform(get("/api/mentorships?status=CANCELLED")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(mentorship3Id))
+                .andExpect(jsonPath("$.content[0].status").value("CANCELLED"));
+    }
+
+    @Test
+    void statusAll_paginationWorks_size2Page0AndPage1() throws Exception {
+        // Page 0 with size 2 → first two items from the sorted list.
+        mockMvc.perform(get("/api/mentorships?status=ALL&page=0&size=2")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].id").value(mentorship1Id))
+                .andExpect(jsonPath("$.content[1].id").value(mentorship2Id))
+                .andExpect(jsonPath("$.totalPages").value(2));
+
+        // Page 1 with size 2 → the remaining one.
+        mockMvc.perform(get("/api/mentorships?status=ALL&page=1&size=2")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].id").value(mentorship3Id));
+    }
+
+    @Test
+    void statusAll_caseInsensitive_alsoWorks() throws Exception {
+        mockMvc.perform(get("/api/mentorships?status=all")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(3));
+    }
+
+    @Test
+    void statusInvalidString_returns400() throws Exception {
+        mockMvc.perform(get("/api/mentorships?status=BOGUS")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void nonParticipantUser_seesEmptyResult_notForbidden() throws Exception {
+        // A user who isn't a participant of any of these mentorships.
+        String thirdToken = registerAndLogin("hist_third@test.com", true);
+
+        mockMvc.perform(get("/api/mentorships?status=ALL")
+                        .header("Authorization", "Bearer " + thirdToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.content.length()").value(0));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private long seedMentorship(Mentor mentor, Mentee mentee,
+                                 MentorshipStatus status,
+                                 OffsetDateTime startDate,
+                                 OffsetDateTime endDate) {
+        // Mentorship.request_id is NOT NULL — seed an ACCEPTED request first
+        // (one per mentorship; matches the production lifecycle where each
+        // mentorship traces back to a single request).
+        MentorshipRequest req = new MentorshipRequest();
+        req.setMentor(mentor);
+        req.setMentee(mentee);
+        req.setStatus(MentorshipRequestStatus.ACCEPTED);
+        MentorshipRequest savedReq = mentorshipRequestRepository.save(req);
+
+        Mentorship m = new Mentorship();
+        m.setMentor(mentor);
+        m.setMentee(mentee);
+        m.setRequest(savedReq);
+        m.setStatus(status);
+        m.setStartDate(startDate);
+        m.setEndDate(endDate);
+        m.setDuration(3);
+        return mentorshipRepository.save(m).getId();
+    }
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Hist");
+        req.setLastName("Tester");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        var user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+}


### PR DESCRIPTION
Closes #521. Unblocks frontend issue #408 (My Mentorships page).

## Summary

Adds a `status` query parameter to `GET /api/mentorships` so the My
Mentorships page (#408) can fetch the full history view across every
state, not just the dashboard's ACTIVE-only slice. The existing
no-param call path is preserved verbatim — 5+ frontend callers
(`HomePage`, `CalendarPage`, `TasksPage`, `MentorMenteesProgress`,
`MentorshipContext`) all consume the response as a `List` and
continue to work unchanged.

## API shape

| Call | Returns |
|---|---|
| `GET /api/mentorships` (no params) | `List<MentorshipResponse>` ACTIVE-only — **unchanged** |
| `GET /api/mentorships?status=ALL&page=N&size=M` | `Page<MentorshipResponse>` every state, paginated |
| `GET /api/mentorships?status=COMPLETED&...` | `Page<MentorshipResponse>` single state, paginated |

The two return shapes from the same path are wired via
`@GetMapping(params = \"status\")` on the new method; the original
method matches when `status` is absent. Page size is `@Min(1)
@Max(100)`, default 20.

## Sort

Hard-coded in the JPQL via a `CASE` expression so ACTIVE rows float
to the top, then ties resolve by `endDate DESC, startDate DESC`. The
schema has `endDate NOT NULL` on every mentorship (active ones carry
the planned end), so the issue's suggested `endDate DESC NULLS LAST`
wouldn't surface ACTIVE rows the way the spec expects — the explicit
CASE does. The Pageable is passed unsorted so Spring Data doesn't
append a conflicting `ORDER BY`.

## Test plan

- [x] **5 new controller-slice tests** (`MentorshipControllerTest`):
      `status=ALL` paged, single-status filter, invalid status → 400,
      `size>100` → 400, negative `page` → 400.
- [x] **8-case integration test** (`MentorshipHistoryFilterIntegrationTest`)
      against real Postgres: backward-compat list shape, the CASE-based
      sort with 3 statuses, single-status filtering for COMPLETED and
      CANCELLED, pagination boundaries (size=2: page0 returns 2,
      page1 returns 1), case-insensitive `ALL`, BANANA → 400,
      non-participant gets empty result.
- [x] `mvn --batch-mode verify` green locally on the same Postgres 16
      sidecar shape the CI workflow uses (2070 tests, 0 failures, 0 errors).
- [x] Manual smoke test against running backend on isolated Postgres
      (port 5446): 7 scenarios — backward compat List, status=ALL
      sorted [ACTIVE, COMPLETED, CANCELLED], status=COMPLETED single,
      pagination size=2 page0/page1, status=BANANA → 400 with clean
      message, size=200 → 400 with constraint-violation message,
      anon → 403.
- [ ] Backend CI green on this PR.

## Frontend follow-up (after merge)

`#408` is fully unblocked. The new page calls
`GET /api/mentorships?status=ALL&page=N` and partitions the result
into Active / Past sections client-side per the issue's recommendation.