### PR TITLE
feat(backend): social feed enhanced sharing (#484)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/FeedInteractionController.java
+++ b/backend/src/main/java/com/group7/backend/controller/FeedInteractionController.java
@@ -1,6 +1,7 @@
 package com.group7.backend.controller;
 
 import com.group7.backend.controller.support.PageableSupport;
+import com.group7.backend.dto.request.CreateRepostRequest;
 import com.group7.backend.dto.request.FeedCommentRequest;
 import com.group7.backend.dto.response.FeedCommentResponse;
 import com.group7.backend.dto.response.FeedPostInteractionState;
@@ -9,6 +10,7 @@ import com.group7.backend.service.FeedInteractionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -127,6 +129,38 @@ public class FeedInteractionController {
             Authentication authentication) {
         Long sharerId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(interactionService.recordShare(id, sharerId));
+    }
+
+    @PostMapping("/posts/{id:\\d+}/reposts")
+    @Operation(summary = "Repost or quote-share a feed post",
+            description = "Empty body or null = bare repost; non-blank body = quote-share. "
+                    + "Both fan out via STOMP to the sharer's followers and notify the original "
+                    + "author (unless the sharer is the author). Repeating the same payload "
+                    + "within the configured idempotency window (default 60s) collapses to the "
+                    + "existing row without re-firing fanout. Distinct from POST /share, which "
+                    + "is a silent analytics event and does not fan out.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(examples = {
+                            @ExampleObject(name = "bare-repost",
+                                    summary = "Bare repost with no commentary",
+                                    value = "{}"),
+                            @ExampleObject(name = "quote-share",
+                                    summary = "Quote-share with commentary",
+                                    value = "{\"body\": \"Great take on this — fully agree.\"}")
+                    })))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Repost recorded; current interaction state returned"),
+            @ApiResponse(responseCode = "400", description = "Body exceeds 2000 chars", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Post not found or soft-deleted", content = @Content)
+    })
+    public ResponseEntity<FeedPostInteractionState> repost(
+            @Parameter(description = "Feed post id") @PathVariable Long id,
+            @Valid @RequestBody(required = false) CreateRepostRequest request,
+            Authentication authentication) {
+        Long sharerId = (Long) authentication.getCredentials();
+        CreateRepostRequest effective = request != null ? request : CreateRepostRequest.empty();
+        return ResponseEntity.ok(interactionService.recordRepost(id, sharerId, effective));
     }
 
     // ── Comments ───────────────────────────────────────────────────────────

--- a/backend/src/main/java/com/group7/backend/dto/request/CreateRepostRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/CreateRepostRequest.java
@@ -1,0 +1,29 @@
+package com.group7.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request body for {@code POST /api/feed/posts/{id}/reposts}. The body
+ * field disambiguates the two sharing modes the endpoint supports:
+ * <ul>
+ *   <li>{@code null} or blank → bare repost (no commentary).</li>
+ *   <li>non-blank up to 2000 characters → quote-share with commentary.</li>
+ * </ul>
+ *
+ * <p>The whole request body is optional. {@code {}}, missing JSON body,
+ * and {@code {"body": null}} all deserialise to a {@code body = null}
+ * record and produce a bare repost. The service layer additionally
+ * normalises blank input ({@code "   "}) to {@code null} so the
+ * non-blank DB CHECK constraint never fires.
+ */
+@Schema(description = "Repost or quote-share payload. Null/blank body = bare repost; non-blank body = quote-share.")
+public record CreateRepostRequest(
+        @Schema(description = "Optional commentary attached to a quote-share. Capped at 2000 characters.",
+                example = "Great take on this — fully agree.")
+        @Size(max = 2000) String body
+) {
+    public static CreateRepostRequest empty() {
+        return new CreateRepostRequest(null);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/FeedPostListItem.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FeedPostListItem.java
@@ -50,6 +50,27 @@ public record FeedPostListItem(
                 + "Codes from the advanced ranker are namespaced with a `feed:` prefix; the "
                 + "frontend strips the prefix and maps each code to a localized chip.",
                 example = "[\"feed:semantic-match:0.82\", \"feed:fresh\", \"feed:follow-boost\"]")
-        List<String> factors
+        List<String> factors,
+
+        @Schema(description = "User id of the follower who reposted this post into the viewer's "
+                + "Following feed. Null when the row originates from the post's own author "
+                + "(i.e., not a repost surface).",
+                nullable = true, example = "42")
+        Long sharedById,
+
+        @Schema(description = "First name of the reposting follower, denormalised for the UI. "
+                + "Null on non-repost rows.",
+                nullable = true, example = "Ada")
+        String sharedByFirstName,
+
+        @Schema(description = "Quote-share commentary; null on bare reposts and on non-repost rows.",
+                nullable = true, example = "Great take — fully agree.")
+        String shareCommentary,
+
+        @Schema(description = "Server-side timestamp of the repost (feed_post_shares.created_at). "
+                + "Used by the UI to render \"reposted N minutes ago\" alongside the post's own "
+                + "createdAt. Null on non-repost rows.",
+                nullable = true)
+        OffsetDateTime sharedAt
 ) {
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/FeedSharePushPayload.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FeedSharePushPayload.java
@@ -1,0 +1,42 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Slim STOMP push payload broadcast over {@code /topic/feed.{userId}}
+ * when a user the recipient follows reposts or quote-shares a post.
+ * Mirrors {@link FeedPostPushPayload} for original-post pushes but
+ * adds {@code sharerId} / {@code sharerFirstName} / {@code commentary}
+ * so the UI can render the "X reposted this" attribution without an
+ * extra fetch.
+ *
+ * <p>Clients still call {@code GET /api/feed/posts/{postId}} for the
+ * full post body and hashtags; this payload only carries enough to
+ * surface the timeline entry.
+ */
+@Schema(description = "Slim repost push payload over /topic/feed.{userId} STOMP. " +
+        "Commentary is null for bare reposts; non-null for quote-shares.")
+public record FeedSharePushPayload(
+        @Schema(description = "Share row id (feed_post_shares.id)", example = "501")
+        Long shareId,
+
+        @Schema(description = "Reposted post id", example = "42")
+        Long postId,
+
+        @Schema(description = "User id of the user who reposted", example = "17")
+        Long sharerId,
+
+        @Schema(description = "First name of the sharer (denormalised for the UI)", example = "Ada")
+        String sharerFirstName,
+
+        @Schema(description = "Quote-share commentary; null on bare reposts",
+                nullable = true,
+                example = "Great take on this — fully agree.")
+        String commentary,
+
+        @Schema(description = "Server-side share timestamp (feed_post_shares.created_at)")
+        OffsetDateTime sharedAt
+) {
+}

--- a/backend/src/main/java/com/group7/backend/entity/FeedPostShare.java
+++ b/backend/src/main/java/com/group7/backend/entity/FeedPostShare.java
@@ -13,13 +13,34 @@ import lombok.Setter;
 import java.time.OffsetDateTime;
 
 /**
- * A share event on a feed post (#347). Append-only — sharing the same
- * post twice records two separate events, since shares are
- * fundamentally events ("user X shared this") not relationships
- * (unlike likes / bookmarks). No idempotency, no soft-delete.
+ * A share event on a feed post. Append-only by design: sharing the same
+ * post twice records two separate events, since shares are fundamentally
+ * events ("user X shared this") not relationships (unlike likes /
+ * bookmarks). No soft-delete column — to undo a share, hard-delete the
+ * row (the FK is ON DELETE CASCADE from both post and sharer).
  *
- * <p>Share-fanout (notifying the original author) is out of scope
- * here per the issue body — this entity just logs the event.
+ * <p>The row carries three sharing modes via two flags:
+ * <ul>
+ *   <li>{@code is_repost = FALSE, body = NULL} — silent analytics share.
+ *       The {@code POST /api/feed/posts/{id}/share} endpoint writes this
+ *       shape and notifies the original author, but does not fan out to
+ *       the sharer's followers and does not appear in any Following
+ *       feed.</li>
+ *   <li>{@code is_repost = TRUE,  body = NULL} — bare repost. The
+ *       {@code POST /api/feed/posts/{id}/reposts} endpoint writes this
+ *       shape; the original post surfaces in the sharer's followers'
+ *       Following feed with "shared by X" attribution.</li>
+ *   <li>{@code is_repost = TRUE,  body = "<commentary>"} — quote-share.
+ *       Same fanout as bare repost; the commentary travels in the STOMP
+ *       payload and the Following-feed row.</li>
+ * </ul>
+ *
+ * <p>Quote-share commentary length is capped at 2000 characters,
+ * matching {@code FeedPost.body}. The DB CHECK constraint
+ * {@code feed_post_shares_body_nonblank} additionally rejects
+ * whitespace-only bodies as defence-in-depth against a malformed write
+ * path; the service normalises blank input to NULL before persisting
+ * so the constraint is only a backstop.
  */
 @Entity
 @Table(name = "feed_post_shares")
@@ -40,6 +61,24 @@ public class FeedPostShare {
 
     @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
     private OffsetDateTime createdAt;
+
+    /**
+     * Quote-share commentary. NULL on silent shares and bare reposts.
+     * Length cap of 2000 chars enforced by DB CHECK + DTO {@code @Size};
+     * blank-string inputs are normalised to NULL at the service layer
+     * before persist, so the non-blank CHECK is purely a defence-in-depth
+     * backstop.
+     */
+    @Column(length = 2000)
+    private String body;
+
+    /**
+     * False for silent analytics shares (the existing /share endpoint),
+     * true for reposts and quote-shares (the new /reposts endpoint).
+     * The Following feed surfaces only rows where this flag is true.
+     */
+    @Column(name = "is_repost", nullable = false)
+    private boolean repost = false;
 
     public FeedPostShare(Long postId, Long sharerId) {
         this.postId = postId;

--- a/backend/src/main/java/com/group7/backend/event/FeedFanoutListener.java
+++ b/backend/src/main/java/com/group7/backend/event/FeedFanoutListener.java
@@ -2,6 +2,7 @@ package com.group7.backend.event;
 
 import com.group7.backend.dto.feed.FeedTopics;
 import com.group7.backend.dto.response.FeedPostPushPayload;
+import com.group7.backend.dto.response.FeedSharePushPayload;
 import com.group7.backend.repository.FollowRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,12 +84,50 @@ public class FeedFanoutListener {
         }
     }
 
+    /**
+     * Mirror of {@link #onFeedPostCreated} for repost / quote-share
+     * events. Fans out a slim {@link FeedSharePushPayload} to every
+     * follower of the sharer (NOT the post author) so the repost
+     * surfaces in those followers' Following feed in near-real-time.
+     *
+     * <p>Silent shares (the existing {@code /share} endpoint) do not
+     * publish {@link FeedPostSharedEvent} and therefore never reach this
+     * listener — their semantics remain unchanged.
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onFeedPostShared(FeedPostSharedEvent event) {
+        try {
+            Set<Long> followers = followRepository.findFollowerIdsByFolloweeId(event.sharerId());
+            if (followers.isEmpty()) {
+                return;
+            }
+            FeedSharePushPayload payload = new FeedSharePushPayload(
+                    event.shareId(),
+                    event.postId(),
+                    event.sharerId(),
+                    event.sharerFirstName(),
+                    event.commentary(),
+                    event.sharedAt());
+            int delivered = broadcastTo(followers, payload, event.postId());
+            log.info("Share fanout: shareId={}, sharerId={}, postId={}, recipients={}, delivered={}",
+                    event.shareId(), event.sharerId(), event.postId(), followers.size(), delivered);
+        } catch (RuntimeException ex) {
+            log.error("Share fanout aborted: shareId={}, sharerId={}: {}",
+                    event.shareId(), event.sharerId(), ex.getMessage(), ex);
+        }
+    }
+
     private static FeedPostPushPayload toPayload(FeedPostCreatedEvent event) {
         return new FeedPostPushPayload(
                 event.postId(), event.authorId(), event.authorFirstName(), event.createdAt());
     }
 
-    private int broadcastTo(Set<Long> recipients, FeedPostPushPayload payload, Long postId) {
+    // Payload typed as Object: SimpMessagingTemplate.convertAndSend is itself
+    // untyped, and the share-fanout path needs to send FeedSharePushPayload
+    // through the same helper. The previous strongly-typed FeedPostPushPayload
+    // parameter blocked reuse.
+    private int broadcastTo(Set<Long> recipients, Object payload, Long postId) {
         int delivered = 0;
         for (Long recipientId : recipients) {
             try {

--- a/backend/src/main/java/com/group7/backend/event/FeedPostSharedEvent.java
+++ b/backend/src/main/java/com/group7/backend/event/FeedPostSharedEvent.java
@@ -1,0 +1,29 @@
+package com.group7.backend.event;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Published when a {@link com.group7.backend.entity.FeedPostShare} commits
+ * with {@code is_repost = TRUE} (i.e., a repost or quote-share via
+ * {@code POST /api/feed/posts/{id}/reposts}). {@link FeedFanoutListener}
+ * subscribes via {@code @TransactionalEventListener(AFTER_COMMIT)} and
+ * fans out a slim STOMP push to every follower of the sharer.
+ *
+ * <p>Silent shares (the existing {@code /share} endpoint, which writes
+ * {@code is_repost = FALSE}) do <b>not</b> publish this event — they
+ * only emit the {@code FEED_SHARE} notification side-effect and never
+ * fan out to followers.
+ *
+ * <p>Mirrors {@link FeedPostCreatedEvent}'s all-values record shape so
+ * the {@code @Async} listener never crosses a thread boundary with a
+ * managed entity (no {@code LazyInitializationException} risk).
+ */
+public record FeedPostSharedEvent(
+        Long shareId,
+        Long postId,
+        Long sharerId,
+        String sharerFirstName,
+        String commentary,
+        OffsetDateTime sharedAt
+) {
+}

--- a/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
@@ -60,23 +60,80 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
      * countQuery} is provided so Spring Data does not attempt to derive
      * one from the native query (which it cannot do reliably).
      */
+    /**
+     * Following-feed read. UNIONs two branches:
+     * <ul>
+     *   <li>Original posts authored by users the viewer follows.</li>
+     *   <li>Posts reposted (is_repost = TRUE) by users the viewer follows.</li>
+     * </ul>
+     *
+     * <p>Both branches filter {@code p.deleted_at IS NULL}, so a soft-
+     * deleted post never surfaces — its share rows are silently dropped.
+     *
+     * <p>Sort key is {@code sort_at} (post-creation time on the original
+     * branch, share-creation time on the repost branch) so reposts
+     * inserted today rank above untouched posts from earlier. The
+     * {@code share_row_id DESC NULLS LAST} tiebreaker guarantees stable
+     * pagination when two reposts of the same post share a millisecond
+     * — without it, page boundaries could drop or duplicate rows.
+     *
+     * <p>The same post can surface twice if the viewer follows both the
+     * post's author and a separate user who reposted it. Frontend may
+     * collapse if desired; this is documented contract behaviour, not a
+     * bug.
+     */
     @Query(value = """
-            SELECT * FROM feed_posts p
-            WHERE p.deleted_at IS NULL
-              AND p.author_id IN (
-                  SELECT f.followee_id FROM follows f WHERE f.follower_id = :viewerId
-              )
-            ORDER BY p.created_at DESC, p.id DESC
+            SELECT * FROM (
+                SELECT p.id, p.author_id, p.body, p.created_at,
+                       NULL::BIGINT      AS shared_by_id,
+                       NULL::TEXT        AS share_commentary,
+                       NULL::BIGINT      AS share_row_id,
+                       NULL::TIMESTAMPTZ AS shared_at,
+                       p.created_at      AS sort_at
+                FROM feed_posts p
+                WHERE p.deleted_at IS NULL
+                  AND p.author_id IN (
+                      SELECT f.followee_id FROM follows f WHERE f.follower_id = :viewerId
+                  )
+                UNION ALL
+                SELECT p.id, p.author_id, p.body, p.created_at,
+                       s.sharer_id  AS shared_by_id,
+                       s.body       AS share_commentary,
+                       s.id         AS share_row_id,
+                       s.created_at AS shared_at,
+                       s.created_at AS sort_at
+                FROM feed_post_shares s
+                JOIN feed_posts p ON p.id = s.post_id
+                WHERE s.is_repost = TRUE
+                  AND p.deleted_at IS NULL
+                  AND s.sharer_id IN (
+                      SELECT f.followee_id FROM follows f WHERE f.follower_id = :viewerId
+                  )
+            ) merged
+            ORDER BY sort_at DESC, id DESC, share_row_id DESC NULLS LAST
             """,
             countQuery = """
-            SELECT COUNT(*) FROM feed_posts p
-            WHERE p.deleted_at IS NULL
-              AND p.author_id IN (
-                  SELECT f.followee_id FROM follows f WHERE f.follower_id = :viewerId
-              )
+            SELECT COUNT(*) FROM (
+                SELECT 1
+                FROM feed_posts p
+                WHERE p.deleted_at IS NULL
+                  AND p.author_id IN (
+                      SELECT f.followee_id FROM follows f WHERE f.follower_id = :viewerId
+                  )
+                UNION ALL
+                SELECT 1
+                FROM feed_post_shares s
+                JOIN feed_posts p ON p.id = s.post_id
+                WHERE s.is_repost = TRUE
+                  AND p.deleted_at IS NULL
+                  AND s.sharer_id IN (
+                      SELECT f.followee_id FROM follows f WHERE f.follower_id = :viewerId
+                  )
+            ) merged
             """,
             nativeQuery = true)
-    Page<FeedPost> findFollowingFeed(@Param("viewerId") Long viewerId, Pageable pageable);
+    Page<com.group7.backend.repository.projection.FollowingFeedRow> findFollowingFeed(
+            @Param("viewerId") Long viewerId, Pageable pageable);
 
     /**
      * Author-profile feed query (#471). Returns non-deleted posts for a

--- a/backend/src/main/java/com/group7/backend/repository/FeedPostShareRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostShareRepository.java
@@ -2,9 +2,47 @@ package com.group7.backend.repository;
 
 import com.group7.backend.entity.FeedPostShare;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
 
 @Repository
 public interface FeedPostShareRepository extends JpaRepository<FeedPostShare, Long> {
     long countByPostId(Long postId);
+
+    /**
+     * Soft-idempotency lookup for the repost endpoint: returns the most
+     * recent repost row with the same {@code (post_id, sharer_id, body)}
+     * created within the configured window, or empty if no such row
+     * exists.
+     *
+     * <p>{@code IS NOT DISTINCT FROM} provides null-safe equality on the
+     * {@code body} column — two bare reposts (both {@code body = NULL})
+     * collapse without special-casing in Java. Postgres' default
+     * {@code NULL = NULL → UNKNOWN} semantics would otherwise fail to
+     * match.
+     *
+     * <p>Native query because JPQL has no portable equivalent of
+     * {@code IS NOT DISTINCT FROM}. The mapping back to the entity is
+     * automatic because the SELECT projects all columns of
+     * {@code feed_post_shares}.
+     */
+    @Query(value = """
+            SELECT s.* FROM feed_post_shares s
+            WHERE s.post_id = :postId
+              AND s.sharer_id = :sharerId
+              AND s.is_repost = TRUE
+              AND s.body IS NOT DISTINCT FROM :body
+              AND s.created_at >= :since
+            ORDER BY s.created_at DESC
+            LIMIT 1
+            """, nativeQuery = true)
+    Optional<FeedPostShare> findRecentRepost(
+            @Param("postId") Long postId,
+            @Param("sharerId") Long sharerId,
+            @Param("body") String body,
+            @Param("since") OffsetDateTime since);
 }

--- a/backend/src/main/java/com/group7/backend/repository/projection/FollowingFeedRow.java
+++ b/backend/src/main/java/com/group7/backend/repository/projection/FollowingFeedRow.java
@@ -1,0 +1,87 @@
+package com.group7.backend.repository.projection;
+
+import java.time.Instant;
+
+/**
+ * Spring Data interface projection for the merged Following-feed read.
+ * The native query UNIONs two branches:
+ * <ul>
+ *   <li>Original-post branch — posts authored by users the viewer
+ *       follows. {@link #getSharedById()}, {@link #getShareCommentary()},
+ *       {@link #getShareRowId()}, and {@link #getSharedAt()} are all
+ *       null on this branch.</li>
+ *   <li>Repost branch — posts that users the viewer follows have
+ *       reposted (i.e., {@code feed_post_shares.is_repost = TRUE}). All
+ *       four share-metadata getters are populated.</li>
+ * </ul>
+ *
+ * <p>{@link #getSortAt()} drives {@code ORDER BY} in the SQL; it is the
+ * post's creation time on the original-post branch and the share's
+ * creation time on the repost branch — so a post reposted today by a
+ * followee surfaces above a freshly authored post from yesterday.
+ *
+ * <p>{@link #getShareRowId()} provides a unique pagination tiebreaker:
+ * when two reposts of the same post share the same {@code (sort_at,
+ * id)}, the share row's surrogate key breaks the tie deterministically.
+ *
+ * <p>Spring Data binds getter names to native-query column aliases via
+ * lowercase-with-underscores camel-casing — {@code shared_by_id}
+ * binds to {@link #getSharedById()}. Renaming a SQL alias without
+ * updating this interface silently breaks pagination, so any change to
+ * either side must be paired with an integration-test assertion.
+ *
+ * <p>Precedent for interface projections on native queries lives at
+ * {@code ConversationLastMessageView}.
+ */
+public interface FollowingFeedRow {
+
+    /** Post id. Same value across both branches for the same post. */
+    Long getId();
+
+    /** Author of the original post. */
+    Long getAuthorId();
+
+    /** Post body. */
+    String getBody();
+
+    /**
+     * Post creation timestamp ({@code feed_posts.created_at}), NOT the
+     * share creation time. Stays stable across both branches so the UI
+     * can render "posted X ago" regardless of whether the row arrived
+     * via the post or the repost surface.
+     *
+     * <p>Returns {@link Instant} because Spring Data interface projections
+     * on native queries materialise TIMESTAMPTZ as {@code Instant} by
+     * default; the consuming service converts to {@code OffsetDateTime}
+     * at the UTC offset before populating the response DTO.
+     */
+    Instant getCreatedAt();
+
+    /** User id of the reposting follower; null on the original-post branch. */
+    Long getSharedById();
+
+    /** Quote-share commentary; null on bare reposts and on the original-post branch. */
+    String getShareCommentary();
+
+    /**
+     * Surrogate key of the {@code feed_post_shares} row — null on the
+     * original-post branch. Used only by the ORDER BY tiebreaker, not
+     * surfaced in the response.
+     */
+    Long getShareRowId();
+
+    /**
+     * Share creation timestamp ({@code feed_post_shares.created_at});
+     * null on the original-post branch. The UI uses this to render
+     * "reposted X ago" alongside {@link #getCreatedAt()}. Same Instant /
+     * OffsetDateTime conversion contract as {@link #getCreatedAt()}.
+     */
+    Instant getSharedAt();
+
+    /**
+     * Sort key for the merged result: post creation time on the original
+     * branch, share creation time on the repost branch. Drives the
+     * {@code ORDER BY} clause in the native query.
+     */
+    Instant getSortAt();
+}

--- a/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
@@ -1,5 +1,6 @@
 package com.group7.backend.service;
 
+import com.group7.backend.dto.request.CreateRepostRequest;
 import com.group7.backend.dto.response.FeedCommentResponse;
 import com.group7.backend.dto.response.FeedPostInteractionState;
 import com.group7.backend.dto.response.FeedPostListItem;
@@ -11,6 +12,7 @@ import com.group7.backend.entity.FeedPostShare;
 import com.group7.backend.entity.User;
 import com.group7.backend.entity.FeedPostHashtag;
 import com.group7.backend.event.FeedEngagementEvent;
+import com.group7.backend.event.FeedPostSharedEvent;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.FeedPostBookmarkRepository;
 import com.group7.backend.repository.FeedPostCommentRepository;
@@ -21,6 +23,7 @@ import com.group7.backend.repository.UserRepository;
 import com.group7.backend.repository.projection.PostCountTuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -29,12 +32,14 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -81,6 +86,15 @@ public class FeedInteractionService {
     private final NotificationEventPublisher notificationEventPublisher;
     private final ApplicationEventPublisher eventPublisher;
 
+    /**
+     * Window during which an identical-payload repost from the same
+     * sharer collapses to the existing row instead of creating a
+     * duplicate. Defends against network retries causing double-fanout;
+     * not a defence against simultaneous-click races. Configurable for
+     * ops tuning, ISO 8601 duration syntax.
+     */
+    private final Duration repostIdempotencyWindow;
+
     public FeedInteractionService(FeedPostRepository feedPostRepository,
                                    FeedPostLikeRepository likeRepository,
                                    FeedPostBookmarkRepository bookmarkRepository,
@@ -89,7 +103,9 @@ public class FeedInteractionService {
                                    UserRepository userRepository,
                                    FeedPostMapper feedPostMapper,
                                    NotificationEventPublisher notificationEventPublisher,
-                                   ApplicationEventPublisher eventPublisher) {
+                                   ApplicationEventPublisher eventPublisher,
+                                   @Value("${app.feed.repost.idempotency-window:PT60S}")
+                                   Duration repostIdempotencyWindow) {
         this.feedPostRepository = feedPostRepository;
         this.likeRepository = likeRepository;
         this.bookmarkRepository = bookmarkRepository;
@@ -99,6 +115,7 @@ public class FeedInteractionService {
         this.feedPostMapper = feedPostMapper;
         this.notificationEventPublisher = notificationEventPublisher;
         this.eventPublisher = eventPublisher;
+        this.repostIdempotencyWindow = repostIdempotencyWindow;
     }
 
     // ── Likes ──────────────────────────────────────────────────────────────
@@ -253,6 +270,75 @@ public class FeedInteractionService {
                     post.getAuthorId(), resolveAuthorName(sharerId), postId);
         }
         return interactionState(postId, sharerId);
+    }
+
+    /**
+     * Repost or quote-share a post. Distinct from {@link #recordShare}:
+     * the row is written with {@code is_repost = TRUE} and the share
+     * fans out via STOMP to the sharer's followers. The original post
+     * surfaces in those followers' Following feeds with "shared by X"
+     * attribution.
+     *
+     * <p>Idempotency is enforced at the service layer with a sliding
+     * {@link #repostIdempotencyWindow}: an identical
+     * {@code (post_id, sharer_id, body)} write inside the window
+     * collapses to the existing row, returning the same interaction
+     * state without re-firing fanout or notification. NULL bodies match
+     * NULL bodies via Postgres' {@code IS NOT DISTINCT FROM}.
+     *
+     * <p>The race where two simultaneous identical requests both pass
+     * the idempotency check is a known v1 limitation; both rows insert
+     * and both fanouts fire. Realistic client retries are serialised by
+     * the network round-trip, so the window is enough in practice.
+     */
+    @Transactional
+    public FeedPostInteractionState recordRepost(Long postId, Long sharerId,
+                                                  CreateRepostRequest request) {
+        FeedPost post = requireVisiblePost(postId);
+        String body = blankToNull(request != null ? request.body() : null);
+
+        Optional<FeedPostShare> recent = shareRepository.findRecentRepost(
+                postId, sharerId, body,
+                OffsetDateTime.now().minus(repostIdempotencyWindow));
+        if (recent.isPresent()) {
+            log.info("Repost idempotent collapse: postId={}, sharerId={}, withinSec={}",
+                    postId, sharerId, repostIdempotencyWindow.toSeconds());
+            return interactionState(postId, sharerId);
+        }
+
+        FeedPostShare share = new FeedPostShare(postId, sharerId);
+        share.setBody(body);
+        share.setRepost(true);
+        FeedPostShare saved = shareRepository.save(share);
+
+        String sharerFirstName = resolveAuthorName(sharerId);
+
+        // FeedPostShare.createdAt is insertable=false, so the entity field is
+        // NULL right after save() until a refresh. Use the JVM clock — same
+        // transaction, sub-millisecond drift from the DB DEFAULT NOW(), and
+        // STOMP fanout ordering does not depend on the exact persisted
+        // microsecond.
+        eventPublisher.publishEvent(new FeedPostSharedEvent(
+                saved.getId(),
+                saved.getPostId(),
+                saved.getSharerId(),
+                sharerFirstName,
+                saved.getBody(),
+                OffsetDateTime.now()));
+
+        publishEngagement(post, sharerId);
+        log.info("Recorded repost: postId={}, sharerId={}, hasCommentary={}",
+                postId, sharerId, body != null);
+
+        if (!sharerId.equals(post.getAuthorId())) {
+            notificationEventPublisher.publishFeedShare(
+                    post.getAuthorId(), sharerFirstName, postId);
+        }
+        return interactionState(postId, sharerId);
+    }
+
+    private static String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
     }
 
     // ── Comments ───────────────────────────────────────────────────────────

--- a/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
@@ -219,7 +219,11 @@ public class FeedInteractionService {
                     p.getCreatedAt(),
                     likeCount,
                     commentCount,
-                    List.of()
+                    List.of(),
+                    null,   // sharedById — bookmarks are user-scoped, not a repost surface
+                    null,   // sharedByFirstName
+                    null,   // shareCommentary
+                    null    // sharedAt
             );
         }).toList();
         return new PageImpl<>(items, pageable, postIds.getTotalElements());

--- a/backend/src/main/java/com/group7/backend/service/FeedReadService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedReadService.java
@@ -10,6 +10,7 @@ import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.FollowRepository;
 import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.projection.FollowingFeedRow;
 import com.group7.backend.service.ranking.FeedRanker;
 import com.group7.backend.service.ranking.FeedScoreResult;
 import com.group7.backend.service.ranking.feed.ForYouScoringPipeline;
@@ -193,17 +194,112 @@ public class FeedReadService {
                 post.getCreatedAt(),
                 likeCount,
                 commentCount,
-                ranked.factors()
+                ranked.factors(),
+                null,   // sharedById — For-You is not a repost surface
+                null,   // sharedByFirstName
+                null,   // shareCommentary
+                null    // sharedAt
         );
     }
 
     /**
-     * Following feed (#350, requirement 1.1.7.4). Chronological over
-     * posts authored by users the viewer follows.
+     * Following feed (#350, requirement 1.1.7.4). Chronological merge of
+     * two streams: posts authored by users the viewer follows, and
+     * posts reposted by users the viewer follows. The repository's
+     * UNION-ALL query returns a projection carrying the share metadata
+     * when the row originates from the repost branch; this mapper
+     * threads that metadata through into {@link FeedPostListItem}.
+     *
+     * <p>Cost: one projection query (paged) + one batch fetch of post
+     * entities (for hashtag collections, which the projection
+     * deliberately does not carry) + one user batch fetch (authors
+     * union sharers) + one counts batch. No N+1 against the page size.
      */
     public Page<FeedPostListItem> followingFeed(Long viewerId, Pageable pageable) {
-        Page<FeedPost> page = feedPostRepository.findFollowingFeed(viewerId, pageable);
-        return mapPage(page);
+        Page<FollowingFeedRow> page = feedPostRepository.findFollowingFeed(viewerId, pageable);
+        if (page.isEmpty()) {
+            return Page.empty(page.getPageable());
+        }
+
+        List<FollowingFeedRow> rows = page.getContent();
+
+        // Distinct post ids to fetch FeedPost entities (only for the
+        // hashtag collection, which the projection omits to keep its
+        // shape narrow). @BatchSize on FeedPost.hashtags collapses
+        // the lazy load to a single query for the whole page.
+        Set<Long> postIds = rows.stream()
+                .map(FollowingFeedRow::getId)
+                .collect(Collectors.toSet());
+        Map<Long, FeedPost> postsById = feedPostRepository.findAllById(postIds).stream()
+                .collect(Collectors.toMap(FeedPost::getId, p -> p));
+
+        // Single user-batch covering both authors and sharers — one round
+        // trip even when most rows originate from the repost branch.
+        Set<Long> userIds = new java.util.HashSet<>();
+        rows.forEach(r -> {
+            userIds.add(r.getAuthorId());
+            if (r.getSharedById() != null) userIds.add(r.getSharedById());
+        });
+        Map<Long, String> names = new HashMap<>();
+        userRepository.findAllById(userIds).forEach(u -> names.put(u.getId(), u.getFirstName()));
+
+        Map<Long, FeedInteractionService.PostCounts> counts =
+                feedInteractionService.batchCounts(postIds.stream().toList());
+
+        return page.map(row -> followingRowToListItem(row, postsById, names, counts));
+    }
+
+    /**
+     * Builds a {@link FeedPostListItem} for the Following feed from the
+     * UNION-ALL projection. Falls back to an empty hashtag list if the
+     * post entity is unexpectedly missing (e.g., hard-deleted between
+     * the projection query and the entity batch), so the response
+     * remains well-formed.
+     */
+    private static FeedPostListItem followingRowToListItem(
+            FollowingFeedRow row,
+            Map<Long, FeedPost> postsById,
+            Map<Long, String> names,
+            Map<Long, FeedInteractionService.PostCounts> counts) {
+        FeedPost post = postsById.get(row.getId());
+        List<String> tags = (post == null)
+                ? List.of()
+                : post.getHashtags().stream()
+                        .map(FeedPostHashtag::getId)
+                        .map(id -> id.getTag())
+                        .sorted()
+                        .toList();
+        FeedInteractionService.PostCounts c = counts.get(row.getId());
+        long likeCount = (c == null) ? 0L : c.likeCount();
+        long commentCount = (c == null) ? 0L : c.commentCount();
+        String sharerName = row.getSharedById() == null
+                ? null
+                : names.get(row.getSharedById());
+
+        // Spring Data interface projections on native queries return
+        // TIMESTAMPTZ as java.time.Instant; FeedPostListItem carries
+        // OffsetDateTime. Convert at UTC — the database stores UTC and
+        // the existing direct-entity reads (FeedPost.createdAt as
+        // OffsetDateTime) effectively use UTC too, so this keeps the
+        // wire shape identical across both feed read paths.
+        return new FeedPostListItem(
+                row.getId(),
+                row.getAuthorId(),
+                names.get(row.getAuthorId()),
+                row.getBody(),
+                tags,
+                row.getCreatedAt() == null
+                        ? null
+                        : row.getCreatedAt().atOffset(java.time.ZoneOffset.UTC),
+                likeCount,
+                commentCount,
+                List.of(),                    // factors — Following is chronological, not ranked
+                row.getSharedById(),
+                sharerName,
+                row.getShareCommentary(),
+                row.getSharedAt() == null
+                        ? null
+                        : row.getSharedAt().atOffset(java.time.ZoneOffset.UTC));
     }
 
     /**
@@ -377,7 +473,11 @@ public class FeedReadService {
                 post.getCreatedAt(),
                 likeCount,
                 commentCount,
-                factors
+                factors,
+                null,   // sharedById — not a repost surface
+                null,   // sharedByFirstName
+                null,   // shareCommentary
+                null    // sharedAt
         );
     }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -186,6 +186,15 @@ app.ratelimit.rules.feed-share.key-strategy=USER
 app.ratelimit.rules.feed-share.capacity=${APP_FEED_INTERACTION_CAPACITY:60}
 app.ratelimit.rules.feed-share.refill=PT1M
 
+# Repost / quote-share fanout. Tighter than the silent /share cap because
+# every repost triggers a STOMP broadcast to the sharer's followers and
+# carries higher abuse cost than an analytics-only event.
+app.ratelimit.rules.feed-repost.method=POST
+app.ratelimit.rules.feed-repost.pattern=/api/feed/posts/*/reposts
+app.ratelimit.rules.feed-repost.key-strategy=USER
+app.ratelimit.rules.feed-repost.capacity=${APP_FEED_REPOST_CAPACITY:30}
+app.ratelimit.rules.feed-repost.refill=PT1M
+
 app.ratelimit.rules.feed-comment.method=POST
 app.ratelimit.rules.feed-comment.pattern=/api/feed/posts/*/comments
 app.ratelimit.rules.feed-comment.key-strategy=USER

--- a/backend/src/main/resources/db/migration/V40__add_feed_share_repost_columns.sql
+++ b/backend/src/main/resources/db/migration/V40__add_feed_share_repost_columns.sql
@@ -1,0 +1,26 @@
+-- Quote-share commentary and a repost flag for feed_post_shares. The
+-- existing silent /share endpoint continues to insert with body=NULL,
+-- is_repost=FALSE so its semantics are preserved exactly. The new
+-- /reposts endpoint writes rows with is_repost=TRUE and optional body
+-- (NULL = bare repost, non-blank = quote-share).
+
+ALTER TABLE feed_post_shares
+    ADD COLUMN body      VARCHAR(2000),
+    ADD COLUMN is_repost BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Partial index so the Following-feed UNION-ALL only scans reposts when
+-- joining feed_post_shares; analytics-style silent shares stay out of
+-- the index altogether.
+CREATE INDEX idx_feed_post_shares_sharer_repost_created
+    ON feed_post_shares (sharer_id, created_at DESC)
+    WHERE is_repost = TRUE;
+
+-- Defence-in-depth: length cap matches feed_posts.body, plus non-blank
+-- guard so the DTO validator (@Size) isn't the only gate against
+-- whitespace-only commentary. The negated whitespace-only regex matches
+-- the V26 pattern for feed_posts: \s covers tabs, newlines, formfeeds.
+ALTER TABLE feed_post_shares
+    ADD CONSTRAINT feed_post_shares_body_length
+        CHECK (body IS NULL OR length(body) <= 2000),
+    ADD CONSTRAINT feed_post_shares_body_nonblank
+        CHECK (body IS NULL OR body !~ '^\s*$');

--- a/backend/src/test/java/com/group7/backend/integration/FeedInteractionIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedInteractionIntegrationTest.java
@@ -254,6 +254,210 @@ class FeedInteractionIntegrationTest {
                 .andExpect(jsonPath("$.shareCount").value(2));
     }
 
+    // ── Reposts (#484) ─────────────────────────────────────────────────────
+
+    @Test
+    void repost_bare_createsRow_andNotifiesAuthor() throws Exception {
+        String authorToken = registerAndLogin("repost_bare_author@test.com");
+        String sharerToken = registerAndLogin("repost_bare_sharer@test.com");
+        long pid = createPost(authorToken, "post to bare-repost", List.of());
+        long authorId = userIdByEmail("repost_bare_author@test.com");
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.shareCount").value(1));
+
+        // DB row: exactly one share, is_repost=TRUE, body=NULL.
+        Integer repostRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_shares WHERE post_id = ? AND is_repost = TRUE AND body IS NULL",
+                Integer.class, pid);
+        assertThat(repostRows).isEqualTo(1);
+
+        // Author notified via the existing FEED_SHARE channel.
+        awaitNotifications(authorId, NotificationType.FEED_SHARE, 1);
+    }
+
+    @Test
+    void repost_quote_persistsCommentary_andNotifiesAuthor() throws Exception {
+        String authorToken = registerAndLogin("repost_quote_author@test.com");
+        String sharerToken = registerAndLogin("repost_quote_sharer@test.com");
+        long pid = createPost(authorToken, "post to quote-share", List.of());
+        long authorId = userIdByEmail("repost_quote_author@test.com");
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"great take\"}"))
+                .andExpect(status().isOk());
+
+        String body = jdbcTemplate.queryForObject(
+                "SELECT body FROM feed_post_shares WHERE post_id = ? AND is_repost = TRUE",
+                String.class, pid);
+        assertThat(body).isEqualTo("great take");
+
+        awaitNotifications(authorId, NotificationType.FEED_SHARE, 1);
+    }
+
+    @Test
+    void repost_softDeletedPost_returns404() throws Exception {
+        String authorToken = registerAndLogin("repost_404_author@test.com");
+        String sharerToken = registerAndLogin("repost_404_sharer@test.com");
+        long pid = createPost(authorToken, "to be deleted", List.of());
+
+        mockMvc.perform(delete("/api/feed/posts/" + pid)
+                        .header("Authorization", "Bearer " + authorToken))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void repost_self_doesNotNotifyAuthor() throws Exception {
+        String authorToken = registerAndLogin("repost_self_author@test.com");
+        long pid = createPost(authorToken, "self-repost", List.of());
+        long authorId = userIdByEmail("repost_self_author@test.com");
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + authorToken))
+                .andExpect(status().isOk());
+
+        // Give the AFTER_COMMIT listener a beat; FEED_SHARE count must stay
+        // at zero because the sharer is the author.
+        Thread.sleep(300);
+        assertThat(notificationsFor(authorId, NotificationType.FEED_SHARE)).isEmpty();
+    }
+
+    @Test
+    void repost_idempotencyWindow_secondCallCollapses() throws Exception {
+        String authorToken = registerAndLogin("repost_idem_author@test.com");
+        String sharerToken = registerAndLogin("repost_idem_sharer@test.com");
+        long pid = createPost(authorToken, "post for idempotency", List.of());
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"identical\"}"))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"identical\"}"))
+                .andExpect(status().isOk());
+
+        Integer rows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_shares WHERE post_id = ? AND is_repost = TRUE",
+                Integer.class, pid);
+        assertThat(rows).isEqualTo(1);
+    }
+
+    @Test
+    void repost_idempotencyKeyHeader_acceptedAndIgnored() throws Exception {
+        String authorToken = registerAndLogin("repost_key_author@test.com");
+        String sharerToken = registerAndLogin("repost_key_sharer@test.com");
+        long pid = createPost(authorToken, "post for idempotency key", List.of());
+
+        // With header — must accept normally (no 4xx).
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken)
+                        .header("Idempotency-Key", "00000000-0000-0000-0000-000000000001"))
+                .andExpect(status().isOk());
+
+        // Different sharer, same pattern — header on, but content differs so
+        // the idempotency window does not collapse this independent action.
+        String sharer2 = registerAndLogin("repost_key_sharer2@test.com");
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharer2)
+                        .header("Idempotency-Key", "00000000-0000-0000-0000-000000000002"))
+                .andExpect(status().isOk());
+
+        Integer rows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_shares WHERE post_id = ? AND is_repost = TRUE",
+                Integer.class, pid);
+        assertThat(rows).isEqualTo(2);
+    }
+
+    @Test
+    void repost_validation_oversizeBody_returns400() throws Exception {
+        String authorToken = registerAndLogin("repost_val_author@test.com");
+        String sharerToken = registerAndLogin("repost_val_sharer@test.com");
+        long pid = createPost(authorToken, "post for validation", List.of());
+
+        String oversize = "x".repeat(2001);
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("body", oversize))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void repost_blankBody_isAcceptedAsBareRepost() throws Exception {
+        String authorToken = registerAndLogin("repost_blank_author@test.com");
+        String sharerToken = registerAndLogin("repost_blank_sharer@test.com");
+        long pid = createPost(authorToken, "blank-body repost", List.of());
+
+        // {"body":"   "} — whitespace-only collapses to NULL via blankToNull;
+        // the DB CHECK feed_post_shares_body_nonblank never fires because
+        // the persisted value is NULL.
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"   \"}"))
+                .andExpect(status().isOk());
+
+        String body = jdbcTemplate.queryForObject(
+                "SELECT body FROM feed_post_shares WHERE post_id = ? AND is_repost = TRUE",
+                String.class, pid);
+        assertThat(body).isNull();
+    }
+
+    @Test
+    void repost_emptyJsonBody_isAcceptedAsBareRepost() throws Exception {
+        String authorToken = registerAndLogin("repost_empty_author@test.com");
+        String sharerToken = registerAndLogin("repost_empty_sharer@test.com");
+        long pid = createPost(authorToken, "empty-json repost", List.of());
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isOk());
+        // No request body at all — same outcome.
+        String sharer2 = registerAndLogin("repost_empty_sharer2@test.com");
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharer2))
+                .andExpect(status().isOk());
+
+        Integer rows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_shares WHERE post_id = ? AND is_repost = TRUE AND body IS NULL",
+                Integer.class, pid);
+        assertThat(rows).isEqualTo(2);
+    }
+
+    @Test
+    void repost_silentShareUnchanged_doesNotWriteIsRepostFlag() throws Exception {
+        // Regression guard: existing /share contract preserved verbatim.
+        String authorToken = registerAndLogin("repost_silent_author@test.com");
+        String sharerToken = registerAndLogin("repost_silent_sharer@test.com");
+        long pid = createPost(authorToken, "silent share test", List.of());
+
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/share")
+                        .header("Authorization", "Bearer " + sharerToken))
+                .andExpect(status().isOk());
+
+        Integer silentRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_shares WHERE post_id = ? AND is_repost = FALSE AND body IS NULL",
+                Integer.class, pid);
+        assertThat(silentRows).isEqualTo(1);
+        Integer repostRows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM feed_post_shares WHERE post_id = ? AND is_repost = TRUE",
+                Integer.class, pid);
+        assertThat(repostRows).isZero();
+    }
+
     // ── Comments ───────────────────────────────────────────────────────────
 
     @Test

--- a/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
@@ -603,4 +603,170 @@ class FeedReadIntegrationTest {
         assertThat(post.get("likeCount").asLong()).isEqualTo(2L);
         assertThat(post.get("commentCount").asLong()).isEqualTo(1L);
     }
+
+    // ── Following feed: repost surfacing (#484) ────────────────────────────
+
+    @Test
+    void followingFeed_surfacesReposts_attributedToSharer() throws Exception {
+        String viewerToken = registerAndLogin("repost_view_viewer@test.com", true);
+        String sharerToken = registerAndLogin("repost_view_sharer@test.com", true);
+        String authorToken = registerAndLogin("repost_view_author@test.com", true);
+        Long sharerId = userRepository.findByEmail("repost_view_sharer@test.com").orElseThrow().getId();
+
+        // Viewer follows the sharer (but NOT the original author).
+        mockMvc.perform(post("/api/users/" + sharerId + "/follow")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isCreated());
+
+        long pid = createPost(authorToken, "post that will be reposted", List.of("track"));
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken))
+                .andExpect(status().isOk());
+
+        MvcResult result = mockMvc.perform(get("/api/feed/following")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andReturn();
+
+        JsonNode row = objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("content").get(0);
+        assertThat(row.get("id").asLong()).isEqualTo(pid);
+        assertThat(row.get("sharedById").asLong()).isEqualTo(sharerId);
+        assertThat(row.get("sharedByFirstName").asText()).isEqualTo("Feed");  // helper uses "Feed" as firstName
+        assertThat(row.get("shareCommentary").isNull()).isTrue();
+        assertThat(row.get("sharedAt").isNull()).isFalse();
+    }
+
+    @Test
+    void followingFeed_quoteShare_surfacesCommentary() throws Exception {
+        String viewerToken = registerAndLogin("quote_view_viewer@test.com", true);
+        String sharerToken = registerAndLogin("quote_view_sharer@test.com", true);
+        String authorToken = registerAndLogin("quote_view_author@test.com", true);
+        Long sharerId = userRepository.findByEmail("quote_view_sharer@test.com").orElseThrow().getId();
+
+        mockMvc.perform(post("/api/users/" + sharerId + "/follow")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isCreated());
+
+        long pid = createPost(authorToken, "post that will be quoted", List.of());
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"body\":\"my commentary\"}"))
+                .andExpect(status().isOk());
+
+        MvcResult result = mockMvc.perform(get("/api/feed/following")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode row = objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("content").get(0);
+        assertThat(row.get("shareCommentary").asText()).isEqualTo("my commentary");
+    }
+
+    @Test
+    void followingFeed_silentShares_doNotSurface() throws Exception {
+        String viewerToken = registerAndLogin("silent_view_viewer@test.com", true);
+        String sharerToken = registerAndLogin("silent_view_sharer@test.com", true);
+        String authorToken = registerAndLogin("silent_view_author@test.com", true);
+        Long sharerId = userRepository.findByEmail("silent_view_sharer@test.com").orElseThrow().getId();
+
+        mockMvc.perform(post("/api/users/" + sharerId + "/follow")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isCreated());
+
+        long pid = createPost(authorToken, "silent-share target", List.of());
+        // Sharer hits the SILENT endpoint, not /reposts.
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/share")
+                        .header("Authorization", "Bearer " + sharerToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/feed/following")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.content.length()").value(0));
+    }
+
+    @Test
+    void followingFeed_samePostFromBothBranches_appearsTwice() throws Exception {
+        // Viewer follows BOTH the author and the sharer; the reposted post
+        // surfaces twice — once as an original post (via the author branch)
+        // and once as a repost (via the share branch).
+        String viewerToken = registerAndLogin("dual_view_viewer@test.com", true);
+        String sharerToken = registerAndLogin("dual_view_sharer@test.com", true);
+        String authorToken = registerAndLogin("dual_view_author@test.com", true);
+        Long sharerId = userRepository.findByEmail("dual_view_sharer@test.com").orElseThrow().getId();
+        Long authorId = userRepository.findByEmail("dual_view_author@test.com").orElseThrow().getId();
+
+        mockMvc.perform(post("/api/users/" + authorId + "/follow")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/api/users/" + sharerId + "/follow")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isCreated());
+
+        long pid = createPost(authorToken, "post followed twice", List.of());
+        Thread.sleep(20);  // ensure share.created_at > post.created_at
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharerToken))
+                .andExpect(status().isOk());
+
+        MvcResult result = mockMvc.perform(get("/api/feed/following")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andReturn();
+        JsonNode content = objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("content");
+        // First row (newer sort_at) is the repost; second is the original post.
+        assertThat(content.get(0).get("sharedById").asLong()).isEqualTo(sharerId);
+        assertThat(content.get(1).get("sharedById").isNull()).isTrue();
+    }
+
+    @Test
+    void followingFeed_paginationStability_acrossRepostTies() throws Exception {
+        // Two distinct sharers repost the same post in rapid succession.
+        // Pagination must not drop or duplicate rows when the merged
+        // ORDER BY sees (sort_at, id) tied between the two repost rows;
+        // share_row_id breaks the tie.
+        String viewerToken = registerAndLogin("ties_view_viewer@test.com", true);
+        String sharer1 = registerAndLogin("ties_view_sharer1@test.com", true);
+        String sharer2 = registerAndLogin("ties_view_sharer2@test.com", true);
+        String authorToken = registerAndLogin("ties_view_author@test.com", true);
+        Long s1 = userRepository.findByEmail("ties_view_sharer1@test.com").orElseThrow().getId();
+        Long s2 = userRepository.findByEmail("ties_view_sharer2@test.com").orElseThrow().getId();
+
+        mockMvc.perform(post("/api/users/" + s1 + "/follow")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isCreated());
+        mockMvc.perform(post("/api/users/" + s2 + "/follow")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isCreated());
+
+        long pid = createPost(authorToken, "ties post", List.of());
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharer1))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/feed/posts/" + pid + "/reposts")
+                        .header("Authorization", "Bearer " + sharer2))
+                .andExpect(status().isOk());
+
+        // size=1 to force pagination; assert page 0 + page 1 together return
+        // exactly {s1, s2} share rows with no duplication or omission.
+        MvcResult page0 = mockMvc.perform(get("/api/feed/following")
+                        .param("size", "1").param("page", "0")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk()).andReturn();
+        MvcResult page1 = mockMvc.perform(get("/api/feed/following")
+                        .param("size", "1").param("page", "1")
+                        .header("Authorization", "Bearer " + viewerToken))
+                .andExpect(status().isOk()).andReturn();
+        Long sharedBy0 = objectMapper.readTree(page0.getResponse().getContentAsString())
+                .get("content").get(0).get("sharedById").asLong();
+        Long sharedBy1 = objectMapper.readTree(page1.getResponse().getContentAsString())
+                .get("content").get(0).get("sharedById").asLong();
+        assertThat(java.util.Set.of(sharedBy0, sharedBy1)).containsExactlyInAnyOrder(s1, s2);
+    }
 }

--- a/backend/src/test/java/com/group7/backend/integration/FeedRealtimeIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedRealtimeIntegrationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.group7.backend.dto.request.LoginRequest;
 import com.group7.backend.dto.request.RegisterRequest;
 import com.group7.backend.dto.response.FeedPostPushPayload;
+import com.group7.backend.dto.response.FeedSharePushPayload;
 import com.group7.backend.dto.response.FeedUnreadCountResponse;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.FollowRepository;
@@ -175,6 +176,111 @@ class FeedRealtimeIntegrationTest {
 
         boolean rejected = handler.rejection.await(5, TimeUnit.SECONDS);
         assertThat(rejected).isTrue();
+    }
+
+    @Test
+    void followerReceivesFeedSharePushPayload_onBareRepost() throws Exception {
+        // Author posts; follower follows the sharer (a third party); sharer
+        // reposts the post. Follower receives FeedSharePushPayload on
+        // /topic/feed.{followerId}.
+        Pair pair = setupAuthorAndFollower();
+        // Re-purpose: sharer = follower here (they are a follower of the
+        // author and ALSO the sharer of the resulting repost). The setup
+        // suffices.
+        String authorToken = pair.authorToken();
+        String sharerToken = pair.followerToken();
+        Long sharerId = pair.followerId();
+
+        // Register a third party who follows the sharer so the fanout fires.
+        String observerToken = registerAndLogin("ws_repost_observer@test.com", false, "Observer");
+        Long observerId = userRepository.findByEmail("ws_repost_observer@test.com").orElseThrow().getId();
+        ResponseEntity<String> followResponse = restTemplate.exchange(
+                "http://localhost:" + port + "/api/users/" + sharerId + "/follow",
+                HttpMethod.POST, authedJson(observerToken, null), String.class);
+        assertThat(followResponse.getStatusCode().is2xxSuccessful()).isTrue();
+
+        StompSession session = connect(observerToken);
+        LinkedBlockingDeque<FeedSharePushPayload> received = new LinkedBlockingDeque<>();
+        session.subscribe("/topic/feed." + observerId, new StompFrameHandler() {
+            @Override public Type getPayloadType(StompHeaders headers) { return FeedSharePushPayload.class; }
+            @Override public void handleFrame(StompHeaders headers, Object payload) {
+                if (payload instanceof FeedSharePushPayload p) {
+                    received.add(p);
+                }
+            }
+        });
+        Thread.sleep(2000);
+
+        // Author posts.
+        ResponseEntity<String> createResponse = restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts",
+                HttpMethod.POST,
+                authedJson(authorToken, Map.of(
+                        "body", "Reposted via STOMP",
+                        "hashtags", java.util.List.of())),
+                String.class);
+        assertThat(createResponse.getStatusCode().value()).isEqualTo(201);
+        Long postId = objectMapper.readTree(createResponse.getBody()).get("id").asLong();
+
+        // Sharer reposts.
+        ResponseEntity<String> repostResponse = restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + postId + "/reposts",
+                HttpMethod.POST, authedJson(sharerToken, java.util.Map.of()), String.class);
+        assertThat(repostResponse.getStatusCode().value()).isEqualTo(200);
+
+        FeedSharePushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered.postId()).isEqualTo(postId);
+        assertThat(delivered.sharerId()).isEqualTo(sharerId);
+        assertThat(delivered.sharerFirstName()).isEqualTo("Follower");  // setupAuthorAndFollower names the follower "Follower"
+        assertThat(delivered.commentary()).isNull();   // bare repost
+        assertThat(delivered.sharedAt()).isNotNull();
+
+        session.disconnect();
+    }
+
+    @Test
+    void followerReceivesFeedSharePushPayload_onQuoteShareWithCommentary() throws Exception {
+        Pair pair = setupAuthorAndFollower();
+        String authorToken = pair.authorToken();
+        String sharerToken = pair.followerToken();
+        Long sharerId = pair.followerId();
+
+        String observerToken = registerAndLogin("ws_quote_observer@test.com", false, "Observer");
+        Long observerId = userRepository.findByEmail("ws_quote_observer@test.com").orElseThrow().getId();
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/users/" + sharerId + "/follow",
+                HttpMethod.POST, authedJson(observerToken, null), String.class);
+
+        StompSession session = connect(observerToken);
+        LinkedBlockingDeque<FeedSharePushPayload> received = new LinkedBlockingDeque<>();
+        session.subscribe("/topic/feed." + observerId, new StompFrameHandler() {
+            @Override public Type getPayloadType(StompHeaders headers) { return FeedSharePushPayload.class; }
+            @Override public void handleFrame(StompHeaders headers, Object payload) {
+                if (payload instanceof FeedSharePushPayload p) {
+                    received.add(p);
+                }
+            }
+        });
+        Thread.sleep(2000);
+
+        ResponseEntity<String> createResponse = restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts",
+                HttpMethod.POST,
+                authedJson(authorToken, Map.of("body", "to be quoted", "hashtags", java.util.List.of())),
+                String.class);
+        Long postId = objectMapper.readTree(createResponse.getBody()).get("id").asLong();
+
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + postId + "/reposts",
+                HttpMethod.POST, authedJson(sharerToken, Map.of("body", "my added commentary")),
+                String.class);
+
+        FeedSharePushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered.commentary()).isEqualTo("my added commentary");
+
+        session.disconnect();
     }
 
     @Test


### PR DESCRIPTION
Closes #484.

## Summary

Introduces two new sharing modes — bare repost and quote-share — through a brand-new `POST /api/feed/posts/{id}/reposts` endpoint, while preserving the existing silent `POST /share` endpoint's contract verbatim. The Following feed is rewritten as a UNION ALL so reposts from followed users surface alongside original posts with "shared by X" attribution.

| Mode | Endpoint | Effect |
|---|---|---|
| Silent (existing) | `POST /api/feed/posts/{id}/share` | DB row, no fanout. **Contract preserved exactly.** The `FEED_SHARE` notification side-effect from PR #495 (#482) stays as-is. |
| Bare repost | `POST /api/feed/posts/{id}/reposts` (no body) | DB row + STOMP fanout to sharer's followers + author notified |
| Quote-share | `POST /api/feed/posts/{id}/reposts` `{"body": "…"}` | DB row + commentary + fanout + author notified |

The Following feed surfaces both branches: a viewer following both the post's author and a separate sharer will see the post twice — once chronological at post creation, once at share time. This is deliberate; frontend may collapse if desired.

## Commits

| Commit | Scope |
|---|---|
| [`77dc8e2`](../commit/77dc8e2) | V40 migration: `body VARCHAR(2000)`, `is_repost BOOLEAN NOT NULL DEFAULT FALSE`, partial index, 2 CHECK constraints |
| [`7f3dac7`](../commit/7f3dac7) | `FeedPostShare` entity + `FeedPostShareRepository.findRecentRepost` (null-safe `IS NOT DISTINCT FROM`) |
| [`0618692`](../commit/0618692) | Repost endpoint + `recordRepost` service + `FeedPostSharedEvent` + `FeedFanoutListener.onFeedPostShared` + `CreateRepostRequest` + `FeedSharePushPayload` + rate-limit rule + 9 interaction integration tests |
| [`ba471a6`](../commit/ba471a6) | UNION ALL `findFollowingFeed` + `FollowingFeedRow` projection + `FeedReadService.followingFeed` parallel mapper + `FeedPostListItem` 4 new nullable fields + 5 Following integration tests |
| [`b9f07fe`](../commit/b9f07fe) | 2 STOMP fanout integration tests against real WebSocket + Postgres |

## API surface changes

| Method | Path | What changed |
|---|---|---|
| `POST` | `/api/feed/posts/{id:\d+}/reposts` | **New endpoint.** Empty body → bare repost; `{"body":"..."}` → quote-share. Both fan out to sharer's followers via `/topic/feed.{userId}` STOMP and notify the post author. Soft-idempotent within a configurable 60s window. Accepts `Idempotency-Key` header (currently ignored; future-compatible). |
| `POST` | `/api/feed/posts/{id:\d+}/share` | **Unchanged.** Still writes `(is_repost=FALSE, body=NULL)`. |
| `GET` | `/api/feed/following` | Now surfaces reposts from followed users. The slim `FeedPostListItem` payload gains four nullable fields (`sharedById`, `sharedByFirstName`, `shareCommentary`, `sharedAt`) populated only on repost rows. Additive — non-repost clients ignore. |

## Migration V40

```sql
ALTER TABLE feed_post_shares
    ADD COLUMN body      VARCHAR(2000),
    ADD COLUMN is_repost BOOLEAN NOT NULL DEFAULT FALSE;

CREATE INDEX idx_feed_post_shares_sharer_repost_created
    ON feed_post_shares (sharer_id, created_at DESC)
    WHERE is_repost = TRUE;

ALTER TABLE feed_post_shares
    ADD CONSTRAINT feed_post_shares_body_length      CHECK (body IS NULL OR length(body) <= 2000),
    ADD CONSTRAINT feed_post_shares_body_nonblank    CHECK (body IS NULL OR body !~ '^\s*$');
```

**Flyway out-of-order caveat:** PR #497 (#438 advanced For-You feed) jumped from V39 → V47 / V48, leaving V40–V46 open. This PR uses V40. `spring.flyway.out-of-order` is NOT set in `application.properties`. For fresh / migration-clean environments (CI, local dev with the test profile's `clean-disabled=false`), V40 applies cleanly. Any deployed environment that already has V47 / V48 applied will need `spring.flyway.out-of-order=true` set before this PR can deploy — flagged here for reviewers to decide whether to ship that flag in this PR or a follow-up.

## Idempotency contract

A duplicate `(post_id, sharer_id, body)` write inside `app.feed.repost.idempotency-window` (default `PT60S`, env-overrideable) collapses to the existing row — same response, no second fanout, no second notification. `NULL` bodies match `NULL` bodies (Postgres `IS NOT DISTINCT FROM`). The race where two simultaneous identical requests both pass the check is a known v1 limitation: realistic client retries are serialised by the network round-trip. Tests deliberately do not enforce simultaneity behaviour.

`Idempotency-Key` request header is accepted (no 4xx) but not yet enforced — clients can adopt it without a contract change later.

## Rate limiting

New property-driven rule alongside the existing `feed-share`:

```
app.ratelimit.rules.feed-repost.method=POST
app.ratelimit.rules.feed-repost.pattern=/api/feed/posts/*/reposts
app.ratelimit.rules.feed-repost.key-strategy=USER
app.ratelimit.rules.feed-repost.capacity=${APP_FEED_REPOST_CAPACITY:30}
app.ratelimit.rules.feed-repost.refill=PT1M
```

Tighter than the 60/min `/share` cap because every repost triggers a STOMP broadcast to all of the sharer's followers and carries higher abuse cost than an analytics-only event.

## Following-feed read path

`findFollowingFeed` is now a UNION ALL over:

- Original posts authored by users the viewer follows (`shared_*` columns NULL).
- Posts reposted by users the viewer follows (`is_repost = TRUE`).

`share_row_id` participates in `ORDER BY` as a unique tiebreaker so two reposts of the same post in the same millisecond paginate stably. The mapper batch-resolves authors and sharers in a single `findAllById` call and lazily loads hashtags through the `FeedPost` entity (`@BatchSize(100)` collapses the per-page load). Spring Data interface projections on native queries materialise `TIMESTAMPTZ` as `java.time.Instant`; the mapper converts at UTC before populating `OffsetDateTime` fields on the DTO.

## Test coverage

Local `mvn --batch-mode verify` on Postgres 16: **1770 tests, 0 failures, 0 errors**, JaCoCo coverage gate met.

- 9 new repost integration tests in `FeedInteractionIntegrationTest`: bare / quote / 404 / self-skip / idempotency / `Idempotency-Key` accept-but-ignore / oversize / blank / empty-JSON / silent-share regression guard.
- 5 new Following-feed tests in `FeedReadIntegrationTest`: repost surfacing / quote commentary / silent-share NOT surfacing / both branches / pagination stability across ties.
- 2 new STOMP fanout tests in `FeedRealtimeIntegrationTest`: bare repost and quote-share end-to-end against real WebSocket.

## Cross-PR coordination

OpenAPI examples are inlined (`@ExampleObject(value = "{}")` and the quote-share JSON literal) rather than referenced from a shared `FeedApiExamples` constants class. The reason: `FeedApiExamples` lives in open PR #499 (#489 API ergonomics) and hasn't merged to `dev` yet. A follow-up after #499 merges can consolidate.

## Out of scope (deliberate)

- AS 2.0 `Announce` JSON-LD serialisation — sibling issue #490.
- `Idempotency-Key` enforcement (server-side replay cache) — v1 accepts the header, ignores it.
- Repost chain resolution — frontend sends the canonical post id.
- For-You ranker integration — reposted posts already participate via the original post's `follow-boost` signal.
- Repost un-do / soft-delete — `feed_post_shares` has no `deleted_at` column. Hard `DELETE` is a follow-up.

## Test plan

- [ ] Backend CI green on the PR.
- [ ] Hit `POST /api/feed/posts/{id}/reposts` with empty body — verify DB row has `is_repost=TRUE, body=NULL` and a `FEED_SHARE` notification fires for the author.
- [ ] Hit `POST /api/feed/posts/{id}/reposts -d '{"body":"x"}'` — verify body persisted and STOMP frame carries the commentary.
- [ ] Repeat the same `(post, body)` within 60s — verify only one DB row.
- [ ] `GET /api/feed/following` as a follower of the sharer — verify the post appears with `sharedById`, `sharedByFirstName`, `sharedAt` populated.
- [ ] `POST /share` regression — verify existing client behaviour unchanged.