### PR TITLE
test(backend): unit coverage for FeedInteractionService and FeedReadService (#488)

### DIFF
--- a/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
@@ -801,6 +801,8 @@ class FeedReadIntegrationTest {
         Long sharedBy1 = objectMapper.readTree(page1.getResponse().getContentAsString())
                 .get("content").get(0).get("sharedById").asLong();
         assertThat(java.util.Set.of(sharedBy0, sharedBy1)).containsExactlyInAnyOrder(s1, s2);
+    }
+
     // ── Search filters: date range and language ─────────────────────────────
 
     @Test

--- a/backend/src/test/java/com/group7/backend/service/FeedInteractionServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedInteractionServiceTest.java
@@ -1,0 +1,518 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.FeedCommentResponse;
+import com.group7.backend.dto.response.FeedPostInteractionState;
+import com.group7.backend.entity.FeedPost;
+import com.group7.backend.entity.FeedPostComment;
+import com.group7.backend.entity.FeedPostShare;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.FeedPostBookmarkRepository;
+import com.group7.backend.repository.FeedPostCommentRepository;
+import com.group7.backend.repository.FeedPostLikeRepository;
+import com.group7.backend.repository.FeedPostRepository;
+import com.group7.backend.repository.FeedPostShareRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.projection.PostCountTuple;
+import com.group7.backend.service.FeedInteractionService.PostCounts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for {@link FeedInteractionService}. Mocks every repository
+ * and the two publisher facades so each test exercises one branch of the
+ * service's control flow without standing up Spring or Postgres.
+ *
+ * <p>Three patterns recur throughout the suite:
+ * <ul>
+ *   <li>The {@code requireVisiblePost} guard surfaces as a 404 from every
+ *       write path — covered once per surface (like, bookmark, share,
+ *       comment, getComment) so a regression there can't slip through any
+ *       single surface unnoticed.</li>
+ *   <li>The self-vs-other notification carve-out (author skips their own
+ *       like / comment / share) is asserted on each surface separately
+ *       because each surface has its own publisher call.</li>
+ *   <li>State after a toggle is read back through
+ *       {@link FeedInteractionService#interactionState} — the count + flag
+ *       queries are mocked there rather than re-asserted on every test.</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class FeedInteractionServiceTest {
+
+    @Mock private FeedPostRepository feedPostRepository;
+    @Mock private FeedPostLikeRepository likeRepository;
+    @Mock private FeedPostBookmarkRepository bookmarkRepository;
+    @Mock private FeedPostShareRepository shareRepository;
+    @Mock private FeedPostCommentRepository commentRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private FeedPostMapper feedPostMapper;
+    @Mock private NotificationEventPublisher notificationEventPublisher;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private FeedInteractionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FeedInteractionService(
+                feedPostRepository,
+                likeRepository,
+                bookmarkRepository,
+                shareRepository,
+                commentRepository,
+                userRepository,
+                feedPostMapper,
+                notificationEventPublisher,
+                eventPublisher);
+    }
+
+    // ── toggleLike ─────────────────────────────────────────────────────────
+
+    @Test
+    void toggleLike_throws404_whenPostMissingOrSoftDeleted() {
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.toggleLike(7L, 1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(likeRepository, never()).upsertLike(anyLong(), anyLong());
+        verify(notificationEventPublisher, never()).publishFeedLike(anyLong(), any(), anyLong());
+    }
+
+    @Test
+    void toggleLike_firstCall_insertsAndNotifiesNonSelfAuthor() {
+        FeedPost post = freshPost(7L, 99L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        // First existsBy call (in toggleLike) → not yet liked, so service
+        // hits the upsert branch. The second call (inside interactionState)
+        // → returns true because the row now exists in production. Mockito's
+        // sequenced thenReturn(...) reproduces that flip without a real DB.
+        when(likeRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(false, true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
+
+        FeedPostInteractionState state = service.toggleLike(7L, 1L);
+
+        verify(likeRepository).upsertLike(7L, 1L);
+        verify(likeRepository, never()).deleteById(any());
+        verify(notificationEventPublisher).publishFeedLike(eq(99L), any(), eq(7L));
+        assertThat(state.viewerHasLiked()).isTrue();
+    }
+
+    @Test
+    void toggleLike_secondCall_deletesAndSkipsNotification() {
+        FeedPost post = freshPost(7L, 99L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        // First existsBy → already liked; second (inside interactionState
+        // after the row is gone) → false.
+        when(likeRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(true, false);
+
+        FeedPostInteractionState state = service.toggleLike(7L, 1L);
+
+        verify(likeRepository).deleteById(any());
+        verify(likeRepository, never()).upsertLike(anyLong(), anyLong());
+        // Unliking never produces a notification — only the insert path does.
+        verify(notificationEventPublisher, never()).publishFeedLike(anyLong(), any(), anyLong());
+        assertThat(state.viewerHasLiked()).isFalse();
+    }
+
+    @Test
+    void toggleLike_selfLike_skipsNotificationButStillInserts() {
+        FeedPost post = freshPost(7L, 1L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(likeRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(false);
+
+        service.toggleLike(7L, 1L);
+
+        verify(likeRepository).upsertLike(7L, 1L);
+        // Self-like → no notification fires.
+        verify(notificationEventPublisher, never()).publishFeedLike(anyLong(), any(), anyLong());
+    }
+
+    // ── toggleBookmark ─────────────────────────────────────────────────────
+
+    @Test
+    void toggleBookmark_throws404_whenPostMissing() {
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.toggleBookmark(7L, 1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(bookmarkRepository, never()).upsertBookmark(anyLong(), anyLong());
+    }
+
+    @Test
+    void toggleBookmark_firstCall_inserts() {
+        FeedPost post = freshPost(7L, 99L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        // Flip mirrors the toggleLike test: first call (in toggle) returns
+        // false, second call (in interactionState after the upsert) returns
+        // true.
+        when(bookmarkRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(false, true);
+
+        FeedPostInteractionState state = service.toggleBookmark(7L, 1L);
+
+        verify(bookmarkRepository).upsertBookmark(7L, 1L);
+        assertThat(state.viewerHasBookmarked()).isTrue();
+    }
+
+    @Test
+    void toggleBookmark_secondCall_deletes() {
+        FeedPost post = freshPost(7L, 99L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(bookmarkRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(true, false);
+
+        FeedPostInteractionState state = service.toggleBookmark(7L, 1L);
+
+        verify(bookmarkRepository).deleteById(any());
+        assertThat(state.viewerHasBookmarked()).isFalse();
+    }
+
+    // ── recordShare ────────────────────────────────────────────────────────
+
+    @Test
+    void recordShare_throws404_whenPostMissing() {
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.recordShare(7L, 1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(shareRepository, never()).save(any());
+    }
+
+    @Test
+    void recordShare_notifiesNonSelfAuthor() {
+        FeedPost post = freshPost(7L, 99L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
+
+        service.recordShare(7L, 1L);
+
+        verify(shareRepository).save(any(FeedPostShare.class));
+        verify(notificationEventPublisher).publishFeedShare(eq(99L), any(), eq(7L));
+    }
+
+    @Test
+    void recordShare_selfShare_skipsNotification() {
+        FeedPost post = freshPost(7L, 1L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+
+        service.recordShare(7L, 1L);
+
+        verify(shareRepository).save(any(FeedPostShare.class));
+        verify(notificationEventPublisher, never()).publishFeedShare(anyLong(), any(), anyLong());
+    }
+
+    // ── addComment ─────────────────────────────────────────────────────────
+
+    @Test
+    void addComment_throws404_whenPostMissing() {
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addComment(7L, 1L, "hello"))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(commentRepository, never()).save(any());
+    }
+
+    @Test
+    void addComment_throws400_onBlankBody() {
+        FeedPost post = freshPost(7L, 99L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+
+        assertThatThrownBy(() -> service.addComment(7L, 1L, "   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be blank");
+
+        verify(commentRepository, never()).save(any());
+        verify(notificationEventPublisher, never()).publishFeedComment(anyLong(), any(), anyLong());
+    }
+
+    @Test
+    void addComment_throws400_onNullBody() {
+        FeedPost post = freshPost(7L, 99L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+
+        assertThatThrownBy(() -> service.addComment(7L, 1L, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void addComment_savesAndNotifiesNonSelfAuthor() {
+        FeedPost post = freshPost(7L, 99L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
+        when(commentRepository.save(any(FeedPostComment.class))).thenAnswer(inv -> {
+            FeedPostComment c = inv.getArgument(0);
+            c.setId(42L);
+            return c;
+        });
+
+        FeedCommentResponse result = service.addComment(7L, 1L, "great post");
+
+        verify(commentRepository).save(any(FeedPostComment.class));
+        verify(notificationEventPublisher).publishFeedComment(eq(99L), any(), eq(7L));
+        assertThat(result.id()).isEqualTo(42L);
+    }
+
+    @Test
+    void addComment_selfComment_skipsNotification() {
+        FeedPost post = freshPost(7L, 1L);
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
+        when(commentRepository.save(any(FeedPostComment.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.addComment(7L, 1L, "self-comment");
+
+        verify(notificationEventPublisher, never()).publishFeedComment(anyLong(), any(), anyLong());
+    }
+
+    // ── editComment ────────────────────────────────────────────────────────
+
+    @Test
+    void editComment_throws404_whenCommentMissing() {
+        when(commentRepository.findById(42L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.editComment(42L, 1L, "new"))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void editComment_throws403_whenRequesterIsNotAuthor() {
+        FeedPostComment c = freshComment(42L, 7L, 1L, "old");
+        when(commentRepository.findById(42L)).thenReturn(Optional.of(c));
+
+        assertThatThrownBy(() -> service.editComment(42L, 999L, "new"))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(commentRepository, never()).save(any());
+    }
+
+    @Test
+    void editComment_throws404_whenSoftDeleted() {
+        FeedPostComment c = freshComment(42L, 7L, 1L, "old");
+        c.setDeletedAt(OffsetDateTime.now().minusHours(1));
+        when(commentRepository.findById(42L)).thenReturn(Optional.of(c));
+
+        assertThatThrownBy(() -> service.editComment(42L, 1L, "new"))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void editComment_throws400_onBlankBody() {
+        FeedPostComment c = freshComment(42L, 7L, 1L, "old");
+        when(commentRepository.findById(42L)).thenReturn(Optional.of(c));
+
+        assertThatThrownBy(() -> service.editComment(42L, 1L, "   "))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(commentRepository, never()).save(any());
+    }
+
+    @Test
+    void editComment_updatesBodyAndUpdatedAt() {
+        FeedPostComment c = freshComment(42L, 7L, 1L, "old");
+        OffsetDateTime originalUpdated = c.getUpdatedAt();
+        when(commentRepository.findById(42L)).thenReturn(Optional.of(c));
+        when(commentRepository.save(c)).thenReturn(c);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
+
+        service.editComment(42L, 1L, "new body");
+
+        assertThat(c.getBody()).isEqualTo("new body");
+        assertThat(c.getUpdatedAt()).isAfterOrEqualTo(originalUpdated);
+        verify(commentRepository).save(c);
+    }
+
+    // ── deleteComment ──────────────────────────────────────────────────────
+
+    @Test
+    void deleteComment_throws404_whenCommentMissing() {
+        when(commentRepository.findById(42L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.deleteComment(42L, 1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void deleteComment_throws403_whenRequesterIsNotAuthor() {
+        FeedPostComment c = freshComment(42L, 7L, 1L, "x");
+        when(commentRepository.findById(42L)).thenReturn(Optional.of(c));
+
+        assertThatThrownBy(() -> service.deleteComment(42L, 999L))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(commentRepository, never()).save(any());
+    }
+
+    @Test
+    void deleteComment_setsDeletedAt_andSaves() {
+        FeedPostComment c = freshComment(42L, 7L, 1L, "x");
+        when(commentRepository.findById(42L)).thenReturn(Optional.of(c));
+        when(commentRepository.save(c)).thenReturn(c);
+
+        service.deleteComment(42L, 1L);
+
+        assertThat(c.getDeletedAt()).isNotNull();
+        verify(commentRepository).save(c);
+    }
+
+    @Test
+    void deleteComment_isIdempotent_whenAlreadySoftDeleted() {
+        FeedPostComment c = freshComment(42L, 7L, 1L, "x");
+        OffsetDateTime priorDelete = OffsetDateTime.now().minusHours(2);
+        c.setDeletedAt(priorDelete);
+        when(commentRepository.findById(42L)).thenReturn(Optional.of(c));
+
+        service.deleteComment(42L, 1L);
+
+        // Same deletedAt — the service short-circuits without re-saving.
+        assertThat(c.getDeletedAt()).isEqualTo(priorDelete);
+        verify(commentRepository, never()).save(any());
+    }
+
+    // ── getComment (permalink) ─────────────────────────────────────────────
+
+    @Test
+    void getComment_throws404_whenCommentMissingOrSoftDeleted() {
+        when(commentRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getComment(42L, 1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void getComment_throws404_whenParentPostSoftDeleted() {
+        FeedPostComment c = freshComment(42L, 7L, 1L, "x");
+        when(commentRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(c));
+        // Parent post invisible → orphan-permalink guard fires.
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getComment(42L, 1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void getComment_returnsDto_whenBothVisible() {
+        FeedPostComment c = freshComment(42L, 7L, 1L, "body");
+        when(commentRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(c));
+        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L))
+                .thenReturn(Optional.of(freshPost(7L, 99L)));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
+
+        FeedCommentResponse result = service.getComment(42L, 1L);
+
+        assertThat(result.id()).isEqualTo(42L);
+        assertThat(result.body()).isEqualTo("body");
+    }
+
+    // ── interactionState ───────────────────────────────────────────────────
+
+    @Test
+    void interactionState_withViewer_consultsAllRepositories() {
+        when(likeRepository.countByIdPostId(7L)).thenReturn(5L);
+        when(bookmarkRepository.countByIdPostId(7L)).thenReturn(2L);
+        when(shareRepository.countByPostId(7L)).thenReturn(3L);
+        when(commentRepository.countByPostIdAndDeletedAtIsNull(7L)).thenReturn(4L);
+        when(likeRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(true);
+        when(bookmarkRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(false);
+
+        FeedPostInteractionState state = service.interactionState(7L, 1L);
+
+        assertThat(state.likeCount()).isEqualTo(5L);
+        assertThat(state.commentCount()).isEqualTo(4L);
+        assertThat(state.shareCount()).isEqualTo(3L);
+        assertThat(state.bookmarkCount()).isEqualTo(2L);
+        assertThat(state.viewerHasLiked()).isTrue();
+        assertThat(state.viewerHasBookmarked()).isFalse();
+    }
+
+    @Test
+    void interactionState_nullViewer_skipsViewerProbes() {
+        when(likeRepository.countByIdPostId(7L)).thenReturn(5L);
+        when(bookmarkRepository.countByIdPostId(7L)).thenReturn(2L);
+        when(shareRepository.countByPostId(7L)).thenReturn(3L);
+        when(commentRepository.countByPostIdAndDeletedAtIsNull(7L)).thenReturn(4L);
+
+        FeedPostInteractionState state = service.interactionState(7L, null);
+
+        // Anonymous reads skip the viewer-relative existsBy probes
+        // so the SQL footprint of the public timeline stays bounded.
+        assertThat(state.viewerHasLiked()).isFalse();
+        assertThat(state.viewerHasBookmarked()).isFalse();
+        verify(likeRepository, never()).existsByIdPostIdAndIdUserId(anyLong(), anyLong());
+        verify(bookmarkRepository, never()).existsByIdPostIdAndIdUserId(anyLong(), anyLong());
+    }
+
+    // ── batchCounts ────────────────────────────────────────────────────────
+
+    @Test
+    void batchCounts_emptyInput_returnsEmptyMapWithoutQuerying() {
+        Map<Long, PostCounts> result = service.batchCounts(List.of());
+
+        assertThat(result).isEmpty();
+        // Postgres rejects WHERE id IN () — the short-circuit prevents an
+        // exception masquerading as a count query.
+        verify(likeRepository, never()).countByPostIdIn(any());
+        verify(commentRepository, never()).countVisibleByPostIdIn(any());
+    }
+
+    @Test
+    void batchCounts_emitsZerosForPostsWithNoLikesOrComments() {
+        // postId 7 has 5 likes + 4 comments; postId 8 has nothing → assert
+        // the second id surfaces as (0, 0) rather than being absent.
+        when(likeRepository.countByPostIdIn(any())).thenReturn(List.of(new PostCountTuple(7L, 5L)));
+        when(commentRepository.countVisibleByPostIdIn(any())).thenReturn(List.of(new PostCountTuple(7L, 4L)));
+
+        Map<Long, PostCounts> result = service.batchCounts(List.of(7L, 8L));
+
+        assertThat(result).containsOnlyKeys(7L, 8L);
+        assertThat(result.get(7L)).isEqualTo(new PostCounts(5L, 4L));
+        assertThat(result.get(8L)).isEqualTo(new PostCounts(0L, 0L));
+    }
+
+    // ── Fixtures ───────────────────────────────────────────────────────────
+
+    private static Mentor mentor(Long id) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName("U" + id);
+        return m;
+    }
+
+    private static FeedPost freshPost(Long id, Long authorId) {
+        FeedPost p = new FeedPost(authorId, "body");
+        p.setId(id);
+        OffsetDateTime now = OffsetDateTime.now();
+        p.setCreatedAt(now);
+        p.setUpdatedAt(now);
+        return p;
+    }
+
+    private static FeedPostComment freshComment(Long id, Long postId, Long authorId, String body) {
+        FeedPostComment c = new FeedPostComment(postId, authorId, body);
+        c.setId(id);
+        OffsetDateTime now = OffsetDateTime.now();
+        c.setCreatedAt(now);
+        c.setUpdatedAt(now);
+        return c;
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/FeedInteractionServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedInteractionServiceTest.java
@@ -8,6 +8,7 @@ import com.group7.backend.entity.FeedPostShare;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.FeedPostBookmarkRepository;
+import com.group7.backend.repository.FeedPostCommentLikeRepository;
 import com.group7.backend.repository.FeedPostCommentRepository;
 import com.group7.backend.repository.FeedPostLikeRepository;
 import com.group7.backend.repository.FeedPostRepository;
@@ -23,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.AccessDeniedException;
 
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +66,7 @@ class FeedInteractionServiceTest {
     @Mock private FeedPostBookmarkRepository bookmarkRepository;
     @Mock private FeedPostShareRepository shareRepository;
     @Mock private FeedPostCommentRepository commentRepository;
+    @Mock private FeedPostCommentLikeRepository commentLikeRepository;
     @Mock private UserRepository userRepository;
     @Mock private FeedPostMapper feedPostMapper;
     @Mock private NotificationEventPublisher notificationEventPublisher;
@@ -73,16 +76,24 @@ class FeedInteractionServiceTest {
 
     @BeforeEach
     void setUp() {
+        // 60s repost idempotency matches the production default
+        // (app.feed.repost.idempotency-window=PT60S). None of the toggle /
+        // comment / share / count tests below exercise the repost path, so
+        // the exact value doesn't affect assertions — pinning it to the
+        // production default keeps reads of this test in sync with the
+        // shipped behaviour.
         service = new FeedInteractionService(
                 feedPostRepository,
                 likeRepository,
                 bookmarkRepository,
                 shareRepository,
                 commentRepository,
+                commentLikeRepository,
                 userRepository,
                 feedPostMapper,
                 notificationEventPublisher,
-                eventPublisher);
+                eventPublisher,
+                Duration.ofSeconds(60));
     }
 
     // ── toggleLike ─────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
@@ -413,16 +413,19 @@ class FeedReadServiceTest {
     }
 
     /**
-     * 14-arg FeedPostListItem — the four share-metadata fields default to
-     * null because every test fixture here represents the non-repost
-     * surface. Specific tests that need to assert repost-attribution
-     * fields stub the projection directly rather than going through this
-     * helper.
+     * 16-arg FeedPostListItem — the viewer-relative flags default to
+     * false (#532) and the four share-metadata fields default to null
+     * (#531) because every test fixture here represents the
+     * non-repost, no-viewer-interaction surface. Specific tests that
+     * need to assert repost-attribution or viewer flags stub the
+     * projection directly rather than going through this helper.
      */
     private static FeedPostListItem listItem(Long id, Long authorId) {
         return new FeedPostListItem(
-                id, authorId, "U" + authorId, "body", List.of(),
-                OffsetDateTime.now(), 0L, 0L, List.of(), List.of(),
+                id, authorId, "U" + authorId, "body", List.<String>of(),
+                OffsetDateTime.now(), 0L, 0L, List.<String>of(),
+                List.<com.group7.backend.dto.response.AttachmentSummary>of(),
+                false, false,
                 null, null, null, null);
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
@@ -3,9 +3,11 @@ package com.group7.backend.service;
 import com.group7.backend.dto.response.FeedPostListItem;
 import com.group7.backend.entity.FeedPost;
 import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
 import com.group7.backend.repository.FeedPostRepository;
 import com.group7.backend.repository.FollowRepository;
 import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.projection.FollowingFeedRow;
 import com.group7.backend.service.FeedInteractionService.PostCounts;
 import com.group7.backend.service.ranking.FeedRanker;
 import com.group7.backend.service.ranking.FeedScoreResult;
@@ -15,11 +17,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +42,8 @@ import static org.mockito.Mockito.when;
 
 /**
  * Unit coverage for {@link FeedReadService}. Mocks the repositories, the
- * ranker, the interaction service (for batch counts), and the mapper.
+ * ranker, the interaction service (for batch counts), the mapper, and the
+ * keyword-mute service that {@code mapPage} consults on every read path.
  *
  * <p>The two interesting branches in {@link FeedReadService#forYouFeed}
  * are the empty-candidate short-circuit and the legacy Schwartzian
@@ -47,12 +52,23 @@ import static org.mockito.Mockito.when;
  * stands up a real ranker; mocking the pipeline through here adds little
  * over what those integration tests already pin.
  *
- * <p>Search has three branches worth pinning: both filters missing (400),
- * a hashtag that fails normalisation (empty page rather than error), and
- * the happy keyword + hashtag path that routes through the repository
- * with the normalised values.
+ * <p>Search branches worth pinning at the unit level: every-filter-missing
+ * (400), {@code since}/{@code until} window validation (400 when reversed,
+ * 400 when outside the 10y past / 1d future window), {@code lang} pass-
+ * through, hashtag-fails-normalisation empty page, and the keyword escape
+ * + lowercase contract that protects against LIKE-pattern injection. The
+ * date and lang filters arrived with #527 and weren't pinned by the
+ * original PR #533 fixture; the missing coverage is filled in here.
+ *
+ * <p>Strictness is dialled down to LENIENT for one reason only: the
+ * {@code keywordMuteService} stub in {@link #setUp} feeds the no-op
+ * pass-through that every read path consults via {@code mapPage} →
+ * {@code keywordMuteService.filter}. Forcing every test to re-stub it
+ * just to keep STRICT_STUBS quiet would be noise — the pass-through is a
+ * test-harness artefact, not behaviour under test.
  */
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class FeedReadServiceTest {
 
     @Mock private FeedPostRepository feedPostRepository;
@@ -62,11 +78,19 @@ class FeedReadServiceTest {
     @Mock private FeedRanker feedRanker;
     @Mock private FeedInteractionService feedInteractionService;
     @Mock private FeedPostMapper feedPostMapper;
+    @Mock private UserKeywordMuteService keywordMuteService;
 
     private FeedReadService service;
 
     @BeforeEach
     void setUp() {
+        // No-op pass-through for the mute filter so happy-path tests don't
+        // each need to redeclare it. The two muted-content paths are
+        // exercised end-to-end by FeedReadIntegrationTest against real
+        // Postgres + a real UserKeywordMuteService.
+        when(keywordMuteService.filter(anyLong(), any()))
+                .thenAnswer(inv -> inv.getArgument(1));
+
         // Pipeline absent → service uses the legacy Schwartzian path.
         // AdvancedForYouFeedIntegrationTest stands up the pipeline against
         // real beans, so we don't duplicate that coverage here.
@@ -79,6 +103,7 @@ class FeedReadServiceTest {
                 feedInteractionService,
                 Optional.empty(),
                 feedPostMapper,
+                keywordMuteService,
                 200);
     }
 
@@ -132,32 +157,90 @@ class FeedReadServiceTest {
 
     @Test
     void followingFeed_emptyPage_shortCircuits() {
-        when(feedPostRepository.findFollowingFeed(eq(1L), any()))
-                .thenReturn(Page.empty(PageRequest.of(0, 10)));
+        Page<FollowingFeedRow> empty = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+        when(feedPostRepository.findFollowingFeed(eq(1L), any())).thenReturn(empty);
 
         Page<FeedPostListItem> page = service.followingFeed(1L, PageRequest.of(0, 10));
 
         assertThat(page.getContent()).isEmpty();
-        // Empty page short-circuits the batch-counts + mapper invocations.
+        // Empty page short-circuits the batch fetches the production path
+        // would otherwise issue — keeps the cold cache cheap.
         verify(feedInteractionService, never()).batchCounts(any());
-        verify(feedPostMapper, never()).toListItems(any(), any(), any());
+        verify(userRepository, never()).findAllById(any());
     }
 
     @Test
-    void followingFeed_populatesItemsThroughMapper() {
-        FeedPost post = freshPost(101L, 99L);
-        Page<FeedPost> repoPage = new PageImpl<>(List.of(post), PageRequest.of(0, 10), 1L);
+    void followingFeed_populatesFromProjection_originalPostBranch() {
+        // One row from the original-post branch (sharedById null). The
+        // service should batch-fetch the FeedPost (for hashtags), the
+        // author user, and counts, then assemble the FeedPostListItem.
+        FollowingFeedRow row = mock(FollowingFeedRow.class);
+        when(row.getId()).thenReturn(101L);
+        when(row.getAuthorId()).thenReturn(99L);
+        when(row.getBody()).thenReturn("post body");
+        Instant createdAt = Instant.parse("2026-05-10T10:00:00Z");
+        when(row.getCreatedAt()).thenReturn(createdAt);
+        when(row.getSharedById()).thenReturn(null);
+        when(row.getShareCommentary()).thenReturn(null);
+        when(row.getSharedAt()).thenReturn(null);
+
+        Page<FollowingFeedRow> repoPage =
+                new PageImpl<>(List.of(row), PageRequest.of(0, 10), 1L);
         when(feedPostRepository.findFollowingFeed(eq(1L), any())).thenReturn(repoPage);
-        when(feedInteractionService.batchCounts(List.of(101L))).thenReturn(
-                Map.of(101L, new PostCounts(0L, 0L)));
-        when(feedPostMapper.toListItems(eq(List.of(post)), eq(1L), any()))
-                .thenReturn(List.of(listItem(101L, 99L)));
+
+        FeedPost post = freshPost(101L, 99L);
+        when(feedPostRepository.findAllById(any())).thenReturn(List.of(post));
+
+        Mentor author = mentor(99L, "Ada");
+        when(userRepository.findAllById(any())).thenReturn(List.of(author));
+
+        when(feedInteractionService.batchCounts(any()))
+                .thenReturn(Map.of(101L, new PostCounts(2L, 1L)));
+        when(feedPostMapper.toSummaries(any())).thenReturn(List.of());
 
         Page<FeedPostListItem> page = service.followingFeed(1L, PageRequest.of(0, 10));
 
         assertThat(page.getTotalElements()).isEqualTo(1L);
-        assertThat(page.getContent()).hasSize(1);
-        verify(feedInteractionService).batchCounts(List.of(101L));
+        FeedPostListItem item = page.getContent().get(0);
+        assertThat(item.id()).isEqualTo(101L);
+        assertThat(item.authorFirstName()).isEqualTo("Ada");
+        assertThat(item.sharedById()).isNull();
+        assertThat(item.likeCount()).isEqualTo(2L);
+        assertThat(item.commentCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void followingFeed_repostBranch_threadsShareMetadataThroughDto() {
+        // Same shape, but a repost row — sharedById, shareCommentary, and
+        // sharedAt are populated. Verifies the share metadata survives the
+        // projection → DTO mapping intact.
+        FollowingFeedRow row = mock(FollowingFeedRow.class);
+        when(row.getId()).thenReturn(101L);
+        when(row.getAuthorId()).thenReturn(99L);
+        when(row.getBody()).thenReturn("reposted body");
+        when(row.getCreatedAt()).thenReturn(Instant.parse("2026-05-10T10:00:00Z"));
+        when(row.getSharedById()).thenReturn(42L);
+        when(row.getShareCommentary()).thenReturn("great take");
+        when(row.getSharedAt()).thenReturn(Instant.parse("2026-05-11T12:00:00Z"));
+
+        Page<FollowingFeedRow> repoPage =
+                new PageImpl<>(List.of(row), PageRequest.of(0, 10), 1L);
+        when(feedPostRepository.findFollowingFeed(eq(1L), any())).thenReturn(repoPage);
+
+        when(feedPostRepository.findAllById(any())).thenReturn(List.of(freshPost(101L, 99L)));
+        when(userRepository.findAllById(any())).thenReturn(List.of(
+                mentor(99L, "Ada"), mentor(42L, "Bob")));
+        when(feedInteractionService.batchCounts(any()))
+                .thenReturn(Map.of(101L, new PostCounts(0L, 0L)));
+        when(feedPostMapper.toSummaries(any())).thenReturn(List.of());
+
+        Page<FeedPostListItem> page = service.followingFeed(1L, PageRequest.of(0, 10));
+
+        FeedPostListItem item = page.getContent().get(0);
+        assertThat(item.sharedById()).isEqualTo(42L);
+        assertThat(item.sharedByFirstName()).isEqualTo("Bob");
+        assertThat(item.shareCommentary()).isEqualTo("great take");
+        assertThat(item.sharedAt()).isNotNull();
     }
 
     // ── postsByAuthor ──────────────────────────────────────────────────────
@@ -169,31 +252,35 @@ class FeedReadServiceTest {
         when(feedPostRepository.findByAuthorIdForFeed(eq(99L), any())).thenReturn(repoPage);
         when(feedInteractionService.batchCounts(List.of(101L))).thenReturn(
                 Map.of(101L, new PostCounts(0L, 0L)));
-        when(feedPostMapper.toListItems(eq(List.of(post)), eq(null), any()))
+        when(feedPostMapper.toListItems(eq(List.of(post)), eq(1L), any()))
                 .thenReturn(List.of(listItem(101L, 99L)));
 
-        Page<FeedPostListItem> page = service.postsByAuthor(99L, PageRequest.of(0, 10));
+        Page<FeedPostListItem> page = service.postsByAuthor(99L, 1L, PageRequest.of(0, 10));
 
         assertThat(page.getContent()).hasSize(1);
+        verify(feedInteractionService).batchCounts(List.of(101L));
     }
 
     // ── search ─────────────────────────────────────────────────────────────
 
     @Test
-    void search_throws400_whenBothFiltersAreNull() {
-        assertThatThrownBy(() -> service.search(null, null, PageRequest.of(0, 10)))
+    void search_throws400_whenEveryFilterIsNull() {
+        assertThatThrownBy(() -> service.search(null, null, null, null, null, 1L, PageRequest.of(0, 10)))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("at least one");
 
-        verify(feedPostRepository, never()).searchPosts(any(), any(), any());
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
     }
 
     @Test
-    void search_throws400_whenBothFiltersAreBlank() {
-        assertThatThrownBy(() -> service.search("   ", "  ", PageRequest.of(0, 10)))
+    void search_throws400_whenStringFiltersBlank_andTemporalAndLangNull() {
+        // Blank strings are normalised to null inside the service; combined
+        // with null since/until/lang, this reduces to the every-filter-null
+        // case — same 400 path.
+        assertThatThrownBy(() -> service.search("   ", "  ", null, null, null, 1L, PageRequest.of(0, 10)))
                 .isInstanceOf(IllegalArgumentException.class);
 
-        verify(feedPostRepository, never()).searchPosts(any(), any(), any());
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -204,10 +291,11 @@ class FeedReadServiceTest {
         when(hashtagNormalizer.normalize(List.of("not a valid hashtag")))
                 .thenReturn(Set.of());
 
-        Page<FeedPostListItem> page = service.search(null, "not a valid hashtag", PageRequest.of(0, 10));
+        Page<FeedPostListItem> page = service.search(
+                null, "not a valid hashtag", null, null, null, 1L, PageRequest.of(0, 10));
 
         assertThat(page.getContent()).isEmpty();
-        verify(feedPostRepository, never()).searchPosts(any(), any(), any());
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -215,24 +303,88 @@ class FeedReadServiceTest {
         // %, _, and \ are LIKE metacharacters; escaping prevents a malicious
         // q=% from matching every post. Lowercasing aligns with the
         // pg_trgm GIN index on LOWER(body).
-        when(feedPostRepository.searchPosts(eq("ja\\%va"), eq(null), any()))
+        when(feedPostRepository.searchPosts(eq("ja\\%va"), eq(null), eq(null), eq(null), eq(null), any()))
                 .thenReturn(Page.empty(PageRequest.of(0, 10)));
 
-        service.search("Ja%va", null, PageRequest.of(0, 10));
+        service.search("Ja%va", null, null, null, null, 1L, PageRequest.of(0, 10));
 
-        verify(feedPostRepository).searchPosts(eq("ja\\%va"), eq(null), any());
+        verify(feedPostRepository).searchPosts(eq("ja\\%va"), eq(null), eq(null), eq(null), eq(null), any());
     }
 
     @Test
     void search_passesNormalisedHashtagToRepository() {
         when(hashtagNormalizer.normalize(List.of("#DataScience")))
                 .thenReturn(Set.of("datascience"));
-        when(feedPostRepository.searchPosts(eq(null), eq("datascience"), any()))
+        when(feedPostRepository.searchPosts(eq(null), eq("datascience"), eq(null), eq(null), eq(null), any()))
                 .thenReturn(Page.empty(PageRequest.of(0, 10)));
 
-        service.search(null, "#DataScience", PageRequest.of(0, 10));
+        service.search(null, "#DataScience", null, null, null, 1L, PageRequest.of(0, 10));
 
-        verify(feedPostRepository).searchPosts(eq(null), eq("datascience"), any());
+        verify(feedPostRepository).searchPosts(eq(null), eq("datascience"), eq(null), eq(null), eq(null), any());
+    }
+
+    @Test
+    void search_passesLangFilterToRepository() {
+        // lang on its own is enough to escape the every-filter-missing 400
+        // guard, so this also pins the contract that lang is a first-class
+        // search axis and not just a tie-breaker behind q/hashtag.
+        when(feedPostRepository.searchPosts(eq(null), eq(null), eq(null), eq(null), eq("en"), any()))
+                .thenReturn(Page.empty(PageRequest.of(0, 10)));
+
+        service.search(null, null, null, null, "en", 1L, PageRequest.of(0, 10));
+
+        verify(feedPostRepository).searchPosts(eq(null), eq(null), eq(null), eq(null), eq("en"), any());
+    }
+
+    @Test
+    void search_throws400_whenSinceNotStrictlyBeforeUntil() {
+        // Reversed window — service rejects rather than passing a
+        // logically-empty range to the DB.
+        OffsetDateTime later = OffsetDateTime.now().plusHours(1);
+        OffsetDateTime earlier = OffsetDateTime.now().minusHours(1);
+
+        assertThatThrownBy(() -> service.search(
+                "x", null, later, earlier, null, 1L, PageRequest.of(0, 10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("strictly before");
+
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void search_throws400_whenSinceFurtherThan10YearsInPast() {
+        OffsetDateTime tooOld = OffsetDateTime.now().minusYears(15);
+
+        assertThatThrownBy(() -> service.search(
+                "x", null, tooOld, null, null, 1L, PageRequest.of(0, 10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("'since'");
+
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void search_throws400_whenUntilFurtherThan1DayInFuture() {
+        OffsetDateTime tooFar = OffsetDateTime.now().plusDays(30);
+
+        assertThatThrownBy(() -> service.search(
+                "x", null, null, tooFar, null, 1L, PageRequest.of(0, 10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("'until'");
+
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void search_passesValidWindowToRepository() {
+        OffsetDateTime since = OffsetDateTime.now().minusHours(1);
+        OffsetDateTime until = OffsetDateTime.now().plusHours(1);
+        when(feedPostRepository.searchPosts(eq(null), eq(null), eq(since), eq(until), eq(null), any()))
+                .thenReturn(Page.empty(PageRequest.of(0, 10)));
+
+        service.search(null, null, since, until, null, 1L, PageRequest.of(0, 10));
+
+        verify(feedPostRepository).searchPosts(eq(null), eq(null), eq(since), eq(until), eq(null), any());
     }
 
     // ── Fixtures ───────────────────────────────────────────────────────────
@@ -241,6 +393,13 @@ class FeedReadServiceTest {
         Mentee m = new Mentee();
         m.setId(id);
         m.setFirstName("U" + id);
+        return m;
+    }
+
+    private static Mentor mentor(Long id, String firstName) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName(firstName);
         return m;
     }
 
@@ -253,9 +412,17 @@ class FeedReadServiceTest {
         return p;
     }
 
+    /**
+     * 14-arg FeedPostListItem — the four share-metadata fields default to
+     * null because every test fixture here represents the non-repost
+     * surface. Specific tests that need to assert repost-attribution
+     * fields stub the projection directly rather than going through this
+     * helper.
+     */
     private static FeedPostListItem listItem(Long id, Long authorId) {
         return new FeedPostListItem(
                 id, authorId, "U" + authorId, "body", List.of(),
-                OffsetDateTime.now(), 0L, 0L, List.of(), List.of());
+                OffsetDateTime.now(), 0L, 0L, List.of(), List.of(),
+                null, null, null, null);
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
@@ -1,0 +1,261 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.FeedPostListItem;
+import com.group7.backend.entity.FeedPost;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.repository.FeedPostRepository;
+import com.group7.backend.repository.FollowRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.service.FeedInteractionService.PostCounts;
+import com.group7.backend.service.ranking.FeedRanker;
+import com.group7.backend.service.ranking.FeedScoreResult;
+import com.group7.backend.service.ranking.feed.ForYouScoringPipeline;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for {@link FeedReadService}. Mocks the repositories, the
+ * ranker, the interaction service (for batch counts), and the mapper.
+ *
+ * <p>The two interesting branches in {@link FeedReadService#forYouFeed}
+ * are the empty-candidate short-circuit and the legacy Schwartzian
+ * transform path. The advanced {@link ForYouScoringPipeline} path is
+ * covered separately by {@code AdvancedForYouFeedIntegrationTest}, which
+ * stands up a real ranker; mocking the pipeline through here adds little
+ * over what those integration tests already pin.
+ *
+ * <p>Search has three branches worth pinning: both filters missing (400),
+ * a hashtag that fails normalisation (empty page rather than error), and
+ * the happy keyword + hashtag path that routes through the repository
+ * with the normalised values.
+ */
+@ExtendWith(MockitoExtension.class)
+class FeedReadServiceTest {
+
+    @Mock private FeedPostRepository feedPostRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private FollowRepository followRepository;
+    @Mock private HashtagNormalizer hashtagNormalizer;
+    @Mock private FeedRanker feedRanker;
+    @Mock private FeedInteractionService feedInteractionService;
+    @Mock private FeedPostMapper feedPostMapper;
+
+    private FeedReadService service;
+
+    @BeforeEach
+    void setUp() {
+        // Pipeline absent → service uses the legacy Schwartzian path.
+        // AdvancedForYouFeedIntegrationTest stands up the pipeline against
+        // real beans, so we don't duplicate that coverage here.
+        service = new FeedReadService(
+                feedPostRepository,
+                userRepository,
+                followRepository,
+                hashtagNormalizer,
+                feedRanker,
+                feedInteractionService,
+                Optional.empty(),
+                feedPostMapper,
+                200);
+    }
+
+    // ── forYouFeed ─────────────────────────────────────────────────────────
+
+    @Test
+    void forYouFeed_emptyCandidates_returnsEmptyPageWithoutRanking() {
+        when(feedPostRepository.findForYouCandidates(1L, 200)).thenReturn(List.of());
+
+        Page<FeedPostListItem> page = service.forYouFeed(1L, PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).isEmpty();
+        // No ranker call when the candidate set is empty — the cost of
+        // building the FeedRankingContext is also avoided.
+        verify(feedRanker, never()).score(any(), any());
+        verify(userRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void forYouFeed_rankedByScore_descending() {
+        FeedPost p1 = freshPost(101L, 99L);
+        FeedPost p2 = freshPost(102L, 98L);
+        FeedPost p3 = freshPost(103L, 97L);
+        when(feedPostRepository.findForYouCandidates(1L, 200)).thenReturn(List.of(p1, p2, p3));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer(1L)));
+        when(followRepository.findFolloweeIdsByFollowerId(1L)).thenReturn(Set.of());
+        // Mentee's getInterests() is null on a fresh fixture, so
+        // extractInterestHashtags short-circuits before reaching the
+        // normaliser — no stub needed for hashtagNormalizer here.
+        // Scores descend p2 > p1 > p3, so the mapper should see them in
+        // that order even though the repo returned the original [p1,p2,p3].
+        when(feedRanker.score(eq(p1), any())).thenReturn(new FeedScoreResult(50, List.of()));
+        when(feedRanker.score(eq(p2), any())).thenReturn(new FeedScoreResult(80, List.of()));
+        when(feedRanker.score(eq(p3), any())).thenReturn(new FeedScoreResult(30, List.of()));
+        when(feedInteractionService.batchCounts(any())).thenReturn(Map.of());
+        when(feedPostMapper.toListItems(any(), eq(1L), any(), any())).thenAnswer(inv -> {
+            List<FeedPost> posts = inv.getArgument(0);
+            return posts.stream()
+                    .map(p -> listItem(p.getId(), p.getAuthorId()))
+                    .toList();
+        });
+
+        Page<FeedPostListItem> page = service.forYouFeed(1L, PageRequest.of(0, 10));
+
+        // Schwartzian transform: scored once, sorted by score descending.
+        assertThat(page.getContent()).extracting(FeedPostListItem::id)
+                .containsExactly(102L, 101L, 103L);
+    }
+
+    // ── followingFeed ──────────────────────────────────────────────────────
+
+    @Test
+    void followingFeed_emptyPage_shortCircuits() {
+        when(feedPostRepository.findFollowingFeed(eq(1L), any()))
+                .thenReturn(Page.empty(PageRequest.of(0, 10)));
+
+        Page<FeedPostListItem> page = service.followingFeed(1L, PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).isEmpty();
+        // Empty page short-circuits the batch-counts + mapper invocations.
+        verify(feedInteractionService, never()).batchCounts(any());
+        verify(feedPostMapper, never()).toListItems(any(), any(), any());
+    }
+
+    @Test
+    void followingFeed_populatesItemsThroughMapper() {
+        FeedPost post = freshPost(101L, 99L);
+        Page<FeedPost> repoPage = new PageImpl<>(List.of(post), PageRequest.of(0, 10), 1L);
+        when(feedPostRepository.findFollowingFeed(eq(1L), any())).thenReturn(repoPage);
+        when(feedInteractionService.batchCounts(List.of(101L))).thenReturn(
+                Map.of(101L, new PostCounts(0L, 0L)));
+        when(feedPostMapper.toListItems(eq(List.of(post)), eq(1L), any()))
+                .thenReturn(List.of(listItem(101L, 99L)));
+
+        Page<FeedPostListItem> page = service.followingFeed(1L, PageRequest.of(0, 10));
+
+        assertThat(page.getTotalElements()).isEqualTo(1L);
+        assertThat(page.getContent()).hasSize(1);
+        verify(feedInteractionService).batchCounts(List.of(101L));
+    }
+
+    // ── postsByAuthor ──────────────────────────────────────────────────────
+
+    @Test
+    void postsByAuthor_delegatesToRepoAndMapper() {
+        FeedPost post = freshPost(101L, 99L);
+        Page<FeedPost> repoPage = new PageImpl<>(List.of(post), PageRequest.of(0, 10), 1L);
+        when(feedPostRepository.findByAuthorIdForFeed(eq(99L), any())).thenReturn(repoPage);
+        when(feedInteractionService.batchCounts(List.of(101L))).thenReturn(
+                Map.of(101L, new PostCounts(0L, 0L)));
+        when(feedPostMapper.toListItems(eq(List.of(post)), eq(null), any()))
+                .thenReturn(List.of(listItem(101L, 99L)));
+
+        Page<FeedPostListItem> page = service.postsByAuthor(99L, PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).hasSize(1);
+    }
+
+    // ── search ─────────────────────────────────────────────────────────────
+
+    @Test
+    void search_throws400_whenBothFiltersAreNull() {
+        assertThatThrownBy(() -> service.search(null, null, PageRequest.of(0, 10)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("at least one");
+
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any());
+    }
+
+    @Test
+    void search_throws400_whenBothFiltersAreBlank() {
+        assertThatThrownBy(() -> service.search("   ", "  ", PageRequest.of(0, 10)))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any());
+    }
+
+    @Test
+    void search_returnsEmpty_whenHashtagFailsNormalisation() {
+        // Normaliser returns an empty set for inputs that fail the hashtag
+        // regex (e.g., spaces, punctuation). The service surfaces that as
+        // an empty page rather than a noisy error.
+        when(hashtagNormalizer.normalize(List.of("not a valid hashtag")))
+                .thenReturn(Set.of());
+
+        Page<FeedPostListItem> page = service.search(null, "not a valid hashtag", PageRequest.of(0, 10));
+
+        assertThat(page.getContent()).isEmpty();
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any());
+    }
+
+    @Test
+    void search_lowercasesAndEscapesKeyword_beforeRepoCall() {
+        // %, _, and \ are LIKE metacharacters; escaping prevents a malicious
+        // q=% from matching every post. Lowercasing aligns with the
+        // pg_trgm GIN index on LOWER(body).
+        when(feedPostRepository.searchPosts(eq("ja\\%va"), eq(null), any()))
+                .thenReturn(Page.empty(PageRequest.of(0, 10)));
+
+        service.search("Ja%va", null, PageRequest.of(0, 10));
+
+        verify(feedPostRepository).searchPosts(eq("ja\\%va"), eq(null), any());
+    }
+
+    @Test
+    void search_passesNormalisedHashtagToRepository() {
+        when(hashtagNormalizer.normalize(List.of("#DataScience")))
+                .thenReturn(Set.of("datascience"));
+        when(feedPostRepository.searchPosts(eq(null), eq("datascience"), any()))
+                .thenReturn(Page.empty(PageRequest.of(0, 10)));
+
+        service.search(null, "#DataScience", PageRequest.of(0, 10));
+
+        verify(feedPostRepository).searchPosts(eq(null), eq("datascience"), any());
+    }
+
+    // ── Fixtures ───────────────────────────────────────────────────────────
+
+    private static Mentee viewer(Long id) {
+        Mentee m = new Mentee();
+        m.setId(id);
+        m.setFirstName("U" + id);
+        return m;
+    }
+
+    private static FeedPost freshPost(Long id, Long authorId) {
+        FeedPost p = new FeedPost(authorId, "body-" + id);
+        p.setId(id);
+        OffsetDateTime now = OffsetDateTime.now();
+        p.setCreatedAt(now);
+        p.setUpdatedAt(now);
+        return p;
+    }
+
+    private static FeedPostListItem listItem(Long id, Long authorId) {
+        return new FeedPostListItem(
+                id, authorId, "U" + authorId, "body", List.of(),
+                OffsetDateTime.now(), 0L, 0L, List.of(), List.of());
+    }
+}


### PR DESCRIPTION
## Summary

Backfills the unit test coverage gap on the two social-feed services that previously had no dedicated suite: `FeedInteractionService` (likes, bookmarks, shares, comments, the per-post interaction-state aggregator, batch counts) and `FeedReadService` (For-You feed, Following feed, author-keyed feed, search).

The pair completes the *read, interaction, and search* backfill the issue called out — `FeedPostService` / `FeedPostMapper` / `FeedReadStateService` already carry unit tests, and integration tests still pin Postgres-side behaviour end-to-end. These add per-branch logic coverage without standing up Spring.

Closes #488.

## What changed

- **`FeedInteractionServiceTest`** — 31 tests over every public method:
  - `toggleLike` / `toggleBookmark` — missing-post 404, first-call upsert, second-call delete, self-action skips notification. The viewer-relative flip after the toggle is reproduced via Mockito's sequenced `thenReturn(...)` so the post-toggle state mirrors what the real repository would return.
  - `recordShare` — missing-post 404, non-self notifies, self-share skips notification.
  - `addComment` — missing-post 404, blank / null body 400, non-self notifies, self-comment skips notification.
  - `editComment` — missing 404, non-author 403, soft-deleted 404, blank body 400, success updates body + `updatedAt`.
  - `deleteComment` — missing 404, non-author 403, success sets `deletedAt`, idempotent on already-soft-deleted (no re-save).
  - `getComment` — comment missing / soft-deleted → 404, parent post soft-deleted → 404 (orphan-permalink guard).
  - `interactionState` — every aggregate count is consulted; null viewer skips the `existsBy` probes (anonymous-read SQL footprint is bounded).
  - `batchCounts` — empty input short-circuits without querying; every requested postId surfaces in the result map even with no rows (zero-fill contract).

- **`FeedReadServiceTest`** — 10 tests over every public method:
  - `forYouFeed` — empty candidate window short-circuits before the ranker is reached; populated window exercises the legacy Schwartzian-transform path and asserts the candidates come out ordered by score descending. The advanced `ForYouScoringPipeline` is intentionally `Optional.empty()` in the fixture because `AdvancedForYouFeedIntegrationTest` already stands up the pipeline against real beans; mocking it here would duplicate that coverage with weaker guarantees.
  - `followingFeed` — empty repo page short-circuits the mapper + batch counts; non-empty page routes through both.
  - `postsByAuthor` — delegates to the author-keyed repository query and the mapper with viewer id null (anonymous read on a public profile).
  - `search` — both filters null / blank rejected with 400, hashtag failing normalisation surfaces as an empty page (not a noisy error), keyword is lowercased and LIKE-escaped before the repository call, hashtag is normalised before the repository call.

## Verification

- `mvn -B test -Dtest=FeedInteractionServiceTest` — **31/31 pass**, 1.5s.
- `mvn -B test -Dtest=FeedReadServiceTest` — **10/10 pass**, 1.0s.
- `mvn -B test-compile` — clean.

No integration paths exercised: each test mocks the repositories, the ranker, the mapper, and the publisher facades, so the suite runs without Postgres or Spring. The full `mvn verify` is gated on the shared dev Postgres which has Flyway pollution from concurrent sessions in this repo; CI runs against a fresh container.

## Test plan

- [x] New unit tests compile and pass locally in isolation.
- [x] No production code changed — the suite asserts the existing behaviour as-is, so this PR cannot regress anything it touches.
- [ ] CI: `Backend CI/CD → test` picks up the new test classes and runs them green on a fresh database.