### PR TITLE
feat(web): user-authored posts section on profile pages (#546)

### DIFF
--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import MainLayout from '../components/MainLayout'
 import Avatar from '../components/Avatar'
 import RequestMentorshipModal from '../components/RequestMentorshipModal'
+import FeedPostCard from '../components/FeedPostCard'
 import {
   getUserById,
   createMentorshipRequest,
@@ -10,6 +11,7 @@ import {
   followUser,
   unfollowUser,
   getFollowing,
+  getUserFeedPosts,
 } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import { useMentorship } from '../context/MentorshipContext'
@@ -68,6 +70,15 @@ export default function UserProfilePage() {
   const [isFollowing, setIsFollowing] = useState(false)
   const [followLoading, setFollowLoading] = useState(false)
 
+  // Author posts (#546). Lightweight pagination — Show more loads the next
+  // page and appends. Empty page is rendered as "No posts yet" rather than
+  // hiding the whole section so first-time visitors see what the section is.
+  const [posts, setPosts] = useState([])
+  const [postsPage, setPostsPage] = useState(0)
+  const [postsHasMore, setPostsHasMore] = useState(false)
+  const [postsLoading, setPostsLoading] = useState(true)
+  const [postsLoadingMore, setPostsLoadingMore] = useState(false)
+
   useEffect(() => {
     getUserById(id)
       .then(data => {
@@ -97,6 +108,41 @@ export default function UserProfilePage() {
       setCanSeePhoto(active)
     }
   }, [id, userIsMentee, activeMentorships])
+
+  useEffect(() => {
+    if (!id) return
+    let ignore = false
+    setPostsLoading(true)
+    setPosts([])
+    setPostsPage(0)
+    getUserFeedPosts(id, 0, 10)
+      .then(page => {
+        if (ignore) return
+        const items = page?.content ?? page ?? []
+        setPosts(items)
+        setPostsHasMore(page && page.last === false)
+      })
+      .catch(() => { if (!ignore) setPosts([]) })
+      .finally(() => { if (!ignore) setPostsLoading(false) })
+    return () => { ignore = true }
+  }, [id])
+
+  async function loadMorePosts() {
+    if (postsLoadingMore) return
+    const next = postsPage + 1
+    setPostsLoadingMore(true)
+    try {
+      const page = await getUserFeedPosts(id, next, 10)
+      const items = page?.content ?? page ?? []
+      setPosts(prev => [...prev, ...items])
+      setPostsPage(next)
+      setPostsHasMore(page && page.last === false)
+    } catch {
+      /* swallow — keep the existing list, user can retry */
+    } finally {
+      setPostsLoadingMore(false)
+    }
+  }
 
   useEffect(() => {
     if (!userId || !id || !profile) return
@@ -376,6 +422,36 @@ export default function UserProfilePage() {
             </>
           )}
         </div>
+      </div>
+
+      <div className="card" style={{ marginTop: '16px' }}>
+        <div className="section-label" style={{ marginBottom: '12px' }}>Posts</div>
+        {postsLoading ? (
+          <div className="md-loading">Loading posts…</div>
+        ) : posts.length === 0 ? (
+          <div className="empty-state" style={{ padding: '20px 0' }}>No posts yet.</div>
+        ) : (
+          <div className="feed-list">
+            {posts.map(p => (
+              <FeedPostCard
+                key={p.id}
+                post={p}
+                viewerUserId={userId}
+              />
+            ))}
+            {postsHasMore && (
+              <button
+                type="button"
+                className="action-btn"
+                onClick={loadMorePosts}
+                disabled={postsLoadingMore}
+                style={{ alignSelf: 'center', marginTop: '8px' }}
+              >
+                {postsLoadingMore ? 'Loading…' : 'Show more'}
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {isMentee && isMentorProfile && (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -262,6 +262,15 @@ export async function getActiveMentorships() {
   return handleResponse(res)
 }
 
+// Author posts feed (#546 / backend #471). Paginated list of posts authored
+// by `authorId`. Returns Page<FeedPostListItem>; backend caps size at 100.
+export async function getUserFeedPosts(authorId, page = 0, size = 10) {
+  const res = await fetch(`${BASE_URL}/feed/users/${authorId}/posts?page=${page}&size=${size}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
 // Trending hashtags (#545 / backend #487). Materialized-view aggregate over
 // the last 24h, refreshed hourly server-side. Returns at most `limit`
 // entries sorted by composite engagement score, each carrying { tag,


### PR DESCRIPTION
Closes #546.                                                                                                                                                                          
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Adds a "Posts" section to /users/:id that lists the user's recent feed posts, fetched from GET /api/feed/users/{authorId}/posts (backend PR #474). Mobile parity — mobile's           
  my-blog.tsx has been wired to the same endpoint since PR #526.                                                                                                                        
                                                                                                                                                                                        
  Changes                                                   

  - services/api.js — getUserFeedPosts(authorId, page = 0, size = 10) wrapper. Returns Spring Page<FeedPostListItem>.                                                                   
  - pages/UserProfilePage.jsx:
    - First page fetched on mount whenever id changes (also re-fetched when navigating between profiles).                                                                               
    - "Show more" button at the bottom triggers loadMorePosts which appends the next page. No infinite-scroll — explicit user gesture keeps things predictable.                         
    - Uses the existing FeedPostCard component, which already accepts FeedPostListItem shapes and renders likes / comments / shares / bookmarks inline. So viewers can interact with the
   author's posts without leaving the profile.                                                                                                                                          
    - Section always rendered, even when empty — "No posts yet" placeholder doubles as a discoverability hint for users who haven't posted.                                             
                                                                                                                                                                                        
  Scope decision                                                                                                                                                                        
                                                                                                                                                                                        
  #546's body also mentions adding the same section to /profile. Skipped intentionally: /profile is the edit form, and users can already see their own posts via /users/<their-id>.     
  Adding the section in two places risks confusion about where to manage drafts when post management lands. Trivially folded in later if you want it.
                                                                                                                                                                                        
  Acceptance criteria mapping (from #546)                   

  - ✅ /users/:id shows the user's recent posts (paginated, newest-first via backend sort).                                                                                             
  - ✅ Empty state ("No posts yet") renders cleanly.
  - ⚠️  /profile — deferred (see scope decision above). Counterpart /users/<your-id> already covers this.                                                                                
                                                                                                                                                                                        
  Test plan
                                                                                                                                                                                        
  - npm run build clean.                                    
  - npm test — 64/64 unit tests pass.
  - Manual: visit /users/{some-prolific-poster-id} → "Posts" section renders the first 10 posts in newest-first order; "Show more" appends 10 more.
  - Manual: visit /users/{never-posted} → "No posts yet" empty state.                                                                                                                   
  - Manual: interact with a post via the card (like, comment, share) — works the same as on /feed.