### PR TITLE
fix(test): close FeedReadIntegrationTest method body broken in #531 merge

### DIFF
--- a/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedReadIntegrationTest.java
@@ -801,6 +801,8 @@ class FeedReadIntegrationTest {
         Long sharedBy1 = objectMapper.readTree(page1.getResponse().getContentAsString())
                 .get("content").get(0).get("sharedById").asLong();
         assertThat(java.util.Set.of(sharedBy0, sharedBy1)).containsExactlyInAnyOrder(s1, s2);
+    }
+
     // ── Search filters: date range and language ─────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary
**Hotfix — dev backend is currently uncompilable.** PR #531 (feature/484-enhanced-sharing) merged with a missing closing `}` brace on the test method right before the search-filters section in `FeedReadIntegrationTest.java`. The compiler cascades into 8+ `';' expected / not a statement` errors across every subsequent `@Test` method.

Every PR that branches off dev right now fails its backend build before any test runs (~32s fast-fail). Confirmed: PRs #532 and #537 just hit this.

## The fix
One line. Insert the missing `}` between the previous test's final `assertThat(...)` and the section-divider comment:

\`\`\`java
        assertThat(java.util.Set.of(sharedBy0, sharedBy1)).containsExactlyInAnyOrder(s1, s2);
+   }
+
    // ── Search filters: date range and language ─────────────────────────────
\`\`\`

No semantic change to either test; just makes the method boundary the original code clearly intended.

## Verification
- [x] `mvn -f backend/pom.xml test-compile` clean post-fix
- [ ] CI will confirm end-to-end

## Urgency
Critical — nothing else can merge to dev until this lands. Recommend fast-track review.