### PR TITLE
feat(profile): add affiliation field to mentee profile

### DIFF
--- a/backend/src/main/java/com/group7/backend/dto/request/MenteeProfileRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/MenteeProfileRequest.java
@@ -70,6 +70,10 @@ public class MenteeProfileRequest extends EditProfileRequest {
     @Schema(description = "Background information", example = "2nd year student interested in AI")
     private String backgroundInfo;
 
+    @Size(max = 200, message = "Affiliation must not exceed 200 characters")
+    @Schema(description = "Affiliation (university/company)", example = "Bogazici University")
+    private String affiliation;
+
     /**
      * Each parallel URI list must align with its label list when supplied.
      * A null URI list means "no URIs for any entry"; otherwise lengths must

--- a/backend/src/main/java/com/group7/backend/dto/response/MenteeResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MenteeResponse.java
@@ -52,6 +52,9 @@ public final class MenteeResponse extends UserResponse implements ProfileRespons
     @Schema(description = "Background information", example = "2nd year student interested in AI research")
     private String backgroundInfo;
 
+    @Schema(description = "Affiliation (university/company)", example = "Bogazici University")
+    private String affiliation;
+
     @Schema(description = "Number of cancelled mentorships", example = "0")
     private Integer cancelCount;
 

--- a/backend/src/main/java/com/group7/backend/entity/Mentee.java
+++ b/backend/src/main/java/com/group7/backend/entity/Mentee.java
@@ -41,6 +41,16 @@ public class Mentee extends User {
 
     private String backgroundInfo;
 
+    /**
+     * University / company the mentee is affiliated with. Symmetric to
+     * {@link Mentor#getAffiliation()} (V1) — mentees may need to surface
+     * where they study or work when looking for a mentor. Added in V51
+     * because the mentees table was created without the column and the
+     * API could not round-trip the value through
+     * {@code MenteeProfileRequest} / {@code MenteeResponse}.
+     */
+    private String affiliation;
+
     @Column(nullable = false)
     private Integer cancelCount = 0;
 

--- a/backend/src/main/java/com/group7/backend/service/UserService.java
+++ b/backend/src/main/java/com/group7/backend/service/UserService.java
@@ -477,6 +477,9 @@ public class UserService {
         if (request.getBackgroundInfo() != null) {
             mentee.setBackgroundInfo(request.getBackgroundInfo());
         }
+        if (request.getAffiliation() != null) {
+            mentee.setAffiliation(request.getAffiliation());
+        }
     }
 
 }

--- a/backend/src/main/resources/db/migration/V52__add_mentee_affiliation.sql
+++ b/backend/src/main/resources/db/migration/V52__add_mentee_affiliation.sql
@@ -1,0 +1,15 @@
+-- Mirrors the mentor-side `affiliation` column on `mentees` so the mentee
+-- profile can also surface a university / company affiliation. Mentor
+-- carries this in V1 (`mentors.affiliation VARCHAR(255)`); the mentee
+-- table was created without it, leaving the API unable to round-trip the
+-- value even though the profile UI has a slot for it.
+--
+-- VARCHAR(255) matches the mentor column for symmetry. Application-level
+-- validation in `MenteeProfileRequest` caps user input at 200 characters
+-- (matching `MentorProfileRequest.affiliation`); the DB ceiling is the
+-- defence-in-depth backstop.
+--
+-- Nullable: existing rows have no affiliation. Future rows may omit it.
+
+ALTER TABLE mentees
+    ADD COLUMN affiliation VARCHAR(255);

--- a/backend/src/test/java/com/group7/backend/integration/ProfileIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/ProfileIntegrationTest.java
@@ -287,6 +287,7 @@ class ProfileIntegrationTest {
         update.setSkills(List.of("Python", "Go", "Docker", "Kubernetes"));
         update.setMeetingFreqPref("Bi-weekly");
         update.setBackgroundInfo("3rd year student with internship at a cloud company");
+        update.setAffiliation("Bogazici University");
         update.setProfileVisibility(false);
 
         mockMvc.perform(patch("/api/users/me/mentee")
@@ -301,13 +302,62 @@ class ProfileIntegrationTest {
                 .andExpect(jsonPath("$.skills.length()").value(4))
                 .andExpect(jsonPath("$.meetingFreqPref").value("Bi-weekly"))
                 .andExpect(jsonPath("$.backgroundInfo").value("3rd year student with internship at a cloud company"))
+                .andExpect(jsonPath("$.affiliation").value("Bogazici University"))
                 .andExpect(jsonPath("$.profileVisibility").value(false));
 
         // Verify persisted via GET
         mockMvc.perform(get("/api/users/me")
                         .header("Authorization", "Bearer " + token))
                 .andExpect(jsonPath("$.skills.length()").value(4))
+                .andExpect(jsonPath("$.affiliation").value("Bogazici University"))
                 .andExpect(jsonPath("$.profileVisibility").value(false));
+    }
+
+    @Test
+    void updateMenteeProfile_affiliationOnly_persistsAndSurfacesOnPublicProfile() throws Exception {
+        // V51 added the column / DTO field / service mapping in lockstep.
+        // This test pins the round-trip through PATCH /api/users/me/mentee
+        // → GET /api/users/me → GET /api/users/{id} so a regression that
+        // drops the field on any leg fails loudly. Mentors had this since
+        // V1; mentees were silently missing it until now.
+        String token = registerAndLogin("affiliation-mentee@test.com", false);
+
+        MenteeProfileRequest update = new MenteeProfileRequest();
+        update.setAffiliation("Istanbul Technical University");
+
+        mockMvc.perform(patch("/api/users/me/mentee")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(update)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.affiliation").value("Istanbul Technical University"));
+
+        long menteeId = userRepository
+                .findByEmail("affiliation-mentee@test.com").orElseThrow().getId();
+
+        mockMvc.perform(get("/api/users/me").header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.affiliation").value("Istanbul Technical University"));
+
+        mockMvc.perform(get("/api/users/" + menteeId).header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.affiliation").value("Istanbul Technical University"));
+    }
+
+    @Test
+    void updateMenteeProfile_affiliationOver200Chars_rejectedAt400() throws Exception {
+        // Mirrors MentorProfileRequest's @Size(max = 200) cap. DB column is
+        // VARCHAR(255) as defence in depth, but the API contract is 200.
+        String token = registerAndLogin("aff-validation@test.com", false);
+
+        MenteeProfileRequest update = new MenteeProfileRequest();
+        update.setAffiliation("X".repeat(201));
+
+        mockMvc.perform(patch("/api/users/me/mentee")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(update)))
+                .andExpect(status().isBadRequest());
     }
 
     // ── Common field updates ────────────────────────────────


### PR DESCRIPTION
## Summary
Mentor profiles have carried `affiliation` since V1; mentees never did, even though the field is meaningful for students or working mentees who want to surface their university or employer. The mentee entity, request DTO, response DTO, and service mapper all lacked the field, so the API could not round-trip the value even when the frontend form supplied it — the symptom that surfaced this gap was the mentee profile page silently missing affiliation.

This PR closes that gap by mirroring exactly what the mentor side already does.

## Changes
- **Migration V51** (`backend/src/main/resources/db/migration/V51__add_mentee_affiliation.sql`) — `ALTER TABLE mentees ADD COLUMN affiliation VARCHAR(255)`. Nullable so existing rows are unaffected. `VARCHAR(255)` matches `mentors.affiliation` for symmetry; the API caps user input at 200 characters via `@Size`, leaving the DB ceiling as defence in depth.
- **`Mentee` entity** — new `String affiliation` field with a javadoc note explaining the symmetric origin in `Mentor`. Lombok `@Getter`/`@Setter` provide accessors; `MenteeResponse.from`'s `BeanUtils.copyProperties` picks up the field automatically.
- **`MenteeProfileRequest`** — new field with `@Size(max = 200)` + `@Schema` matching `MentorProfileRequest.affiliation` verbatim.
- **`MenteeResponse`** — new field with the same `@Schema` as `MentorResponse.affiliation`.
- **`UserService.applyMenteeFields`** — one extra null-safe block in the existing partial-update pattern.

No new endpoints, no contract changes, no breaking renames.

## Test plan
- [x] `mvn clean verify` against isolated Postgres — **2059/2059 tests pass**.
- [x] Existing `updateMenteeProfile_allMenteeFields_updatesCorrectly` extended to also set + assert `affiliation` on both the PATCH response and the follow-up `GET /api/users/me`.
- [x] New `updateMenteeProfile_affiliationOnly_persistsAndSurfacesOnPublicProfile` — exercises an affiliation-only PATCH, then reads it back through `GET /api/users/me` and `GET /api/users/{id}` so a regression that drops the field on any leg fails loudly.
- [x] New `updateMenteeProfile_affiliationOver200Chars_rejectedAt400` — pins the @Size cap symmetric to the mentor side.

## Migration ordering note
Dev's max applied migration is currently V49. PR #501 has V50 reserved (open against `dev`). This PR uses **V51** to avoid the slot collision; if #501 lands first, V50 fills and V51 sits cleanly on top. If this PR lands first, V51 leaves the V50 slot open for #501 — Flyway tolerates the gap.

## Out of scope
- Frontend form: the existing mentee profile editor likely already binds to a generic affiliation input that will now light up automatically. If a dedicated input needs to be added on the web/mobile side, that is a separate PR.
- Mentor-side affiliation surface is unchanged.