### PR TITLE
feat(web): my mentorships page with active/past tabs + pagination (#408)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import ProtectedRoute from './components/ProtectedRoute'
 import UserProfilePage from './pages/UserProfilePage'
 import UserFollowListPage from './pages/UserFollowListPage'
 import MentorshipDetailPage from './pages/MentorshipDetailPage'
+import MentorshipsListPage from './pages/MentorshipsListPage'
 import MessagesPage from './pages/MessagesPage'
 import TasksPage from './pages/TasksPage'
 import SchedulePage from './pages/SchedulePage'
@@ -41,6 +42,7 @@ export default function App() {
           <Route path="/users/:id" element={<UserProfilePage />} />
           <Route path="/users/:id/followers" element={<UserFollowListPage mode="followers" />} />
           <Route path="/users/:id/following" element={<UserFollowListPage mode="following" />} />
+          <Route path="/mentorships" element={<MentorshipsListPage />} />
           <Route path="/mentorships/:id" element={<MentorshipDetailPage />} />
           <Route path="/messages" element={<MessagesPage />} />
           <Route path="/tasks" element={<TasksPage />} />

--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -7,7 +7,7 @@ import { useMentorship } from '../context/MentorshipContext'
 import usePresence from '../hooks/usePresence'
 import {
   Home, Compass, MessageCircle, CheckSquare, CalendarDays,
-  Clock, User, Newspaper,
+  Clock, User, Newspaper, Users,
 } from 'lucide-react'
 import '../styles/main.css'
 
@@ -18,6 +18,7 @@ const NAV_TABS = [
   { label: 'Explore', path: '/explore' },
   { label: 'Feed', path: '/feed' },
   { label: 'Messages', path: '/messages' },
+  { label: 'Mentorships', path: '/mentorships' },
   { label: 'Tasks', path: '/tasks' },
   { label: 'Schedule', path: '/schedule' },
   { label: 'Calendar', path: '/calendar' },
@@ -30,6 +31,7 @@ const SIDEBAR_LINKS = [
   { label: 'Explore', path: '/explore', icon: Compass },
   { label: 'Feed', path: '/feed', icon: Newspaper },
   { label: 'Messages', path: '/messages', icon: MessageCircle },
+  { label: 'My Mentorships', path: '/mentorships', icon: Users },
   { label: 'My Tasks', path: '/tasks', icon: CheckSquare },
   { label: 'Schedule', path: '/schedule', icon: CalendarDays },
   { label: 'Calendar', path: '/calendar', icon: CalendarDays },

--- a/frontend/src/pages/MentorshipsListPage.jsx
+++ b/frontend/src/pages/MentorshipsListPage.jsx
@@ -1,0 +1,211 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import MainLayout from '../components/MainLayout'
+import Avatar from '../components/Avatar'
+import { getMentorshipsByStatus } from '../services/api'
+import { useAuth } from '../context/AuthContext'
+import '../styles/main.css'
+
+/**
+ * "My Mentorships" history page (#408). Backed by the paginated
+ * GET /api/mentorships?status= endpoint that shipped in backend #529 / #521.
+ *
+ * Single tabbed view: All / Active / Past. Backend sorts by endDate DESC
+ * NULLS LAST so active mentorships float to the top of the All tab. Each
+ * row renders the counterpart's name + avatar, date range, status badge,
+ * and clicks through to the detail page.
+ */
+
+const TABS = [
+  { key: 'ALL', label: 'All' },
+  { key: 'ACTIVE', label: 'Active' },
+  { key: 'PAST', label: 'Past' }, // client-side fan-out — server has no PAST filter
+]
+
+// Past tab pulls every non-active state. Backend rejects unknown values, so we
+// can't pass "PAST" through the wire; instead we fetch with status=ALL and
+// filter client-side. With size=20 this is a single page in most cases.
+const PAST_STATUSES = new Set(['COMPLETED', 'CANCELLED', 'TERMINATED'])
+
+function fmtDate(iso) {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function statusBadgeClass(status) {
+  switch (status) {
+    case 'ACTIVE': return 'ml-status ml-status--active'
+    case 'COMPLETED': return 'ml-status ml-status--completed'
+    case 'CANCELLED': return 'ml-status ml-status--cancelled'
+    case 'TERMINATED': return 'ml-status ml-status--terminated'
+    default: return 'ml-status'
+  }
+}
+
+function statusLabel(status) {
+  switch (status) {
+    case 'ACTIVE': return 'Active'
+    case 'COMPLETED': return 'Completed'
+    case 'CANCELLED': return 'Cancelled'
+    case 'TERMINATED': return 'Terminated'
+    default: return status || 'Unknown'
+  }
+}
+
+export default function MentorshipsListPage() {
+  const navigate = useNavigate()
+  const { userId } = useAuth()
+  const [tab, setTab] = useState('ALL')
+  const [data, setData] = useState(null) // Page<MentorshipResponse>
+  const [page, setPage] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      // Past tab uses ALL + client-side filter so we still get paginated payloads.
+      const requestedStatus = tab === 'PAST' ? 'ALL' : tab
+      const res = await getMentorshipsByStatus({ status: requestedStatus, page, size: 20 })
+      setData(res || { content: [], totalPages: 1 })
+    } catch (err) {
+      setError(err?.message || 'Failed to load mentorships.')
+      setData({ content: [], totalPages: 1 })
+    } finally {
+      setLoading(false)
+    }
+  }, [tab, page])
+
+  useEffect(() => { load() }, [load])
+
+  function changeTab(next) {
+    if (next === tab) return
+    setTab(next)
+    setPage(0)
+  }
+
+  const visible = (() => {
+    const all = data?.content || []
+    if (tab === 'PAST') return all.filter(m => PAST_STATUSES.has(m.status))
+    return all
+  })()
+
+  const totalPages = data?.totalPages ?? 1
+  const isFirst = page === 0
+  const isLast = page >= totalPages - 1
+
+  return (
+    <MainLayout>
+      <div className="page-header">
+        <div>
+          <div className="page-title">My Mentorships</div>
+          <div className="page-sub">Every mentorship you've participated in, active or past.</div>
+        </div>
+      </div>
+
+      <div className="feed-tabs" role="tablist" aria-label="Mentorship status filter">
+        {TABS.map(t => (
+          <button
+            key={t.key}
+            type="button"
+            role="tab"
+            aria-selected={tab === t.key}
+            className={`feed-tab${tab === t.key ? ' feed-tab--active' : ''}`}
+            onClick={() => changeTab(t.key)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="md-error-card" style={{ marginBottom: '12px' }}>
+          <div className="md-error-title">Couldn’t load mentorships</div>
+          <div className="md-error-sub">{error}</div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="md-loading">Loading mentorships…</div>
+      ) : visible.length === 0 ? (
+        <div className="empty-state">
+          {tab === 'ACTIVE'
+            ? 'You have no active mentorships.'
+            : tab === 'PAST'
+              ? 'No past mentorships yet — they will appear here once your active ones end.'
+              : "You haven't participated in any mentorships yet."}
+        </div>
+      ) : (
+        <ul className="ml-list" data-testid="my-mentorships-list">
+          {visible.map(m => {
+            const viewerIsMentor = String(userId) === String(m.mentorId)
+            const counterpartName = viewerIsMentor ? m.menteeFirstName : m.mentorFirstName
+            const counterpartId = viewerIsMentor ? m.menteeId : m.mentorId
+            const initials = (counterpartName?.[0] || '?').toUpperCase()
+            return (
+              <li key={m.id} className="ml-card">
+                <button
+                  type="button"
+                  className="ml-card-btn"
+                  onClick={() => navigate(`/mentorships/${m.id}`)}
+                  aria-label={`Open mentorship with ${counterpartName || 'unknown user'}`}
+                >
+                  <Avatar initials={initials} size="md" />
+                  <div className="ml-card-main">
+                    <div className="ml-card-row">
+                      <span className="ml-card-name">{counterpartName || 'Unknown'}</span>
+                      <span className={statusBadgeClass(m.status)}>{statusLabel(m.status)}</span>
+                    </div>
+                    <div className="ml-card-meta">
+                      <span>
+                        {viewerIsMentor ? 'Mentee' : 'Mentor'}
+                        {counterpartId ? ` · #${counterpartId}` : ''}
+                      </span>
+                      <span>·</span>
+                      <span>
+                        {fmtDate(m.startDate)} – {fmtDate(m.endDate)}
+                      </span>
+                      {m.duration != null && (
+                        <>
+                          <span>·</span>
+                          <span>{m.duration} month{m.duration !== 1 ? 's' : ''}</span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      {!loading && !error && totalPages > 1 && (
+        <div className="follow-pagination" style={{ marginTop: '16px' }}>
+          <button
+            type="button"
+            className="action-btn"
+            onClick={() => setPage(p => Math.max(0, p - 1))}
+            disabled={isFirst}
+          >
+            Previous
+          </button>
+          <div className="follow-page-indicator">
+            Page {page + 1} of {totalPages}
+          </div>
+          <button
+            type="button"
+            className="action-btn"
+            onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+            disabled={isLast}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </MainLayout>
+  )
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -262,6 +262,18 @@ export async function getActiveMentorships() {
   return handleResponse(res)
 }
 
+// Paginated mentorship history filter (#408 / backend #521). status accepts
+// 'ALL' or any MentorshipStatus name (ACTIVE / COMPLETED / CANCELLED /
+// TERMINATED). Backend caps size at 100. Returns a Spring Page<>:
+//   { content, totalPages, totalElements, number, size, last, ... }
+export async function getMentorshipsByStatus({ status = 'ALL', page = 0, size = 20 } = {}) {
+  const params = new URLSearchParams({ status, page: String(page), size: String(size) })
+  const res = await fetch(`${BASE_URL}/mentorships?${params}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
 // Backend has no GET /api/mentorships/{id} yet — fetch the user's list and
 // filter client-side. If the id isn't in the list, the caller treats it as 403.
 export async function getMentorshipById(id) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3218,6 +3218,78 @@
 .md-primary-btn { background: var(--green-dark); }
 .md-primary-btn:hover:not(:disabled) { background: var(--green-mid); }
 
+/* My Mentorships list (#408). */
+.ml-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.ml-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.ml-card-btn {
+  width: 100%;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  padding: 14px 16px;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  color: var(--text);
+}
+.ml-card-btn:hover {
+  background: var(--green-pale);
+}
+.ml-card-main {
+  flex: 1;
+  min-width: 0;
+}
+.ml-card-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+.ml-card-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ml-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.ml-status {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+.ml-status--active     { background: #d1fae5; color: #047857; border-color: #a7f3d0; }
+.ml-status--completed  { background: #dbeafe; color: #1d4ed8; border-color: #bfdbfe; }
+.ml-status--cancelled  { background: #fee2e2; color: #b91c1c; border-color: #fecaca; }
+.ml-status--terminated { background: #ede9fe; color: #6d28d9; border-color: #ddd6fe; }
+
 /* Calendar weekly grid (#123). */
 .cal-nav {
   display: flex;


### PR DESCRIPTION
Closes #408.                                                                                                                                                                          
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  New /mentorships route is a paginated history view of every mentorship the viewer has participated in, with All / Active / Past tabs. Backed by the paginated history endpoint that   
  shipped in backend PR #529 / #521 — GET /api/mentorships?status=ALL&page=N&size=M.                                                                                                    
                                                                                                                                                                                        
  Changes                                                   

  - services/api.js — getMentorshipsByStatus({ status, page, size }) wrapper. Accepts ALL, ACTIVE, COMPLETED, CANCELLED, TERMINATED (backend rejects anything else). Returns a Spring   
  Page<MentorshipResponse>.
  - pages/MentorshipsListPage.jsx (new) — single component. Tabbed view + paged list with status badges (Active green, Completed blue, Cancelled red, Terminated purple). Past tab      
  fetches status=ALL and filters client-side because the backend has no "PAST" alias — keeps the implementation honest with one round-trip per tab change.                              
  - App.jsx — registered /mentorships route under <ProtectedRoute />, placed before the :id detail route (more-specific route still wins via React Router).
  - components/MainLayout.jsx — added "My Mentorships" entry to both the top nav tabs and the sidebar links (Users icon).                                                               
  - styles/main.css — .ml-list, .ml-card, .ml-status* styles for the list + status badges.                                                                                              
                                                                                                                                                                                        
  Acceptance criteria mapping (from #408)                                                                                                                                               
                                                                                                                                                                                        
  - ✅ /mentorships route lists every mentorship the caller participated in, including ENDED ones.
  - ✅ Sections / filters expose Active vs. Past separately, with All as the default. Empty states per tab.
  - ✅ Each row shows: counterpart name + avatar, start/end dates, status badge, role, duration, click → /mentorships/:id.                                                              
  - ✅ Both mentor and mentee viewers see the page; nav entry visible to both roles.                                                                                                    
  - ✅ Pagination if > 20 mentorships (backend page size = 20 by default).                                                                                                              
                                                                                                                                                                                        
  Out of scope                                                                                                                                                                          
                                                                                                                                                                                        
  - Final mentor rating per row — would need #518 (backend GET-ratings endpoint that I filed earlier; still open). Will fold in when that ships.                                        
   
  Test plan                                                                                                                                                                             
                                                            
  - npm run build clean.                                                                                                                                                                
  - npm test — 64/64 unit tests pass.
  - Manual (mentor with active + past mentorships): All tab shows everything sorted with active at top, Active tab shows only active, Past tab shows only ended ones.                   
  - Manual (user with zero mentorships): all three tabs show the right empty-state copy.                                                                                                
  - Manual: click any row → routes to /mentorships/{id} correctly.          