### PR TITLE
fix(backend): allow admins to view their own /me endpoint (#553)

### DIFF
--- a/backend/src/main/java/com/group7/backend/dto/response/AdminResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/AdminResponse.java
@@ -1,0 +1,45 @@
+package com.group7.backend.dto.response;
+
+import com.group7.backend.entity.Admin;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.beans.BeanUtils;
+
+/**
+ * Admin profile response. Returned only by the self-view path
+ * {@code GET /api/users/me} when the authenticated user is an
+ * {@link Admin}.
+ *
+ * <p>Admin opacity to third parties is preserved upstream:
+ * <ul>
+ *   <li>{@code UserService.getProfileById} short-circuits with 403 for
+ *       admin targets before reaching {@code mapToResponse}.</li>
+ *   <li>{@code UserRepository.findAllNonAdmins} filters admins out of
+ *       list and search surfaces.</li>
+ *   <li>{@code FollowService.checkVisibility} throws 403 on admin
+ *       targets for follower / following list endpoints.</li>
+ * </ul>
+ *
+ * <p>Carries no admin-specific fields: the {@link Admin} entity adds
+ * none over {@link com.group7.backend.entity.User}, so the wire shape
+ * is exactly the common {@link UserResponse} envelope plus
+ * {@code role = "ADMIN"}. Keeping the DTO empty is deliberate — if a
+ * future change adds an admin-only entity field, surfacing it must be
+ * an explicit decision rather than a silent {@code BeanUtils} copy
+ * side-effect.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "Admin profile response (self-view only, /me).")
+public final class AdminResponse extends UserResponse implements ProfileResponse {
+
+    public static AdminResponse from(Admin admin) {
+        AdminResponse response = new AdminResponse();
+        BeanUtils.copyProperties(admin, response);
+        response.setRole("ADMIN");
+        return response;
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/ProfileResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/ProfileResponse.java
@@ -1,15 +1,25 @@
 package com.group7.backend.dto.response;
 
 /**
- * Marker interface for profile response DTOs.
- * Implemented by {@link MentorResponse} and {@link MenteeResponse}.
- * Provides type safety for service methods that return role-specific profiles.
+ * Marker interface for profile response DTOs. Implemented by
+ * {@link MentorResponse}, {@link MenteeResponse}, and
+ * {@link AdminResponse}. Provides type safety for service methods that
+ * return role-specific profiles.
+ *
+ * <p>{@link AdminResponse} is reachable only via the self-view path
+ * {@code GET /api/users/me} (see {@code UserService.getOwnProfile}).
+ * All third-party admin lookups short-circuit with 403 in
+ * {@code UserService.getProfileById} and
+ * {@code FollowService.checkVisibility} before mapping runs, and
+ * admins are filtered out of list / search / follow-graph results at
+ * the repository or service layer upstream.
  */
-public sealed interface ProfileResponse permits MentorResponse, MenteeResponse {
+public sealed interface ProfileResponse
+        permits MentorResponse, MenteeResponse, AdminResponse {
 
     /**
-     * Returns the profile photo URL.
-     * Both MentorResponse and MenteeResponse inherit this from UserResponse.
+     * Returns the profile photo URL. All permitted subtypes inherit
+     * this from {@link UserResponse}.
      */
     String getProfilePhoto();
 }

--- a/backend/src/main/java/com/group7/backend/service/UserService.java
+++ b/backend/src/main/java/com/group7/backend/service/UserService.java
@@ -4,6 +4,7 @@ import com.group7.backend.dto.request.EditProfileRequest;
 import com.group7.backend.dto.request.MenteeProfileRequest;
 import com.group7.backend.dto.request.MentorProfileRequest;
 import com.group7.backend.dto.request.SearchRole;
+import com.group7.backend.dto.response.AdminResponse;
 import com.group7.backend.dto.response.MenteeResponse;
 import com.group7.backend.dto.response.MentorResponse;
 import com.group7.backend.dto.response.ProfileResponse;
@@ -387,16 +388,34 @@ public class UserService {
         }
     }
 
+    /**
+     * Maps a {@link User} entity to its role-specific {@link ProfileResponse}.
+     *
+     * <p>Admins map to {@link AdminResponse} so the self-view path
+     * {@code GET /api/users/me} returns 200 for authenticated admins.
+     * This is the only call path that legitimately reaches the admin
+     * branch:
+     * <ul>
+     *   <li>{@link #getProfileById(Long, Long)} short-circuits with 403
+     *       for admin targets before invoking this helper, preserving
+     *       admin opacity to third parties.</li>
+     *   <li>{@link #getAllUsersFiltered(Long, Pageable)} filters admins
+     *       at the repository layer via {@code findAllNonAdmins}.</li>
+     *   <li>{@link #searchUsers(Long, String, Pageable, SearchRole)}
+     *       dispatches to mentor / mentee repositories that never load
+     *       admins.</li>
+     *   <li>Profile-edit / photo paths are scoped to {@code /me}, so
+     *       admins reaching them is privacy-equivalent to viewing
+     *       {@code /me} itself.</li>
+     * </ul>
+     */
     private ProfileResponse mapToResponse(User user) {
         if (user instanceof Mentor mentor) {
             return MentorResponse.from(mentor);
         } else if (user instanceof Mentee mentee) {
             return MenteeResponse.from(mentee);
-        } else if (user instanceof Admin) {
-            // Defensive: admins are filtered upstream via findAllNonAdmins and
-            // rejected explicitly in getProfileById, so this path should be
-            // unreachable. Throw the same 403 mapping if a future caller forgets.
-            throw new ProfileNotVisibleException("Admin profile is not visible");
+        } else if (user instanceof Admin admin) {
+            return AdminResponse.from(admin);
         }
         throw new IllegalStateException("Unknown user type: " + user.getClass().getSimpleName());
     }

--- a/backend/src/test/java/com/group7/backend/controller/ProfileControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/ProfileControllerTest.java
@@ -6,6 +6,7 @@ import com.group7.backend.config.SecurityConfig;
 import com.group7.backend.dto.request.EditProfileRequest;
 import com.group7.backend.dto.request.MentorProfileRequest;
 import com.group7.backend.dto.request.MenteeProfileRequest;
+import com.group7.backend.dto.response.AdminResponse;
 import com.group7.backend.dto.response.MenteeResponse;
 import com.group7.backend.dto.response.MentorResponse;
 import com.group7.backend.dto.response.UserProfileResponse;
@@ -78,6 +79,23 @@ class ProfileControllerTest {
 
     private UserProfileResponse wrapMentee() {
         return new UserProfileResponse(buildMenteeResponse(), 0L, 0L, false);
+    }
+
+    private UserProfileResponse wrapAdmin() {
+        return new UserProfileResponse(buildAdminResponse(), 0L, 0L, false);
+    }
+
+    private AdminResponse buildAdminResponse() {
+        AdminResponse response = new AdminResponse();
+        response.setId(3L);
+        response.setFirstName("Root");
+        response.setLastName("Admin");
+        response.setEmail("admin@example.com");
+        response.setProfilePhoto(null);
+        response.setIsEmailVerified(true);
+        response.setCreatedAt(OffsetDateTime.of(2026, 3, 17, 10, 0, 0, 0, ZoneOffset.UTC));
+        response.setRole("ADMIN");
+        return response;
     }
 
     private MentorResponse buildMentorResponse() {
@@ -209,6 +227,35 @@ class ProfileControllerTest {
                 .andExpect(jsonPath("$.bio").doesNotExist())
                 .andExpect(jsonPath("$.expertise").doesNotExist())
                 .andExpect(jsonPath("$.maxMenteeCapacity").doesNotExist());
+    }
+
+    // ── GET /api/users/me — Admin (#553) ─────────────────────
+
+    @Test
+    void getOwnProfile_admin_returns200WithRoleADMIN() throws Exception {
+        // Prior to #553 the admin self-view returned 403 because
+        // UserService.mapToResponse threw unconditionally on Admin
+        // entities. The fix carves out the /me path: admins get an
+        // AdminResponse with the common UserResponse envelope and
+        // role="ADMIN". Admin opacity to third parties stays intact;
+        // see UserServiceTest.getProfileById_thirdPartyAdminLookup_stillReturns403.
+        mockValidToken(3L, "ADMIN");
+        when(userService.getOwnUserProfile(3L)).thenReturn(wrapAdmin());
+
+        mockMvc.perform(get("/api/users/me")
+                        .header("Authorization", "Bearer " + TEST_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(3))
+                .andExpect(jsonPath("$.firstName").value("Root"))
+                .andExpect(jsonPath("$.lastName").value("Admin"))
+                .andExpect(jsonPath("$.email").value("admin@example.com"))
+                .andExpect(jsonPath("$.role").value("ADMIN"))
+                .andExpect(jsonPath("$.isEmailVerified").value(true))
+                // No role-specific fields leak from Mentor/Mentee responses.
+                .andExpect(jsonPath("$.bio").doesNotExist())
+                .andExpect(jsonPath("$.maxMenteeCapacity").doesNotExist())
+                .andExpect(jsonPath("$.skills").doesNotExist())
+                .andExpect(jsonPath("$.passwordHash").doesNotExist());
     }
 
     // ── GET /api/users/me — Auth ────────────────────────────

--- a/backend/src/test/java/com/group7/backend/service/UserServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/UserServiceTest.java
@@ -1,0 +1,108 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.AdminResponse;
+import com.group7.backend.dto.response.UserProfileResponse;
+import com.group7.backend.dto.response.UserRatingSummary;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.exception.ProfileNotVisibleException;
+import com.group7.backend.repository.AvailabilitySlotRepository;
+import com.group7.backend.repository.FollowRepository;
+import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
+import com.group7.backend.repository.MenteeRepository;
+import com.group7.backend.repository.MentorRepository;
+import com.group7.backend.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Service-layer Mockito coverage for {@link UserService}. Scoped to the
+ * admin-self-view carve-out introduced for issue #553 plus the regression
+ * that third-party admin lookups continue to surface 403.
+ *
+ * <p>Broader UserService behaviour is exercised by
+ * {@code ProfileIntegrationTest} against a real Postgres; this slice is
+ * the cheaper feedback loop for the targeted change.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private MentorRepository mentorRepository;
+    @Mock private MenteeRepository menteeRepository;
+    @Mock private AvailabilitySlotRepository availabilitySlotRepository;
+    @Mock private MenteeAvailabilitySlotRepository menteeAvailabilitySlotRepository;
+    @Mock private FollowRepository followRepository;
+    @Mock private FileStorageService fileStorageService;
+    @Mock private MentorRatingService mentorRatingService;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks private UserService userService;
+
+    @Test
+    void getOwnUserProfile_admin_returnsAdminResponseWithRoleADMIN() {
+        Admin self = admin(42L, "Root", "Admin", "admin553@local.dev");
+        when(userRepository.findById(42L)).thenReturn(Optional.of(self));
+        when(followRepository.countByIdFolloweeId(42L)).thenReturn(0L);
+        when(followRepository.countByIdFollowerId(42L)).thenReturn(0L);
+        when(mentorRatingService.aggregateForMentor(42L))
+                .thenReturn(new UserRatingSummary(null, 0L));
+
+        UserProfileResponse result = userService.getOwnUserProfile(42L);
+
+        assertThat(result.getProfile()).isInstanceOf(AdminResponse.class);
+        AdminResponse profile = (AdminResponse) result.getProfile();
+        assertThat(profile.getId()).isEqualTo(42L);
+        assertThat(profile.getFirstName()).isEqualTo("Root");
+        assertThat(profile.getLastName()).isEqualTo("Admin");
+        assertThat(profile.getEmail()).isEqualTo("admin553@local.dev");
+        assertThat(profile.getRole()).isEqualTo("ADMIN");
+        assertThat(result.getFollowerCount()).isZero();
+        assertThat(result.getFollowingCount()).isZero();
+        // Self-view skips the follow-existence probe, so isFollowing is
+        // false by construction — never call existsById for a self-view.
+        assertThat(result.isFollowing()).isFalse();
+    }
+
+    @Test
+    void getProfileById_thirdPartyAdminLookup_stillReturns403() {
+        // Carve-out regression: the /me path is the only permitted route to
+        // an admin's profile. Third-party lookup must still short-circuit
+        // in getProfileById with ProfileNotVisibleException before the
+        // mapping helper runs.
+        Mentor requester = mentor(7L);
+        Admin target = admin(42L, "Root", "Admin", "admin@local.dev");
+        when(userRepository.findById(7L)).thenReturn(Optional.of(requester));
+        when(userRepository.findById(42L)).thenReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> userService.getProfileById(42L, 7L))
+                .isInstanceOf(ProfileNotVisibleException.class)
+                .hasMessageContaining("Admin");
+    }
+
+    private static Admin admin(Long id, String firstName, String lastName, String email) {
+        Admin admin = new Admin();
+        admin.setId(id);
+        admin.setFirstName(firstName);
+        admin.setLastName(lastName);
+        admin.setEmail(email);
+        return admin;
+    }
+
+    private static Mentor mentor(Long id) {
+        Mentor mentor = new Mentor();
+        mentor.setId(id);
+        mentor.setEmail("mentor" + id + "@local.dev");
+        return mentor;
+    }
+}


### PR DESCRIPTION
Closes #553.

## Summary

`UserService.mapToResponse` threw `ProfileNotVisibleException` for any `Admin` entity, so `GET /api/users/me` returned **403** to authenticated admins. The existing Javadoc on `getOwnUserProfile` (line 212–214 of `UserService.java`) explicitly states admins ARE allowed to view their own profile, and several mobile screens that call `/users/me` on mount survived the bug only via try/catch — logging noisy 403s on every launch.

The fix introduces `AdminResponse`, a new permittee of the sealed `ProfileResponse` interface, and changes the admin branch of `mapToResponse` to return `AdminResponse.from(admin)` instead of throwing.

**Admin opacity to third parties is preserved verbatim** — `getProfileById` already short-circuits with 403 for admin targets before reaching `mapToResponse`, and list / search / follow-graph surfaces filter admins at the repository or service layer. The `/me` path is the only call site that now reaches the admin branch.

## Endpoint impact

| Endpoint | Caller | Before | After |
|---|---|---|---|
| `GET /api/users/me` | admin | **403** | **200** |
| `GET /api/users/me` | mentor / mentee | 200 | 200 |
| `GET /api/users/{adminId}` | any non-admin | 403 | 403 |
| `GET /api/users/{adminId}/followers` | any caller (incl. the admin) | 403 | 403 |
| `GET /api/users/{adminId}/following` | any caller (incl. the admin) | 403 | 403 |
| `GET /api/users` (list) | any caller | admin-filtered | admin-filtered |
| `GET /api/users/search` | any caller | admin-filtered | admin-filtered |

## Files changed

| Status | Path |
|---|---|
| NEW | `backend/src/main/java/com/group7/backend/dto/response/AdminResponse.java` |
| MOD | `backend/src/main/java/com/group7/backend/dto/response/ProfileResponse.java` — `permits` extension + Javadoc |
| MOD | `backend/src/main/java/com/group7/backend/service/UserService.java` — admin branch returns `AdminResponse`; stale "should be unreachable" comment replaced with accurate post-fix Javadoc |
| NEW | `backend/src/test/java/com/group7/backend/service/UserServiceTest.java` — service-layer Mockito coverage |
| MOD | `backend/src/test/java/com/group7/backend/controller/ProfileControllerTest.java` — admin `/me` slice test |

Three production files, two test files. No controller, no `SecurityConfig`, no DB migration, no Flyway change.

## Design notes

`AdminResponse extends UserResponse implements ProfileResponse` carries no admin-specific fields — the `Admin` entity itself adds none over `User`, so the wire shape is exactly the common `UserResponse` envelope plus `role = "ADMIN"`. Keeping the DTO empty is deliberate: if a future change adds an admin-only entity field, surfacing it must be an explicit decision rather than a silent `BeanUtils.copyProperties` side-effect.

The carve-out is implicit, not flag-based. After this fix, the admin branch of `mapToResponse` is reachable only via the `/me` path:

- `getProfileById(targetId, requesterId)` throws 403 for admin targets **before** invoking `mapToResponse`.
- `getAllUsersFiltered` uses `findAllNonAdmins` at the repository layer.
- `searchUsers` dispatches to mentor- / mentee-only repositories.
- `FollowService.checkVisibility` throws 403 on admin targets for follower / following list endpoints.

Adding `AdminResponse` to the sealed `permits` clause is binary-compatible — there are no `switch` statements over `ProfileResponse` anywhere in the codebase (verified via grep). Future `switch` adopters will get a compile-time warning if they forget the admin case, which is the correct outcome.

## Test coverage

**New (`UserServiceTest`, Mockito slice):**

- `getOwnUserProfile_admin_returnsAdminResponseWithRoleADMIN` — happy path.
- `getProfileById_thirdPartyAdminLookup_stillReturns403` — carve-out regression.

**New (`ProfileControllerTest`, MVC slice):**

- `getOwnProfile_admin_returns200WithRoleADMIN` — asserts 200 + `role: "ADMIN"` + that no mentor-/mentee-specific fields (`bio`, `maxMenteeCapacity`, `skills`) leak into the body.

**Regression (must stay green; not modified):**

- `FollowServiceTest.listFollowers_returns403_whenTargetIsAdmin`
- `FollowServiceTest.listFollowers_filtersAdminEntriesFromContent`
- `UserSummaryTest.from_admin_setsRoleADMIN_evenThoughServiceFiltersThemFirst`
- All other `ProfileControllerTest` and `FollowServiceTest` cases

**Local `mvn --batch-mode verify`**: 2190 tests, 0 failures, 0 errors. JaCoCo coverage gate met.

## Manual smoke

Bootstrapped an admin locally via `APP_ADMIN_BOOTSTRAP_*` env vars on a fresh Postgres, then probed each documented path. Observed results (all match expectations):

| Probe | Expected | Observed |
|---|---|---|
| `GET /api/users/me` as admin | 200 + `role: "ADMIN"` | `200`, `{"id":2413,"email":"admin553@local.dev","firstName":"System","role":"ADMIN","isEmailVerified":true,"followerCount":0,"followingCount":0,"isFollowing":false}` |
| `GET /api/users/{adminId}` as mentor | 403 | `403` |
| `GET /api/users/{adminId}/followers` as admin (self) | 403 | `403` |
| `GET /api/users/{adminId}/following` as admin (self) | 403 | `403` |
| `GET /api/users/{adminId}/followers` as mentor | 403 | `403` |

## Known follow-ups

- **OpenAPI schema**: `@ApiResponse(content = @Content(schema = @Schema(oneOf = {MentorResponse.class, MenteeResponse.class})))` on `UserController.getOwnProfile` does not list `AdminResponse`. Documentation only — the runtime behaviour is correct. Deliberately not touched in this `fix(` PR to avoid surprising the mobile codegen pipeline; can ship as a doc-only follow-up.
- **Mobile role union**: if the mobile clients (React Native / Kotlin / Swift) type `role` as `'MENTOR' | 'MENTEE'` (excluding `'ADMIN'`), the new 200 response with `role: "ADMIN"` may surface a fresh decoding error in place of the silenced 403. Backend behaviour matches the issue spec; the mobile team should confirm their role union accepts `"ADMIN"` as part of merging.

## Test plan

- [ ] Backend CI green on the PR.
- [ ] `GET /api/users/me` with admin JWT returns 200 in the deployed environment.
- [ ] `GET /api/users/{adminId}` with a non-admin JWT still returns 403.
- [ ] Mobile admin panel renders after login without the 403 console error.