### PR TITLE
feat(backend): rating read endpoints — single mentorship + paginated mentor list (#518)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MentorshipController.java
@@ -231,6 +231,30 @@ public class MentorshipController {
         return ResponseEntity.ok(mentorshipService.extendMentorship(userId, id, request));
     }
 
+    @GetMapping("/{id}/rating")
+    @Operation(
+            summary = "Get the rating for this mentorship (mentor or mentee, #518)",
+            description = "Returns the rating row submitted by this mentorship's mentee, "
+                    + "if any. Visible to both the mentor and the mentee — non-participants "
+                    + "get 404 (uniform with the rest of the mentorship surface). 404 also "
+                    + "when the mentorship has no rating yet — lets the web client "
+                    + "deterministically render the 'You rated …' block on first paint "
+                    + "without depending on localStorage or a duplicate-POST probe."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Rating found",
+                    content = @Content(schema = @Schema(implementation = MentorRatingResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Mentorship not found, caller is not a participant, "
+                    + "or no rating exists yet", content = @Content)
+    })
+    public ResponseEntity<MentorRatingResponse> getMentorshipRating(
+            @PathVariable Long id,
+            Authentication authentication) {
+        Long userId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(mentorRatingService.getMentorshipRating(userId, id));
+    }
+
     @PostMapping("/{id}/rating")
     @Operation(
             summary = "Submit a mentor rating (mentee-only, #237)",

--- a/backend/src/main/java/com/group7/backend/controller/UserController.java
+++ b/backend/src/main/java/com/group7/backend/controller/UserController.java
@@ -5,10 +5,12 @@ import com.group7.backend.dto.request.MenteeProfileRequest;
 import com.group7.backend.dto.request.MentorProfileRequest;
 import com.group7.backend.dto.request.SearchRole;
 import com.group7.backend.dto.response.MenteeResponse;
+import com.group7.backend.dto.response.MentorRatingResponse;
 import com.group7.backend.dto.response.MentorResponse;
 import com.group7.backend.dto.response.ProfileResponse;
 import com.group7.backend.dto.response.UserProfileResponse;
 import com.group7.backend.exception.ProfileNotVisibleException;
+import com.group7.backend.service.MentorRatingService;
 import com.group7.backend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -35,9 +37,11 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final MentorRatingService mentorRatingService;
 
-    public UserController(UserService userService) {
+    public UserController(UserService userService, MentorRatingService mentorRatingService) {
         this.userService = userService;
+        this.mentorRatingService = mentorRatingService;
     }
 
     // ── Get own profile ─────────────────────────────────────
@@ -159,6 +163,29 @@ public class UserController {
             Authentication authentication) {
         Long requesterId = (Long) authentication.getCredentials();
         return ResponseEntity.ok(userService.getUserProfile(id, requesterId));
+    }
+
+    @GetMapping("/{id:\\d+}/ratings")
+    @Operation(summary = "Paginated mentor ratings list (#518)",
+            description = "Returns the ratings a mentor has received, newest-first. Powers the "
+                    + "'Recent feedback' block on the public mentor profile. Includes ratings "
+                    + "with and without comments — the client decides what to display. "
+                    + "menteeId surfaces in the response as the rater's user id; the client "
+                    + "batch-resolves names via the existing user-summary endpoint when it "
+                    + "wants to render attribution. Authenticated callers only — there is no "
+                    + "anonymous read of the ratings list.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated rating list (newest first)"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated", content = @Content)
+    })
+    public ResponseEntity<Page<MentorRatingResponse>> getMentorRatings(
+            @Parameter(description = "Mentor user id") @PathVariable Long id,
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size; clamped to [1, 50]") @RequestParam(defaultValue = "10") int size) {
+        // Reuse the project's existing clamp helper (same one feeding /mentors etc.) —
+        // Spring Data caps size at PageableSupport's policy and keeps page >= 0.
+        Pageable pageable = PageableSupport.clampPageable(page, Math.min(size, 50));
+        return ResponseEntity.ok(mentorRatingService.getMentorRatings(id, pageable));
     }
 
     @GetMapping("/mentors")

--- a/backend/src/main/java/com/group7/backend/repository/MentorRatingRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorRatingRepository.java
@@ -2,6 +2,8 @@ package com.group7.backend.repository;
 
 import com.group7.backend.dto.response.UserRatingSummary;
 import com.group7.backend.entity.MentorRating;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +17,14 @@ public interface MentorRatingRepository extends JpaRepository<MentorRating, Long
     Optional<MentorRating> findByMentorshipId(Long mentorshipId);
 
     boolean existsByMentorshipId(Long mentorshipId);
+
+    /**
+     * Paginated mentor-ratings list for a mentor's public profile (#518).
+     * Sort lives on the derived method name so callers don't have to pass
+     * a Sort — the frontend's "Recent feedback" surface always wants
+     * newest-first.
+     */
+    Page<MentorRating> findByMentorIdOrderByCreatedAtDesc(Long mentorId, Pageable pageable);
 
     /**
      * Aggregate average + count for a mentor in one query (#237). Returns

--- a/backend/src/main/java/com/group7/backend/service/MentorRatingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MentorRatingService.java
@@ -13,6 +13,8 @@ import com.group7.backend.repository.MentorshipRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -85,5 +87,54 @@ public class MentorRatingService {
     public UserRatingSummary aggregateForMentor(Long mentorId) {
         UserRatingSummary summary = mentorRatingRepository.aggregateForMentor(mentorId);
         return summary != null ? summary : UserRatingSummary.empty();
+    }
+
+    /**
+     * Single-mentorship rating lookup (#518). ACL: caller must be the
+     * mentor or the mentee of the mentorship — non-participants get
+     * {@code 404} (uniform with the rest of the {@code MentorshipController}
+     * surface, which never leaks "this id exists but you can't see it").
+     * Returns {@code 404} when no rating row exists for the mentorship —
+     * lets the web client deterministically render the "You rated …"
+     * block on first paint without depending on {@code localStorage} or
+     * a duplicate-POST probe.
+     */
+    @Transactional(readOnly = true)
+    public MentorRatingResponse getMentorshipRating(Long callerUserId, Long mentorshipId) {
+        // Reuse the existing participant-scoped lookup so the 404 vs 403
+        // semantics match the rest of the mentorship surface.
+        Mentorship mentorship = mentorshipRepository
+                .findByIdAndParticipant(mentorshipId, callerUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Mentorship not found"));
+        MentorRating rating = mentorRatingRepository
+                .findByMentorshipId(mentorship.getId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No rating exists for mentorship " + mentorshipId));
+        return MentorRatingResponse.from(rating);
+    }
+
+    /**
+     * Paginated mentor-ratings list (#518) — powers the "Recent feedback"
+     * block on the public mentor profile. No participant ACL: the rating
+     * surface is part of the mentor's public reputation, available to
+     * any authenticated caller.
+     *
+     * <p>Includes ratings with and without comments; the client decides
+     * what to display. Filtering server-side would force two endpoints
+     * (one for comment-bearing, one for the score-only aggregate) which
+     * isn't worth the surface area.
+     *
+     * <p>{@code menteeId} surfaces in the response as the rater's user
+     * id; the client batch-resolves names via the existing
+     * user-summary endpoint when it wants to render attribution. The
+     * service does not enrich names automatically — keeping the list
+     * cheap and respecting the "anonymous-by-default" reading the
+     * issue alludes to.
+     */
+    @Transactional(readOnly = true)
+    public Page<MentorRatingResponse> getMentorRatings(Long mentorId, Pageable pageable) {
+        return mentorRatingRepository
+                .findByMentorIdOrderByCreatedAtDesc(mentorId, pageable)
+                .map(MentorRatingResponse::from);
     }
 }

--- a/backend/src/test/java/com/group7/backend/controller/PhotoUploadControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/PhotoUploadControllerTest.java
@@ -34,6 +34,10 @@ class PhotoUploadControllerTest {
     @MockitoBean
     private UserService userService;
 
+    // #518: UserController constructor now also depends on MentorRatingService.
+    @MockitoBean
+    private com.group7.backend.service.MentorRatingService mentorRatingService;
+
     @MockitoBean
     private JwtService jwtService;
 

--- a/backend/src/test/java/com/group7/backend/controller/ProfileControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/ProfileControllerTest.java
@@ -47,6 +47,10 @@ class ProfileControllerTest {
     @MockitoBean
     private UserService userService;
 
+    // #518: UserController constructor now also depends on MentorRatingService.
+    @MockitoBean
+    private com.group7.backend.service.MentorRatingService mentorRatingService;
+
     @MockitoBean
     private JwtService jwtService;
 

--- a/backend/src/test/java/com/group7/backend/controller/UserSearchControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/UserSearchControllerTest.java
@@ -43,6 +43,8 @@ class UserSearchControllerTest {
 
     @Autowired private MockMvc mockMvc;
     @MockitoBean private UserService userService;
+    // #518: UserController constructor now also depends on MentorRatingService.
+    @MockitoBean private com.group7.backend.service.MentorRatingService mentorRatingService;
     @MockitoBean private JwtService jwtService;
 
     private static final String TOKEN = "test-jwt";

--- a/backend/src/test/java/com/group7/backend/integration/MentorRatingReadIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/MentorRatingReadIntegrationTest.java
@@ -1,0 +1,278 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.MentorRating;
+import com.group7.backend.entity.Mentorship;
+import com.group7.backend.entity.MentorshipRequest;
+import com.group7.backend.entity.MentorshipRequestStatus;
+import com.group7.backend.entity.MentorshipStatus;
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRatingRepository;
+import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.repository.MentorshipRepository;
+import com.group7.backend.repository.MentorshipRequestRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the rating read endpoints (#518) against real
+ * Postgres:
+ *   - GET /api/mentorships/{id}/rating  (single, ACL'd to participants)
+ *   - GET /api/users/{id}/ratings       (paginated, authenticated public)
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MentorRatingReadIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private MentorRepository mentorRepository;
+    @Autowired private MenteeRepository menteeRepository;
+    @Autowired private MentorshipRepository mentorshipRepository;
+    @Autowired private MentorshipRequestRepository mentorshipRequestRepository;
+    @Autowired private MentorRatingRepository mentorRatingRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @MockitoBean private EmailService emailService;
+
+    private Long mentorId;
+    private Long menteeId;
+    private String mentorToken;
+    private String menteeToken;
+    private String thirdToken;
+    private long mentorship1Id;  // has rating
+    private long mentorship2Id;  // no rating
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcTemplate.update("DELETE FROM mentor_ratings");
+        jdbcTemplate.update("DELETE FROM mentorship_audit_log");
+        jdbcTemplate.update("DELETE FROM mentorships");
+        jdbcTemplate.update("DELETE FROM mentorship_requests");
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+
+        mentorToken = registerAndLogin("rrm@test.com", true);
+        menteeToken = registerAndLogin("rrme@test.com", false);
+        thirdToken = registerAndLogin("rrt@test.com", true);
+
+        mentorId = userRepository.findByEmail("rrm@test.com").orElseThrow().getId();
+        menteeId = userRepository.findByEmail("rrme@test.com").orElseThrow().getId();
+
+        Mentor mentor = mentorRepository.findById(mentorId).orElseThrow();
+        Mentee mentee = menteeRepository.findById(menteeId).orElseThrow();
+
+        mentorship1Id = seedMentorship(mentor, mentee, MentorshipStatus.COMPLETED);
+        mentorship2Id = seedMentorship(mentor, mentee, MentorshipStatus.COMPLETED);
+
+        // Seed ratings — three on mentorship1 sorted across createdAt; the
+        // second mentorship deliberately has no rating to exercise the 404
+        // branch on the single-rating endpoint.
+        seedRating(mentorship1Id, mentorId, menteeId, 5, "first comment",
+                OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC));
+    }
+
+    // ── GET /api/mentorships/{id}/rating ───────────────────────────────────
+
+    @Test
+    void mentorshipRating_menteeReadsOwnRating_returns200() throws Exception {
+        mockMvc.perform(get("/api/mentorships/" + mentorship1Id + "/rating")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mentorshipId").value(mentorship1Id))
+                .andExpect(jsonPath("$.score").value(5))
+                .andExpect(jsonPath("$.comment").value("first comment"));
+    }
+
+    @Test
+    void mentorshipRating_mentorReadsRatingTheyReceived_returns200() throws Exception {
+        // Both mentorship participants can read — the ACL is "either side",
+        // not "mentee only". Lets the mentor see how a former mentee rated them.
+        mockMvc.perform(get("/api/mentorships/" + mentorship1Id + "/rating")
+                        .header("Authorization", "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.score").value(5));
+    }
+
+    @Test
+    void mentorshipRating_nonParticipant_returns404() throws Exception {
+        // Hide existence of the mentorship from anyone who isn't a
+        // participant — uniform with the other mentorship endpoints
+        // (404, not 403).
+        mockMvc.perform(get("/api/mentorships/" + mentorship1Id + "/rating")
+                        .header("Authorization", "Bearer " + thirdToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void mentorshipRating_noRatingExistsYet_returns404() throws Exception {
+        mockMvc.perform(get("/api/mentorships/" + mentorship2Id + "/rating")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void mentorshipRating_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/mentorships/" + mentorship1Id + "/rating"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── GET /api/users/{id}/ratings ────────────────────────────────────────
+
+    @Test
+    void mentorRatings_returnsPagedListSortedNewestFirst() throws Exception {
+        // Add two more ratings at different timestamps to validate the sort.
+        seedRating(mentorship2Id, mentorId, menteeId, 4, "older",
+                OffsetDateTime.of(2026, 4, 1, 10, 0, 0, 0, ZoneOffset.UTC));
+
+        mockMvc.perform(get("/api/users/" + mentorId + "/ratings")
+                        .header("Authorization", "Bearer " + thirdToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.content.length()").value(2))
+                // Newest first via the derived OrderByCreatedAtDesc.
+                .andExpect(jsonPath("$.content[0].comment").value("first comment"))
+                .andExpect(jsonPath("$.content[1].comment").value("older"));
+    }
+
+    @Test
+    void mentorRatings_includesRatingsWithoutComment() throws Exception {
+        // Server doesn't filter score-only ratings — the client decides
+        // what to display. Pin that contract.
+        seedRating(mentorship2Id, mentorId, menteeId, 3, null,
+                OffsetDateTime.of(2026, 4, 15, 10, 0, 0, 0, ZoneOffset.UTC));
+
+        mockMvc.perform(get("/api/users/" + mentorId + "/ratings")
+                        .header("Authorization", "Bearer " + thirdToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    void mentorRatings_paginationWorks_size1Page0AndPage1() throws Exception {
+        seedRating(mentorship2Id, mentorId, menteeId, 4, "older",
+                OffsetDateTime.of(2026, 4, 1, 10, 0, 0, 0, ZoneOffset.UTC));
+
+        mockMvc.perform(get("/api/users/" + mentorId + "/ratings?page=0&size=1")
+                        .header("Authorization", "Bearer " + thirdToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.totalPages").value(2))
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].comment").value("first comment"));
+
+        mockMvc.perform(get("/api/users/" + mentorId + "/ratings?page=1&size=1")
+                        .header("Authorization", "Bearer " + thirdToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].comment").value("older"));
+    }
+
+    @Test
+    void mentorRatings_emptyForUserWithNoRatings() throws Exception {
+        // The third user is a freshly-registered mentor with zero ratings —
+        // the endpoint returns an empty page rather than a 404, so the
+        // client can render an empty-state UI without a 404 round-trip.
+        long thirdUserId = userRepository.findByEmail("rrt@test.com").orElseThrow().getId();
+        mockMvc.perform(get("/api/users/" + thirdUserId + "/ratings")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0))
+                .andExpect(jsonPath("$.content.length()").value(0));
+    }
+
+    @Test
+    void mentorRatings_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/users/" + mentorId + "/ratings"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private long seedMentorship(Mentor mentor, Mentee mentee, MentorshipStatus status) {
+        MentorshipRequest req = new MentorshipRequest();
+        req.setMentor(mentor);
+        req.setMentee(mentee);
+        req.setStatus(MentorshipRequestStatus.ACCEPTED);
+        MentorshipRequest savedReq = mentorshipRequestRepository.save(req);
+
+        Mentorship m = new Mentorship();
+        m.setMentor(mentor);
+        m.setMentee(mentee);
+        m.setRequest(savedReq);
+        m.setStatus(status);
+        m.setStartDate(OffsetDateTime.of(2026, 1, 1, 10, 0, 0, 0, ZoneOffset.UTC));
+        m.setEndDate(OffsetDateTime.of(2026, 4, 1, 10, 0, 0, 0, ZoneOffset.UTC));
+        m.setDuration(3);
+        return mentorshipRepository.save(m).getId();
+    }
+
+    private void seedRating(long mentorshipId, Long mentorUserId, Long menteeUserId,
+                             int score, String comment, OffsetDateTime createdAt) {
+        MentorRating rating = MentorRating.of(mentorshipId, mentorUserId, menteeUserId, score, comment);
+        // Bypass the @PrePersist default so the test can fix createdAt
+        // ordering deterministically.
+        rating.setCreatedAt(createdAt);
+        mentorRatingRepository.save(rating);
+    }
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("RR");
+        req.setLastName("Tester");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        var user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/MentorRatingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MentorRatingServiceTest.java
@@ -184,4 +184,82 @@ class MentorRatingServiceTest {
         assertThat(summary.averageRating()).isNull();
         assertThat(summary.ratingCount()).isZero();
     }
+
+    // ── Read endpoints (#518) ─────────────────────────────────────────────
+
+    @Test
+    void getMentorshipRating_returnsRatingForMentee() {
+        MentorRating rating = MentorRating.of(100L, 1L, 2L, 5, "Great!");
+        rating.setId(42L);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L))
+                .thenReturn(Optional.of(mentorship));
+        when(mentorRatingRepository.findByMentorshipId(100L))
+                .thenReturn(Optional.of(rating));
+
+        MentorRatingResponse response = mentorRatingService.getMentorshipRating(2L, 100L);
+
+        assertThat(response.getId()).isEqualTo(42L);
+        assertThat(response.getMentorshipId()).isEqualTo(100L);
+        assertThat(response.getScore()).isEqualTo(5);
+        assertThat(response.getComment()).isEqualTo("Great!");
+    }
+
+    @Test
+    void getMentorshipRating_alsoReturnsRatingForMentor() {
+        // The mentor on the mentorship can also fetch the rating they
+        // received — the ACL is "either participant", not "mentee only".
+        MentorRating rating = MentorRating.of(100L, 1L, 2L, 4, "Good");
+        rating.setId(43L);
+        when(mentorshipRepository.findByIdAndParticipant(100L, 1L))
+                .thenReturn(Optional.of(mentorship));
+        when(mentorRatingRepository.findByMentorshipId(100L))
+                .thenReturn(Optional.of(rating));
+
+        MentorRatingResponse response = mentorRatingService.getMentorshipRating(1L, 100L);
+
+        assertThat(response.getId()).isEqualTo(43L);
+    }
+
+    @Test
+    void getMentorshipRating_throws404_whenCallerIsNotParticipant() {
+        when(mentorshipRepository.findByIdAndParticipant(100L, 999L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> mentorRatingService.getMentorshipRating(999L, 100L))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        verify(mentorRatingRepository, never()).findByMentorshipId(any());
+    }
+
+    @Test
+    void getMentorshipRating_throws404_whenNoRatingExistsYet() {
+        when(mentorshipRepository.findByIdAndParticipant(100L, 2L))
+                .thenReturn(Optional.of(mentorship));
+        when(mentorRatingRepository.findByMentorshipId(100L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> mentorRatingService.getMentorshipRating(2L, 100L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("No rating exists");
+    }
+
+    @Test
+    void getMentorRatings_passesPageableThroughToRepository() {
+        org.springframework.data.domain.Pageable pageable =
+                org.springframework.data.domain.PageRequest.of(0, 10);
+        org.springframework.data.domain.Page<MentorRating> page =
+                new org.springframework.data.domain.PageImpl<>(java.util.List.of(
+                        MentorRating.of(100L, 1L, 2L, 5, "newest"),
+                        MentorRating.of(101L, 1L, 3L, 4, "older")),
+                        pageable, 2);
+        when(mentorRatingRepository.findByMentorIdOrderByCreatedAtDesc(1L, pageable))
+                .thenReturn(page);
+
+        org.springframework.data.domain.Page<MentorRatingResponse> result =
+                mentorRatingService.getMentorRatings(1L, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent().get(0).getComment()).isEqualTo("newest");
+        assertThat(result.getContent().get(1).getComment()).isEqualTo("older");
+    }
 }


### PR DESCRIPTION
Closes #518. Unblocks the two workarounds in #278's web rating UI.

## Summary

Adds two GET endpoints so the web mentor-rating UI can stop relying on
`localStorage` hydration and duplicate-POST 409 probing:

| Endpoint | Auth | Returns |
|---|---|---|
| `GET /api/mentorships/{id}/rating` | mentor or mentee of mentorship | `200` with rating, or `404` if no rating yet / non-participant |
| `GET /api/users/{id}/ratings?page=N&size=M` | any authenticated user | `Page<MentorRatingResponse>` sorted createdAt DESC, default size 10, capped at 50 |

### `GET /api/mentorships/{id}/rating`

- Both mentorship participants can read — the mentor sees how the
  mentee rated them.
- Non-participants get `404` (uniform with the rest of the mentorship
  surface; never \"this id exists but you can't see it\").
- `404` also when the mentorship has no rating yet — lets the web
  client deterministically render the read-only \"You rated …\" block
  on first paint.

### `GET /api/users/{id}/ratings`

- Includes ratings with and without comments — the client decides
  what to display. Filtering server-side would force two endpoints
  (one for comment-bearing, one for the score-only aggregate) which
  isn't worth the surface area.
- `menteeId` surfaces in the response as the rater's user id; the
  client batch-resolves names via the existing user-summary endpoint
  when it wants to render attribution. **No automatic name enrichment**
  — keeps the list cheap and respects the \"anonymous-by-default\"
  reading the issue alludes to.

## Test plan

- [x] **5 new service unit tests** (`MentorRatingServiceTest`):
      mentee reads own rating, mentor reads received rating,
      non-participant 404, no-rating-yet 404, paginated list
      pass-through.
- [x] **10-case integration test** (`MentorRatingReadIntegrationTest`)
      against real Postgres: full ACL matrix on the single-rating
      endpoint (mentee 200, mentor 200, third-party 404, no-rating 404,
      anon 403), newest-first sort across 2 timestamped ratings,
      ratings-without-comment included in the list, pagination
      boundaries (size=1: page0/page1 returning sequential items),
      empty page for a fresh mentor, anon → 403.
- [x] `mvn --batch-mode verify` green locally on the same Postgres 16
      sidecar shape the CI workflow uses (2072 tests, 0 failures, 0 errors).
- [x] Manual smoke test against running backend on isolated Postgres
      (port 5447): 7 scenarios — mentee reads own (200, score=5),
      mentor reads received (200), non-participant 404, no-rating-yet
      404, mentor ratings list 3 items DESC with null-comment
      surfacing, size=1 pagination across 3 pages each returning
      sequential scores, anon → 403 on both endpoints.
- [ ] Backend CI green on this PR.

## Frontend follow-up (after merge)

Per the issue's plan, in `frontend/src/pages/MentorshipDetailPage.jsx`:
- Replace the `localStorage` hydration `useEffect` with a
  `getMentorshipRating(id)` call alongside the existing
  `getMentorshipById` fetch.
- Drop the 409-as-success branch in `handleRateConfirm` (no longer
  reachable in a healthy flow).

In `frontend/src/pages/UserProfilePage.jsx`:
- Add a \"Recent feedback\" section under the stats row that lists
  the first page of `getMentorRatings(id)`.

## Touch radius beyond the rating surface

3 `@WebMvcTest` slices that mock the `UserController`
(`PhotoUploadControllerTest`, `ProfileControllerTest`,
`UserSearchControllerTest`) gain a `@MockitoBean MentorRatingService`
since the controller's constructor now depends on it. One-line each;
no logic change.