### PR TITLE
feat(web): wire rating-read endpoints, drop localStorage workaround, …

### DIFF
--- a/frontend/src/pages/MentorshipDetailPage.jsx
+++ b/frontend/src/pages/MentorshipDetailPage.jsx
@@ -13,6 +13,7 @@ import {
   endMentorship,
   extendMentorship,
   rateMentor,
+  getMentorshipRating,
   listMentorshipMeetings,
 } from '../services/api'
 import { useAuth } from '../context/AuthContext'
@@ -562,24 +563,27 @@ export default function MentorshipDetailPage() {
   const [rateOpen, setRateOpen] = useState(false)
   const [rateLoading, setRateLoading] = useState(false)
   const [rateError, setRateError] = useState(null)
-  // Backend doesn't expose a GET-rating endpoint today, so we mirror successful
-  // submissions in localStorage to suppress the prompt on subsequent visits.
-  // The 409-on-duplicate-POST path also flips this so cross-device
-  // resubmission is caught.
+  // #556: hydrated from the backend rating-read endpoint (#534). Null means
+  // either "still loading" or "no rating yet" — we treat them the same since
+  // we only render the prompt once the page is visible and the mentorship is
+  // already non-ACTIVE; an empty hydration is the no-rating case.
   const [submittedRating, setSubmittedRating] = useState(null)
 
   const [cancelOpen, setCancelOpen] = useState(false)
   const [cancelLoading, setCancelLoading] = useState(false)
   const [cancelError, setCancelError] = useState(null)
 
-  // Hydrate already-submitted rating from localStorage so the prompt doesn't
-  // reappear on revisit. Backend has no GET-rating endpoint today (#278 follow-up).
+  // Hydrate any existing rating from the backend so the prompt doesn't flash
+  // before the read-only block on revisit. 404 = no rating yet (expected
+  // first-time path). Any other error is silent — worst case the user gets
+  // the prompt and the duplicate-POST 409 path below catches it.
   useEffect(() => {
     if (!id) return
-    try {
-      const raw = localStorage.getItem(`rated_mentorship_${id}`)
-      if (raw) setSubmittedRating(JSON.parse(raw))
-    } catch { /* malformed entry — ignore */ }
+    let cancelled = false
+    getMentorshipRating(id)
+      .then(r => { if (!cancelled) setSubmittedRating(r) })
+      .catch(err => { if (!cancelled && err?.status !== 404) { /* swallow */ } })
+    return () => { cancelled = true }
   }, [id])
 
   useEffect(() => {
@@ -653,25 +657,21 @@ export default function MentorshipDetailPage() {
     try {
       const created = await rateMentor(mentorship.id, score, comment)
       setSubmittedRating(created)
-      try {
-        localStorage.setItem(`rated_mentorship_${mentorship.id}`, JSON.stringify({
-          score: created.score,
-          comment: created.comment,
-          createdAt: created.createdAt,
-        }))
-      } catch { /* localStorage disabled — fall back to in-memory state */ }
       setRateOpen(false)
     } catch (err) {
       const msg = err?.message || ''
       // Duplicate-rating path: backend returns 409 with "already rated" wording.
-      // Treat as success-ish — flip to the read-only block so the user isn't stuck.
+      // Refetch the canonical rating so we display whatever the user actually
+      // submitted previously, not the new attempt's score.
       if (msg.includes('409') || /already.*rated/i.test(msg)) {
-        setSubmittedRating({ score, comment, createdAt: new Date().toISOString() })
         try {
-          localStorage.setItem(`rated_mentorship_${mentorship.id}`, JSON.stringify({
-            score, comment, createdAt: new Date().toISOString(),
-          }))
-        } catch { /* ignore */ }
+          const existing = await getMentorshipRating(mentorship.id)
+          setSubmittedRating(existing)
+        } catch {
+          // 404 shouldn't happen after a 409, but fall back to the attempt
+          // so the user isn't stuck on the prompt.
+          setSubmittedRating({ score, comment, createdAt: new Date().toISOString() })
+        }
         setRateOpen(false)
       } else {
         setRateError(msg || 'Failed to submit rating')

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -12,10 +12,18 @@ import {
   unfollowUser,
   getFollowing,
   getUserFeedPosts,
+  getMentorRatings,
 } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import { useMentorship } from '../context/MentorshipContext'
 import '../styles/main.css'
+
+function formatRatingDate(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
 
 function ProfileField({ label, value, chips = false }) {
   const isEmpty = !value && value !== 0
@@ -79,6 +87,14 @@ export default function UserProfilePage() {
   const [postsLoading, setPostsLoading] = useState(true)
   const [postsLoadingMore, setPostsLoadingMore] = useState(false)
 
+  // Mentor ratings ("Recent feedback", #556 / backend #534). Only mentors
+  // accumulate ratings; mentee profiles skip the section entirely.
+  const [ratings, setRatings] = useState([])
+  const [ratingsPage, setRatingsPage] = useState(0)
+  const [ratingsHasMore, setRatingsHasMore] = useState(false)
+  const [ratingsLoading, setRatingsLoading] = useState(true)
+  const [ratingsLoadingMore, setRatingsLoadingMore] = useState(false)
+
   useEffect(() => {
     getUserById(id)
       .then(data => {
@@ -141,6 +157,46 @@ export default function UserProfilePage() {
       /* swallow — keep the existing list, user can retry */
     } finally {
       setPostsLoadingMore(false)
+    }
+  }
+
+  // Mentor ratings ("Recent feedback") — only fetch once profile is loaded
+  // and the viewer is on a mentor profile. Mentees never accumulate ratings.
+  useEffect(() => {
+    if (!id || !profile || profile.role !== 'MENTOR') {
+      setRatingsLoading(false)
+      return undefined
+    }
+    let ignore = false
+    setRatingsLoading(true)
+    setRatings([])
+    setRatingsPage(0)
+    getMentorRatings(id, 0, 10)
+      .then(page => {
+        if (ignore) return
+        const items = page?.content ?? page ?? []
+        setRatings(items)
+        setRatingsHasMore(page && page.last === false)
+      })
+      .catch(() => { if (!ignore) setRatings([]) })
+      .finally(() => { if (!ignore) setRatingsLoading(false) })
+    return () => { ignore = true }
+  }, [id, profile])
+
+  async function loadMoreRatings() {
+    if (ratingsLoadingMore) return
+    const next = ratingsPage + 1
+    setRatingsLoadingMore(true)
+    try {
+      const page = await getMentorRatings(id, next, 10)
+      const items = page?.content ?? page ?? []
+      setRatings(prev => [...prev, ...items])
+      setRatingsPage(next)
+      setRatingsHasMore(page && page.last === false)
+    } catch {
+      /* swallow — keep the existing list, user can retry */
+    } finally {
+      setRatingsLoadingMore(false)
     }
   }
 
@@ -424,6 +480,49 @@ export default function UserProfilePage() {
           )}
         </div>
       </div>
+
+      {isMentorProfile && (
+        <div className="card" style={{ marginTop: '16px' }}>
+          <div className="section-label" style={{ marginBottom: '12px' }}>Recent Feedback</div>
+          {ratingsLoading ? (
+            <div className="md-loading">Loading feedback…</div>
+          ) : ratings.length === 0 ? (
+            <div className="empty-state" style={{ padding: '20px 0' }}>No ratings yet.</div>
+          ) : (
+            <ul className="rating-list">
+              {ratings.map(r => (
+                <li key={r.id} className="rating-card">
+                  <div className="rating-card-head">
+                    <span className="md-rating-stars md-rating-stars--readonly" aria-label={`${r.score} out of 5 stars`}>
+                      {[1, 2, 3, 4, 5].map(n => (
+                        <span
+                          key={n}
+                          className={`md-rating-star${r.score >= n ? ' md-rating-star--filled' : ''}`}
+                        >★</span>
+                      ))}
+                    </span>
+                    <span className="rating-card-date">{formatRatingDate(r.createdAt)}</span>
+                  </div>
+                  {r.comment && (
+                    <p className="rating-card-comment">"{r.comment}"</p>
+                  )}
+                </li>
+              ))}
+              {ratingsHasMore && (
+                <button
+                  type="button"
+                  className="action-btn"
+                  onClick={loadMoreRatings}
+                  disabled={ratingsLoadingMore}
+                  style={{ alignSelf: 'center', marginTop: '8px' }}
+                >
+                  {ratingsLoadingMore ? 'Loading…' : 'Show more'}
+                </button>
+              )}
+            </ul>
+          )}
+        </div>
+      )}
 
       <div className="card" style={{ marginTop: '16px' }}>
         <div className="section-label" style={{ marginBottom: '12px' }}>Posts</div>

--- a/frontend/src/pages/__tests__/MentorshipDetailPage.test.jsx
+++ b/frontend/src/pages/__tests__/MentorshipDetailPage.test.jsx
@@ -32,6 +32,10 @@ describe('MentorshipDetailPage - Shared Goal Feature', () => {
     // subsequent deriveNextUpcomingMeeting() resolve cleanly in tests that
     // don't care about meeting data.
     api.listMentorshipMeetings.mockResolvedValue([])
+    // #556: page hydrates an existing rating on mount. Reject with a 404-like
+    // error so it falls through to the "not rated yet" path without crashing
+    // on undefined.then().
+    api.getMentorshipRating.mockRejectedValue(Object.assign(new Error('not rated yet'), { status: 404 }))
   })
 
   const renderComponent = async (mentorshipData) => {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -363,6 +363,30 @@ export async function updateNotificationPreferences(patch) {
   return handleResponse(res)
 }
 
+// Read the rating for a mentorship (#556 / backend #534 / #518). Visible to
+// both participants. Returns 404 when no rating exists yet — wrappers throw
+// an Error with a status field so callers can branch cleanly on first paint.
+export async function getMentorshipRating(id) {
+  const res = await fetch(`${BASE_URL}/mentorships/${id}/rating`, {
+    headers: authHeaders(),
+  })
+  if (res.status === 404) {
+    const err = new Error('Not rated yet')
+    err.status = 404
+    throw err
+  }
+  return handleResponse(res)
+}
+
+// Paginated mentor ratings list (#556 / backend #534 / #518). Newest-first.
+// Returns Spring Page<MentorRatingResponse>. Size capped at 50 server-side.
+export async function getMentorRatings(userId, page = 0, size = 10) {
+  const res = await fetch(`${BASE_URL}/users/${userId}/ratings?page=${page}&size=${size}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
 // Mentee-only rating (#278 / 1.1.1.1.11). Backend rejects with 409 if the
 // mentorship is still ACTIVE or already rated; 403 if a mentor calls it.
 // Score must be 1..5; comment is optional and capped at 1000 chars.

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3605,6 +3605,38 @@
   overflow: hidden;
 }
 
+/* Recent feedback list on mentor profile (#556 / #278). */
+.rating-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.rating-card {
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fff;
+}
+.rating-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.rating-card-date {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.rating-card-comment {
+  margin: 8px 0 0;
+  font-size: 14px;
+  color: var(--text);
+  font-style: italic;
+}
+
 /* Mentor rating modal + post-end prompt (#278). */
 .md-rating-card {
   margin: 12px 0;


### PR DESCRIPTION
Closes #556.                                                                                                                                                                          
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Wires the rating-read endpoints that shipped in backend PR #534, removing two workarounds I left behind in #517 and adding the "Recent feedback" section that #278's AC originally    
  called for.                                                                                                                                                                           
                                                                                                                                                                                        
  Changes                                                                                                                                                                             

  - services/api.js:
    - getMentorshipRating(id) — calls GET /api/mentorships/{id}/rating. Throws an Error with status: 404 when no rating exists, so callers can branch on first paint without parsing
  string messages.                                                                                                                                                                      
    - getMentorRatings(userId, page = 0, size = 10) — calls GET /api/users/{id}/ratings, returns Spring Page<MentorRatingResponse>.
  - pages/MentorshipDetailPage.jsx:                                                                                                                                                     
    - The localStorage hydration useEffect is replaced with a getMentorshipRating(id) call. 404 (no rating yet) is treated as "not rated"; any other error is silent — worst case the 
  prompt flashes and the duplicate-POST 409 below catches it.                                                                                                                           
    - handleRateConfirm's 409 branch no longer fabricates a rating from the user's attempt — it refetches via getMentorshipRating so the displayed score matches what was actually    
  persisted (relevant if the user submitted a different score from a different device).                                                                                                 
    - All localStorage.setItem/getItem calls keyed on rated_mentorship_* are deleted.                                                                                                 
  - pages/UserProfilePage.jsx:                                                                                                                                                          
    - New mentor-only "Recent Feedback" card below the profile detail, above Posts.                                                                                                     
    - Lightweight pagination via Show more (10 per page, backend caps at 50).                                                                                                           
    - Renders ★ stars + date + optional italicised comment per rating. Anonymised — no rater name (backend exposes menteeId but we don't batch-resolve names today; keeps scope tight   
  and matches the "your comment may appear without your name attached" policy).                                                                                                         
    - Mentee profiles skip the section entirely.                                                                                                                                        
  - pages/__tests__/MentorshipDetailPage.test.jsx — added api.getMentorshipRating.mockRejectedValue(...) with a 404-status error in beforeEach so the auto-mocked undefined.then()      
  doesn't crash the shared-goal tests.                                                                                                                                                  
  - styles/main.css — .rating-list, .rating-card, .rating-card-head, .rating-card-date, .rating-card-comment.
                                                                                                                                                                                        
  Acceptance criteria mapping (from #556)                   
                                                                                                                                                                                        
  - ✅ MentorshipDetailPage no longer reads or writes rated_mentorship_* in localStorage.                                                                                               
  - ✅ Returning to the page after rating shows the read-only "You rated …" block immediately (the GET runs alongside the main fetch; in practice it resolves before paint settles).
  - ✅ Mentor profile pages display a "Recent feedback" section with up to 10 ratings; "Show more" appends the next page.                                                               
  - ✅ Mentor with zero ratings shows the section with "No ratings yet."                                                                                                                
                                                                                                                                                                                        
  Test plan                                                                                                                                                                             
                                                            
  - npm run build clean.                                                                                                                                                                
  - npm test — 64/64 unit tests pass (existing MentorshipDetailPage tests updated to mock the new endpoint).
  - Manual: rate a mentor → reload /mentorships/:id → page shows read-only block on first paint (no prompt flash, no localStorage entry).                                               
  - Manual: from a second device / incognito, attempt to rate same mentorship → 409 path refetches the canonical rating and renders that, not the new attempt.                          
  - Manual: visit /users/:mentorId of a mentor with several ratings → "Recent Feedback" card lists them newest-first; Show more appends.                                                
  - Manual: visit a fresh mentor's profile → "No ratings yet" empty state.