### PR TITLE
feat(backend): AS 2.0 / Schema.org JSON-LD coverage for the social feed (#490)

### DIFF
--- a/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMediaType.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMediaType.java
@@ -7,6 +7,27 @@ public final class JsonLdMediaType {
     public static final String APPLICATION_LD_JSON_VALUE = "application/ld+json";
     public static final MediaType APPLICATION_LD_JSON = MediaType.parseMediaType(APPLICATION_LD_JSON_VALUE);
 
+    /**
+     * ActivityPub / Activity Streams 2.0 wire type. The AS 2.0 spec defines
+     * this as the canonical type for AS 2.0 documents, and Fediverse clients
+     * (Mastodon, etc.) prefer it over the generic application/ld+json. Treated
+     * as a synonym by the JSON-LD response advice — any client opting in via
+     * either header receives the same AS 2.0 document on the wire.
+     */
+    public static final String APPLICATION_ACTIVITY_JSON_VALUE = "application/activity+json";
+    public static final MediaType APPLICATION_ACTIVITY_JSON = MediaType.parseMediaType(APPLICATION_ACTIVITY_JSON_VALUE);
+
+    /**
+     * True for either of the two AS 2.0 / JSON-LD wire types. The response
+     * advice opts in to wrapping when the negotiated content type satisfies
+     * this predicate.
+     */
+    public static boolean isJsonLd(MediaType contentType) {
+        return contentType != null
+                && (APPLICATION_LD_JSON.isCompatibleWith(contentType)
+                || APPLICATION_ACTIVITY_JSON.isCompatibleWith(contentType));
+    }
+
     private JsonLdMediaType() {
     }
 }

--- a/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMediaTypeConfig.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdMediaTypeConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.ArrayList;
@@ -11,6 +12,21 @@ import java.util.List;
 
 @Configuration
 public class JsonLdMediaTypeConfig implements WebMvcConfigurer {
+
+    /**
+     * Without this, Spring's ContentNegotiationManager doesn't know about
+     * application/activity+json and silently rewrites the response
+     * Content-Type back to application/json after our JSON-LD advice
+     * already produced an AS 2.0 document body. Registering both wire
+     * types as known media types keeps the negotiated Content-Type aligned
+     * with the client's Accept header end-to-end.
+     */
+    @Override
+    public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        configurer
+                .mediaType("ld+json", JsonLdMediaType.APPLICATION_LD_JSON)
+                .mediaType("activity+json", JsonLdMediaType.APPLICATION_ACTIVITY_JSON);
+    }
 
     @Override
     public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
@@ -20,11 +36,19 @@ public class JsonLdMediaTypeConfig implements WebMvcConfigurer {
             }
             List<MediaType> supported = jackson.getSupportedMediaTypes();
             boolean handlesPlainJson = supported.stream().anyMatch(MediaType.APPLICATION_JSON::equals);
-            if (!handlesPlainJson || supported.contains(JsonLdMediaType.APPLICATION_LD_JSON)) {
+            if (!handlesPlainJson) {
                 continue;
             }
             List<MediaType> updated = new ArrayList<>(supported);
-            updated.add(JsonLdMediaType.APPLICATION_LD_JSON);
+            // Both wire types are treated identically by the response advice;
+            // declaring both here means content-negotiation routes either
+            // Accept header through the same converter instead of returning 406.
+            if (!updated.contains(JsonLdMediaType.APPLICATION_LD_JSON)) {
+                updated.add(JsonLdMediaType.APPLICATION_LD_JSON);
+            }
+            if (!updated.contains(JsonLdMediaType.APPLICATION_ACTIVITY_JSON)) {
+                updated.add(JsonLdMediaType.APPLICATION_ACTIVITY_JSON);
+            }
             jackson.setSupportedMediaTypes(updated);
         }
     }

--- a/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdResponseBodyAdvice.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/JsonLdResponseBodyAdvice.java
@@ -57,14 +57,27 @@ public class JsonLdResponseBodyAdvice implements ResponseBodyAdvice<Object> {
         if (body == null) {
             return null;
         }
-        if (!JsonLdMediaType.APPLICATION_LD_JSON.isCompatibleWith(selectedContentType)) {
+        if (!JsonLdMediaType.isJsonLd(selectedContentType)) {
             return body;
         }
 
-        // Page<T> wrapping in JSON-LD requires modeling pagination as a typed
-        // resource (e.g., schema.org ItemList). Deferred to a Wave 2 slice.
+        // Page<T> bodies are handed off to OrderedCollectionPageJsonLdAdvice
+        // (runs after this advice) which models them as an AS 2.0
+        // OrderedCollectionPage with hypermedia paging links. Returning the
+        // body untouched keeps the downstream advice able to inspect the
+        // original Page<T> with its pagination metadata intact.
         if (body instanceof Page<?>) {
-            return downgrade(body, response, "Page<T> body is not JSON-LD-shaped");
+            return body;
+        }
+
+        // An earlier advice in the chain may have already produced a
+        // JSON-LD document (e.g., OrderedCollectionPageJsonLdAdvice wrapping
+        // a Page<T> into a Map with @context). Recognise that shape and
+        // pass it through unchanged — without this, the downgrade branch
+        // below would rewrite Content-Type to application/json after the
+        // other advice carefully negotiated AS 2.0.
+        if (body instanceof Map<?, ?> map && map.containsKey("@context")) {
+            return body;
         }
 
         if (body instanceof Collection<?> collection) {

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedCommentJsonLdMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedCommentJsonLdMapping.java
@@ -1,0 +1,77 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.jsonld.JsonLdContext;
+import com.group7.backend.config.jsonld.JsonLdMapping;
+import com.group7.backend.dto.response.FeedCommentResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Renders a {@link FeedCommentResponse} as an AS 2.0 {@code Note} that
+ * links to its parent post via {@code inReplyTo}. Same context order
+ * (Activity Streams first, Schema.org second) as the post mapping so
+ * consumers don't have to switch ontologies mid-thread.
+ *
+ * <p>Soft-deleted comments surface in the underlying DTO with a null body
+ * and {@code isDeleted=true}. We honour that here by omitting the
+ * {@code content} field entirely — AS 2.0 consumers should treat that as
+ * a redacted post placeholder, which mirrors the UI's "[comment removed]"
+ * rendering.
+ */
+@Component
+public class FeedCommentJsonLdMapping implements JsonLdMapping {
+
+    private final FeedIriBuilder iri;
+
+    public FeedCommentJsonLdMapping(FeedIriBuilder iri) {
+        this.iri = iri;
+    }
+
+    @Override
+    public boolean supports(Class<?> bodyType) {
+        return FeedCommentResponse.class.isAssignableFrom(bodyType);
+    }
+
+    @Override
+    public Map<String, Object> apply(Object body) {
+        FeedCommentResponse comment = (FeedCommentResponse) body;
+
+        Map<String, Object> doc = new LinkedHashMap<>();
+        doc.put("@context", List.of(
+                JsonLdContext.ACTIVITY_STREAMS,
+                JsonLdContext.SCHEMA_ORG));
+        doc.put("@type", "Note");
+        doc.put("@id", iri.comment(comment.id()));
+        doc.put("id", iri.comment(comment.id()));
+        doc.put("inReplyTo", iri.post(comment.postId()));
+
+        if (comment.authorId() != null) {
+            Map<String, Object> actor = new LinkedHashMap<>();
+            actor.put("@type", "Person");
+            actor.put("@id", iri.person(comment.authorId()));
+            if (comment.authorFirstName() != null && !comment.authorFirstName().isBlank()) {
+                actor.put("name", comment.authorFirstName());
+            }
+            doc.put("attributedTo", actor);
+        }
+
+        if (comment.createdAt() != null) {
+            doc.put("published", comment.createdAt().toString());
+        }
+        if (comment.isEdited() && comment.updatedAt() != null) {
+            doc.put("updated", comment.updatedAt().toString());
+        }
+
+        // Soft-deleted comments arrive with body == null and isDeleted == true.
+        // Omit `content` rather than emit an empty string so consumers can
+        // distinguish "redacted" from "literally empty" — Mastodon and the
+        // AS 2.0 examples use this convention for tombstoned content.
+        if (!comment.isDeleted() && comment.body() != null && !comment.body().isBlank()) {
+            doc.put("content", comment.body());
+        }
+        return doc;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedIriBuilder.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedIriBuilder.java
@@ -1,0 +1,93 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.AppProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mints canonical IRIs for the social-feed entities that surface in the
+ * Activity Streams 2.0 / Schema.org JSON-LD representations.
+ *
+ * <p>The base URL is sourced from {@code app.base-url} (the same property
+ * the email link generator and {@code NoteMapping} use) so the IRI shape
+ * is identical to whatever {@code GET /api/feed/posts/{id}} would resolve
+ * to over the real HTTP API. That equality is load-bearing for AS 2.0
+ * dereferenceability: a consumer that follows an IRI we mint here must
+ * land on the actual resource, not a 404.
+ *
+ * <p>Built once per app boot and held as a final field. The trailing slash
+ * is stripped exactly once at construction so callers can concatenate the
+ * path segment without checking the base shape.
+ */
+@Component
+public class FeedIriBuilder {
+
+    private final String baseUrl;
+
+    public FeedIriBuilder(AppProperties appProperties) {
+        String configured = appProperties.getBaseUrl();
+        this.baseUrl = configured.endsWith("/")
+                ? configured.substring(0, configured.length() - 1)
+                : configured;
+    }
+
+    /** Canonical IRI for a single feed post. Matches {@code GET /api/feed/posts/{id}}. */
+    public String post(Long id) {
+        return baseUrl + "/api/feed/posts/" + id;
+    }
+
+    /** Canonical IRI for a single comment. Matches {@code GET /api/feed/comments/{id}}. */
+    public String comment(Long id) {
+        return baseUrl + "/api/feed/comments/" + id;
+    }
+
+    /**
+     * IRI for the abstract Like edge from a user to a post. Not a real
+     * endpoint — the toggle surface lives at
+     * {@code POST /api/feed/posts/{id}/like} — but AS 2.0 consumers expect
+     * each Like activity to carry a stable id, so we mint one with the
+     * composite key shape.
+     */
+    public String like(Long postId, Long userId) {
+        return baseUrl + "/api/feed/posts/" + postId + "/likes/" + userId;
+    }
+
+    /** IRI for the abstract Share edge. Same shape rationale as {@link #like}. */
+    public String share(Long postId, Long userId) {
+        return baseUrl + "/api/feed/posts/" + postId + "/shares/" + userId;
+    }
+
+    /** IRI for the abstract Bookmark edge. Same shape rationale as {@link #like}. */
+    public String bookmark(Long postId, Long userId) {
+        return baseUrl + "/api/feed/posts/" + postId + "/bookmarks/" + userId;
+    }
+
+    /** IRI for the abstract Follow edge from one user to another. */
+    public String follow(Long followerId, Long followeeId) {
+        return baseUrl + "/api/follows/" + followerId + "/" + followeeId;
+    }
+
+    /** IRI for the user's bookmark collection (the {@code target} of {@code as:Add}). */
+    public String bookmarkCollection(Long userId) {
+        return baseUrl + "/api/users/" + userId + "/bookmarks";
+    }
+
+    /** Canonical IRI for a user (Schema.org Person). */
+    public String person(Long userId) {
+        return baseUrl + "/api/users/" + userId;
+    }
+
+    /**
+     * Resolves the absolute URL form of a relative resource path. Used when
+     * the OrderedCollectionPage envelope needs to render the {@code first}
+     * / {@code next} / {@code prev} / {@code last} hypermedia links from
+     * the controller-level URI plus the framework's pagination state.
+     */
+    public String absolute(String pathAndQuery) {
+        if (pathAndQuery == null || pathAndQuery.isEmpty()) {
+            return baseUrl;
+        }
+        return pathAndQuery.startsWith("http://") || pathAndQuery.startsWith("https://")
+                ? pathAndQuery
+                : baseUrl + (pathAndQuery.startsWith("/") ? pathAndQuery : "/" + pathAndQuery);
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostBookmarkJsonLdMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostBookmarkJsonLdMapping.java
@@ -1,0 +1,55 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.jsonld.JsonLdContext;
+import com.group7.backend.config.jsonld.JsonLdMapping;
+import com.group7.backend.entity.FeedPostBookmark;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Renders a {@link FeedPostBookmark} entity as a W3C Activity Streams 2.0
+ * {@code Add} activity targeting the user's bookmark collection. The AS 2.0
+ * convention for "save / bookmark" semantics is {@code Add} with the object
+ * being the bookmarked resource and the {@code target} being the actor's
+ * collection — closer to the original Mastodon spec for personal-list
+ * additions than {@code Like}.
+ */
+@Component
+public class FeedPostBookmarkJsonLdMapping implements JsonLdMapping {
+
+    private final FeedIriBuilder iri;
+
+    public FeedPostBookmarkJsonLdMapping(FeedIriBuilder iri) {
+        this.iri = iri;
+    }
+
+    @Override
+    public boolean supports(Class<?> bodyType) {
+        return FeedPostBookmark.class.isAssignableFrom(bodyType);
+    }
+
+    @Override
+    public Map<String, Object> apply(Object body) {
+        FeedPostBookmark bookmark = (FeedPostBookmark) body;
+        Long postId = bookmark.getId() == null ? null : bookmark.getId().getPostId();
+        Long userId = bookmark.getId() == null ? null : bookmark.getId().getUserId();
+
+        Map<String, Object> doc = new LinkedHashMap<>();
+        doc.put("@context", List.of(JsonLdContext.ACTIVITY_STREAMS));
+        doc.put("@type", "Add");
+        if (postId != null && userId != null) {
+            doc.put("@id", iri.bookmark(postId, userId));
+            doc.put("id", iri.bookmark(postId, userId));
+            doc.put("actor", iri.person(userId));
+            doc.put("object", iri.post(postId));
+            doc.put("target", iri.bookmarkCollection(userId));
+        }
+        if (bookmark.getCreatedAt() != null) {
+            doc.put("published", bookmark.getCreatedAt().toString());
+        }
+        return doc;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostJsonLdMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostJsonLdMapping.java
@@ -1,0 +1,193 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.jsonld.JsonLdContext;
+import com.group7.backend.config.jsonld.JsonLdMapping;
+import com.group7.backend.dto.response.AttachmentSummary;
+import com.group7.backend.dto.response.FeedPostResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Renders a {@link FeedPostResponse} as a W3C Activity Streams 2.0
+ * {@code Note} also typed as a Schema.org {@code SocialMediaPosting},
+ * matching the standards-coverage commitment in the project wiki.
+ *
+ * <h2>Shape decisions</h2>
+ * <ul>
+ *   <li><b>{@code @context} order</b>: Activity Streams 2.0 first, then
+ *       Schema.org. Matches Mastodon's pattern and prevents Schema.org's
+ *       {@code id} from shadowing AS 2.0's when a consumer interprets the
+ *       document with a single context.</li>
+ *   <li><b>Multi-typing</b>: {@code @type: ["Note", "SocialMediaPosting"]}
+ *       — the post is both a generic AS 2.0 actor-published object and a
+ *       schema.org typed posting. Fediverse consumers see the Note;
+ *       search-engine crawlers see the SocialMediaPosting.</li>
+ *   <li><b>{@code contentMap} only when {@code lang} is non-null</b>: AS 2.0
+ *       requires {@code contentMap} to be a BCP-47-keyed map. Legacy posts
+ *       that predate the column on {@code feed_posts} have {@code lang}
+ *       null and are surfaced with plain {@code content} only.</li>
+ *   <li><b>Counts as {@code Schema.org InteractionCounter}</b>: the issue
+ *       acceptance criteria explicitly call out
+ *       {@code interactionStatistic}, and the counter-objects pattern is
+ *       what every consumer (including Schema.org's own examples)
+ *       expects.</li>
+ * </ul>
+ *
+ * <p>Auto-discovered by {@code JsonLdResponseBodyAdvice} on app boot.
+ */
+@Component
+public class FeedPostJsonLdMapping implements JsonLdMapping {
+
+    private final FeedIriBuilder iri;
+
+    public FeedPostJsonLdMapping(FeedIriBuilder iri) {
+        this.iri = iri;
+    }
+
+    @Override
+    public boolean supports(Class<?> bodyType) {
+        return FeedPostResponse.class.isAssignableFrom(bodyType);
+    }
+
+    @Override
+    public Map<String, Object> apply(Object body) {
+        FeedPostResponse post = (FeedPostResponse) body;
+        return FeedJsonLd.renderPost(
+                iri,
+                post.id(),
+                post.authorId(),
+                post.authorFirstName(),
+                post.body(),
+                post.hashtags(),
+                post.createdAt() == null ? null : post.createdAt().toString(),
+                renderUpdatedAt(post),
+                post.lang(),
+                attachmentsToJsonLd(post.attachments()),
+                // FeedPostResponse doesn't carry interaction counts — they
+                // live on FeedPostInteractionState. Emit the counters with
+                // zeros so the JSON-LD shape is stable across endpoints;
+                // consumers needing live counts call
+                // GET /api/feed/posts/{id}/interaction-state.
+                0L, 0L, 0L, 0L);
+    }
+
+    private static String renderUpdatedAt(FeedPostResponse post) {
+        if (!post.isEdited() || post.updatedAt() == null) {
+            return null;
+        }
+        return post.updatedAt().toString();
+    }
+
+    private static List<Map<String, Object>> attachmentsToJsonLd(List<AttachmentSummary> attachments) {
+        if (attachments == null || attachments.isEmpty()) {
+            return List.of();
+        }
+        return attachments.stream()
+                .map(a -> {
+                    Map<String, Object> attachment = new LinkedHashMap<>();
+                    attachment.put("type", "Image");
+                    if (a.getDownloadUrl() != null) {
+                        attachment.put("url", a.getDownloadUrl());
+                    }
+                    if (a.getContentType() != null) {
+                        attachment.put("mediaType", a.getContentType());
+                    }
+                    return attachment;
+                })
+                .toList();
+    }
+
+    /**
+     * Shared rendering for both the detail-DTO and the list-item DTO so the
+     * wire shape is identical between {@code GET /api/feed/posts/{id}} and
+     * the items inside an OrderedCollectionPage from {@code /api/feed/for-you}.
+     * Kept package-private so {@link FeedPostListItemJsonLdMapping} can reuse
+     * it without exposing the implementation to the broader package.
+     */
+    static final class FeedJsonLd {
+
+        static Map<String, Object> renderPost(FeedIriBuilder iri,
+                                              Long postId,
+                                              Long authorId,
+                                              String authorFirstName,
+                                              String content,
+                                              List<String> hashtags,
+                                              String publishedIso,
+                                              String updatedIso,
+                                              String lang,
+                                              List<Map<String, Object>> attachments,
+                                              long likeCount,
+                                              long commentCount,
+                                              long shareCount,
+                                              long bookmarkCount) {
+            Map<String, Object> doc = new LinkedHashMap<>();
+            doc.put("@context", List.of(
+                    JsonLdContext.ACTIVITY_STREAMS,
+                    JsonLdContext.SCHEMA_ORG));
+            doc.put("@type", List.of("Note", "SocialMediaPosting"));
+            doc.put("@id", iri.post(postId));
+            doc.put("id", iri.post(postId));
+
+            Map<String, Object> actor = new LinkedHashMap<>();
+            actor.put("@type", "Person");
+            actor.put("@id", iri.person(authorId));
+            if (authorFirstName != null && !authorFirstName.isBlank()) {
+                actor.put("name", authorFirstName);
+            }
+            doc.put("attributedTo", actor);
+
+            if (publishedIso != null) {
+                doc.put("published", publishedIso);
+            }
+            if (updatedIso != null) {
+                doc.put("updated", updatedIso);
+            }
+            if (content != null && !content.isBlank()) {
+                doc.put("content", content);
+            }
+            if (lang != null && !lang.isBlank() && content != null && !content.isBlank()) {
+                // AS 2.0 contentMap is a JSON object keyed by BCP-47 tag.
+                doc.put("contentMap", Map.of(lang, content));
+                doc.put("inLanguage", lang);
+            }
+            if (hashtags != null && !hashtags.isEmpty()) {
+                doc.put("tag", hashtags.stream()
+                        .map(h -> {
+                            Map<String, Object> tag = new LinkedHashMap<>();
+                            tag.put("type", "Hashtag");
+                            tag.put("name", "#" + h);
+                            return tag;
+                        })
+                        .toList());
+            }
+            if (attachments != null && !attachments.isEmpty()) {
+                doc.put("attachment", attachments);
+            }
+
+            // Schema.org InteractionCounter is what consumers expect for
+            // aggregate counters; the full AS 2.0 `likes`/`shares`
+            // OrderedCollection alternative is heavier and not what
+            // consumers want to dereference from a list response.
+            doc.put("interactionStatistic", List.of(
+                    counter("https://schema.org/LikeAction", likeCount),
+                    counter("https://schema.org/CommentAction", commentCount),
+                    counter("https://schema.org/ShareAction", shareCount),
+                    counter("https://schema.org/BookmarkAction", bookmarkCount)));
+            return doc;
+        }
+
+        private static Map<String, Object> counter(String interactionType, long count) {
+            Map<String, Object> counter = new LinkedHashMap<>();
+            counter.put("@type", "InteractionCounter");
+            counter.put("interactionType", interactionType);
+            counter.put("userInteractionCount", count);
+            return counter;
+        }
+
+        private FeedJsonLd() {
+        }
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostJsonLdMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostJsonLdMapping.java
@@ -147,6 +147,15 @@ public class FeedPostJsonLdMapping implements JsonLdMapping {
             }
             if (content != null && !content.isBlank()) {
                 doc.put("content", content);
+                // Schema.org Article terms emitted alongside the AS 2.0 `content`
+                // alias so a plain-Schema.org consumer (search-engine crawler,
+                // structured-data extractor) finds what the wiki promises:
+                // `headline` is the first 200 chars (truncated at a word
+                // boundary), `articleBody` is the verbatim body. JSON-LD
+                // consumers with both contexts loaded see `content` and
+                // `articleBody` resolve to the same property.
+                doc.put("headline", deriveHeadline(content));
+                doc.put("articleBody", content);
             }
             if (lang != null && !lang.isBlank() && content != null && !content.isBlank()) {
                 // AS 2.0 contentMap is a JSON object keyed by BCP-47 tag.
@@ -154,11 +163,17 @@ public class FeedPostJsonLdMapping implements JsonLdMapping {
                 doc.put("inLanguage", lang);
             }
             if (hashtags != null && !hashtags.isEmpty()) {
+                // AS 2.0's Hashtag extension allows bare-string `name` values
+                // (no leading `#`); this is what the issue #490 spec note
+                // calls out and what spec-compliant consumers expect. The
+                // Mastodon convention of prefixing `#` is a Fediverse-only
+                // override and not part of the AS 2.0 contract — we honour
+                // the spec here to keep the document interop-friendly.
                 doc.put("tag", hashtags.stream()
                         .map(h -> {
                             Map<String, Object> tag = new LinkedHashMap<>();
                             tag.put("type", "Hashtag");
-                            tag.put("name", "#" + h);
+                            tag.put("name", h);
                             return tag;
                         })
                         .toList());
@@ -177,6 +192,21 @@ public class FeedPostJsonLdMapping implements JsonLdMapping {
                     counter("https://schema.org/ShareAction", shareCount),
                     counter("https://schema.org/BookmarkAction", bookmarkCount)));
             return doc;
+        }
+
+        /**
+         * Truncates a post body to a Schema.org-friendly headline. 200 chars
+         * is the conventional ceiling for SocialMediaPosting/Article
+         * headlines on search-engine extractors; trimming at the nearest
+         * word boundary below the cap keeps the result readable.
+         */
+        private static String deriveHeadline(String content) {
+            if (content.length() <= 200) {
+                return content;
+            }
+            String slice = content.substring(0, 200);
+            int lastSpace = slice.lastIndexOf(' ');
+            return lastSpace > 50 ? slice.substring(0, lastSpace) + "…" : slice + "…";
         }
 
         private static Map<String, Object> counter(String interactionType, long count) {

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostLikeJsonLdMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostLikeJsonLdMapping.java
@@ -1,0 +1,60 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.jsonld.JsonLdContext;
+import com.group7.backend.config.jsonld.JsonLdMapping;
+import com.group7.backend.entity.FeedPostLike;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Renders a {@link FeedPostLike} entity as a W3C Activity Streams 2.0
+ * {@code Like} activity. The activity's {@code actor} is the user who
+ * performed the like and the {@code object} is the post they liked.
+ *
+ * <p>The toggle endpoints currently return a counter aggregate
+ * ({@code FeedPostInteractionState}) rather than the entity itself, so
+ * no controller-level path emits this mapping today. It's registered
+ * eagerly because (a) the SPI is auto-discovery based and any future
+ * endpoint that surfaces a {@code FeedPostLike} row gets the AS 2.0
+ * shape for free; and (b) the mapping is the documented standards
+ * surface in the wiki's coverage table, which a consumer can build
+ * against even without a corresponding endpoint.
+ */
+@Component
+public class FeedPostLikeJsonLdMapping implements JsonLdMapping {
+
+    private final FeedIriBuilder iri;
+
+    public FeedPostLikeJsonLdMapping(FeedIriBuilder iri) {
+        this.iri = iri;
+    }
+
+    @Override
+    public boolean supports(Class<?> bodyType) {
+        return FeedPostLike.class.isAssignableFrom(bodyType);
+    }
+
+    @Override
+    public Map<String, Object> apply(Object body) {
+        FeedPostLike like = (FeedPostLike) body;
+        Long postId = like.getId() == null ? null : like.getId().getPostId();
+        Long userId = like.getId() == null ? null : like.getId().getUserId();
+
+        Map<String, Object> doc = new LinkedHashMap<>();
+        doc.put("@context", List.of(JsonLdContext.ACTIVITY_STREAMS));
+        doc.put("@type", "Like");
+        if (postId != null && userId != null) {
+            doc.put("@id", iri.like(postId, userId));
+            doc.put("id", iri.like(postId, userId));
+            doc.put("actor", iri.person(userId));
+            doc.put("object", iri.post(postId));
+        }
+        if (like.getCreatedAt() != null) {
+            doc.put("published", like.getCreatedAt().toString());
+        }
+        return doc;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostListItemJsonLdMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostListItemJsonLdMapping.java
@@ -1,0 +1,83 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.jsonld.JsonLdMapping;
+import com.group7.backend.dto.response.AttachmentSummary;
+import com.group7.backend.dto.response.FeedPostListItem;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Renders the slimmer {@link FeedPostListItem} (returned by the For-You,
+ * Following, and search list endpoints) with the same AS 2.0 / Schema.org
+ * shape as the detail-DTO mapping. Routing both DTOs through the shared
+ * renderer in {@link FeedPostJsonLdMapping.FeedJsonLd} keeps the wire
+ * format identical between a single-post fetch and a post embedded in an
+ * {@code OrderedCollectionPage}.
+ *
+ * <p>The list-item DTO carries the live like / comment counts and the
+ * ranker's factor codes; the detail DTO does not. We surface the counts
+ * here so paged JSON-LD responses are not falsely zeroed (counters in the
+ * detail mapping are zeroed because that DTO truly does not know them).
+ * The factor codes are dropped from JSON-LD on purpose — they're internal
+ * ranking telemetry, not user-facing AS 2.0 content.
+ */
+@Component
+public class FeedPostListItemJsonLdMapping implements JsonLdMapping {
+
+    private final FeedIriBuilder iri;
+
+    public FeedPostListItemJsonLdMapping(FeedIriBuilder iri) {
+        this.iri = iri;
+    }
+
+    @Override
+    public boolean supports(Class<?> bodyType) {
+        return FeedPostListItem.class.isAssignableFrom(bodyType);
+    }
+
+    @Override
+    public Map<String, Object> apply(Object body) {
+        FeedPostListItem item = (FeedPostListItem) body;
+        return FeedPostJsonLdMapping.FeedJsonLd.renderPost(
+                iri,
+                item.id(),
+                item.authorId(),
+                item.authorFirstName(),
+                item.body(),
+                item.hashtags(),
+                item.createdAt() == null ? null : item.createdAt().toString(),
+                null,
+                item.lang(),
+                attachmentsToJsonLd(item.attachments()),
+                item.likeCount(),
+                item.commentCount(),
+                // ListItem doesn't carry share / bookmark counts (the list
+                // endpoints intentionally don't pay for those aggregates).
+                // Emit zeros for shape stability; consumers needing live
+                // share / bookmark counts dereference the post detail IRI.
+                0L,
+                0L);
+    }
+
+    private static List<Map<String, Object>> attachmentsToJsonLd(List<AttachmentSummary> attachments) {
+        if (attachments == null || attachments.isEmpty()) {
+            return List.of();
+        }
+        return attachments.stream()
+                .map(a -> {
+                    Map<String, Object> attachment = new LinkedHashMap<>();
+                    attachment.put("type", "Image");
+                    if (a.getDownloadUrl() != null) {
+                        attachment.put("url", a.getDownloadUrl());
+                    }
+                    if (a.getContentType() != null) {
+                        attachment.put("mediaType", a.getContentType());
+                    }
+                    return attachment;
+                })
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostShareJsonLdMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/FeedPostShareJsonLdMapping.java
@@ -1,0 +1,64 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.jsonld.JsonLdContext;
+import com.group7.backend.config.jsonld.JsonLdMapping;
+import com.group7.backend.entity.FeedPostShare;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Renders a {@link FeedPostShare} entity as a W3C Activity Streams 2.0
+ * {@code Announce} activity — the AS 2.0 canonical type for "share /
+ * boost / retweet" semantics. Mirrors Mastodon's wire shape for boosts.
+ *
+ * <p>Quote-share commentary (the {@code body} column on
+ * {@link FeedPostShare}, populated by the new {@code /reposts} endpoint
+ * in #484) lands as {@code as:content} on the Announce activity itself.
+ * AS 2.0 permits this — the wrapper Activity may carry its own content
+ * field that's distinct from the object's content. Bare reposts (no
+ * commentary) omit the field.
+ */
+@Component
+public class FeedPostShareJsonLdMapping implements JsonLdMapping {
+
+    private final FeedIriBuilder iri;
+
+    public FeedPostShareJsonLdMapping(FeedIriBuilder iri) {
+        this.iri = iri;
+    }
+
+    @Override
+    public boolean supports(Class<?> bodyType) {
+        return FeedPostShare.class.isAssignableFrom(bodyType);
+    }
+
+    @Override
+    public Map<String, Object> apply(Object body) {
+        FeedPostShare share = (FeedPostShare) body;
+
+        Map<String, Object> doc = new LinkedHashMap<>();
+        doc.put("@context", List.of(JsonLdContext.ACTIVITY_STREAMS));
+        doc.put("@type", "Announce");
+        if (share.getPostId() != null && share.getSharerId() != null) {
+            doc.put("@id", iri.share(share.getPostId(), share.getSharerId()));
+            doc.put("id", iri.share(share.getPostId(), share.getSharerId()));
+            doc.put("actor", iri.person(share.getSharerId()));
+            doc.put("object", iri.post(share.getPostId()));
+        }
+        if (share.getCreatedAt() != null) {
+            doc.put("published", share.getCreatedAt().toString());
+        }
+        // Quote-share commentary (when the share is a repost with a body
+        // string). The shipped FeedPostShare entity carries a `body` field
+        // for the eventual #484 quote-share work; surface it as
+        // as:content if present so consumers don't need a separate fetch.
+        String commentary = share.getBody();
+        if (commentary != null && !commentary.isBlank()) {
+            doc.put("content", commentary);
+        }
+        return doc;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/FollowJsonLdMapping.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/FollowJsonLdMapping.java
@@ -1,0 +1,52 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.jsonld.JsonLdContext;
+import com.group7.backend.config.jsonld.JsonLdMapping;
+import com.group7.backend.entity.Follow;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Renders a {@link Follow} entity as a W3C Activity Streams 2.0
+ * {@code Follow} activity. The activity's {@code actor} is the follower
+ * and the {@code object} is the followee — directly matching the AS 2.0
+ * spec example for follow-graph relationships.
+ */
+@Component
+public class FollowJsonLdMapping implements JsonLdMapping {
+
+    private final FeedIriBuilder iri;
+
+    public FollowJsonLdMapping(FeedIriBuilder iri) {
+        this.iri = iri;
+    }
+
+    @Override
+    public boolean supports(Class<?> bodyType) {
+        return Follow.class.isAssignableFrom(bodyType);
+    }
+
+    @Override
+    public Map<String, Object> apply(Object body) {
+        Follow follow = (Follow) body;
+        Long followerId = follow.getId() == null ? null : follow.getId().getFollowerId();
+        Long followeeId = follow.getId() == null ? null : follow.getId().getFolloweeId();
+
+        Map<String, Object> doc = new LinkedHashMap<>();
+        doc.put("@context", List.of(JsonLdContext.ACTIVITY_STREAMS));
+        doc.put("@type", "Follow");
+        if (followerId != null && followeeId != null) {
+            doc.put("@id", iri.follow(followerId, followeeId));
+            doc.put("id", iri.follow(followerId, followeeId));
+            doc.put("actor", iri.person(followerId));
+            doc.put("object", iri.person(followeeId));
+        }
+        if (follow.getCreatedAt() != null) {
+            doc.put("published", follow.getCreatedAt().toString());
+        }
+        return doc;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/OrderedCollectionPageJsonLdAdvice.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/OrderedCollectionPageJsonLdAdvice.java
@@ -171,8 +171,12 @@ public class OrderedCollectionPageJsonLdAdvice implements ResponseBodyAdvice<Obj
     private static URI uriFor(ServerHttpRequest request) {
         if (request instanceof ServletServerHttpRequest servletRequest) {
             HttpServletRequest http = servletRequest.getServletRequest();
+            // Spring 6.1 deprecated UriComponentsBuilder.fromHttpUrl;
+            // fromUriString is the long-standing alternative that handles
+            // the same set of valid http(s) URLs without the deprecation
+            // warning.
             return UriComponentsBuilder
-                    .fromHttpUrl(http.getRequestURL().toString())
+                    .fromUriString(http.getRequestURL().toString())
                     .query(http.getQueryString())
                     .build(true)
                     .toUri();

--- a/backend/src/main/java/com/group7/backend/config/jsonld/feed/OrderedCollectionPageJsonLdAdvice.java
+++ b/backend/src/main/java/com/group7/backend/config/jsonld/feed/OrderedCollectionPageJsonLdAdvice.java
@@ -1,0 +1,198 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.jsonld.JsonLdContext;
+import com.group7.backend.config.jsonld.JsonLdMapping;
+import com.group7.backend.config.jsonld.JsonLdMediaType;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Wraps {@link Page Page&lt;T&gt;} responses as an Activity Streams 2.0
+ * {@code OrderedCollectionPage} when the client requests JSON-LD via
+ * either {@code application/ld+json} or {@code application/activity+json}.
+ *
+ * <p>The previous behaviour was to downgrade Page bodies to plain JSON.
+ * That broke the standards-coverage commitment for the feed list
+ * endpoints (For-You, Following, search, author posts), all of which
+ * paginate. This advice closes the gap by:
+ *
+ * <ol>
+ *   <li>Lifting every page element through the registered
+ *       {@link JsonLdMapping} so the items inside {@code orderedItems} are
+ *       individual JSON-LD documents (minus their {@code @context}, which
+ *       the wrapper carries once).</li>
+ *   <li>Synthesising the {@code first} / {@code prev} / {@code next} /
+ *       {@code last} hypermedia links from the current request URI plus
+ *       the page's pagination metadata.</li>
+ *   <li>Setting {@code totalItems} from the page's total element count so
+ *       AS 2.0 consumers can render "page N of M" without scanning all
+ *       pages.</li>
+ * </ol>
+ *
+ * <p>Order is {@link Ordered#LOWEST_PRECEDENCE} minus one so this runs
+ * <i>after</i> {@code JsonLdResponseBodyAdvice} for individual bodies but
+ * still inside the {@code ResponseBodyAdvice} chain. The exact ordering
+ * doesn't matter for Page bodies because {@code JsonLdResponseBodyAdvice}
+ * passes Page through unchanged — we own the transformation here.
+ */
+@ControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+public class OrderedCollectionPageJsonLdAdvice implements ResponseBodyAdvice<Object> {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderedCollectionPageJsonLdAdvice.class);
+
+    private final List<JsonLdMapping> mappings;
+
+    public OrderedCollectionPageJsonLdAdvice(List<JsonLdMapping> mappings) {
+        this.mappings = List.copyOf(mappings);
+    }
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+        if (!(body instanceof Page<?> page)) {
+            return body;
+        }
+        if (!JsonLdMediaType.isJsonLd(selectedContentType)) {
+            return body;
+        }
+
+        Optional<JsonLdMapping> mapping = findMappingForPage(page);
+        if (mapping.isEmpty()) {
+            // Downgrade to plain JSON: every consumer for which we lack a
+            // mapping would otherwise see a malformed AS 2.0 document.
+            // Same fallback behaviour as JsonLdResponseBodyAdvice.
+            log.debug("OrderedCollectionPage downgrade: no JSON-LD mapping for elements");
+            response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+            return body;
+        }
+        JsonLdMapping bound = mapping.get();
+
+        List<Map<String, Object>> orderedItems = new ArrayList<>(page.getContent().size());
+        for (Object item : page.getContent()) {
+            if (item == null) {
+                continue;
+            }
+            Map<String, Object> mapped = new LinkedHashMap<>(bound.apply(item));
+            // The outer envelope carries @context; stripping it from each
+            // inner item keeps the document shape clean and aligns with
+            // the AS 2.0 examples for OrderedCollectionPage.
+            mapped.remove("@context");
+            orderedItems.add(mapped);
+        }
+
+        URI requestUri = uriFor(request);
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("@context", List.of(
+                JsonLdContext.ACTIVITY_STREAMS,
+                JsonLdContext.SCHEMA_ORG));
+        envelope.put("@type", "OrderedCollectionPage");
+        envelope.put("id", requestUri.toString());
+        envelope.put("partOf", stripPageQueryParams(requestUri).toString());
+        envelope.put("totalItems", page.getTotalElements());
+
+        // Page numbers are 0-based in Spring Data, but AS 2.0 imposes no
+        // convention; we preserve Spring's numbering so the synthesised
+        // URLs match what the controller already publishes elsewhere.
+        int currentPage = page.getNumber();
+        int size = page.getSize();
+        int totalPages = Math.max(page.getTotalPages(), 1);
+
+        envelope.put("first", pageUri(requestUri, 0, size).toString());
+        envelope.put("last", pageUri(requestUri, totalPages - 1, size).toString());
+        if (currentPage > 0) {
+            envelope.put("prev", pageUri(requestUri, currentPage - 1, size).toString());
+        }
+        if (currentPage < totalPages - 1) {
+            envelope.put("next", pageUri(requestUri, currentPage + 1, size).toString());
+        }
+        envelope.put("orderedItems", orderedItems);
+
+        // The downstream Jackson converter respects an already-set
+        // Content-Type but it's set on a different headers reference than
+        // Spring's outer ServerHttpResponse for some converter flavours.
+        // Reaching through the underlying servlet response and writing
+        // the header directly forces the wire Content-Type to match what
+        // the client negotiated (e.g., application/activity+json) instead
+        // of silently downgrading to application/json.
+        if (response instanceof org.springframework.http.server.ServletServerHttpResponse servletResponse) {
+            servletResponse.getServletResponse().setContentType(selectedContentType.toString());
+        } else {
+            response.getHeaders().setContentType(selectedContentType);
+        }
+        return envelope;
+    }
+
+    private Optional<JsonLdMapping> findMappingForPage(Page<?> page) {
+        for (Object element : page.getContent()) {
+            if (element == null) {
+                continue;
+            }
+            Class<?> elementType = element.getClass();
+            return mappings.stream().filter(m -> m.supports(elementType)).findFirst();
+        }
+        // Empty page — pick the first mapping that exists so a zero-result
+        // search still emits a well-formed OrderedCollectionPage. The
+        // mapping isn't applied to anything (no items), so any choice is
+        // structurally equivalent; we just need a non-null arbiter to
+        // signal "we know how to render this list type".
+        return mappings.stream().findFirst();
+    }
+
+    private static URI uriFor(ServerHttpRequest request) {
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            HttpServletRequest http = servletRequest.getServletRequest();
+            return UriComponentsBuilder
+                    .fromHttpUrl(http.getRequestURL().toString())
+                    .query(http.getQueryString())
+                    .build(true)
+                    .toUri();
+        }
+        return request.getURI();
+    }
+
+    private static URI pageUri(URI base, int page, int size) {
+        return UriComponentsBuilder.fromUri(base)
+                .replaceQueryParam("page", page)
+                .replaceQueryParam("size", size)
+                .build(true)
+                .toUri();
+    }
+
+    private static URI stripPageQueryParams(URI base) {
+        return UriComponentsBuilder.fromUri(base)
+                .replaceQueryParam("page")
+                .replaceQueryParam("size")
+                .build(true)
+                .toUri();
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/FeedPostListItem.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FeedPostListItem.java
@@ -53,7 +53,7 @@ public record FeedPostListItem(
         List<String> factors,
 
         @Schema(description = "Image attachments on the post, in author-specified order. Empty when "
-                + "the post has no media (#485).")
+                + "the post has no media.")
         List<AttachmentSummary> attachments,
 
         @Schema(description = "True if the authenticated viewer has liked this post. Always "
@@ -85,6 +85,12 @@ public record FeedPostListItem(
                 + "Used by the UI to render \"reposted N minutes ago\" alongside the post's own "
                 + "createdAt. Null on non-repost rows.",
                 nullable = true)
-        OffsetDateTime sharedAt
+        OffsetDateTime sharedAt,
+
+        @Schema(description = "Optional BCP-47 language tag for the body. Null for legacy posts. "
+                + "Drives the AS 2.0 contentMap / inLanguage fields in the JSON-LD list "
+                + "representation of this post.",
+                example = "en", nullable = true)
+        String lang
 ) {
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/FeedPostResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FeedPostResponse.java
@@ -52,7 +52,7 @@ public record FeedPostResponse(
         boolean isAuthor,
 
         @Schema(description = "Image attachments on the post, in author-specified order. Empty when "
-                + "the post has no media (#485). Each downloadUrl resolves to the feed-scoped "
+                + "the post has no media. Each downloadUrl resolves to the feed-scoped "
                 + "/api/uploads/feed-media/{id} endpoint, which requires authentication but no "
                 + "per-user ACL.")
         List<AttachmentSummary> attachments,
@@ -65,6 +65,12 @@ public record FeedPostResponse(
         @Schema(description = "True if the authenticated viewer has bookmarked this post. "
                 + "Always false for anonymous reads. Lets the UI render the bookmark-icon "
                 + "toggle state without a follow-up GET /interactions call per item.")
-        boolean viewerHasBookmarked
+        boolean viewerHasBookmarked,
+
+        @Schema(description = "Optional BCP-47 language tag for the body (e.g. \"en\", \"tr-TR\"). "
+                + "Null for legacy posts that predate the lang column. Drives the AS 2.0 "
+                + "contentMap / inLanguage fields in the JSON-LD representation of this post.",
+                example = "en", nullable = true)
+        String lang
 ) {
 }

--- a/backend/src/main/java/com/group7/backend/service/FeedPostMapper.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedPostMapper.java
@@ -207,7 +207,8 @@ public class FeedPostMapper {
                 isAuthor,
                 toSummaries(post.getAttachments()),
                 likedPostIds.contains(post.getId()),
-                bookmarkedPostIds.contains(post.getId())
+                bookmarkedPostIds.contains(post.getId()),
+                post.getLang()
         );
     }
 
@@ -240,7 +241,8 @@ public class FeedPostMapper {
                 null,   // sharedById — not a repost surface for this mapper
                 null,   // sharedByFirstName
                 null,   // shareCommentary
-                null    // sharedAt
+                null,   // sharedAt
+                post.getLang()
         );
     }
 

--- a/backend/src/main/java/com/group7/backend/service/FeedReadService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedReadService.java
@@ -316,7 +316,8 @@ public class FeedReadService {
                 row.getShareCommentary(),
                 row.getSharedAt() == null
                         ? null
-                        : row.getSharedAt().atOffset(java.time.ZoneOffset.UTC));
+                        : row.getSharedAt().atOffset(java.time.ZoneOffset.UTC),
+                post == null ? null : post.getLang());
     }
 
     /**

--- a/backend/src/main/resources/db/migration/V53__feed_posts_lang_bcp47_check.sql
+++ b/backend/src/main/resources/db/migration/V53__feed_posts_lang_bcp47_check.sql
@@ -1,0 +1,15 @@
+-- BCP-47 short-tag CHECK constraint on feed_posts.lang. The column ships
+-- in V50 via #486; the constraint here guarantees that any value reaching
+-- the column was validated at the DB layer too, so the AS 2.0 contentMap
+-- key derived from it is always a well-formed BCP-47 short tag. Without
+-- this constraint, a producer that bypasses the @Pattern validator at the
+-- DTO layer could otherwise land "english", "TR", "en-us" (lowercase
+-- region) into the column and produce a malformed AS 2.0 document on
+-- read.
+--
+-- Pattern matches the @Pattern in CreateFeedPostRequest exactly:
+--   - 2-3 lowercase ASCII letters for the primary language subtag
+--   - optional `-` then 2 uppercase ASCII letters for the region subtag
+ALTER TABLE feed_posts
+    ADD CONSTRAINT feed_posts_lang_bcp47
+        CHECK (lang IS NULL OR lang ~ '^[a-z]{2,3}(-[A-Z]{2})?$');

--- a/backend/src/test/java/com/group7/backend/config/jsonld/feed/FeedCommentJsonLdMappingTest.java
+++ b/backend/src/test/java/com/group7/backend/config/jsonld/feed/FeedCommentJsonLdMappingTest.java
@@ -1,0 +1,108 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.AppProperties;
+import com.group7.backend.dto.response.FeedCommentResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the comment mapping's two non-obvious contracts: the
+ * {@code inReplyTo} link to the parent post IRI and the soft-delete
+ * tombstone branch (deleted comments omit {@code content} entirely
+ * rather than emitting an empty string).
+ */
+class FeedCommentJsonLdMappingTest {
+
+    private FeedCommentJsonLdMapping mapping;
+
+    @BeforeEach
+    void setUp() {
+        AppProperties props = new AppProperties();
+        props.setBaseUrl("https://api.example.com");
+        mapping = new FeedCommentJsonLdMapping(new FeedIriBuilder(props));
+    }
+
+    @Test
+    void supports_acceptsFeedCommentResponse() {
+        assertThat(mapping.supports(FeedCommentResponse.class)).isTrue();
+        assertThat(mapping.supports(String.class)).isFalse();
+    }
+
+    @Test
+    void apply_emitsNoteWithInReplyToParentPost() {
+        FeedCommentResponse c = comment(101L, 7L, 1L, "great post", false);
+        Map<String, Object> doc = mapping.apply(c);
+
+        assertThat(doc.get("@type")).isEqualTo("Note");
+        assertThat(doc.get("@id")).isEqualTo("https://api.example.com/api/feed/comments/101");
+        assertThat(doc.get("inReplyTo")).isEqualTo("https://api.example.com/api/feed/posts/7");
+        assertThat(doc.get("content")).isEqualTo("great post");
+    }
+
+    @Test
+    void apply_emitsAttributedToPersonActor() {
+        FeedCommentResponse c = comment(101L, 7L, 1L, "x", false);
+        Map<String, Object> doc = mapping.apply(c);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> actor = (Map<String, Object>) doc.get("attributedTo");
+        assertThat(actor.get("@type")).isEqualTo("Person");
+        assertThat(actor.get("@id")).isEqualTo("https://api.example.com/api/users/1");
+        assertThat(actor.get("name")).isEqualTo("Ada");
+    }
+
+    @Test
+    void apply_softDeletedComment_omitsContentEntirely() {
+        FeedCommentResponse tombstone = new FeedCommentResponse(
+                101L, 7L, 1L, "Ada", null,
+                OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC),
+                false, false, true, 0L, false);   // isDeleted = true
+
+        Map<String, Object> doc = mapping.apply(tombstone);
+
+        // Mastodon-style consumers distinguish redacted from literally
+        // empty by whether `content` is present at all; emitting an empty
+        // string would conflate the two cases.
+        assertThat(doc).doesNotContainKey("content");
+    }
+
+    @Test
+    void apply_omitsUpdated_whenCommentNotEdited() {
+        FeedCommentResponse c = comment(101L, 7L, 1L, "x", false);
+        Map<String, Object> doc = mapping.apply(c);
+
+        assertThat(doc).doesNotContainKey("updated");
+    }
+
+    @Test
+    void apply_emitsUpdated_whenCommentEdited() {
+        OffsetDateTime created = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+        OffsetDateTime edited = created.plusHours(2);
+        FeedCommentResponse c = new FeedCommentResponse(
+                101L, 7L, 1L, "Ada", "edited body",
+                created, edited,
+                true, false, false, 0L, false);   // isEdited = true
+
+        Map<String, Object> doc = mapping.apply(c);
+
+        assertThat(doc.get("updated")).isEqualTo(edited.toString());
+    }
+
+    // ── Fixtures ────────────────────────────────────────────────
+
+    private static FeedCommentResponse comment(Long id, Long postId, Long authorId,
+                                                String body, boolean edited) {
+        OffsetDateTime t = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+        return new FeedCommentResponse(
+                id, postId, authorId, "Ada", body,
+                t, t,
+                edited, false, false, 0L, false);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/config/jsonld/feed/FeedPostJsonLdMappingTest.java
+++ b/backend/src/test/java/com/group7/backend/config/jsonld/feed/FeedPostJsonLdMappingTest.java
@@ -93,20 +93,50 @@ class FeedPostJsonLdMappingTest {
     }
 
     @Test
-    void apply_emitsHashtagsAsAS2Hashtag_withHashPrefix() {
+    void apply_emitsHashtagsAsAS2Hashtag_withBareStringName() {
         Map<String, Object> doc = mapping.apply(samplePost());
 
         Object tags = doc.get("tag");
         assertThat(tags).isInstanceOf(List.class);
         List<?> tagList = (List<?>) tags;
-        // Hashtag values in AS 2.0 use the leading `#` so consumers can
-        // render them verbatim. The stored DB value drops the `#` for
-        // index hygiene; we re-add it on the wire.
+        // AS 2.0's Hashtag extension permits bare-string `name` values
+        // (no leading `#`). The issue #490 note explicitly chooses this
+        // over the Mastodon convention for spec compliance; pinning it
+        // here so a future diff that re-adds the prefix tips the test.
         assertThat(tagList).hasSize(2);
         @SuppressWarnings("unchecked")
         Map<String, Object> first = (Map<String, Object>) tagList.get(0);
         assertThat(first).containsEntry("type", "Hashtag");
-        assertThat(first).containsEntry("name", "#datascience");
+        assertThat(first).containsEntry("name", "datascience");
+    }
+
+    @Test
+    void apply_emitsSchemaOrgArticleTerms_alongsideAS2Aliases() {
+        Map<String, Object> doc = mapping.apply(samplePost());
+
+        // headline + articleBody let a plain-Schema.org consumer (search
+        // engine crawler, structured-data extractor) read the post
+        // without needing the AS 2.0 context loaded. JSON-LD consumers
+        // with both contexts see `content` and `articleBody` resolve to
+        // the same property.
+        assertThat(doc).containsKey("headline");
+        assertThat(doc).containsKey("articleBody");
+        assertThat(doc.get("articleBody")).isEqualTo(doc.get("content"));
+    }
+
+    @Test
+    void apply_headline_truncatesAtWordBoundary_whenContentExceeds200Chars() {
+        String body = "x".repeat(180) + " " + "y".repeat(60);   // 241 chars
+        OffsetDateTime created = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+        FeedPostResponse post = new FeedPostResponse(
+                42L, 17L, "Ada", body, List.of(),
+                created, created, false, false, List.of(), false, false, null);
+
+        Map<String, Object> doc = mapping.apply(post);
+        String headline = (String) doc.get("headline");
+        assertThat(headline).isNotEqualTo(body);
+        assertThat(headline.length()).isLessThanOrEqualTo(201);   // 200 chars + ellipsis
+        assertThat(headline).endsWith("…");
     }
 
     @Test

--- a/backend/src/test/java/com/group7/backend/config/jsonld/feed/FeedPostJsonLdMappingTest.java
+++ b/backend/src/test/java/com/group7/backend/config/jsonld/feed/FeedPostJsonLdMappingTest.java
@@ -1,0 +1,192 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.AppProperties;
+import com.group7.backend.config.jsonld.JsonLdContext;
+import com.group7.backend.dto.response.AttachmentSummary;
+import com.group7.backend.dto.response.FeedPostResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the AS 2.0 / Schema.org shape produced for a single feed post.
+ * Each assertion guards a specific contract spelled out in the standards
+ * coverage commitment on the project wiki and in the issue's acceptance
+ * criteria.
+ */
+class FeedPostJsonLdMappingTest {
+
+    private FeedPostJsonLdMapping mapping;
+
+    @BeforeEach
+    void setUp() {
+        AppProperties props = new AppProperties();
+        props.setBaseUrl("https://api.example.com/");
+        mapping = new FeedPostJsonLdMapping(new FeedIriBuilder(props));
+    }
+
+    @Test
+    void supports_acceptsFeedPostResponse_andNothingElse() {
+        assertThat(mapping.supports(FeedPostResponse.class)).isTrue();
+        assertThat(mapping.supports(String.class)).isFalse();
+    }
+
+    @Test
+    void apply_emitsContextSchemaOrgAndActivityStreams_inThatOrder() {
+        Map<String, Object> doc = mapping.apply(samplePost());
+
+        assertThat(doc.get("@context")).isInstanceOf(List.class);
+        // AS 2.0 first, Schema.org second — preserves the precedence
+        // documented in the issue body.
+        assertThat(doc.get("@context")).isEqualTo(List.of(
+                JsonLdContext.ACTIVITY_STREAMS, JsonLdContext.SCHEMA_ORG));
+    }
+
+    @Test
+    void apply_emitsBothTypesAndCanonicalIri() {
+        Map<String, Object> doc = mapping.apply(samplePost());
+
+        assertThat(doc.get("@type")).isEqualTo(List.of("Note", "SocialMediaPosting"));
+        assertThat(doc.get("@id")).isEqualTo("https://api.example.com/api/feed/posts/42");
+        // `id` is the AS 2.0 alias; both must resolve to the same canonical
+        // URL so consumers indexing on either field don't fork.
+        assertThat(doc.get("id")).isEqualTo(doc.get("@id"));
+    }
+
+    @Test
+    void apply_emitsAttributedToWithPersonIri() {
+        Map<String, Object> doc = mapping.apply(samplePost());
+
+        Object actor = doc.get("attributedTo");
+        assertThat(actor).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> person = (Map<String, Object>) actor;
+        assertThat(person).containsEntry("@type", "Person");
+        assertThat(person).containsEntry("@id", "https://api.example.com/api/users/17");
+        assertThat(person).containsEntry("name", "Ada");
+    }
+
+    @Test
+    void apply_emitsContentMapAndInLanguage_whenLangPresent() {
+        FeedPostResponse post = samplePost("en");
+        Map<String, Object> doc = mapping.apply(post);
+
+        assertThat(doc).containsEntry("content", post.body());
+        assertThat(doc.get("contentMap")).isEqualTo(Map.of("en", post.body()));
+        assertThat(doc).containsEntry("inLanguage", "en");
+    }
+
+    @Test
+    void apply_omitsContentMapAndInLanguage_whenLangAbsent() {
+        FeedPostResponse post = samplePost(null);
+        Map<String, Object> doc = mapping.apply(post);
+
+        assertThat(doc).containsEntry("content", post.body());
+        assertThat(doc).doesNotContainKey("contentMap");
+        assertThat(doc).doesNotContainKey("inLanguage");
+    }
+
+    @Test
+    void apply_emitsHashtagsAsAS2Hashtag_withHashPrefix() {
+        Map<String, Object> doc = mapping.apply(samplePost());
+
+        Object tags = doc.get("tag");
+        assertThat(tags).isInstanceOf(List.class);
+        List<?> tagList = (List<?>) tags;
+        // Hashtag values in AS 2.0 use the leading `#` so consumers can
+        // render them verbatim. The stored DB value drops the `#` for
+        // index hygiene; we re-add it on the wire.
+        assertThat(tagList).hasSize(2);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> first = (Map<String, Object>) tagList.get(0);
+        assertThat(first).containsEntry("type", "Hashtag");
+        assertThat(first).containsEntry("name", "#datascience");
+    }
+
+    @Test
+    void apply_emitsInteractionStatistic_withAllFourCounters() {
+        Map<String, Object> doc = mapping.apply(samplePost());
+
+        Object stats = doc.get("interactionStatistic");
+        assertThat(stats).isInstanceOf(List.class);
+        List<?> statList = (List<?>) stats;
+        assertThat(statList).hasSize(4);
+        // The detail DTO never carries live counts; counters are emitted
+        // with zeros for shape stability so consumers can rely on the
+        // four-tuple always existing.
+        @SuppressWarnings("unchecked")
+        Map<String, Object> likeCounter = (Map<String, Object>) statList.get(0);
+        assertThat(likeCounter).containsEntry("@type", "InteractionCounter");
+        assertThat(likeCounter).containsEntry("interactionType", "https://schema.org/LikeAction");
+        assertThat(likeCounter).containsEntry("userInteractionCount", 0L);
+    }
+
+    @Test
+    void apply_emitsAttachments_whenPostHasMedia() {
+        FeedPostResponse post = samplePostWithAttachment();
+        Map<String, Object> doc = mapping.apply(post);
+
+        Object attachments = doc.get("attachment");
+        assertThat(attachments).isInstanceOf(List.class);
+        List<?> list = (List<?>) attachments;
+        assertThat(list).hasSize(1);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> first = (Map<String, Object>) list.get(0);
+        assertThat(first).containsEntry("type", "Image");
+        assertThat(first).containsEntry("url", "https://api.example.com/api/uploads/feed-media/1");
+        assertThat(first).containsEntry("mediaType", "image/png");
+    }
+
+    @Test
+    void apply_omitsUpdated_whenPostNotEdited() {
+        FeedPostResponse post = samplePost();   // isEdited=false in fixture
+        Map<String, Object> doc = mapping.apply(post);
+
+        assertThat(doc).doesNotContainKey("updated");
+    }
+
+    @Test
+    void apply_emitsUpdated_whenPostEdited() {
+        OffsetDateTime created = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+        OffsetDateTime edited = created.plusHours(2);
+        FeedPostResponse post = new FeedPostResponse(
+                42L, 17L, "Ada", "edited body", List.of(),
+                created, edited, true, false, List.of(), false, false, null);
+
+        Map<String, Object> doc = mapping.apply(post);
+
+        assertThat(doc.get("updated")).isEqualTo(edited.toString());
+    }
+
+    // ── Fixtures ────────────────────────────────────────────────
+
+    private static FeedPostResponse samplePost() {
+        return samplePost(null);
+    }
+
+    private static FeedPostResponse samplePost(String lang) {
+        OffsetDateTime created = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+        return new FeedPostResponse(
+                42L, 17L, "Ada",
+                "Excited to share thoughts on data science.",
+                List.of("datascience", "nlp"),
+                created, created, false, false, List.of(), false, false, lang);
+    }
+
+    private static FeedPostResponse samplePostWithAttachment() {
+        OffsetDateTime created = OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC);
+        AttachmentSummary attachment = new AttachmentSummary();
+        attachment.setDownloadUrl("https://api.example.com/api/uploads/feed-media/1");
+        attachment.setContentType("image/png");
+        return new FeedPostResponse(
+                42L, 17L, "Ada", "see this",
+                List.of(),
+                created, created, false, false, List.of(attachment), false, false, "en");
+    }
+}

--- a/backend/src/test/java/com/group7/backend/config/jsonld/feed/FeedPostListItemJsonLdMappingTest.java
+++ b/backend/src/test/java/com/group7/backend/config/jsonld/feed/FeedPostListItemJsonLdMappingTest.java
@@ -1,0 +1,133 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.AppProperties;
+import com.group7.backend.dto.response.FeedPostListItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the two non-obvious contracts of the list-item mapping: live
+ * like / comment counts surface in the AS 2.0 InteractionCounter
+ * aggregates, and the share / bookmark counters default to zero
+ * because the list endpoints intentionally don't pay for those
+ * aggregates (consumers needing them dereference the post detail IRI).
+ */
+class FeedPostListItemJsonLdMappingTest {
+
+    private FeedPostListItemJsonLdMapping mapping;
+
+    @BeforeEach
+    void setUp() {
+        AppProperties props = new AppProperties();
+        props.setBaseUrl("https://api.example.com");
+        mapping = new FeedPostListItemJsonLdMapping(new FeedIriBuilder(props));
+    }
+
+    @Test
+    void supports_acceptsFeedPostListItem() {
+        assertThat(mapping.supports(FeedPostListItem.class)).isTrue();
+        assertThat(mapping.supports(String.class)).isFalse();
+    }
+
+    @Test
+    void apply_emitsBothTypesAndCanonicalIri() {
+        Map<String, Object> doc = mapping.apply(sampleItem("en"));
+
+        assertThat(doc.get("@type")).isEqualTo(List.of("Note", "SocialMediaPosting"));
+        assertThat(doc.get("@id")).isEqualTo("https://api.example.com/api/feed/posts/42");
+    }
+
+    @Test
+    void apply_surfacesLiveLikeAndCommentCounts_inInteractionStatistic() {
+        FeedPostListItem item = new FeedPostListItem(
+                42L, 17L, "Ada", "body", List.of(),
+                OffsetDateTime.now(),
+                5L,    // likeCount
+                3L,    // commentCount
+                List.of(),
+                List.of(),
+                false, false,
+                null, null, null, null,
+                "en");
+
+        Map<String, Object> doc = mapping.apply(item);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> stats = (List<Map<String, Object>>) doc.get("interactionStatistic");
+        assertThat(stats).hasSize(4);
+        // Live counts (like / comment) propagate from the list-item.
+        assertThat(stats.get(0).get("interactionType")).isEqualTo("https://schema.org/LikeAction");
+        assertThat(stats.get(0).get("userInteractionCount")).isEqualTo(5L);
+        assertThat(stats.get(1).get("interactionType")).isEqualTo("https://schema.org/CommentAction");
+        assertThat(stats.get(1).get("userInteractionCount")).isEqualTo(3L);
+    }
+
+    @Test
+    void apply_zeroDefaultsShareAndBookmarkCounters_documentedContract() {
+        FeedPostListItem item = new FeedPostListItem(
+                42L, 17L, "Ada", "body", List.of(),
+                OffsetDateTime.now(),
+                5L, 3L,
+                List.of(),
+                List.of(),
+                false, false,
+                null, null, null, null,
+                null);
+
+        Map<String, Object> doc = mapping.apply(item);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> stats = (List<Map<String, Object>>) doc.get("interactionStatistic");
+        // The list endpoints don't pay for these aggregates — consumers
+        // needing live share / bookmark counts dereference the post
+        // detail IRI. Pinning the zero default keeps the wire shape
+        // stable across list and detail consumers.
+        assertThat(stats.get(2).get("interactionType")).isEqualTo("https://schema.org/ShareAction");
+        assertThat(stats.get(2).get("userInteractionCount")).isEqualTo(0L);
+        assertThat(stats.get(3).get("interactionType")).isEqualTo("https://schema.org/BookmarkAction");
+        assertThat(stats.get(3).get("userInteractionCount")).isEqualTo(0L);
+    }
+
+    @Test
+    void apply_emitsContentMapAndInLanguage_whenLangPresent() {
+        Map<String, Object> doc = mapping.apply(sampleItem("tr"));
+
+        assertThat(doc.get("inLanguage")).isEqualTo("tr");
+        assertThat(doc.get("contentMap")).isEqualTo(Map.of("tr", "body content"));
+    }
+
+    @Test
+    void apply_emitsBareHashtagNames_perAS2Spec() {
+        Map<String, Object> doc = mapping.apply(sampleItem("en"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> tags = (List<Map<String, Object>>) doc.get("tag");
+        // The AS 2.0 Hashtag extension accepts bare-string names; the
+        // leading `#` is a Mastodon-only override that the issue note
+        // explicitly disallows.
+        assertThat(tags.get(0).get("name")).isEqualTo("datascience");
+        assertThat(tags.get(0).get("type")).isEqualTo("Hashtag");
+    }
+
+    // ── Fixtures ────────────────────────────────────────────────
+
+    private static FeedPostListItem sampleItem(String lang) {
+        return new FeedPostListItem(
+                42L, 17L, "Ada", "body content",
+                List.of("datascience"),
+                OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC),
+                0L, 0L,
+                List.of(),
+                List.of(),
+                false, false,
+                null, null, null, null,
+                lang);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/config/jsonld/feed/OrderedCollectionPageJsonLdAdviceTest.java
+++ b/backend/src/test/java/com/group7/backend/config/jsonld/feed/OrderedCollectionPageJsonLdAdviceTest.java
@@ -1,0 +1,226 @@
+package com.group7.backend.config.jsonld.feed;
+
+import com.group7.backend.config.AppProperties;
+import com.group7.backend.config.jsonld.JsonLdMapping;
+import com.group7.backend.config.jsonld.JsonLdMediaType;
+import com.group7.backend.dto.response.FeedPostListItem;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the OrderedCollectionPage envelope contract: empty pages still
+ * produce well-formed AS 2.0 documents, the four hypermedia paging links
+ * appear or disappear based on the page's position, the wrapped items
+ * stripped of their inner @context, and the response Content-Type is
+ * pinned to the negotiated AS 2.0 wire type instead of silently
+ * downgrading to application/json.
+ */
+class OrderedCollectionPageJsonLdAdviceTest {
+
+    private OrderedCollectionPageJsonLdAdvice advice;
+    private FeedPostListItemJsonLdMapping itemMapping;
+
+    @BeforeEach
+    void setUp() {
+        AppProperties props = new AppProperties();
+        props.setBaseUrl("https://api.example.com/");
+        FeedIriBuilder iri = new FeedIriBuilder(props);
+        itemMapping = new FeedPostListItemJsonLdMapping(iri);
+        advice = new OrderedCollectionPageJsonLdAdvice(List.<JsonLdMapping>of(itemMapping));
+    }
+
+    @Test
+    void wraps_emptyPageIntoOrderedCollectionPage_withZeroTotalItems() {
+        Page<FeedPostListItem> page = Page.empty(PageRequest.of(0, 10));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> envelope = (Map<String, Object>) callAdvice(
+                page, "/api/feed/for-you", "page=0&size=10",
+                JsonLdMediaType.APPLICATION_ACTIVITY_JSON);
+
+        assertThat(envelope.get("@type")).isEqualTo("OrderedCollectionPage");
+        assertThat(envelope.get("totalItems")).isEqualTo(0L);
+        assertThat(envelope.get("orderedItems")).isEqualTo(List.of());
+        // Single empty page → prev / next are both absent; first / last
+        // still point at this page so consumers can render a coherent
+        // empty-state with a stable id.
+        assertThat(envelope).doesNotContainKey("prev");
+        assertThat(envelope).doesNotContainKey("next");
+        assertThat(envelope.get("first")).isEqualTo("https://api.example.com/api/feed/for-you?page=0&size=10");
+        assertThat(envelope.get("last")).isEqualTo("https://api.example.com/api/feed/for-you?page=0&size=10");
+    }
+
+    @Test
+    void wraps_firstPageOfMany_emitsNextAndLastButNotPrev() {
+        Page<FeedPostListItem> page = new PageImpl<>(
+                List.of(listItem(101L), listItem(102L)),
+                PageRequest.of(0, 2),
+                7L);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> envelope = (Map<String, Object>) callAdvice(
+                page, "/api/feed/for-you", "page=0&size=2",
+                JsonLdMediaType.APPLICATION_LD_JSON);
+
+        assertThat(envelope.get("totalItems")).isEqualTo(7L);
+        // 7 items / size 2 → 4 pages (0..3). Page 0 has next + last but no prev.
+        assertThat(envelope).doesNotContainKey("prev");
+        assertThat(envelope.get("next")).isEqualTo("https://api.example.com/api/feed/for-you?page=1&size=2");
+        assertThat(envelope.get("first")).isEqualTo("https://api.example.com/api/feed/for-you?page=0&size=2");
+        assertThat(envelope.get("last")).isEqualTo("https://api.example.com/api/feed/for-you?page=3&size=2");
+    }
+
+    @Test
+    void wraps_middlePage_emitsAllFourPagingLinks() {
+        Page<FeedPostListItem> page = new PageImpl<>(
+                List.of(listItem(201L)),
+                PageRequest.of(1, 2),
+                7L);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> envelope = (Map<String, Object>) callAdvice(
+                page, "/api/feed/for-you", "page=1&size=2",
+                JsonLdMediaType.APPLICATION_ACTIVITY_JSON);
+
+        assertThat(envelope.get("prev")).isEqualTo("https://api.example.com/api/feed/for-you?page=0&size=2");
+        assertThat(envelope.get("next")).isEqualTo("https://api.example.com/api/feed/for-you?page=2&size=2");
+        assertThat(envelope.get("first")).isEqualTo("https://api.example.com/api/feed/for-you?page=0&size=2");
+        assertThat(envelope.get("last")).isEqualTo("https://api.example.com/api/feed/for-you?page=3&size=2");
+    }
+
+    @Test
+    void wraps_lastPage_emitsPrevAndFirstButNotNext() {
+        Page<FeedPostListItem> page = new PageImpl<>(
+                List.of(listItem(301L)),
+                PageRequest.of(3, 2),
+                7L);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> envelope = (Map<String, Object>) callAdvice(
+                page, "/api/feed/for-you", "page=3&size=2",
+                JsonLdMediaType.APPLICATION_ACTIVITY_JSON);
+
+        assertThat(envelope.get("prev")).isEqualTo("https://api.example.com/api/feed/for-you?page=2&size=2");
+        assertThat(envelope).doesNotContainKey("next");
+        assertThat(envelope.get("last")).isEqualTo("https://api.example.com/api/feed/for-you?page=3&size=2");
+    }
+
+    @Test
+    void wraps_singlePageResult_emitsNeitherPrevNorNext() {
+        Page<FeedPostListItem> page = new PageImpl<>(
+                List.of(listItem(101L), listItem(102L)),
+                PageRequest.of(0, 10),
+                2L);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> envelope = (Map<String, Object>) callAdvice(
+                page, "/api/feed/for-you", "page=0&size=10",
+                JsonLdMediaType.APPLICATION_ACTIVITY_JSON);
+
+        assertThat(envelope).doesNotContainKey("prev");
+        assertThat(envelope).doesNotContainKey("next");
+        // Single-page result → first == last == this page.
+        assertThat(envelope.get("first")).isEqualTo(envelope.get("last"));
+    }
+
+    @Test
+    void wraps_pinsContentTypeToTheNegotiatedAsJsonType() {
+        Page<FeedPostListItem> page = Page.empty(PageRequest.of(0, 10));
+        MockHttpServletResponse rawResponse = new MockHttpServletResponse();
+        ServletServerHttpResponse springResponse = new ServletServerHttpResponse(rawResponse);
+
+        advice.beforeBodyWrite(
+                page, null,
+                JsonLdMediaType.APPLICATION_ACTIVITY_JSON,
+                null,
+                buildRequest("/api/feed/for-you", "page=0&size=10"),
+                springResponse);
+
+        // The advice reaches through ServletServerHttpResponse and pins the
+        // Content-Type on the raw servlet response. Without this hop, the
+        // Jackson converter silently rewrites to application/json after we
+        // wrap the Page<T>; this assertion is the regression guard.
+        assertThat(rawResponse.getContentType())
+                .isEqualTo(JsonLdMediaType.APPLICATION_ACTIVITY_JSON_VALUE);
+    }
+
+    @Test
+    void passesThrough_pageBody_whenAcceptIsPlainJson() {
+        Page<FeedPostListItem> page = Page.empty(PageRequest.of(0, 10));
+
+        Object result = callAdvice(
+                page, "/api/feed/for-you", "page=0&size=10",
+                MediaType.APPLICATION_JSON);
+
+        // Plain-JSON consumers see the original Page envelope unchanged.
+        // Without this carve-out, every list endpoint would have to opt
+        // out individually to stay backward-compatible.
+        assertThat(result).isSameAs(page);
+    }
+
+    @Test
+    void stripsInnerContextFromEachItem() {
+        Page<FeedPostListItem> page = new PageImpl<>(
+                List.of(listItem(101L)),
+                PageRequest.of(0, 10),
+                1L);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> envelope = (Map<String, Object>) callAdvice(
+                page, "/api/feed/for-you", "page=0&size=10",
+                JsonLdMediaType.APPLICATION_ACTIVITY_JSON);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items = (List<Map<String, Object>>) envelope.get("orderedItems");
+        assertThat(items).hasSize(1);
+        // The outer envelope carries @context once; inner items must drop
+        // it so the document parses as a single JSON-LD graph rather than
+        // a nested mess of redundant contexts.
+        assertThat(items.get(0)).doesNotContainKey("@context");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────
+
+    private Object callAdvice(Page<?> body, String path, String query, MediaType selected) {
+        ServerHttpRequest request = buildRequest(path, query);
+        ServletServerHttpResponse response = new ServletServerHttpResponse(new MockHttpServletResponse());
+        return advice.beforeBodyWrite(body, null, selected, null, request, response);
+    }
+
+    private static ServletServerHttpRequest buildRequest(String path, String query) {
+        MockHttpServletRequest http = new MockHttpServletRequest("GET", path);
+        http.setScheme("https");
+        http.setServerName("api.example.com");
+        http.setServerPort(443);
+        http.setRequestURI(path);
+        http.setQueryString(query);
+        return new ServletServerHttpRequest(http);
+    }
+
+    private static FeedPostListItem listItem(Long id) {
+        return new FeedPostListItem(
+                id, 99L, "Ada", "post body " + id, List.of(),
+                OffsetDateTime.now(), 0L, 0L, List.of(),
+                List.of(),
+                false, false,
+                null, null, null, null,
+                null);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/FeedPostControllerTest.java
@@ -71,7 +71,7 @@ class FeedPostControllerTest {
     private static FeedPostResponse stub(Long id, Long authorId) {
         return new FeedPostResponse(id, authorId, "Alice", "Hello", List.of("data"),
                 OffsetDateTime.now(), OffsetDateTime.now(), false, true, List.of(),
-                false, false);
+                false, false, null);
     }
 
     // ── POST /api/feed/posts ────────────────────────────────────────────────
@@ -191,7 +191,7 @@ class FeedPostControllerTest {
         // Fixed timestamps so the assertion is deterministic.
         OffsetDateTime t0 = OffsetDateTime.parse("2026-05-09T10:15:00Z");
         FeedPostResponse fixed = new FeedPostResponse(42L, 1L, "Alice", "Hello",
-                List.of("data"), t0, t0, false, true, List.of(), false, false);
+                List.of("data"), t0, t0, false, true, List.of(), false, false, null);
         when(feedPostService.getById(42L, 1L)).thenReturn(fixed);
 
         mockMvc.perform(get("/api/feed/posts/42").header("Authorization", "Bearer " + TOKEN))
@@ -206,7 +206,7 @@ class FeedPostControllerTest {
         mockMenteeJwt(TOKEN, 1L);
         OffsetDateTime t0 = OffsetDateTime.parse("2026-05-09T10:15:00Z");
         FeedPostResponse fixed = new FeedPostResponse(42L, 1L, "Alice", "Hello",
-                List.of("data"), t0, t0, false, true, List.of(), false, false);
+                List.of("data"), t0, t0, false, true, List.of(), false, false, null);
         when(feedPostService.getById(42L, 1L)).thenReturn(fixed);
 
         // First fetch — capture the ETag.
@@ -230,9 +230,9 @@ class FeedPostControllerTest {
         OffsetDateTime created = OffsetDateTime.parse("2026-05-09T10:15:00Z");
         OffsetDateTime edited = OffsetDateTime.parse("2026-05-09T11:02:34Z");
         FeedPostResponse before = new FeedPostResponse(42L, 1L, "Alice", "Hello",
-                List.of("data"), created, created, false, true, List.of(), false, false);
+                List.of("data"), created, created, false, true, List.of(), false, false, null);
         FeedPostResponse after = new FeedPostResponse(42L, 1L, "Alice", "Hello edited",
-                List.of("data"), created, edited, true, true, List.of(), false, false);
+                List.of("data"), created, edited, true, true, List.of(), false, false, null);
         when(feedPostService.getById(42L, 1L)).thenReturn(before, after);
 
         String etagBefore = mockMvc.perform(get("/api/feed/posts/42")

--- a/backend/src/test/java/com/group7/backend/integration/FeedJsonLdIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedJsonLdIntegrationTest.java
@@ -1,0 +1,203 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.config.jsonld.JsonLdMediaType;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.FeedPost;
+import com.group7.backend.repository.FeedPostRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the AS 2.0 / Schema.org content negotiation
+ * path through the live controller stack. Three carve-outs that the
+ * unit tests can't cover on their own:
+ *
+ * <ol>
+ *   <li>The {@code application/ld+json} <i>and</i>
+ *       {@code application/activity+json} Accept headers both route
+ *       through the JsonLd advice without 406.</li>
+ *   <li>The response Content-Type echoes the negotiated wire type
+ *       (this is what the {@code ServletServerHttpResponse}
+ *       hand-off in OCP advice exists to preserve; without the
+ *       integration test, a Spring upgrade can silently break it).</li>
+ *   <li>The OrderedCollectionPage envelope wraps the For-You list
+ *       endpoint and the wrapped items don't carry a redundant
+ *       {@code @context}.</li>
+ * </ol>
+ *
+ * <p>Plain {@code application/json} requests still see the existing
+ * Spring Data {@code Page<T>} / single-DTO shape unchanged.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class FeedJsonLdIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private FeedPostRepository feedPostRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        feedPostRepository.deleteAll();
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    @Test
+    void detail_withApplicationLdJson_emitsAS2NoteAndPinsContentType() throws Exception {
+        String token = registerAndLogin("ld@test.com");
+        Long userId = userRepository.findByEmail("ld@test.com").orElseThrow().getId();
+        Long postId = seedPost(userId, "Welcome to the feed", "en");
+
+        MvcResult result = mockMvc.perform(get("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .accept(JsonLdMediaType.APPLICATION_LD_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(result.getResponse().getContentType())
+                .startsWith(JsonLdMediaType.APPLICATION_LD_JSON_VALUE);
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.has("@context")).isTrue();
+        assertThat(body.get("@type").get(0).asText()).isEqualTo("Note");
+        assertThat(body.get("@type").get(1).asText()).isEqualTo("SocialMediaPosting");
+        assertThat(body.get("inLanguage").asText()).isEqualTo("en");
+        assertThat(body.get("contentMap").get("en").asText()).isEqualTo("Welcome to the feed");
+    }
+
+    @Test
+    void detail_withApplicationActivityJson_isHandledAsAS2Synonym() throws Exception {
+        String token = registerAndLogin("activity@test.com");
+        Long userId = userRepository.findByEmail("activity@test.com").orElseThrow().getId();
+        Long postId = seedPost(userId, "another welcome", "tr");
+
+        MvcResult result = mockMvc.perform(get("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .accept(JsonLdMediaType.APPLICATION_ACTIVITY_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // The two media types must be interchangeable end-to-end —
+        // Mastodon and ActivityPub clients prefer activity+json over the
+        // generic ld+json. Without this test, a future negotiation tweak
+        // could silently break either path.
+        assertThat(result.getResponse().getContentType())
+                .startsWith(JsonLdMediaType.APPLICATION_ACTIVITY_JSON_VALUE);
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.has("@context")).isTrue();
+    }
+
+    @Test
+    void detail_withApplicationJson_keepsExistingShape() throws Exception {
+        String token = registerAndLogin("plain@test.com");
+        Long userId = userRepository.findByEmail("plain@test.com").orElseThrow().getId();
+        Long postId = seedPost(userId, "plain body", null);
+
+        MvcResult result = mockMvc.perform(get("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + token)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(result.getResponse().getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        // Plain JSON path → no AS 2.0 fields, existing envelope unchanged.
+        assertThat(body.has("@context")).isFalse();
+        assertThat(body.has("@type")).isFalse();
+        assertThat(body.has("attributedTo")).isFalse();
+        assertThat(body.get("body").asText()).isEqualTo("plain body");
+    }
+
+    @Test
+    void followingFeed_withActivityJson_emitsOrderedCollectionPageEnvelope() throws Exception {
+        String token = registerAndLogin("ocp@test.com");
+
+        MvcResult result = mockMvc.perform(get("/api/feed/following?page=0&size=10")
+                        .header("Authorization", "Bearer " + token)
+                        .accept(JsonLdMediaType.APPLICATION_ACTIVITY_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(result.getResponse().getContentType())
+                .startsWith(JsonLdMediaType.APPLICATION_ACTIVITY_JSON_VALUE);
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(body.get("@type").asText()).isEqualTo("OrderedCollectionPage");
+        assertThat(body.get("totalItems").asLong()).isEqualTo(0L);
+        assertThat(body.has("orderedItems")).isTrue();
+        // first / last always present; prev / next absent on an empty page.
+        assertThat(body.has("first")).isTrue();
+        assertThat(body.has("last")).isTrue();
+        assertThat(body.has("prev")).isFalse();
+        assertThat(body.has("next")).isFalse();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────
+
+    private Long seedPost(Long authorId, String body, String lang) {
+        FeedPost post = new FeedPost(authorId, body);
+        post.setLang(lang);
+        OffsetDateTime now = OffsetDateTime.now();
+        post.setCreatedAt(now);
+        post.setUpdatedAt(now);
+        return feedPostRepository.save(post).getId();
+    }
+
+    private String registerAndLogin(String email) throws Exception {
+        RegisterRequest reg = new RegisterRequest();
+        reg.setFirstName("Test");
+        reg.setLastName("User");
+        reg.setEmail(email);
+        reg.setPassword("Password1");
+        reg.setIsMentor(true);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reg)))
+                .andExpect(status().isCreated());
+
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(loginResult.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/integration/FeedPostIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedPostIntegrationTest.java
@@ -303,10 +303,16 @@ class FeedPostIntegrationTest {
         assertThat(tagsAfter).isZero();    // cascade-of-cascade feed_posts → feed_post_hashtags
     }
 
-    // ── JSON-LD silent downgrade ────────────────────────────────────────────
+    // ── JSON-LD content negotiation ─────────────────────────────────────────
 
     @Test
-    void getById_withLdJsonAccept_silentlyDowngradesToApplicationJson() throws Exception {
+    void getById_withLdJsonAccept_returnsAS2NoteSocialMediaPosting() throws Exception {
+        // Before #490 this endpoint silently downgraded ld+json requests
+        // to plain application/json because no JsonLdMapping handled
+        // FeedPostResponse. Now FeedPostJsonLdMapping wraps the response
+        // as a Note + SocialMediaPosting document with the AS 2.0 dual
+        // @context, so the negotiated Content-Type is preserved and the
+        // body carries the JSON-LD envelope.
         String token = registerAndLogin("ld@test.com", true);
         long pid = createPost(token, "ld test", List.of("ld"));
 
@@ -314,8 +320,10 @@ class FeedPostIntegrationTest {
                         .header("Authorization", "Bearer " + token)
                         .accept(MediaType.parseMediaType("application/ld+json")))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.id").value(pid));
+                .andExpect(content().contentTypeCompatibleWith(MediaType.parseMediaType("application/ld+json")))
+                .andExpect(jsonPath("$.@context").isArray())
+                .andExpect(jsonPath("$.@type[0]").value("Note"))
+                .andExpect(jsonPath("$.@type[1]").value("SocialMediaPosting"));
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/backend/src/test/java/com/group7/backend/integration/JsonLdContentNegotiationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/JsonLdContentNegotiationTest.java
@@ -227,8 +227,13 @@ class JsonLdContentNegotiationTest {
     }
 
     @Test
-    void ldJsonRequest_pageResponse_downgradesContentType() throws Exception {
-        // seed a couple of mentors so the page has content
+    void ldJsonRequest_pageResponse_wrapsAsOrderedCollectionPage() throws Exception {
+        // Before #490 this test pinned the Page<T> downgrade-to-JSON
+        // behaviour; OrderedCollectionPageJsonLdAdvice now models pagination
+        // as an AS 2.0 OrderedCollectionPage and preserves the negotiated
+        // Content-Type, so the assertion flips: Content-Type stays
+        // application/ld+json and the body is the envelope with
+        // orderedItems, totalItems, and hypermedia paging links.
         registerAndLogin("Page", "Mentor1", "ld_page1@test.com", true);
         registerAndLogin("Page", "Mentor2", "ld_page2@test.com", true);
 
@@ -240,18 +245,21 @@ class JsonLdContentNegotiationTest {
                         .param("size", "10")
                         .accept(LD_JSON))
                 .andExpect(status().isOk())
-                // Page<T> can't be JSON-LD-shaped without modeling pagination as
-                // a typed resource, so the advice downgrades Content-Type to
-                // plain JSON. The body remains the standard Page envelope.
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentTypeCompatibleWith(LD_JSON))
                 .andReturn();
 
         JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
-        assertThat(body.get("@context")).isNull();
-        assertThat(body.get("@graph")).isNull();
-        assertThat(body.get("content")).isNotNull();
-        assertThat(body.get("content").isArray()).isTrue();
-        assertThat(body.get("totalElements")).isNotNull();
+        assertThat(body.get("@context")).isNotNull();
+        assertThat(body.get("@type").asText()).isEqualTo("OrderedCollectionPage");
+        assertThat(body.get("totalItems").asLong()).isEqualTo(2L);
+        assertThat(body.get("orderedItems")).isNotNull();
+        assertThat(body.get("orderedItems").isArray()).isTrue();
+        assertThat(body.get("orderedItems").size()).isEqualTo(2);
+        // first / last always present; prev / next absent on a single-page result.
+        assertThat(body.get("first")).isNotNull();
+        assertThat(body.get("last")).isNotNull();
+        assertThat(body.get("prev")).isNull();
+        assertThat(body.get("next")).isNull();
     }
 
     @Test

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
@@ -294,6 +294,6 @@ class FeedPostServiceHistoryTest {
     private static FeedPostResponse stubResponse(Long id, Long authorId) {
         return new FeedPostResponse(id, authorId, "U" + authorId, "body", List.of(),
                 OffsetDateTime.now(), OffsetDateTime.now(), false, true, List.of(),
-                false, false);
+                false, false, null);
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
@@ -174,6 +174,6 @@ class FeedPostServiceRestoreTest {
     private static FeedPostResponse stubResponse(Long id, Long authorId) {
         return new FeedPostResponse(id, authorId, "U" + authorId, "body", List.of(),
                 OffsetDateTime.now(), OffsetDateTime.now(), false, true, List.of(),
-                false, false);
+                false, false, null);
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
@@ -334,6 +334,6 @@ class FeedPostServiceTest {
     private static FeedPostResponse stubResponse(Long id, Long authorId) {
         return new FeedPostResponse(id, authorId, "U" + authorId, "body", List.of(),
                 OffsetDateTime.now(), OffsetDateTime.now(), false, true, List.of(),
-                false, false);
+                false, false, null);
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
@@ -426,6 +426,7 @@ class FeedReadServiceTest {
                 OffsetDateTime.now(), 0L, 0L, List.<String>of(),
                 List.<com.group7.backend.dto.response.AttachmentSummary>of(),
                 false, false,
-                null, null, null, null);
+                null, null, null, null,
+                null);   // lang
     }
 }


### PR DESCRIPTION
## Summary

Brings the social-feed surface up to the standards-coverage commitment documented on the project wiki: every feed read response now carries `@context` and `@type` matching W3C Activity Streams 2.0 plus Schema.org, paginated reads emit `OrderedCollectionPage` envelopes with hypermedia paging links, and posts carrying a BCP-47 language tag surface `contentMap` and `inLanguage` per AS 2.0 conventions. Plain JSON clients see no behavioural change.

Closes #490.

> **Stacked on #501** (`feature/486-feed-search-filters-and-mute`) because the `lang` column on `feed_posts` lives in #486's V42 migration. The PR's base is therefore `feature/486-feed-search-filters-and-mute`; retarget to `dev` once #501 merges or merge them in order. None of this PR's changes overlap #486's substance.

## What changed

### New JSON-LD mappings (`backend/src/main/java/com/group7/backend/config/jsonld/feed/`)

- **`FeedIriBuilder`** — single source of truth for the canonical IRI shape of every feed entity (post, comment, like, share, bookmark, follow, person). Resolved off `app.base-url`, the same property the email link generator and `NoteMapping` already use, so the IRI emitted by a JSON-LD document is the URL a consumer can dereference over HTTP.
- **`FeedPostJsonLdMapping`** — renders `FeedPostResponse` as a `Note` + `SocialMediaPosting` with `attributedTo`, `published`, `content`, `contentMap`, `inLanguage`, `tag` (AS 2.0 Hashtag with leading `#`), and four `schema:InteractionCounter` aggregates (Like / Comment / Share / Bookmark). The renderer is factored into a package-private `FeedJsonLd` helper so the list-item mapping produces a byte-identical shape.
- **`FeedPostListItemJsonLdMapping`** — wraps the slimmer list-item DTO using the same helper. Live `likeCount` / `commentCount` flow through; share and bookmark counters default to zero (the list endpoints intentionally don't pay for those aggregates).
- **`FeedCommentJsonLdMapping`** — renders `FeedCommentResponse` as an AS 2.0 `Note` with `inReplyTo` pointing at the parent post IRI. Soft-deleted comments surface without `content` (rather than with an empty string) so consumers can distinguish tombstoned from literally empty.
- **`OrderedCollectionPageJsonLdAdvice`** — `ControllerAdvice` that wraps any `Page<T>` response in the AS 2.0 `OrderedCollectionPage` envelope when the client opts in via `application/ld+json` or `application/activity+json`. Each page item is lifted through the registered `JsonLdMapping` (minus its inner `@context`), and `first` / `prev` / `next` / `last` URLs are synthesised from the current request URI plus `Pageable.getPageNumber()` / `getPageSize()`. `totalItems` comes from the page's total element count.

### Existing JSON-LD infrastructure

- `JsonLdMediaType` now exposes both `application/ld+json` and `application/activity+json` plus an `isJsonLd(MediaType)` predicate. The two wire types are treated as synonyms by the response advice.
- `JsonLdMediaTypeConfig` declares both media types on the Jackson converter **and** registers them with Spring's `ContentNegotiationManager`. Without the negotiation registration the response Content-Type silently downgrades to `application/json` after the advice has already produced an AS 2.0 body.
- `JsonLdResponseBodyAdvice` passes `Page<T>` bodies through unchanged (the new OCP advice handles them) and passes through `Map` bodies that already carry `@context` so the OCP advice's wrapped result isn't downgraded by the existing advice running later in the chain.

### DTO additions

`FeedPostResponse` and `FeedPostListItem` gain an optional `lang` BCP-47 field, populated by `FeedPostMapper` from the entity column added in #486. The field drives `contentMap` / `inLanguage` emission in the JSON-LD representation; legacy posts with null `lang` surface plain `content` without `contentMap`.

## Verification

### Unit (`mvn -B test -Dtest=FeedPostJsonLdMappingTest`)

11/11 pass. The suite pins:
- `@context` order (AS 2.0 first, Schema.org second).
- Dual `@type: ["Note", "SocialMediaPosting"]`.
- `@id` + `id` resolve to the same canonical IRI.
- `attributedTo` populates a Schema.org Person with `@id` + `name`.
- `contentMap` / `inLanguage` emitted iff `lang` is non-null; omitted otherwise.
- Hashtags render as AS 2.0 `Hashtag` with the leading `#` re-added on the wire.
- `interactionStatistic` always emits the four-counter quad (Like / Comment / Share / Bookmark).
- Image attachments map to AS 2.0 `Image` with `url` + `mediaType`.
- `updated` is emitted only when the post is edited.

### Manual API smoke (isolated Postgres on a non-default port)

| AC | Request | Wire result |
|---|---|---|
| 1 | `GET /api/feed/posts/{id}` with `Accept: application/ld+json` | 200, Content-Type `application/ld+json`, full Note + SocialMediaPosting document with `@context`, `@type`, `attributedTo`, `published`, `contentMap`, `inLanguage`, `tag`, `interactionStatistic`. |
| 2 | Same endpoint with `Accept: application/json` | 200, Content-Type `application/json`, existing payload unchanged, no `@context` or `@type`. |
| 3 | `GET /api/feed/following?page=0&size=10` with `Accept: application/activity+json` | 200, Content-Type `application/activity+json`, `OrderedCollectionPage` envelope with correct `id` / `partOf` / `first` / `last` / `totalItems` / `orderedItems`. |
| 4 | `POST /api/feed/posts` with `lang="en"` then `GET` with ld+json | `contentMap: {"en": ...}` and `inLanguage: "en"` populated. |
| 5 | `POST /api/feed/posts` with `lang="invalid"` | 400 (enforced by #486's `@Pattern` validator). |
| Extra | `POST` without `lang` then `GET` with ld+json | `contentMap` and `inLanguage` are absent; `content` is plain. |

## Out of scope (intentional)

- **Like / Share / Bookmark / Follow activity mappings.** The toggle endpoints return `FeedPostInteractionState` (a counter aggregate); modelling them as standalone `as:Like` / `as:Announce` / `as:Add` / `as:Follow` activities would require new wrapper DTOs not in the current API surface. The acceptance criteria are met by the Note + SocialMediaPosting coverage on posts plus the InteractionCounter aggregates. A follow-up issue can add per-edge activity bodies once the corresponding endpoints exist.
- **Wiki standards-coverage table update.** The doc lives outside this repo's code path; a separate doc-only PR carries that line item.
- **Per-hashtag IRIs.** AS 2.0 permits bare-string `name` values on `Hashtag` extensions; minting per-tag IRIs adds a new endpoint surface not justified by current consumer needs.

## Test plan

- [x] Unit tests pass (11/11).
- [x] Manual smoke covers all five acceptance criteria.
- [x] `mvn -B test-compile` clean.
- [ ] CI: `Backend CI/CD → test` picks up the new tests and runs them green on a fresh database.