### PR TITLE
feat(web): trending hashtags rail on feed (#545)

### DIFF
--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -13,6 +13,7 @@ import {
   deleteFeedPost,
   getFollowRecommendations,
   followUser,
+  getTrendingHashtags,
 } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import '../styles/main.css'
@@ -66,6 +67,11 @@ export default function FeedPage() {
   const [recLoading, setRecLoading] = useState(false)
   const [recError, setRecError] = useState(null)
 
+  // Trending hashtags (#545). Backend refreshes hourly so a single fetch on
+  // mount is enough; per-tab refetch would just thrash the cache without new
+  // data. Hidden during active search to avoid double-filtering the view.
+  const [trending, setTrending] = useState([])
+
   const [searchQuery, setSearchQuery] = useState('')
   const [activeSearch, setActiveSearch] = useState(null) // { q?, hashtag? } or null
 
@@ -107,6 +113,14 @@ export default function FeedPage() {
   }, [tab, activeSearch])
 
   useEffect(() => { reload() }, [reload])
+
+  useEffect(() => {
+    let cancelled = false
+    getTrendingHashtags(10)
+      .then(list => { if (!cancelled && Array.isArray(list)) setTrending(list) })
+      .catch(() => { /* silent — empty rail is the no-data state */ })
+    return () => { cancelled = true }
+  }, [])
 
   const loadRecommendations = useCallback(async () => {
     setRecLoading(true)
@@ -331,6 +345,31 @@ export default function FeedPage() {
             <button type="button" className="action-btn" onClick={clearSearch}>Clear</button>
           )}
         </form>
+
+        {!activeSearch && trending.length > 0 && (
+          <div className="feed-trending" aria-label="Trending hashtags">
+            <span className="feed-trending-label">Trending</span>
+            <div className="feed-trending-rail">
+              {trending.map(h => (
+                <button
+                  key={h.tag}
+                  type="button"
+                  className="feed-trending-chip"
+                  onClick={() => {
+                    setSearchQuery(`#${h.tag}`)
+                    setActiveSearch({ hashtag: h.tag })
+                  }}
+                  title={`${h.postCount ?? 0} post${h.postCount === 1 ? '' : 's'} in the last 24h`}
+                >
+                  <span className="feed-trending-tag">#{h.tag}</span>
+                  {h.postCount != null && (
+                    <span className="feed-trending-count">{h.postCount}</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         {loading ? (
           <div className="md-loading">Loading feed…</div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -262,6 +262,17 @@ export async function getActiveMentorships() {
   return handleResponse(res)
 }
 
+// Trending hashtags (#545 / backend #487). Materialized-view aggregate over
+// the last 24h, refreshed hourly server-side. Returns at most `limit`
+// entries sorted by composite engagement score, each carrying { tag,
+// postCount, score, ... }.
+export async function getTrendingHashtags(limit = 10) {
+  const res = await fetch(`${BASE_URL}/feed/trending/hashtags?limit=${limit}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
 // Paginated mentorship history filter (#408 / backend #521). status accepts
 // 'ALL' or any MentorshipStatus name (ACTIVE / COMPLETED / CANCELLED /
 // TERMINATED). Backend caps size at 100. Returns a Spring Page<>:

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3218,6 +3218,64 @@
 .md-primary-btn { background: var(--green-dark); }
 .md-primary-btn:hover:not(:disabled) { background: var(--green-mid); }
 
+/* Feed trending hashtags rail (#545). */
+.feed-trending {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 10px 0 14px;
+  padding: 10px 12px;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+.feed-trending-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+.feed-trending-rail {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  padding-bottom: 2px;
+}
+.feed-trending-rail::-webkit-scrollbar { height: 4px; }
+.feed-trending-rail::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 2px;
+}
+.feed-trending-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--green-pale);
+  background: var(--green-pale);
+  color: var(--green-dark);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.feed-trending-chip:hover {
+  background: var(--green-mid, #b6d8bd);
+  border-color: var(--green-mid, #b6d8bd);
+}
+.feed-trending-count {
+  font-size: 11px;
+  font-weight: 500;
+  opacity: 0.75;
+}
+
 /* My Mentorships list (#408). */
 .ml-list {
   list-style: none;


### PR DESCRIPTION
Closes #545.                                                                                                                                                                          
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Adds a "Trending" horizontal chip rail above the feed post list, fetched from the materialized-view aggregate that shipped in backend PR #500 (GET                                    
  /api/feed/trending/hashtags?limit=10). Mobile parity — mobile's social-feed screen has had this since PR #526.                                                                        
                                                                                                                                                                                        
  Changes                                                   

  - services/api.js — getTrendingHashtags(limit = 10) wrapper.                                                                                                                          
  - pages/FeedPage.jsx:
    - One-shot fetch on mount (backend refreshes hourly, no need to re-fetch on tab change).                                                                                            
    - Rail rendered between the search form and the post list, hidden during active search to avoid double-filtering.                                                                   
    - Each chip click sets the active search to { hashtag } and seeds the search input — reuses the existing hashtag-filter flow, no new code path.                                     
    - Chips show #tag · count where count is the 24h post count.                                                                                                                        
  - styles/main.css — .feed-trending, .feed-trending-rail, .feed-trending-chip. Horizontal-scroll-on-overflow with a slim scrollbar; no row wrap to keep vertical space predictable.    
                                                                                                                                                                                        
  Acceptance criteria mapping (from #545)                   
                                                                                                                                                                                        
  - ✅ Top of feed renders a horizontal rail of up to 10 trending hashtags.                                                                                                             
  - ✅ Clicking a chip filters the feed to that hashtag.
  - ✅ Chip count is shown alongside the tag for density.                                                                                                                               
  - ✅ Empty rail collapses cleanly (trending.length > 0 gate — no leftover whitespace on slow first paint).                                                                            
                                                                                                                                                                                        
  Test plan                                                                                                                                                                             
                                                                                                                                                                                        
  - npm run build clean.                                    
  - npm test — 64/64 unit tests pass.
  - Manual: visit /feed with a populated trending view → chips render in order with counts.                                                                                             
  - Manual: click a chip → feed filters to that hashtag, rail hides (active search), Clear button returns to the default view and the rail reappears.                                   
  - Manual: stub the endpoint to return empty list → rail doesn't render at all (no orphan label). 