### PR TITLE
feat: add location entry to mentor and mentee profiles (#462)

### DIFF
--- a/mobile-app/app/(tabs)/profile.tsx
+++ b/mobile-app/app/(tabs)/profile.tsx
@@ -24,6 +24,7 @@ import {
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import ActionModal from '../../components/ActionModal';
+import LocationPicker from '../../components/LocationPicker';
 
 type AppRole = 'mentor' | 'mentee';
 type NotificationPreferences = {
@@ -493,6 +494,7 @@ function MenteeProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
   const [skillInput, setSkillInput] = useState('');
   const [skills, setSkills] = useState<string[]>([]);
   const [profilePhoto, setProfilePhoto] = useState<string | null>(null);
+  const [location, setLocation] = useState<{ city: string; latitude: number; longitude: number } | undefined>();
   const [sentRequests, setSentRequests] = useState<SentRequest[]>([]);
   const [requestsLoading, setRequestsLoading] = useState(true);
 
@@ -512,9 +514,12 @@ function MenteeProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
         profileVisibility,
         interests,
         skills,
+        city: location?.city,
+        latitude: location?.latitude,
+        longitude: location?.longitude,
       };
 
-      await apiClient.patch('/users/me/mentee', updateData);
+      await apiClient.put('/users/me/mentee', updateData);
       Alert.alert('Başarılı', 'Profilin güncellendi!');
     } catch (error: any) {
       const serverMessage = error.response?.data?.message || error.message;
@@ -537,6 +542,13 @@ function MenteeProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
         if (data.profileVisibility != null) setProfileVisibility(data.profileVisibility);
         if (data.interests) setInterests(data.interests);
         if (data.skills) setSkills(data.skills);
+        if (data.city) {
+          setLocation({
+            city: data.city,
+            latitude: data.latitude || 0,
+            longitude: data.longitude || 0,
+          });
+        }
         if (data.profilePhoto) {
           setProfilePhoto(data.profilePhoto);
           await cacheAvatar('mentee', sessionUserId, data.profilePhoto);
@@ -678,6 +690,11 @@ function MenteeProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
                 <Text style={styles.toggleButtonText}>{profileVisibility ? 'Public' : 'Private'}</Text>
               </TouchableOpacity>
             </View>
+            <LocationPicker
+              initialLocation={location}
+              onLocationSelect={setLocation}
+              roleTheme="mentee"
+            />
           </View>
           <TouchableOpacity
             style={styles.saveButtonMentee}
@@ -750,6 +767,7 @@ function MentorProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
   const [maxMenteeCapacity, setMaxMenteeCapacity] = useState('3');
   const [mentorshipDuration, setMentorshipDuration] = useState('');
   const [profilePhoto, setProfilePhoto] = useState<string | null>(null);
+  const [location, setLocation] = useState<{ city: string; latitude: number; longitude: number } | undefined>();
 
   useEffect(() => {
     const fetchProfileData = async () => {
@@ -767,6 +785,13 @@ function MentorProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
         if (data.interests) setInterests(data.interests);
         if (data.maxMenteeCapacity != null) setMaxMenteeCapacity(String(data.maxMenteeCapacity));
         if (data.mentorshipDuration != null) setMentorshipDuration(String(data.mentorshipDuration));
+        if (data.city) {
+          setLocation({
+            city: data.city,
+            latitude: data.latitude || 0,
+            longitude: data.longitude || 0,
+          });
+        }
         if (data.profilePhoto) {
           setProfilePhoto(data.profilePhoto);
           await cacheAvatar('mentor', sessionUserId, data.profilePhoto);
@@ -794,7 +819,7 @@ function MentorProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
     try {
       const nameParts = displayName.trim().split(' ');
       const duration = parseInt(mentorshipDuration, 10);
-      await apiClient.patch('/users/me/mentor', {
+      await apiClient.put('/users/me/mentor', {
         firstName: nameParts[0],
         lastName: nameParts.length > 1 ? nameParts.slice(1).join(' ') : '',
         field: title,
@@ -807,6 +832,9 @@ function MentorProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
         interests,
         maxMenteeCapacity: capacity,
         ...(mentorshipDuration && !isNaN(duration) ? { mentorshipDuration: duration } : {}),
+        city: location?.city,
+        latitude: location?.latitude,
+        longitude: location?.longitude,
       });
       Alert.alert('Başarılı', 'Profilin güncellendi!');
     } catch (error: any) {
@@ -917,6 +945,11 @@ function MentorProfileContent({ onLogout, sessionUserId }: { onLogout: () => voi
               keyboardType="number-pad"
               placeholder="e.g. 3"
               placeholderTextColor="#B5ADA3"
+            />
+            <LocationPicker
+              initialLocation={location}
+              onLocationSelect={setLocation}
+              roleTheme="mentor"
             />
           </View>
           <TouchableOpacity

--- a/mobile-app/components/LocationPicker.tsx
+++ b/mobile-app/components/LocationPicker.tsx
@@ -1,0 +1,264 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  StyleSheet,
+  Alert,
+  FlatList,
+} from 'react-native';
+import * as Location from 'expo-location';
+
+type LocationData = {
+  city: string;
+  latitude: number;
+  longitude: number;
+};
+
+interface LocationPickerProps {
+  initialLocation?: LocationData;
+  onLocationSelect: (location: LocationData) => void;
+  roleTheme?: 'mentor' | 'mentee';
+}
+
+export default function LocationPicker({
+  initialLocation,
+  onLocationSelect,
+  roleTheme = 'mentee',
+}: LocationPickerProps) {
+  const [searchQuery, setSearchQuery] = useState(initialLocation?.city || '');
+  const [suggestions, setSuggestions] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [isManual, setIsManual] = useState(false);
+
+  // Coordinate rounding for privacy (2 decimal places ~1km precision)
+  const roundCoord = (val: number) => Math.round(val * 100) / 100;
+
+  // Validation
+  const isValidLat = (lat: number) => lat >= -90 && lat <= 90;
+  const isValidLon = (lon: number) => lon >= -180 && lon <= 180;
+
+  const handleUseCurrentLocation = async () => {
+    setLoading(true);
+    try {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        Alert.alert(
+          'Permission Denied',
+          'Location permission is required to auto-fill. Please enter your city manually.',
+          [{ text: 'OK', onPress: () => setIsManual(true) }]
+        );
+        return;
+      }
+
+      const location = await Location.getCurrentPositionAsync({});
+      const { latitude, longitude } = location.coords;
+
+      const reverseGeocode = await Location.reverseGeocodeAsync({
+        latitude,
+        longitude,
+      });
+
+      const city = reverseGeocode[0]?.city || reverseGeocode[0]?.subregion || 'Unknown City';
+      const roundedLat = roundCoord(latitude);
+      const roundedLon = roundCoord(longitude);
+
+      if (!isValidLat(roundedLat) || !isValidLon(roundedLon)) {
+        throw new Error('Invalid coordinates detected.');
+      }
+
+      setSearchQuery(city);
+      onLocationSelect({ city, latitude: roundedLat, longitude: roundedLon });
+      setIsManual(false);
+    } catch (error) {
+      console.error('Error getting location:', error);
+      Alert.alert('Error', 'Could not fetch your location. Please try manual entry.');
+      setIsManual(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSearch = async (query: string) => {
+    setSearchQuery(query);
+    if (query.length < 3) {
+      setSuggestions([]);
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
+          query
+        )}&addressdetails=1&limit=5`,
+        {
+          headers: {
+            'User-Agent': 'Bounswe2026Group7-MobileApp',
+          },
+        }
+      );
+      const data = await response.json();
+      setSuggestions(data);
+    } catch (error) {
+      console.error('Nominatim search error:', error);
+    }
+  };
+
+  const selectSuggestion = (item: any) => {
+    const city = item.address.city || item.address.town || item.address.village || item.display_name.split(',')[0];
+    const lat = parseFloat(item.lat);
+    const lon = parseFloat(item.lon);
+    
+    const roundedLat = roundCoord(lat);
+    const roundedLon = roundCoord(lon);
+
+    if (!isValidLat(roundedLat) || !isValidLon(roundedLon)) {
+      Alert.alert('Error', 'Invalid location coordinates selected.');
+      return;
+    }
+
+    setSearchQuery(city);
+    setSuggestions([]);
+    onLocationSelect({
+      city,
+      latitude: roundedLat,
+      longitude: roundedLon,
+    });
+  };
+
+  const isMentor = roleTheme === 'mentor';
+  const themeColor = isMentor ? '#456B50' : '#4B7B57';
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Location</Text>
+      
+      {!isManual && !initialLocation?.city ? (
+        <TouchableOpacity
+          style={[styles.actionButton, { backgroundColor: themeColor }]}
+          onPress={handleUseCurrentLocation}
+          disabled={loading}
+        >
+          {loading ? (
+            <ActivityIndicator color="#F8F6F2" />
+          ) : (
+            <Text style={styles.actionButtonText}>📍 Use My Current Location</Text>
+          )}
+        </TouchableOpacity>
+      ) : null}
+
+      <View style={styles.inputContainer}>
+        <TextInput
+          style={styles.input}
+          placeholder="Search city manually..."
+          placeholderTextColor="#B5ADA3"
+          value={searchQuery}
+          onChangeText={(text) => {
+            setIsManual(true);
+            handleSearch(text);
+          }}
+        />
+        {loading && <ActivityIndicator style={styles.inputIcon} color={themeColor} />}
+      </View>
+
+      {suggestions.length > 0 && (
+        <View style={styles.suggestionsContainer}>
+          {suggestions.map((item, index) => (
+            <TouchableOpacity
+              key={index}
+              style={styles.suggestionItem}
+              onPress={() => selectSuggestion(item)}
+            >
+              <Text style={styles.suggestionText} numberOfLines={1}>
+                {item.display_name}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+
+      {initialLocation?.latitude !== undefined && (
+        <Text style={styles.coordsText}>
+          Selected: {initialLocation.city} ({initialLocation.latitude}, {initialLocation.longitude})
+        </Text>
+      )}
+
+      <Text style={styles.privacyNote}>
+        Note: Your coordinates are rounded to 2 decimal places (~1km precision) for privacy.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 20,
+  },
+  label: {
+    color: '#7E7368',
+    fontSize: 12,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  actionButton: {
+    borderRadius: 18,
+    paddingVertical: 14,
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  actionButtonText: {
+    color: '#F8F6F2',
+    fontWeight: '700',
+    fontSize: 14,
+  },
+  inputContainer: {
+    position: 'relative',
+    justifyContent: 'center',
+  },
+  input: {
+    height: 60,
+    borderRadius: 18,
+    borderWidth: 1.5,
+    borderColor: '#D8CEC0',
+    backgroundColor: '#FCFBF8',
+    paddingHorizontal: 15,
+    fontSize: 16,
+    color: '#4A4138',
+  },
+  inputIcon: {
+    position: 'absolute',
+    right: 15,
+  },
+  suggestionsContainer: {
+    backgroundColor: '#FCFBF8',
+    borderRadius: 18,
+    borderWidth: 1.5,
+    borderColor: '#D8CEC0',
+    marginTop: 5,
+    overflow: 'hidden',
+    zIndex: 10,
+  },
+  suggestionItem: {
+    padding: 15,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F0EBE5',
+  },
+  suggestionText: {
+    fontSize: 14,
+    color: '#4A4138',
+  },
+  coordsText: {
+    fontSize: 12,
+    color: '#456B50',
+    marginTop: 8,
+    fontWeight: '600',
+  },
+  privacyNote: {
+    fontSize: 11,
+    color: '#9A8F82',
+    marginTop: 6,
+    fontStyle: 'italic',
+  },
+});

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -29,6 +29,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-image-picker": "~17.0.11",
+    "expo-location": "~19.0.8",
     "expo-linking": "~8.0.12",
     "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.23",


### PR DESCRIPTION
## Description

This PR introduces the location entry feature for both mentor and mentee profile screens in the mobile app. It provides a hybrid UX, allowing users to either auto-fill their current location using device GPS or manually search for a city using an autocomplete input.

**Note:** This is the mobile companion to the location backend updates and relies on the new `city`, `latitude`, and `longitude` fields.

## Changes Made

*   **Dependencies:** Added `expo-location` to `package.json` for device location access and reverse geocoding.
*   **New Component (`LocationPicker.tsx`):**
    *   Implemented "Use my current location" button with permission handling.
    *   Added smooth fallback to manual entry if location permissions are denied.
    *   Integrated manual city search with autocomplete backed by the Nominatim API.
    *   Implemented client-side coordinate validation (-90..90 for latitude, -180..180 for longitude).
    *   Added client-side coordinate rounding to 2 decimal places (~1km precision) for privacy, along with a visible privacy note.
*   **Profile Integration (`profile.tsx`):**
    *   Added location states to `MenteeProfileContent` and `MentorProfileContent`.
    *   Integrated the `LocationPicker` into both edit flows.
    *   Updated the `handleSave` logic to use `PUT` requests to `/api/users/me/mentee` and `/api/users/me/mentor` with the full payload including location data.
    *   Updated the initial fetch logic to correctly load and display existing location data upon opening the editor.

## Verification / Acceptance Criteria

- [x] Profile edit screens (mentor + mentee) show the location section.
- [x] `expo-location` auto-fill works and correctly requests permissions.
- [x] Permission denied path falls back cleanly to manual input.
- [x] Manual entry with autocomplete works as expected.
- [x] Save persists via `PUT /api/users/me/{role}` and a subsequent reload shows the saved values.
- [x] Coordinates are rounded to 2 decimals before sending to the backend.
- [x] Privacy note is visible to the user.
- [x] Empty form submission doesn't clear an existing location.
