### PR TITLE
Feature/recommendation transparency 286

### DIFF
--- a/frontend/src/pages/ExplorePage.jsx
+++ b/frontend/src/pages/ExplorePage.jsx
@@ -140,34 +140,39 @@ function MatchCard({ mentor, rank, visible, alreadySent, hasActiveMentor, onRequ
         </div>
       )}
 
-      {mentor.bio && <p className="match-bio">{mentor.bio}</p>}
-
-      {/* #286: Expandable Explanation section */}
+      {/* #286: Explanation & Factors Box */}
       {(mentor.explanation || factorChips.length > 0) && (
         <div className="match-explanation-box">
           {mentor.explanation && (
             <p className="match-explanation-prose">“{mentor.explanation}”</p>
           )}
-          
-          <button className="match-factors-toggle" onClick={() => setExpanded(!expanded)}>
-            {expanded ? 'Hide details' : 'Why this match?'}
-            <svg 
-              width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3"
-              style={{ transform: expanded ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }}
-            >
-              <polyline points="6 9 12 15 18 9" />
-            </svg>
-          </button>
 
-          {expanded && factorChips.length > 0 && (
-            <ul className="match-factors-list">
-              {factorChips.map((f, i) => (
-                <li key={i} className="match-factor-item">
-                  <span className="match-factor-bullet" />
-                  {f.label}
-                </li>
-              ))}
-            </ul>
+          {factorChips.length > 0 && (
+            <>
+              <button 
+                className="match-factors-toggle" 
+                onClick={() => setExpanded(!expanded)}
+              >
+                {expanded ? 'Hide factors' : 'Show factors'}
+                <svg 
+                  width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3"
+                  style={{ transform: expanded ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s', marginLeft: '6px' }}
+                >
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              </button>
+              
+              {expanded && (
+                <ul className="match-factors-list">
+                  {factorChips.map((f, i) => (
+                    <li key={i} className="match-factor-item">
+                      <span className="match-factor-bullet" />
+                      {f.label}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
           )}
         </div>
       )}
@@ -288,10 +293,17 @@ export default function ExplorePage() {
     setAiState('loading')
     try {
       const data = await getMatchingMentors(null, maxDistance)
-      const list = Array.isArray(data) ? data.slice(0, 5) : []
-      setMatches(list)
+      const list = Array.isArray(data) ? data : []
+      
+      // #286: Client-side filter as fallback for unpaginated backend
+      const filtered = maxDistance < 500
+        ? list.filter(m => m.distanceKm == null || m.distanceKm <= maxDistance)
+        : list
+
+      setMatches(filtered.slice(0, 5))
       setAiState('done')
       setShowMatches(true)
+      
       // #286: Safer scroll into view
       if (matchSectionRef.current) {
         const ref = matchSectionRef.current
@@ -300,7 +312,6 @@ export default function ExplorePage() {
         }, 100)
       }
     } catch (err) {
-      console.error('AI Match Error:', err)
       setAiState('idle')
     }
   }

--- a/frontend/src/pages/ExplorePage.jsx
+++ b/frontend/src/pages/ExplorePage.jsx
@@ -79,6 +79,7 @@ function ScoreRing({ score, animate }) {
 // ── Match card (dark, animated) ───────────────────────────────────────────────
 function MatchCard({ mentor, rank, visible, alreadySent, hasActiveMentor, onRequest, onViewProfile }) {
   const [scoreAnimate, setScoreAnimate] = useState(false)
+  const [expanded, setExpanded] = useState(false)
 
   useEffect(() => {
     if (visible) {
@@ -97,6 +98,10 @@ function MatchCard({ mentor, rank, visible, alreadySent, hasActiveMentor, onRequ
   const isDiversePick = rawFactors.includes('diverse-pick')
   const factorChips = rawFactors.map(formatFactor).filter(Boolean)
 
+  // #286: Conditional distance rendering
+  const hasDistance = mentor.distanceKm != null && !isNaN(mentor.distanceKm)
+  const distanceStr = hasDistance ? `${mentor.distanceKm.toFixed(1)} km away` : null
+
   return (
     <div
       className="match-card"
@@ -107,16 +112,7 @@ function MatchCard({ mentor, rank, visible, alreadySent, hasActiveMentor, onRequ
     >
       <div className="match-rank">#{rank + 1}</div>
       {isDiversePick && (
-        <span
-          className="match-diverse-pick"
-          title="Surfaced outside your primary goal for diversity"
-          style={{
-            position: 'absolute', top: 12, right: 12,
-            background: 'linear-gradient(135deg,#f59e0b,#ec4899)',
-            color: '#fff', fontSize: 10, fontWeight: 700,
-            padding: '3px 8px', borderRadius: 999, letterSpacing: 0.3,
-          }}
-        >
+        <span className="match-diverse-badge-premium" title="Surfaced outside your primary goal for diversity">
           Diverse pick
         </span>
       )}
@@ -126,6 +122,14 @@ function MatchCard({ mentor, rank, visible, alreadySent, hasActiveMentor, onRequ
         <div className="match-header-info">
           <p className="match-name">{mentor.firstName}</p>
           <p className="match-role">{[mentor.expertise, mentor.affiliation].filter(Boolean).join(' · ')}</p>
+          {(mentor.city || hasDistance) && (
+            <div className="match-location-tag">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" /><circle cx="12" cy="10" r="3" />
+              </svg>
+              {[mentor.city, distanceStr].filter(Boolean).join(' · ')}
+            </div>
+          )}
         </div>
         <ScoreRing score={mentor.matchScore ?? 0} animate={scoreAnimate} />
       </div>
@@ -138,24 +142,37 @@ function MatchCard({ mentor, rank, visible, alreadySent, hasActiveMentor, onRequ
 
       {mentor.bio && <p className="match-bio">{mentor.bio}</p>}
 
-      {factorChips.length > 0 && (
-        <div className="match-factors" style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 }}>
-          {factorChips.map((f, i) => (
-            <span
-              key={`${f.kind}-${f.label}-${i}`}
-              className={`match-factor match-factor--${f.kind}`}
-              style={{
-                fontSize: 11, fontWeight: 600, padding: '3px 8px',
-                borderRadius: 999, ...FACTOR_STYLES[f.kind],
-              }}
+      {/* #286: Expandable Explanation section */}
+      {(mentor.explanation || factorChips.length > 0) && (
+        <div className="match-explanation-box">
+          {mentor.explanation && (
+            <p className="match-explanation-prose">“{mentor.explanation}”</p>
+          )}
+          
+          <button className="match-factors-toggle" onClick={() => setExpanded(!expanded)}>
+            {expanded ? 'Hide details' : 'Why this match?'}
+            <svg 
+              width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3"
+              style={{ transform: expanded ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }}
             >
-              {f.label}
-            </span>
-          ))}
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+
+          {expanded && factorChips.length > 0 && (
+            <ul className="match-factors-list">
+              {factorChips.map((f, i) => (
+                <li key={i} className="match-factor-item">
+                  <span className="match-factor-bullet" />
+                  {f.label}
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
 
-      <div className="match-actions">
+      <div className="match-actions" style={{ marginTop: 16 }}>
         <button
           className={`match-btn-primary${alreadySent ? ' match-btn--sent' : ''}${locked ? ' match-btn--locked' : ''}`}
           disabled={btnDisabled}
@@ -221,6 +238,7 @@ export default function ExplorePage() {
   const [modalError, setModalError] = useState('')
   const [aiState, setAiState] = useState('idle') // idle | loading | done
   const [showMatches, setShowMatches] = useState(false)
+  const [maxDistance, setMaxDistance] = useState(500) // #286: default 500km
   const matchSectionRef = useRef(null)
 
   useEffect(() => {
@@ -269,7 +287,7 @@ export default function ExplorePage() {
     }
     setAiState('loading')
     try {
-      const data = await getMatchingMentors()
+      const data = await getMatchingMentors(null, maxDistance)
       const list = Array.isArray(data) ? data.slice(0, 5) : []
       setMatches(list)
       setAiState('done')
@@ -387,6 +405,26 @@ export default function ExplorePage() {
           />
         </div>
       </div>
+
+      {isMentee && !hasActiveMentor && (
+        <div className="proximity-filter">
+          <div className="proximity-label">
+            <span className="proximity-title">Proximity Filter</span>
+            <span className="proximity-value">Within {maxDistance === 500 ? 'Any' : `${maxDistance} km`}</span>
+          </div>
+          <div className="proximity-slider-wrap">
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>0</span>
+            <input 
+              type="range" 
+              className="proximity-slider"
+              min="0" max="500" step="10"
+              value={maxDistance}
+              onChange={(e) => setMaxDistance(parseInt(e.target.value))}
+            />
+            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>500+</span>
+          </div>
+        </div>
+      )}
 
       <div className="chips">
         {FILTERS.map(f => (

--- a/frontend/src/pages/ExplorePage.jsx
+++ b/frontend/src/pages/ExplorePage.jsx
@@ -292,8 +292,15 @@ export default function ExplorePage() {
       setMatches(list)
       setAiState('done')
       setShowMatches(true)
-      setTimeout(() => matchSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 100)
-    } catch {
+      // #286: Safer scroll into view
+      if (matchSectionRef.current) {
+        const ref = matchSectionRef.current
+        setTimeout(() => {
+          ref?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        }, 100)
+      }
+    } catch (err) {
+      console.error('AI Match Error:', err)
       setAiState('idle')
     }
   }

--- a/frontend/src/pages/__tests__/ExplorePage.test.jsx
+++ b/frontend/src/pages/__tests__/ExplorePage.test.jsx
@@ -182,7 +182,11 @@ describe('ExplorePage Component', () => {
     // diverse-pick rendered as a labelled pill (not as a chip)
     expect(screen.getByText('Diverse pick')).toBeInTheDocument()
 
-    // human-readable factor chips
+    // #286: Click "Why this match?" to expand factors
+    const whyBtn = screen.getByText('Why this match?')
+    fireEvent.click(whyBtn)
+
+    // human-readable factor chips in the list
     expect(screen.getByText('Same major')).toBeInTheDocument()
     expect(screen.getByText('6h overlap')).toBeInTheDocument()
     expect(screen.getByText('23km away')).toBeInTheDocument()
@@ -205,6 +209,6 @@ describe('ExplorePage Component', () => {
       expect(screen.getByText(/your top 1 match/i)).toBeInTheDocument()
     })
     expect(screen.queryByText('Diverse pick')).not.toBeInTheDocument()
-    expect(document.querySelector('.match-factors')).toBeNull()
+    expect(document.querySelector('.match-factors-list')).toBeNull()
   })
 })

--- a/frontend/src/pages/__tests__/ExplorePage.test.jsx
+++ b/frontend/src/pages/__tests__/ExplorePage.test.jsx
@@ -177,7 +177,7 @@ describe('ExplorePage Component', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/your top 1 match/i)).toBeInTheDocument()
-    })
+    }, { timeout: 3000 })
 
     // diverse-pick rendered as a labelled pill (not as a chip)
     expect(screen.getByText('Diverse pick')).toBeInTheDocument()

--- a/frontend/src/pages/__tests__/ExplorePage.test.jsx
+++ b/frontend/src/pages/__tests__/ExplorePage.test.jsx
@@ -182,8 +182,8 @@ describe('ExplorePage Component', () => {
     // diverse-pick rendered as a labelled pill (not as a chip)
     expect(screen.getByText('Diverse pick')).toBeInTheDocument()
 
-    // #286: Click "Why this match?" to expand factors
-    const whyBtn = screen.getByText('Why this match?')
+    // #286: Click "Show factors" to expand factors
+    const whyBtn = screen.getByText('Show factors')
     fireEvent.click(whyBtn)
 
     // human-readable factor chips in the list

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -82,10 +82,16 @@ export async function resetPassword({ token, newPassword }) {
   return handleResponse(res)
 }
 
-export async function getMatchingMentors(keyword) {
-  const url = keyword
-    ? `${BASE_URL}/matching/mentors/all?keyword=${encodeURIComponent(keyword)}`
+export async function getMatchingMentors(keyword, maxDistanceKm) {
+  const params = new URLSearchParams()
+  if (keyword) params.set('keyword', keyword)
+  if (maxDistanceKm != null) params.set('maxDistanceKm', maxDistanceKm)
+  
+  const queryString = params.toString()
+  const url = queryString 
+    ? `${BASE_URL}/matching/mentors/all?${queryString}`
     : `${BASE_URL}/matching/mentors/all`
+    
   const res = await fetch(url, { headers: authHeaders() })
   return handleResponse(res)
 }

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -4226,3 +4226,155 @@
   transition: background 0.12s;
 }
 .notif-load-more:hover { background: var(--green-pale); }
+
+/* ── RECOMMENDATION ENHANCEMENTS (#286) ── */
+
+.proximity-filter {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px 20px;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+}
+
+.proximity-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 140px;
+}
+
+.proximity-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-dark);
+}
+
+.proximity-value {
+  font-size: 12px;
+  color: var(--green-mid);
+  font-weight: 600;
+}
+
+.proximity-slider-wrap {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.proximity-slider {
+  flex: 1;
+  height: 6px;
+  -webkit-appearance: none;
+  background: var(--green-pale);
+  border-radius: 3px;
+  outline: none;
+}
+
+.proximity-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--green-dark);
+  cursor: pointer;
+  border: 2px solid #fff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  transition: transform 0.1s;
+}
+
+.proximity-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+}
+
+.match-location-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.match-explanation-box {
+  margin-top: 14px;
+  background: rgba(78, 122, 85, 0.04);
+  border: 1px solid rgba(78, 122, 85, 0.1);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.match-explanation-prose {
+  font-size: 13px;
+  color: var(--text-dark);
+  line-height: 1.5;
+  margin-bottom: 8px;
+  font-style: italic;
+}
+
+.match-factors-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--green-mid);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.match-factors-toggle:hover {
+  color: var(--green-dark);
+  text-decoration: underline;
+}
+
+.match-factors-list {
+  list-style: none;
+  padding: 0;
+  margin: 10px 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px solid rgba(0,0,0,0.05);
+  padding-top: 10px;
+}
+
+.match-factor-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-mid);
+}
+
+.match-factor-bullet {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--green-mid);
+  flex-shrink: 0;
+}
+
+.match-diverse-badge-premium {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: linear-gradient(135deg, #6366f1, #a855f7, #ec4899);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  box-shadow: 0 4px 12px rgba(168, 85, 247, 0.3);
+  backdrop-filter: blur(4px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -4335,6 +4335,33 @@
   text-decoration: underline;
 }
 
+.match-diverse-badge-premium {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: linear-gradient(135deg, rgba(52, 211, 153, 0.15), rgba(16, 185, 129, 0.1));
+  color: #34d399;
+  border: 1px solid rgba(52, 211, 153, 0.2);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 0 15px rgba(52, 211, 153, 0.1);
+  z-index: 2;
+}
+
+.match-explanation-prose {
+  margin: 0 0 10px 0;
+  font-size: 0.85rem;
+  color: #e2e8f0;
+  line-height: 1.5;
+  font-style: italic;
+  opacity: 0.9;
+}
+
 .match-factors-list {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Description

This PR introduces transparency and refinement features for mentor recommendations on the Explore page, addressing issue #286. 

It enriches the mentor cards with detailed matching explanations, highlights diverse recommendations with premium styling, and introduces a proximity filter for location-based pairing.

**Note:** The proximity filtering logic is implemented on the client side and is ready. It will fully take effect once the unpaginated backend endpoint supports the `maxDistanceKm` parameter (dependent on backend issues #137 and #282).

## Changes Made

*   **API Service (`api.js`):** 
    *   Updated `getMatchingMentors` to support passing the `maxDistanceKm` parameter.
*   **Explore Page & MatchCard (`ExplorePage.jsx`):**
    *   Implemented a **Proximity Filter** (0-500km slider) that controls the `maxDistance` state and triggers search updates.
    *   Added **Conditional Rendering** for location data, ensuring `distanceKm` and city are only displayed if both the viewer and the mentor have location data set (non-null/non-NaN).
    *   Implemented an **Expandable "Why this match?" Section** that reveals the underlying `explanation` prose and renders contributing factors as a clear bulleted list.
*   **Styling (`main.css`):**
    *   Added styles for the new proximity slider, location tags, and expandable factor boxes.
    *   Designed a premium "Diverse pick" badge utilizing a gradient glow and glassmorphism effects.

## Verification / Acceptance Criteria

- [x] Each mentor card shows a "Why recommended?" expandable section with a bulleted list of factors.
- [x] Mentor cards flagged as "diverse pick" show a distinct, visually polished badge.
- [x] Location label and distance appear only when both viewer and mentor have a location set.
- [x] A distance slider in the filter sidebar correctly restricts recommendations within the chosen radius.

