### PR TITLE
feat(web): display + edit affiliation on mentee profiles (#519)

### DIFF
--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -164,6 +164,7 @@ export default function ProfilePage() {
         } : {
           backgroundInfo: form.background || null,
           goals: form.goals || null,
+          affiliation: form.affiliation || null,
           major: form.major || null,
           careerInterest: form.careerInterest || null,
           meetingFreqPref: form.meetingFreqPref || null,
@@ -318,6 +319,7 @@ export default function ProfilePage() {
               <>
                 <ViewField label="Background" value={form.background} visible={form.profileVisible} />
                 <ViewField label="Goals" value={form.goals} visible={form.profileVisible} />
+                <ViewField label="Affiliation" value={form.affiliation} visible={form.profileVisible} />
                 <ViewField label="Skills" value={form.skills} visible={form.profileVisible} chips />
                 <ViewField label="Interests" value={form.interests} visible={form.profileVisible} chips />
                 <ViewField label="Major" value={form.major} visible={form.profileVisible} />
@@ -485,6 +487,18 @@ export default function ProfilePage() {
                     value={form.goals}
                     onChange={e => handleChange('goals', e.target.value)}
                     placeholder="What do you want to achieve..."
+                  />
+                </div>
+
+                <div className="form-field">
+                  <label className="form-label">Affiliation</label>
+                  <input
+                    className="form-input"
+                    type="text"
+                    value={form.affiliation}
+                    onChange={e => handleChange('affiliation', e.target.value)}
+                    placeholder="e.g. Boğaziçi University"
+                    maxLength={200}
                   />
                 </div>
 

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -417,6 +417,7 @@ export default function UserProfilePage() {
               {/* Per req 1.1.2.6: hide lastName and profilePhoto for unmatched mentees */}
               <ProfileField label="Background" value={profile.backgroundInfo} />
               <ProfileField label="Goals" value={profile.goals} />
+              <ProfileField label="Affiliation" value={profile.affiliation} />
               <ProfileField label="Interests" value={profile.interests} chips />
               <ProfileField label="Skills" value={profile.skills} chips />
             </>


### PR DESCRIPTION
Closes #519 (re-opened after backend dependency landed).                                                                                                                              
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Wires the affiliation field through the mentee profile UI now that backend PR #528 added it to Mentee + MenteeResponse + MenteeProfileRequest. Previously this field only rendered on 
  mentor profiles — UserProfilePage.jsx had a single <ProfileField label="Affiliation"> inside the isMentorProfile conditional, and ProfilePage.jsx had a matching input only in the    
  mentor edit branch.                                                                                                                                                                   
                                                            
  Changes

  - pages/UserProfilePage.jsx — added <ProfileField label="Affiliation" value={profile.affiliation} /> to the mentee detail block (line 421). ProfileField already gracefully hides on  
  empty/null, so mentees with no affiliation set don't get an empty section.
  - pages/ProfilePage.jsx:                                                                                                                                                              
    - Added an Affiliation <ViewField> to the mentee view block (line 321), gated on profileVisible like the rest of the mentee fields.
    - Added the matching Affiliation <input> to the mentee edit form (under Goals, before Skills). maxLength={200} mirrors the backend's @Size(max = 200) validator so the user gets    
  browser-side feedback before submitting.                                                                                                                                              
    - Added affiliation: form.affiliation || null to the mentee branch of the save payload spread. Mentor branch already did this; mentee branch was missing it.                        
                                                                                                                                                                                        
  Acceptance criteria mapping (from #519)                   
                                                                                                                                                                                        
  - ✅ Viewing a Mentee's profile shows the "Affiliation" section when data is provided.
  - ✅ Styling matches the Mentor profile view (uses the same <ProfileField> / <ViewField> components).
  - ✅ Empty/null affiliation hides the section cleanly (existing ProfileField / ViewField behaviour).                                                                                  
                                                                                                                                                                                        
  Out of scope                                                                                                                                                                          
                                                                                                                                                                                        
  - Mentee affiliation on MenteeCandidateResponse (used in matching / explore surfaces) — backend doesn't expose it there yet. Filing a small follow-up if you want it visible on       
  Explore mentee cards too, but that's wider than #519 was scoped for.
                                                                                                                                                                                        
  Test plan                                                 

  - npm run build clean.
  - npm test — 64/64 unit tests pass.
  - Manual (mentee user): visit /profile → Edit → enter "Boğaziçi University" in Affiliation → Save → page reloads showing the value under Profile Info.                                
  - Manual (another user viewing the mentee at /users/:id): Affiliation section visible with the saved value.                                                                           
  - Manual (mentee with no affiliation): both surfaces hide the section cleanly.