### PR TITLE
feat(web): feed search date/language filters + viewer keyword-mute (#…

### DIFF
--- a/frontend/src/components/MutedKeywords.jsx
+++ b/frontend/src/components/MutedKeywords.jsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react'
+import { getMutedKeywords, addMutedKeyword, removeMutedKeyword } from '../services/api'
+
+/**
+ * Per-user keyword-mute settings (#543 / backend #486). Mutes are applied
+ * server-side on every feed read, so this UI is just a CRUD list — no
+ * client-side filter logic.
+ *
+ * Backend lowercases the keyword and rejects characters outside [a-z0-9 -]
+ * after normalisation. We surface the server error message verbatim because
+ * it's already user-friendly (e.g. "Keyword already muted").
+ */
+export default function MutedKeywords() {
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [draft, setDraft] = useState('')
+  const [adding, setAdding] = useState(false)
+  const [addError, setAddError] = useState(null)
+  const [removingId, setRemovingId] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    getMutedKeywords()
+      .then(list => { if (!cancelled) setItems(Array.isArray(list) ? list : []) })
+      .catch(err => { if (!cancelled) setError(err?.message || 'Failed to load muted keywords.') })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [])
+
+  async function handleAdd(e) {
+    e.preventDefault()
+    const trimmed = draft.trim()
+    if (!trimmed || adding) return
+    setAdding(true)
+    setAddError(null)
+    try {
+      const saved = await addMutedKeyword(trimmed)
+      setItems(prev => [saved, ...prev])
+      setDraft('')
+    } catch (err) {
+      setAddError(err?.message || 'Failed to add keyword.')
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  async function handleRemove(id) {
+    if (removingId) return
+    setRemovingId(id)
+    const previous = items
+    setItems(prev => prev.filter(m => m.id !== id))
+    try {
+      await removeMutedKeyword(id)
+    } catch (err) {
+      setItems(previous)
+      setError(err?.message || 'Failed to remove keyword.')
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  return (
+    <div className="card" style={{ marginTop: '24px' }} data-testid="muted-keywords">
+      <div className="section-label">Muted Keywords</div>
+      <p style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '4px', marginBottom: '12px' }}>
+        Posts whose body contains any of these substrings are hidden from your feed everywhere.
+        Server lowercases each keyword; only letters, numbers, spaces, and hyphens are allowed.
+      </p>
+
+      <form onSubmit={handleAdd} style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+        <input
+          className="form-input"
+          type="text"
+          placeholder="Add a keyword (e.g. crypto)"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          maxLength={120}
+          disabled={adding}
+          aria-label="New muted keyword"
+        />
+        <button
+          type="submit"
+          className="action-btn"
+          disabled={adding || !draft.trim()}
+        >
+          {adding ? 'Adding…' : 'Add'}
+        </button>
+      </form>
+
+      {addError && (
+        <p style={{ fontSize: '12px', color: 'var(--red-text)', marginBottom: '8px' }}>{addError}</p>
+      )}
+
+      {loading ? (
+        <p style={{ fontSize: '13px', color: 'var(--text-muted)' }}>Loading…</p>
+      ) : error ? (
+        <p style={{ fontSize: '13px', color: 'var(--red-text)' }}>{error}</p>
+      ) : items.length === 0 ? (
+        <p style={{ fontSize: '13px', color: 'var(--text-muted)' }}>No muted keywords yet.</p>
+      ) : (
+        <ul className="muted-kw-list">
+          {items.map(m => (
+            <li key={m.id} className="muted-kw-chip">
+              <span className="muted-kw-label">{m.keyword}</span>
+              <button
+                type="button"
+                className="muted-kw-remove"
+                onClick={() => handleRemove(m.id)}
+                disabled={removingId === m.id}
+                aria-label={`Remove muted keyword ${m.keyword}`}
+                title="Remove"
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -73,7 +73,13 @@ export default function FeedPage() {
   const [trending, setTrending] = useState([])
 
   const [searchQuery, setSearchQuery] = useState('')
-  const [activeSearch, setActiveSearch] = useState(null) // { q?, hashtag? } or null
+  const [activeSearch, setActiveSearch] = useState(null) // { q?, hashtag?, since?, until?, lang? } or null
+  // #543: advanced filters. Open state is a toggle; values persist across
+  // searches so users don't lose a date range when they refine the keyword.
+  const [filtersOpen, setFiltersOpen] = useState(false)
+  const [filterSince, setFilterSince] = useState('')
+  const [filterUntil, setFilterUntil] = useState('')
+  const [filterLang, setFilterLang] = useState('')
 
   // Minimal compose — full UI lands in #353
   const [composeOpen, setComposeOpen] = useState(false)
@@ -155,20 +161,35 @@ export default function FeedPage() {
   function handleSearchSubmit(e) {
     e.preventDefault()
     const trimmed = searchQuery.trim()
-    if (!trimmed) {
+    // Date inputs are LocalDate (YYYY-MM-DD). Backend wants ISO-8601 datetime.
+    // since = start of day inclusive, until = start of next day exclusive
+    // (matches backend's half-open semantics).
+    const sinceIso = filterSince ? new Date(`${filterSince}T00:00:00Z`).toISOString() : undefined
+    const untilIso = filterUntil ? (() => {
+      const d = new Date(`${filterUntil}T00:00:00Z`)
+      d.setUTCDate(d.getUTCDate() + 1)
+      return d.toISOString()
+    })() : undefined
+    const lang = filterLang || undefined
+
+    const hasKeyword = trimmed.length > 0
+    const hasHashtag = hasKeyword && /^#?\w+$/.test(trimmed) && trimmed.startsWith('#')
+    const hasAnyFilter = hasKeyword || sinceIso || untilIso || lang
+    if (!hasAnyFilter) {
       setActiveSearch(null)
       return
     }
-    // Treat any leading "#word" as a hashtag query
-    if (/^#?\w+$/.test(trimmed) && trimmed.startsWith('#')) {
-      setActiveSearch({ hashtag: trimmed.slice(1) })
-    } else {
-      setActiveSearch({ q: trimmed })
-    }
+    const next = { since: sinceIso, until: untilIso, lang }
+    if (hasHashtag) next.hashtag = trimmed.slice(1)
+    else if (hasKeyword) next.q = trimmed
+    setActiveSearch(next)
   }
 
   function clearSearch() {
     setSearchQuery('')
+    setFilterSince('')
+    setFilterUntil('')
+    setFilterLang('')
     setActiveSearch(null)
   }
 
@@ -341,10 +362,74 @@ export default function FeedPage() {
             onChange={(e) => setSearchQuery(e.target.value)}
           />
           <button type="submit" className="action-btn">Search</button>
+          <button
+            type="button"
+            className={`action-btn${filtersOpen || filterSince || filterUntil || filterLang ? ' action-btn--active' : ''}`}
+            onClick={() => setFiltersOpen(v => !v)}
+            aria-expanded={filtersOpen}
+            aria-controls="feed-filters-panel"
+          >
+            Filters{(filterSince || filterUntil || filterLang) ? ' •' : ''}
+          </button>
           {activeSearch && (
             <button type="button" className="action-btn" onClick={clearSearch}>Clear</button>
           )}
         </form>
+
+        {filtersOpen && (
+          <div id="feed-filters-panel" className="feed-filters">
+            <div className="feed-filter-field">
+              <label htmlFor="feed-filter-since">From</label>
+              <input
+                id="feed-filter-since"
+                type="date"
+                className="feed-filter-input"
+                value={filterSince}
+                max={filterUntil || undefined}
+                onChange={(e) => setFilterSince(e.target.value)}
+              />
+            </div>
+            <div className="feed-filter-field">
+              <label htmlFor="feed-filter-until">To</label>
+              <input
+                id="feed-filter-until"
+                type="date"
+                className="feed-filter-input"
+                value={filterUntil}
+                min={filterSince || undefined}
+                onChange={(e) => setFilterUntil(e.target.value)}
+              />
+            </div>
+            <div className="feed-filter-field">
+              <label htmlFor="feed-filter-lang">Language</label>
+              <select
+                id="feed-filter-lang"
+                className="feed-filter-input"
+                value={filterLang}
+                onChange={(e) => setFilterLang(e.target.value)}
+              >
+                <option value="">Any</option>
+                <option value="en">English</option>
+                <option value="tr">Türkçe</option>
+                <option value="de">Deutsch</option>
+                <option value="fr">Français</option>
+                <option value="es">Español</option>
+              </select>
+            </div>
+            <button
+              type="button"
+              className="action-btn"
+              onClick={() => {
+                setFilterSince('')
+                setFilterUntil('')
+                setFilterLang('')
+              }}
+              disabled={!filterSince && !filterUntil && !filterLang}
+            >
+              Reset
+            </button>
+          </div>
+        )}
 
         {!activeSearch && trending.length > 0 && (
           <div className="feed-trending" aria-label="Trending hashtags">

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import MainLayout from '../components/MainLayout'
 import Avatar from '../components/Avatar'
 import NotificationPreferences from '../components/NotificationPreferences'
+import MutedKeywords from '../components/MutedKeywords'
 import usePresence from '../hooks/usePresence'
 import { useAuth } from '../context/AuthContext'
 import { useMentorship } from '../context/MentorshipContext'
@@ -586,6 +587,8 @@ export default function ProfilePage() {
           </form>
 
           <NotificationPreferences />
+
+          <MutedKeywords />
         </div>
 
       </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -785,15 +785,50 @@ export async function getFollowingFeed(page = 0, size = 20) {
   return handleResponse(res)
 }
 
-export async function searchFeed({ q, hashtag, page = 0, size = 20 }) {
+// #543 / backend #486: feed search accepts q + hashtag + since + until + lang.
+// since is inclusive, until is exclusive (both ISO 8601). lang is a BCP-47
+// short tag (e.g. "en", "tr-TR"). Backend requires at least one filter and
+// returns 400 if all are null; the UI gates the request when needed.
+export async function searchFeed({ q, hashtag, since, until, lang, page = 0, size = 20 }) {
   const params = new URLSearchParams()
   if (q) params.set('q', q)
   if (hashtag) params.set('hashtag', hashtag)
+  if (since) params.set('since', since)
+  if (until) params.set('until', until)
+  if (lang) params.set('lang', lang)
   params.set('page', String(page))
   params.set('size', String(size))
   const res = await fetch(`${BASE_URL}/feed/search?${params.toString()}`, {
     headers: authHeaders(),
   })
+  return handleResponse(res)
+}
+
+// Per-user keyword mutes (#543 / backend #486). Server lowercases + validates
+// charset on add. Add returns 201; remove returns 204. Mutes are applied
+// transparently by every feed read path on the server side.
+export async function getMutedKeywords() {
+  const res = await fetch(`${BASE_URL}/users/me/keyword-mutes`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function addMutedKeyword(keyword) {
+  const res = await fetch(`${BASE_URL}/users/me/keyword-mutes`, {
+    method: 'POST',
+    headers: authJsonHeaders(),
+    body: JSON.stringify({ keyword }),
+  })
+  return handleResponse(res)
+}
+
+export async function removeMutedKeyword(id) {
+  const res = await fetch(`${BASE_URL}/users/me/keyword-mutes/${id}`, {
+    method: 'DELETE',
+    headers: authHeaders(),
+  })
+  if (res.status === 204) return null
   return handleResponse(res)
 }
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3218,6 +3218,93 @@
 .md-primary-btn { background: var(--green-dark); }
 .md-primary-btn:hover:not(:disabled) { background: var(--green-mid); }
 
+/* Feed advanced search filters (#543). */
+.feed-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  padding: 12px 14px;
+  margin: 8px 0 14px;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+.feed-filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 140px;
+}
+.feed-filter-field label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.feed-filter-input {
+  padding: 7px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #fff;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: var(--text);
+}
+.feed-filter-input:focus {
+  outline: 2px solid var(--green-pale);
+  border-color: var(--green-mid);
+}
+.action-btn--active {
+  background: var(--green-pale);
+  border-color: var(--green-mid);
+  color: var(--green-dark);
+}
+
+/* Muted keywords settings (#543). */
+.muted-kw-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.muted-kw-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 4px 4px 12px;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid var(--border);
+  font-size: 13px;
+  color: var(--text);
+}
+.muted-kw-label {
+  font-family: 'DM Sans', sans-serif;
+}
+.muted-kw-remove {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.muted-kw-remove:hover:not(:disabled) {
+  background: var(--red-soft, #fee2e2);
+  color: var(--red-text, #b91c1c);
+}
+.muted-kw-remove:disabled { opacity: 0.5; cursor: not-allowed; }
+
 /* Feed trending hashtags rail (#545). */
 .feed-trending {
   display: flex;


### PR DESCRIPTION
Closes #543.                                                                                                                                                                          

  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Wires the advanced feed search and per-viewer keyword-mute backends (PR #501) through to web. Three new affordances:                                                                  
                                                                                                                                                                                        
  1. Date range filter on feed search — From / To inputs that map to backend's half-open since (inclusive) / until (exclusive) ISO-8601 datetime params.                                
  2. Language filter — BCP-47 short-tag select (en / tr / de / fr / es) sent as lang.
  3. Muted-keyword settings on /profile — per-user mutes that the backend applies on every feed read (for-you / following / per-author / search).                                       
                                                                                                                                                                                        
  Changes                                                                                                                                                                               
                                                                                                                                                                                        
  - services/api.js:                                                                                                                                                                    
    - Extended searchFeed to accept { q, hashtag, since, until, lang, page, size }. Empty optional params are omitted from the URL.
    - New getMutedKeywords(), addMutedKeyword(keyword), removeMutedKeyword(id) wrappers for GET / POST / DELETE /api/users/me/keyword-mutes.                                            
  - pages/FeedPage.jsx:                                                                                                                                                                 
    - "Filters" toggle button next to Search; opens a collapsible panel with From / To date inputs and a language select.                                                               
    - Filter values persist across searches so refining the keyword doesn't lose the date range.                                                                                        
    - Submit now considers filters too — pure-keyword and pure-filter searches both work; submitting with everything empty clears the active search (matches the backend's "at least one
   filter required" 400 path).                                                                                                                                                          
    - Date conversion: From YYYY-MM-DD becomes start-of-day UTC; To becomes start-of-next-day UTC, so the half-open semantic is naturally end-of-day inclusive from a user perspective. 
    - Clear button now also resets the filter state.                                                                                                                                    
  - components/MutedKeywords.jsx (new) — CRUD card for muted keywords. Optimistic add / remove with rollback on failure. Surfaces server errors verbatim (already user-friendly:        
  "Keyword already muted", etc.).                                                                                                                                                       
  - pages/ProfilePage.jsx — mounts <MutedKeywords /> directly below <NotificationPreferences /> so all viewer-side feed controls live in one place.                                     
  - styles/main.css — .feed-filters panel + inputs, .muted-kw-list + .muted-kw-chip styles. Also added an .action-btn--active modifier so the Filters button shows it's open / has      
  active values.                                                                                                                                                                        
                                                                                                                                                                                        
  Acceptance criteria mapping (from #543)                                                                                                                                               
                                                            
  - ✅ Search results respect from-date / to-date / language filters.                                                                                                                   
  - ✅ Muted-keyword settings persist server-side; muted keywords are hidden from all feed surfaces (server-applied, transparent to the client).
  - ✅ Filter UI is discoverable but doesn't dominate the search bar layout (toggle button, collapsible panel).                                                                         
                                                            
  Out of scope                                                                                                                                                                          
                                                            
  - Saved-search / advanced query syntax.                                                                                                                                               
  - Bulk import/export of muted keywords.                   
  - Filter-state in URL (current implementation persists in component state only; reopening the tab forgets filters).
                                                                                                                                                                                        
  Test plan
                                                                                                                                                                                        
  - npm run build clean.                                                                                                                                                                
  - npm test — 64/64 unit tests pass.
  - Manual: /feed → click Filters → pick From=last week, To=today, Language=en → Search → results are filtered as expected.                                                             
  - Manual: search with empty keyword but a date range alone → results return (no q is fine if any other filter is set).                                                                
  - Manual: /profile → Muted Keywords section → add "crypto" → posts containing "crypto" disappear from /feed immediately on next refresh. Remove it → posts come back.                 
  - Manual: try to add an illegal keyword (e.g. foo!@#) — backend rejects with 400 → the error message surfaces inline.