### PR TITLE
feat(backend): admin messaging read endpoints (#280)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/AdminDirectInboxController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AdminDirectInboxController.java
@@ -1,0 +1,71 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.controller.support.PageableSupport;
+import com.group7.backend.dto.response.AdminDirectInboxItem;
+import com.group7.backend.service.AdminDirectInboxService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin-direct inbox listing for the authenticated caller: their
+ * conversations with platform admins (or, for an admin caller, the users
+ * they have DMed), with last-message preview and unread count, paginated
+ * newest-first.
+ *
+ * <p>Companion to the existing admin-direct write surface at
+ * {@code POST /api/admin/messages/direct/{userId}}: writes flow through
+ * that admin-only path; reads flow through this endpoint and the per-
+ * conversation message endpoint at {@code /api/conversations/admin-direct/
+ * {otherUserId}/messages}.
+ *
+ * <p>No role gate: a regular user receiving an admin DM must be able to
+ * list it. The list is naturally scoped to conversations the caller is a
+ * participant in.
+ */
+@RestController
+@RequestMapping("/api/conversations/admin-direct")
+@Tag(name = "Admin Direct Inbox",
+        description = "Listing of the caller's admin-direct conversations")
+public class AdminDirectInboxController {
+
+    private final AdminDirectInboxService inboxService;
+
+    public AdminDirectInboxController(AdminDirectInboxService inboxService) {
+        this.inboxService = inboxService;
+    }
+
+    @GetMapping
+    @Operation(summary = "List my admin-direct conversations",
+            description = "Returns the caller's admin-direct conversations, paginated and "
+                    + "ordered by most recent activity. Each item carries peer identity, a "
+                    + "flag indicating whether the peer is an admin, the last message's "
+                    + "content and timestamp (nullable when the conversation has no messages "
+                    + "yet), and the caller's unread count.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated inbox"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated",
+                    content = @Content)
+    })
+    public ResponseEntity<Page<AdminDirectInboxItem>> listInbox(
+            @Parameter(description = "Page number (0-based)")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size; clamped to [1, 100]")
+            @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        Pageable pageable = PageableSupport.clampPageable(page, size);
+        return ResponseEntity.ok(inboxService.listInbox(requesterId, pageable));
+    }
+}

--- a/backend/src/main/java/com/group7/backend/controller/AdminDirectMessageController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AdminDirectMessageController.java
@@ -1,0 +1,107 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.dto.response.MessageResponse;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.service.ConversationService;
+import com.group7.backend.service.MessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Read surface for the authenticated caller's admin-direct thread with
+ * {@code otherUserId}. Mirrors {@link MentorPairMessageController} in shape;
+ * the only structural difference is that this controller does NOT expose a
+ * POST — writes flow through the admin-only path at
+ * {@code POST /api/admin/messages/direct/{userId}}. A non-admin recipient
+ * cannot reply through this surface today; widening that is captured as a
+ * follow-up if/when the product calls for two-way admin DMs.
+ *
+ * <p>Conversation lookup is read-only ({@link ConversationService#findAdminDirectByPair}):
+ * a recipient opening a thread that has never been DMed gets a clean 404
+ * rather than synthesising an empty conversation row.
+ */
+@RestController
+@RequestMapping("/api/conversations/admin-direct/{otherUserId}/messages")
+@Tag(name = "Admin Direct Messages",
+        description = "Read-side surface for the caller's admin-direct thread")
+public class AdminDirectMessageController {
+
+    private final MessageService messageService;
+    private final ConversationService conversationService;
+
+    public AdminDirectMessageController(MessageService messageService,
+                                        ConversationService conversationService) {
+        this.messageService = messageService;
+        this.conversationService = conversationService;
+    }
+
+    @GetMapping
+    @Operation(summary = "List admin-direct messages",
+            description = "Returns paginated message history of the caller's admin-direct "
+                    + "conversation with {otherUserId}, newest first. 404 if no such "
+                    + "conversation exists for the pair.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated messages"),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Caller is not a participant",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "No admin-direct conversation for the pair",
+                    content = @Content)
+    })
+    public ResponseEntity<Page<MessageResponse>> list(
+            @PathVariable Long otherUserId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        Conversation conversation = resolveOrThrow(requesterId, otherUserId);
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(messageService.list(requesterId, conversation.getId(), pageable));
+    }
+
+    @PatchMapping("/read")
+    @Operation(summary = "Mark all admin-direct messages as read",
+            description = "Marks every unread message in this admin-direct thread that was "
+                    + "NOT sent by the authenticated caller as read. Returns 204.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Read receipts updated",
+                    content = @Content),
+            @ApiResponse(responseCode = "401", description = "Unauthenticated",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Caller is not a participant",
+                    content = @Content),
+            @ApiResponse(responseCode = "404", description = "No admin-direct conversation for the pair",
+                    content = @Content)
+    })
+    public ResponseEntity<Void> markAllRead(
+            @PathVariable Long otherUserId,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        Conversation conversation = resolveOrThrow(requesterId, otherUserId);
+        messageService.markAllRead(requesterId, conversation.getId());
+        return ResponseEntity.noContent().build();
+    }
+
+    private Conversation resolveOrThrow(Long requesterId, Long otherUserId) {
+        return conversationService.findAdminDirectByPair(requesterId, otherUserId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "No admin-direct conversation between users " + requesterId
+                                + " and " + otherUserId));
+    }
+}

--- a/backend/src/main/java/com/group7/backend/controller/AdminMessagingController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AdminMessagingController.java
@@ -106,10 +106,12 @@ public class AdminMessagingController {
     @GetMapping("/broadcast")
     @Operation(summary = "List admin broadcast messages",
             description = "Returns paginated message history of the singleton "
-                    + "ADMIN_BROADCAST thread, newest first. The find-or-create call "
-                    + "ensures the caller is a participant before reading, so a newly "
-                    + "promoted admin opening their broadcast inbox for the first time "
-                    + "gets the full backlog rather than a 404.")
+                    + "ADMIN_BROADCAST thread, newest first. Pure read — no stub "
+                    + "conversation is created if no broadcast has ever been sent "
+                    + "(the response is an empty page in that case). If a newly "
+                    + "promoted admin is missing from the participant list when they "
+                    + "first read, they are added in-line so they see the full backlog "
+                    + "rather than a 403.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Paginated broadcast messages"),
             @ApiResponse(responseCode = "403", description = "Caller is not an admin",
@@ -122,25 +124,27 @@ public class AdminMessagingController {
             @RequestParam(defaultValue = "20") int size,
             Authentication authentication) {
         Long adminId = (Long) authentication.getCredentials();
-        Conversation conversation = conversationService.findOrCreateAdminBroadcast();
         Pageable pageable = PageRequest.of(page, size);
-        return ResponseEntity.ok(messageService.list(adminId, conversation.getId(), pageable));
+        return conversationService.findAdminBroadcastForReader(adminId)
+                .map(c -> ResponseEntity.ok(messageService.list(adminId, c.getId(), pageable)))
+                .orElseGet(() -> ResponseEntity.ok(Page.empty(pageable)));
     }
 
     @PatchMapping("/broadcast/read")
     @Operation(summary = "Mark all broadcast messages as read",
             description = "Marks every unread message in the broadcast thread that was NOT "
-                    + "sent by the calling admin as read. Returns 204.")
+                    + "sent by the calling admin as read. No-op (204) when no broadcast "
+                    + "has ever been sent.")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "Read receipts updated",
+            @ApiResponse(responseCode = "204", description = "Read receipts updated (or no-op)",
                     content = @Content),
             @ApiResponse(responseCode = "403", description = "Caller is not an admin",
                     content = @Content)
     })
     public ResponseEntity<Void> markBroadcastRead(Authentication authentication) {
         Long adminId = (Long) authentication.getCredentials();
-        Conversation conversation = conversationService.findOrCreateAdminBroadcast();
-        messageService.markAllRead(adminId, conversation.getId());
+        conversationService.findAdminBroadcastForReader(adminId)
+                .ifPresent(c -> messageService.markAllRead(adminId, c.getId()));
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/group7/backend/controller/AdminMessagingController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AdminMessagingController.java
@@ -13,14 +13,20 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -95,5 +101,46 @@ public class AdminMessagingController {
         Conversation conversation = conversationService.findOrCreateAdminBroadcast();
         MessageResponse created = messageService.send(adminId, conversation.getId(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @GetMapping("/broadcast")
+    @Operation(summary = "List admin broadcast messages",
+            description = "Returns paginated message history of the singleton "
+                    + "ADMIN_BROADCAST thread, newest first. The find-or-create call "
+                    + "ensures the caller is a participant before reading, so a newly "
+                    + "promoted admin opening their broadcast inbox for the first time "
+                    + "gets the full backlog rather than a 404.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Paginated broadcast messages"),
+            @ApiResponse(responseCode = "403", description = "Caller is not an admin",
+                    content = @Content)
+    })
+    public ResponseEntity<Page<MessageResponse>> listBroadcast(
+            @Parameter(description = "Page number (0-based)")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size")
+            @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long adminId = (Long) authentication.getCredentials();
+        Conversation conversation = conversationService.findOrCreateAdminBroadcast();
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(messageService.list(adminId, conversation.getId(), pageable));
+    }
+
+    @PatchMapping("/broadcast/read")
+    @Operation(summary = "Mark all broadcast messages as read",
+            description = "Marks every unread message in the broadcast thread that was NOT "
+                    + "sent by the calling admin as read. Returns 204.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Read receipts updated",
+                    content = @Content),
+            @ApiResponse(responseCode = "403", description = "Caller is not an admin",
+                    content = @Content)
+    })
+    public ResponseEntity<Void> markBroadcastRead(Authentication authentication) {
+        Long adminId = (Long) authentication.getCredentials();
+        Conversation conversation = conversationService.findOrCreateAdminBroadcast();
+        messageService.markAllRead(adminId, conversation.getId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/group7/backend/dto/response/AdminDirectInboxItem.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/AdminDirectInboxItem.java
@@ -1,0 +1,50 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Wire shape for one row of an admin-direct inbox: peer identity (with a
+ * flag telling the caller whether the peer is an admin), last-message
+ * preview, and unread count. Built by {@code AdminDirectInboxService}.
+ *
+ * <p>The {@code peerIsAdmin} flag lets the UI render the right chrome:
+ * a non-admin viewer sees this row as "message from the platform admin",
+ * while an admin viewer sees it as "DM with user X".
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "A user's view of one admin-direct conversation in their inbox")
+public class AdminDirectInboxItem {
+
+    @Schema(description = "Conversation ID", example = "1024")
+    private Long conversationId;
+
+    @Schema(description = "Peer's user ID", example = "42")
+    private Long peerId;
+
+    @Schema(description = "Peer's first name", example = "Admin")
+    private String peerFirstName;
+
+    @Schema(description = "True when the peer is an admin (the typical case for "
+            + "a non-admin viewer); false when the viewer is the admin and the "
+            + "peer is a regular user", example = "true")
+    private boolean peerIsAdmin;
+
+    @Schema(description = "Content of the most recent message; null if the conversation has no messages yet",
+            example = "Please review the community guidelines.")
+    private String lastMessageContent;
+
+    @Schema(description = "Timestamp of the most recent message; null if the conversation has no messages yet",
+            example = "2026-05-12T10:00:00Z")
+    private OffsetDateTime lastMessageSentAt;
+
+    @Schema(description = "Number of messages in this conversation that the caller has not read",
+            example = "1")
+    private long unreadCount;
+}

--- a/backend/src/main/java/com/group7/backend/repository/ConversationRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/ConversationRepository.java
@@ -65,4 +65,25 @@ public interface ConversationRepository extends JpaRepository<Conversation, Long
      * matches and the query is constant-time.
      */
     Optional<Conversation> findFirstByKind(ConversationKind kind);
+
+    /**
+     * Page of ADMIN_DIRECT conversations the given user participates in,
+     * ordered by most-recent activity (NULLS LAST) with a deterministic
+     * tiebreaker on {@code c.id}. Mirrors the mentor-pair query above and
+     * uses the same participant-junction lookup so the same
+     * {@code idx_conversation_participants_user} index serves both kinds.
+     */
+    @Query(
+            value = "SELECT c FROM Conversation c "
+                    + "JOIN ConversationParticipant cp ON cp.conversation = c "
+                    + "WHERE cp.user.id = :userId "
+                    + "AND c.kind = com.group7.backend.entity.ConversationKind.ADMIN_DIRECT "
+                    + "ORDER BY (SELECT MAX(m.sentAt) FROM Message m WHERE m.conversation = c) DESC NULLS LAST, "
+                    + "c.id DESC",
+            countQuery = "SELECT COUNT(c) FROM Conversation c "
+                    + "WHERE c.kind = com.group7.backend.entity.ConversationKind.ADMIN_DIRECT "
+                    + "AND EXISTS (SELECT 1 FROM ConversationParticipant cp "
+                    + "WHERE cp.conversation = c AND cp.user.id = :userId)")
+    Page<Conversation> findAdminDirectConversationsForUserOrderedByLastMessage(
+            @Param("userId") Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/com/group7/backend/service/AdminDirectInboxService.java
+++ b/backend/src/main/java/com/group7/backend/service/AdminDirectInboxService.java
@@ -1,0 +1,128 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.AdminDirectInboxItem;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.ConversationRepository;
+import com.group7.backend.repository.MessageRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.projection.ConversationLastMessageView;
+import com.group7.backend.repository.projection.ConversationUnreadCount;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Read-side service that assembles an authenticated user's ADMIN_DIRECT
+ * inbox: their conversations with platform admins (or, for an admin, with
+ * the users they have DMed) with last-message preview and unread count,
+ * paginated newest-first.
+ *
+ * <p>Mirrors {@link MentorPairInboxService} in shape — page once, then
+ * three batch lookups keyed by the page's conversation ids. The only
+ * differences are the kind filter and the {@code peerIsAdmin} flag on the
+ * output row so the UI can render the right side of the conversation.
+ *
+ * <p><b>Invariant trusted by this service.</b> Every {@code ADMIN_DIRECT}
+ * participant row has the matching user in {@code pair_a_id} or
+ * {@code pair_b_id}, written atomically by {@code ConversationCreator}.
+ * The peer-id computation here silently picks the wrong user if a future
+ * writer breaks that assumption.
+ */
+@Service
+public class AdminDirectInboxService {
+
+    private final ConversationRepository conversationRepository;
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+
+    public AdminDirectInboxService(ConversationRepository conversationRepository,
+                                   MessageRepository messageRepository,
+                                   UserRepository userRepository) {
+        this.conversationRepository = conversationRepository;
+        this.messageRepository = messageRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AdminDirectInboxItem> listInbox(Long requesterId, Pageable pageable) {
+        Page<Conversation> page = conversationRepository
+                .findAdminDirectConversationsForUserOrderedByLastMessage(requesterId, pageable);
+        if (page.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, page.getTotalElements());
+        }
+
+        List<Long> conversationIds = page.getContent().stream()
+                .map(Conversation::getId)
+                .toList();
+
+        Map<Long, ConversationLastMessageView> latestByConversation = messageRepository
+                .findLatestPerConversation(conversationIds).stream()
+                .collect(Collectors.toMap(
+                        ConversationLastMessageView::getConversationId,
+                        Function.identity()));
+
+        Map<Long, Long> unreadByConversation = messageRepository
+                .countUnreadPerConversationForReader(conversationIds, requesterId).stream()
+                .collect(Collectors.toMap(
+                        ConversationUnreadCount::getConversationId,
+                        ConversationUnreadCount::getUnreadCount));
+
+        List<Long> peerIds = page.getContent().stream()
+                .map(c -> peerIdFor(c, requesterId))
+                .toList();
+
+        Map<Long, User> peersById = userRepository.findAllById(peerIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<AdminDirectInboxItem> items = page.getContent().stream()
+                .map(c -> toItem(c, requesterId, latestByConversation, unreadByConversation, peersById))
+                .filter(Objects::nonNull)
+                .toList();
+
+        return new PageImpl<>(items, pageable, page.getTotalElements());
+    }
+
+    private static AdminDirectInboxItem toItem(Conversation conversation,
+                                               Long requesterId,
+                                               Map<Long, ConversationLastMessageView> latestByConversation,
+                                               Map<Long, Long> unreadByConversation,
+                                               Map<Long, User> peersById) {
+        Long peerId = peerIdFor(conversation, requesterId);
+        User peer = peersById.get(peerId);
+        if (peer == null) {
+            return null;
+        }
+
+        ConversationLastMessageView latest = latestByConversation.get(conversation.getId());
+
+        AdminDirectInboxItem item = new AdminDirectInboxItem();
+        item.setConversationId(conversation.getId());
+        item.setPeerId(peerId);
+        item.setPeerFirstName(peer.getFirstName());
+        item.setPeerIsAdmin(peer instanceof Admin);
+        item.setLastMessageContent(latest != null ? latest.getContent() : null);
+        item.setLastMessageSentAt(latest != null
+                ? OffsetDateTime.ofInstant(latest.getSentAt(), ZoneOffset.UTC)
+                : null);
+        item.setUnreadCount(unreadByConversation.getOrDefault(conversation.getId(), 0L));
+        return item;
+    }
+
+    private static Long peerIdFor(Conversation conversation, Long requesterId) {
+        return conversation.getPairAId().equals(requesterId)
+                ? conversation.getPairBId()
+                : conversation.getPairAId();
+    }
+}

--- a/backend/src/main/java/com/group7/backend/service/ConversationService.java
+++ b/backend/src/main/java/com/group7/backend/service/ConversationService.java
@@ -260,6 +260,26 @@ public class ConversationService {
     }
 
     /**
+     * Read-only lookup of an existing {@link ConversationKind#ADMIN_DIRECT}
+     * row for the given pair, or empty if none exists. Used by the read
+     * endpoints that must NOT auto-create a conversation on first access —
+     * a recipient opening their inbox should not synthesise a thread.
+     *
+     * @param userIdA one side of the pair (order does not matter; this method
+     *                normalises to {@code min/max})
+     * @param userIdB the other side
+     */
+    public Optional<Conversation> findAdminDirectByPair(Long userIdA, Long userIdB) {
+        if (userIdA == null || userIdB == null || Objects.equals(userIdA, userIdB)) {
+            return Optional.empty();
+        }
+        long lower = Math.min(userIdA, userIdB);
+        long higher = Math.max(userIdA, userIdB);
+        return conversationRepository
+                .findByPairAIdAndPairBIdAndKind(lower, higher, ConversationKind.ADMIN_DIRECT);
+    }
+
+    /**
      * Returns the singleton {@link ConversationKind#ADMIN_BROADCAST}
      * conversation, creating it on first call and re-syncing its participant
      * list to include every current admin. Re-syncing on each access is what

--- a/backend/src/main/java/com/group7/backend/service/ConversationService.java
+++ b/backend/src/main/java/com/group7/backend/service/ConversationService.java
@@ -280,6 +280,37 @@ public class ConversationService {
     }
 
     /**
+     * Read-side resolution of the singleton {@link ConversationKind#ADMIN_BROADCAST}
+     * conversation. Returns {@code Optional.empty()} when no broadcast has ever
+     * been sent — so a fresh-install GET doesn't synthesise a stub row.
+     *
+     * <p>When the singleton exists, runs a targeted "ensure caller is a
+     * participant" check: a single {@code existsByConversationIdAndUserId}
+     * probe, followed by the full participant resync only when the calling
+     * user is missing from the participant list. That keeps the common
+     * already-a-participant GET path at one extra query instead of N (one per
+     * admin), while still adding a newly promoted admin on their first read so
+     * they see the full backlog rather than a 403.
+     *
+     * <p>Callers should be the broadcast read endpoints — the write path
+     * continues to call {@link #findOrCreateAdminBroadcast} which both creates
+     * the singleton on first send and unconditionally resyncs.
+     */
+    public Optional<Conversation> findAdminBroadcastForReader(Long callerId) {
+        Optional<Conversation> existing = conversationRepository.findFirstByKind(
+                ConversationKind.ADMIN_BROADCAST);
+        if (existing.isEmpty() || callerId == null) {
+            return existing;
+        }
+        Conversation broadcast = existing.get();
+        if (!participantRepository.existsByConversationIdAndUserId(
+                broadcast.getId(), callerId)) {
+            syncAdminBroadcastParticipants(broadcast);
+        }
+        return existing;
+    }
+
+    /**
      * Returns the singleton {@link ConversationKind#ADMIN_BROADCAST}
      * conversation, creating it on first call and re-syncing its participant
      * list to include every current admin. Re-syncing on each access is what

--- a/backend/src/test/java/com/group7/backend/controller/AdminDirectInboxControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/AdminDirectInboxControllerTest.java
@@ -1,0 +1,131 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.AdminDirectInboxItem;
+import com.group7.backend.service.AdminDirectInboxService;
+import com.group7.backend.service.JwtService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminDirectInboxController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class AdminDirectInboxControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private AdminDirectInboxService inboxService;
+    @MockitoBean private JwtService jwtService;
+
+    private void mockJwt(String token, String role, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn(role.toLowerCase() + "@example.com");
+        when(jwtService.extractRole(token)).thenReturn(role);
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private AdminDirectInboxItem sampleItem(boolean peerIsAdmin) {
+        AdminDirectInboxItem item = new AdminDirectInboxItem();
+        item.setConversationId(901L);
+        item.setPeerId(42L);
+        item.setPeerFirstName(peerIsAdmin ? "Ops" : "Mira");
+        item.setPeerIsAdmin(peerIsAdmin);
+        item.setLastMessageContent("Please review the guidelines.");
+        item.setLastMessageSentAt(OffsetDateTime.parse("2026-05-12T10:00:00Z"));
+        item.setUnreadCount(1L);
+        return item;
+    }
+
+    @Test
+    void listInbox_asMentee_returns200WithPagedBody() throws Exception {
+        mockJwt("mentee-token", "MENTEE", 1L);
+        when(inboxService.listInbox(eq(1L), any()))
+                .thenReturn(new PageImpl<>(List.of(sampleItem(true))));
+
+        mockMvc.perform(get("/api/conversations/admin-direct")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].conversationId").value(901))
+                .andExpect(jsonPath("$.content[0].peerId").value(42))
+                .andExpect(jsonPath("$.content[0].peerFirstName").value("Ops"))
+                .andExpect(jsonPath("$.content[0].peerIsAdmin").value(true))
+                .andExpect(jsonPath("$.content[0].lastMessageContent").value("Please review the guidelines."))
+                .andExpect(jsonPath("$.content[0].unreadCount").value(1));
+    }
+
+    @Test
+    void listInbox_asMentor_returns200() throws Exception {
+        mockJwt("mentor-token", "MENTOR", 7L);
+        when(inboxService.listInbox(eq(7L), any())).thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/conversations/admin-direct")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void listInbox_asAdmin_returnsOwnAdminDirectThreads() throws Exception {
+        mockJwt("admin-token", "ADMIN", 99L);
+        when(inboxService.listInbox(eq(99L), any()))
+                .thenReturn(new PageImpl<>(List.of(sampleItem(false))));
+
+        mockMvc.perform(get("/api/conversations/admin-direct")
+                        .header("Authorization", "Bearer admin-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].peerIsAdmin").value(false));
+    }
+
+    @Test
+    void listInbox_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/conversations/admin-direct"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void listInbox_paginationParamsHonored() throws Exception {
+        mockJwt("mentee-token", "MENTEE", 1L);
+        when(inboxService.listInbox(eq(1L), any())).thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/conversations/admin-direct?page=2&size=5")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(inboxService).listInbox(eq(1L), captor.capture());
+        assertThat(captor.getValue().getPageNumber()).isEqualTo(2);
+        assertThat(captor.getValue().getPageSize()).isEqualTo(5);
+    }
+
+    @Test
+    void listInbox_clampsOversizedPageSize() throws Exception {
+        mockJwt("mentee-token", "MENTEE", 1L);
+        when(inboxService.listInbox(eq(1L), any())).thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/conversations/admin-direct?size=10000")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(inboxService).listInbox(eq(1L), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isEqualTo(100);
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/AdminDirectMessageControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/AdminDirectMessageControllerTest.java
@@ -1,0 +1,141 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.MessageResponse;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
+import com.group7.backend.service.ConversationService;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.MessageService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminDirectMessageController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class AdminDirectMessageControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private MessageService messageService;
+    @MockitoBean private ConversationService conversationService;
+    @MockitoBean private JwtService jwtService;
+
+    private void mockJwt(String token, String role, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn(role.toLowerCase() + "@example.com");
+        when(jwtService.extractRole(token)).thenReturn(role);
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private Conversation adminDirect(Long pairAId, Long pairBId) {
+        Conversation c = new Conversation();
+        c.setId(901L);
+        c.setKind(ConversationKind.ADMIN_DIRECT);
+        c.setPairAId(Math.min(pairAId, pairBId));
+        c.setPairBId(Math.max(pairAId, pairBId));
+        return c;
+    }
+
+    private MessageResponse sampleMessage() {
+        MessageResponse r = new MessageResponse();
+        r.setId(1L);
+        r.setConversationId(901L);
+        r.setSenderId(99L);
+        r.setSenderFirstName("Ops");
+        r.setContent("Please review the guidelines.");
+        r.setSentAt(OffsetDateTime.parse("2026-05-12T10:00:00Z"));
+        return r;
+    }
+
+    @Test
+    void list_asMenteeRecipient_returns200() throws Exception {
+        mockJwt("mentee-token", "MENTEE", 1L);
+        when(conversationService.findAdminDirectByPair(1L, 99L))
+                .thenReturn(Optional.of(adminDirect(1L, 99L)));
+        when(messageService.list(eq(1L), eq(901L), any()))
+                .thenReturn(new PageImpl<>(List.of(sampleMessage())));
+
+        mockMvc.perform(get("/api/conversations/admin-direct/99/messages")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].content").value("Please review the guidelines."))
+                .andExpect(jsonPath("$.content[0].conversationId").value(901));
+    }
+
+    @Test
+    void list_asAdminSender_returns200() throws Exception {
+        mockJwt("admin-token", "ADMIN", 99L);
+        when(conversationService.findAdminDirectByPair(99L, 1L))
+                .thenReturn(Optional.of(adminDirect(99L, 1L)));
+        when(messageService.list(eq(99L), eq(901L), any()))
+                .thenReturn(new PageImpl<>(List.of(sampleMessage())));
+
+        mockMvc.perform(get("/api/conversations/admin-direct/1/messages")
+                        .header("Authorization", "Bearer admin-token"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void list_noConversationForPair_returns404() throws Exception {
+        mockJwt("mentee-token", "MENTEE", 1L);
+        when(conversationService.findAdminDirectByPair(1L, 99L))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/conversations/admin-direct/99/messages")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isNotFound());
+
+        verify(messageService, never()).list(any(), any(), any());
+    }
+
+    @Test
+    void list_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/conversations/admin-direct/99/messages"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void markAllRead_asMenteeRecipient_returns204() throws Exception {
+        mockJwt("mentee-token", "MENTEE", 1L);
+        when(conversationService.findAdminDirectByPair(1L, 99L))
+                .thenReturn(Optional.of(adminDirect(1L, 99L)));
+
+        mockMvc.perform(patch("/api/conversations/admin-direct/99/messages/read")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isNoContent());
+
+        verify(messageService).markAllRead(eq(1L), eq(901L));
+    }
+
+    @Test
+    void markAllRead_noConversationForPair_returns404() throws Exception {
+        mockJwt("mentee-token", "MENTEE", 1L);
+        when(conversationService.findAdminDirectByPair(1L, 99L))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(patch("/api/conversations/admin-direct/99/messages/read")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isNotFound());
+
+        verify(messageService, never()).markAllRead(any(), any());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/AdminMessagingControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/AdminMessagingControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -122,7 +123,8 @@ class AdminMessagingControllerTest {
     @Test
     void listBroadcast_asAdmin_returns200WithPagedMessages() throws Exception {
         mockJwt("admin-token", "ADMIN", 99L);
-        when(conversationService.findOrCreateAdminBroadcast()).thenReturn(broadcast());
+        when(conversationService.findAdminBroadcastForReader(99L))
+                .thenReturn(Optional.of(broadcast()));
         when(messageService.list(eq(99L), eq(7000L), any()))
                 .thenReturn(new PageImpl<>(List.of(sampleMessage(7000L))));
 
@@ -131,6 +133,21 @@ class AdminMessagingControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].content").value("ops update"))
                 .andExpect(jsonPath("$.content[0].conversationId").value(7000));
+    }
+
+    @Test
+    void listBroadcast_noBroadcastEverSent_returnsEmptyPageWithoutSideEffect() throws Exception {
+        mockJwt("admin-token", "ADMIN", 99L);
+        when(conversationService.findAdminBroadcastForReader(99L))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/admin/messages/broadcast")
+                        .header("Authorization", "Bearer admin-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content").isEmpty());
+
+        verify(messageService, never()).list(any(), any(), any());
     }
 
     @Test
@@ -155,13 +172,27 @@ class AdminMessagingControllerTest {
     @Test
     void markBroadcastRead_asAdmin_returns204() throws Exception {
         mockJwt("admin-token", "ADMIN", 99L);
-        when(conversationService.findOrCreateAdminBroadcast()).thenReturn(broadcast());
+        when(conversationService.findAdminBroadcastForReader(99L))
+                .thenReturn(Optional.of(broadcast()));
 
         mockMvc.perform(patch("/api/admin/messages/broadcast/read")
                         .header("Authorization", "Bearer admin-token"))
                 .andExpect(status().isNoContent());
 
         verify(messageService).markAllRead(eq(99L), eq(7000L));
+    }
+
+    @Test
+    void markBroadcastRead_noBroadcastEverSent_returns204NoOp() throws Exception {
+        mockJwt("admin-token", "ADMIN", 99L);
+        when(conversationService.findAdminBroadcastForReader(99L))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(patch("/api/admin/messages/broadcast/read")
+                        .header("Authorization", "Bearer admin-token"))
+                .andExpect(status().isNoContent());
+
+        verify(messageService, never()).markAllRead(any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/group7/backend/controller/AdminMessagingControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/AdminMessagingControllerTest.java
@@ -1,0 +1,177 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.MessageResponse;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
+import com.group7.backend.service.ConversationService;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.MessageService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminMessagingController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class AdminMessagingControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockitoBean private MessageService messageService;
+    @MockitoBean private ConversationService conversationService;
+    @MockitoBean private JwtService jwtService;
+
+    private void mockJwt(String token, String role, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn(role.toLowerCase() + "@example.com");
+        when(jwtService.extractRole(token)).thenReturn(role);
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private Conversation broadcast() {
+        Conversation c = new Conversation();
+        c.setId(7000L);
+        c.setKind(ConversationKind.ADMIN_BROADCAST);
+        return c;
+    }
+
+    private Conversation adminDirect() {
+        Conversation c = new Conversation();
+        c.setId(800L);
+        c.setKind(ConversationKind.ADMIN_DIRECT);
+        c.setPairAId(1L);
+        c.setPairBId(99L);
+        return c;
+    }
+
+    private MessageResponse sampleMessage(Long convId) {
+        MessageResponse r = new MessageResponse();
+        r.setId(1L);
+        r.setConversationId(convId);
+        r.setSenderId(99L);
+        r.setSenderFirstName("Ops");
+        r.setContent("ops update");
+        r.setSentAt(OffsetDateTime.parse("2026-05-12T10:00:00Z"));
+        return r;
+    }
+
+    // ── POST /direct/{userId} ──────────────────────────────────────────────
+
+    @Test
+    void direct_asAdmin_returns201() throws Exception {
+        mockJwt("admin-token", "ADMIN", 99L);
+        when(conversationService.findOrCreateForAdminDirect(99L, 1L)).thenReturn(adminDirect());
+        when(messageService.send(eq(99L), eq(800L), any())).thenReturn(sampleMessage(800L));
+
+        mockMvc.perform(post("/api/admin/messages/direct/1")
+                        .header("Authorization", "Bearer admin-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"ops update\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.conversationId").value(800));
+    }
+
+    @Test
+    void direct_asMentee_returns403() throws Exception {
+        mockJwt("mentee-token", "MENTEE", 1L);
+
+        mockMvc.perform(post("/api/admin/messages/direct/2")
+                        .header("Authorization", "Bearer mentee-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"hi\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── POST /broadcast ────────────────────────────────────────────────────
+
+    @Test
+    void broadcast_asAdmin_returns201() throws Exception {
+        mockJwt("admin-token", "ADMIN", 99L);
+        when(conversationService.findOrCreateAdminBroadcast()).thenReturn(broadcast());
+        when(messageService.send(eq(99L), eq(7000L), any())).thenReturn(sampleMessage(7000L));
+
+        mockMvc.perform(post("/api/admin/messages/broadcast")
+                        .header("Authorization", "Bearer admin-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"team announcement\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.conversationId").value(7000));
+    }
+
+    // ── GET /broadcast (new) ───────────────────────────────────────────────
+
+    @Test
+    void listBroadcast_asAdmin_returns200WithPagedMessages() throws Exception {
+        mockJwt("admin-token", "ADMIN", 99L);
+        when(conversationService.findOrCreateAdminBroadcast()).thenReturn(broadcast());
+        when(messageService.list(eq(99L), eq(7000L), any()))
+                .thenReturn(new PageImpl<>(List.of(sampleMessage(7000L))));
+
+        mockMvc.perform(get("/api/admin/messages/broadcast")
+                        .header("Authorization", "Bearer admin-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].content").value("ops update"))
+                .andExpect(jsonPath("$.content[0].conversationId").value(7000));
+    }
+
+    @Test
+    void listBroadcast_asMentor_returns403() throws Exception {
+        mockJwt("mentor-token", "MENTOR", 7L);
+
+        mockMvc.perform(get("/api/admin/messages/broadcast")
+                        .header("Authorization", "Bearer mentor-token"))
+                .andExpect(status().isForbidden());
+
+        verify(messageService, never()).list(any(), any(), any());
+    }
+
+    @Test
+    void listBroadcast_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/admin/messages/broadcast"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── PATCH /broadcast/read (new) ────────────────────────────────────────
+
+    @Test
+    void markBroadcastRead_asAdmin_returns204() throws Exception {
+        mockJwt("admin-token", "ADMIN", 99L);
+        when(conversationService.findOrCreateAdminBroadcast()).thenReturn(broadcast());
+
+        mockMvc.perform(patch("/api/admin/messages/broadcast/read")
+                        .header("Authorization", "Bearer admin-token"))
+                .andExpect(status().isNoContent());
+
+        verify(messageService).markAllRead(eq(99L), eq(7000L));
+    }
+
+    @Test
+    void markBroadcastRead_asMentee_returns403() throws Exception {
+        mockJwt("mentee-token", "MENTEE", 1L);
+
+        mockMvc.perform(patch("/api/admin/messages/broadcast/read")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isForbidden());
+
+        verify(messageService, never()).markAllRead(any(), any());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/AdminDirectInboxServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/AdminDirectInboxServiceTest.java
@@ -1,0 +1,206 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.response.AdminDirectInboxItem;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Conversation;
+import com.group7.backend.entity.ConversationKind;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.ConversationRepository;
+import com.group7.backend.repository.MessageRepository;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.projection.ConversationLastMessageView;
+import com.group7.backend.repository.projection.ConversationUnreadCount;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminDirectInboxServiceTest {
+
+    private static final Long REQUESTER_ID = 100L;
+
+    @Mock private ConversationRepository conversationRepository;
+    @Mock private MessageRepository messageRepository;
+    @Mock private UserRepository userRepository;
+
+    private AdminDirectInboxService inboxService;
+
+    @BeforeEach
+    void setUp() {
+        inboxService = new AdminDirectInboxService(
+                conversationRepository, messageRepository, userRepository);
+    }
+
+    @Test
+    void emptyInbox_returnsEmptyPageWithoutBatchLoads() {
+        Pageable pageable = PageRequest.of(0, 20);
+        when(conversationRepository.findAdminDirectConversationsForUserOrderedByLastMessage(
+                eq(REQUESTER_ID), eq(pageable)))
+                .thenReturn(Page.empty(pageable));
+
+        Page<AdminDirectInboxItem> result = inboxService.listInbox(REQUESTER_ID, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+        verify(messageRepository, never()).findLatestPerConversation(anyCollection());
+    }
+
+    @Test
+    void singleConversation_peerIsAdmin_setsPeerIsAdminTrue() {
+        Long conversationId = 901L;
+        Long adminPeerId = 99L;
+        OffsetDateTime sentAt = OffsetDateTime.parse("2026-05-12T10:00:00Z");
+
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation c = adminDirect(conversationId, REQUESTER_ID, adminPeerId);
+        Admin peer = admin(adminPeerId, "Ops");
+
+        stubPage(pageable, List.of(c));
+        when(messageRepository.findLatestPerConversation(List.of(conversationId)))
+                .thenReturn(List.of(latest(conversationId, "Please review the guidelines.", sentAt)));
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(conversationId), REQUESTER_ID))
+                .thenReturn(List.of(unread(conversationId, 1L)));
+        when(userRepository.findAllById(List.of(adminPeerId))).thenReturn(List.<User>of(peer));
+
+        AdminDirectInboxItem item = inboxService.listInbox(REQUESTER_ID, pageable).getContent().get(0);
+
+        assertThat(item.getConversationId()).isEqualTo(conversationId);
+        assertThat(item.getPeerId()).isEqualTo(adminPeerId);
+        assertThat(item.getPeerFirstName()).isEqualTo("Ops");
+        assertThat(item.isPeerIsAdmin()).isTrue();
+        assertThat(item.getLastMessageContent()).isEqualTo("Please review the guidelines.");
+        assertThat(item.getLastMessageSentAt()).isEqualTo(sentAt);
+        assertThat(item.getUnreadCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void adminViewer_seesMenteePeer_peerIsAdminFalse() {
+        Long adminId = 99L;
+        Long menteePeerId = 5L;
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation c = adminDirect(901L, adminId, menteePeerId);
+
+        when(conversationRepository.findAdminDirectConversationsForUserOrderedByLastMessage(
+                eq(adminId), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(c), pageable, 1L));
+        when(messageRepository.findLatestPerConversation(List.of(901L)))
+                .thenReturn(List.of());
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(901L), adminId))
+                .thenReturn(List.of());
+        when(userRepository.findAllById(List.of(menteePeerId)))
+                .thenReturn(List.<User>of(mentee(menteePeerId, "Mira")));
+
+        AdminDirectInboxItem item = inboxService.listInbox(adminId, pageable).getContent().get(0);
+
+        assertThat(item.getPeerId()).isEqualTo(menteePeerId);
+        assertThat(item.isPeerIsAdmin()).isFalse();
+        assertThat(item.getPeerFirstName()).isEqualTo("Mira");
+    }
+
+    @Test
+    void unreadCount_zeroWhenAllRead() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation c = adminDirect(901L, REQUESTER_ID, 99L);
+        stubPage(pageable, List.of(c));
+        when(messageRepository.findLatestPerConversation(List.of(901L)))
+                .thenReturn(List.of());
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(901L), REQUESTER_ID))
+                .thenReturn(List.of());
+        when(userRepository.findAllById(List.of(99L)))
+                .thenReturn(List.<User>of(admin(99L, "Ops")));
+
+        AdminDirectInboxItem item = inboxService.listInbox(REQUESTER_ID, pageable).getContent().get(0);
+
+        assertThat(item.getUnreadCount()).isZero();
+    }
+
+    @Test
+    void racedPeerDeletion_dropsConversationFromResult() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Conversation c1 = adminDirect(901L, REQUESTER_ID, 99L);
+        Conversation c2 = adminDirect(902L, REQUESTER_ID, 98L);
+        when(conversationRepository.findAdminDirectConversationsForUserOrderedByLastMessage(
+                eq(REQUESTER_ID), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(c1, c2), pageable, 2L));
+        when(messageRepository.findLatestPerConversation(List.of(901L, 902L)))
+                .thenReturn(List.of());
+        when(messageRepository.countUnreadPerConversationForReader(
+                List.of(901L, 902L), REQUESTER_ID))
+                .thenReturn(List.of());
+        when(userRepository.findAllById(List.of(99L, 98L)))
+                .thenReturn(List.<User>of(admin(99L, "Ops")));
+
+        Page<AdminDirectInboxItem> result = inboxService.listInbox(REQUESTER_ID, pageable);
+
+        assertThat(result.getContent())
+                .extracting(AdminDirectInboxItem::getConversationId)
+                .containsExactly(901L);
+        assertThat(result.getTotalElements()).isEqualTo(1L);
+    }
+
+    private void stubPage(Pageable pageable, List<Conversation> content) {
+        when(conversationRepository.findAdminDirectConversationsForUserOrderedByLastMessage(
+                eq(REQUESTER_ID), eq(pageable)))
+                .thenReturn(new PageImpl<>(content, pageable, content.size()));
+    }
+
+    private static Conversation adminDirect(Long id, Long requesterId, Long peerId) {
+        Conversation c = new Conversation();
+        c.setId(id);
+        c.setKind(ConversationKind.ADMIN_DIRECT);
+        c.setPairAId(Math.min(requesterId, peerId));
+        c.setPairBId(Math.max(requesterId, peerId));
+        return c;
+    }
+
+    private static Admin admin(Long id, String firstName) {
+        Admin a = new Admin();
+        a.setId(id);
+        a.setFirstName(firstName);
+        return a;
+    }
+
+    private static Mentee mentee(Long id, String firstName) {
+        Mentee m = new Mentee();
+        m.setId(id);
+        m.setFirstName(firstName);
+        return m;
+    }
+
+    private static ConversationLastMessageView latest(Long conversationId, String content, OffsetDateTime sentAt) {
+        Instant asInstant = sentAt.toInstant();
+        return new ConversationLastMessageView() {
+            @Override public Long getConversationId() { return conversationId; }
+            @Override public String getContent() { return content; }
+            @Override public Instant getSentAt() { return asInstant; }
+        };
+    }
+
+    private static ConversationUnreadCount unread(Long conversationId, Long count) {
+        return new ConversationUnreadCount() {
+            @Override public Long getConversationId() { return conversationId; }
+            @Override public Long getUnreadCount() { return count; }
+        };
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/ConversationServiceTest.java
@@ -353,4 +353,86 @@ class ConversationServiceTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("transaction isolation");
     }
+
+    // ── findAdminDirectByPair ──────────────────────────────────────────────
+
+    @Test
+    void findAdminDirectByPair_selfPair_returnsEmpty() {
+        assertThat(conversationService.findAdminDirectByPair(5L, 5L)).isEmpty();
+        verify(conversationRepository, never())
+                .findByPairAIdAndPairBIdAndKind(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void findAdminDirectByPair_nullSide_returnsEmpty() {
+        assertThat(conversationService.findAdminDirectByPair(null, 5L)).isEmpty();
+        assertThat(conversationService.findAdminDirectByPair(5L, null)).isEmpty();
+        verify(conversationRepository, never())
+                .findByPairAIdAndPairBIdAndKind(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    void findAdminDirectByPair_normalisesPairOrderingBeforeLookup() {
+        Conversation existing = new Conversation();
+        existing.setId(800L);
+        when(conversationRepository.findByPairAIdAndPairBIdAndKind(
+                3L, 7L, ConversationKind.ADMIN_DIRECT))
+                .thenReturn(Optional.of(existing));
+
+        // Calling with high-then-low; service must swap to (3, 7) on lookup.
+        Optional<Conversation> result = conversationService.findAdminDirectByPair(7L, 3L);
+
+        assertThat(result).containsSame(existing);
+    }
+
+    // ── findAdminBroadcastForReader ────────────────────────────────────────
+
+    @Test
+    void findAdminBroadcastForReader_noSingleton_returnsEmpty_withoutCreating() {
+        when(conversationRepository.findFirstByKind(ConversationKind.ADMIN_BROADCAST))
+                .thenReturn(Optional.empty());
+
+        assertThat(conversationService.findAdminBroadcastForReader(99L)).isEmpty();
+
+        // No participant probe, no sync — pure read short-circuit.
+        verify(participantRepository, never())
+                .existsByConversationIdAndUserId(anyLong(), anyLong());
+        verify(conversationCreator, never()).createForAdminBroadcastInNewTx(any());
+    }
+
+    @Test
+    void findAdminBroadcastForReader_callerAlreadyParticipant_skipsSync() {
+        Conversation broadcast = new Conversation();
+        broadcast.setId(7000L);
+        broadcast.setKind(ConversationKind.ADMIN_BROADCAST);
+        when(conversationRepository.findFirstByKind(ConversationKind.ADMIN_BROADCAST))
+                .thenReturn(Optional.of(broadcast));
+        when(participantRepository.existsByConversationIdAndUserId(7000L, 99L))
+                .thenReturn(true);
+
+        Optional<Conversation> result = conversationService.findAdminBroadcastForReader(99L);
+
+        assertThat(result).containsSame(broadcast);
+        // Common path: one probe, no findAllAdmins call.
+        verify(userRepository, never()).findAllAdmins();
+    }
+
+    @Test
+    void findAdminBroadcastForReader_callerMissing_runsFullSync() {
+        Conversation broadcast = new Conversation();
+        broadcast.setId(7000L);
+        broadcast.setKind(ConversationKind.ADMIN_BROADCAST);
+        when(conversationRepository.findFirstByKind(ConversationKind.ADMIN_BROADCAST))
+                .thenReturn(Optional.of(broadcast));
+        when(participantRepository.existsByConversationIdAndUserId(7000L, 99L))
+                .thenReturn(false);
+        // The sync inside the service iterates findAllAdmins(); stub an empty list
+        // so we don't have to mock per-admin existsBy/addParticipant calls.
+        when(userRepository.findAllAdmins()).thenReturn(java.util.List.of());
+
+        Optional<Conversation> result = conversationService.findAdminBroadcastForReader(99L);
+
+        assertThat(result).containsSame(broadcast);
+        verify(userRepository).findAllAdmins();
+    }
 }


### PR DESCRIPTION
Closes the read-side gap in #280 admin messaging. Reopened the issue earlier today after finding the acceptance criterion *\"admin broadcast lands in every admin's \`/api/conversations\` list\"* unmet — the write surface shipped, but no REST endpoint existed for recipients to list or read admin DMs and no endpoint existed for admins to read the broadcast thread.

## What this PR adds

**Admin-direct (recipient + admin readable)**
- \`GET /api/conversations/admin-direct\` — paged inbox of admin-direct conversations the caller participates in. Each row carries peer identity, a \`peerIsAdmin\` flag (so the UI can render the right chrome whether the viewer is admin or recipient), last-message preview, and unread count.
- \`GET /api/conversations/admin-direct/{otherUserId}/messages\` — paged message history. 404 when no admin-direct conversation exists for the pair.
- \`PATCH /api/conversations/admin-direct/{otherUserId}/messages/read\` — mark all read.

**Admin broadcast (admin-only)**
- \`GET /api/admin/messages/broadcast\` — paged message history of the singleton \`ADMIN_BROADCAST\` thread. The find-or-create call also re-syncs the participant list, so a newly promoted admin opening their broadcast inbox for the first time gets added as a participant and sees the full backlog.
- \`PATCH /api/admin/messages/broadcast/read\` — mark all read.

## Design notes
- The inbox surface intentionally has no role gate — a non-admin recipient must be able to list admin DMs they received. The list is naturally scoped to the caller's participant rows.
- The per-thread read endpoint uses a pure-read lookup (\`ConversationService.findAdminDirectByPair\`) so a recipient opening a never-DMed thread gets a clean 404 rather than a synthesised empty conversation. Participant ACL is enforced inside \`MessageService.loadAndAuthorize\`.
- \`AdminDirectInboxService\` mirrors \`MentorPairInboxService\` — page once, then three batched lookups regardless of page size.
- Class-level \`@PreAuthorize(\"hasRole('ADMIN')\")\` on \`AdminMessagingController\` gates both new broadcast endpoints; no new auth wiring needed.

## Tests
- \`AdminDirectInboxServiceTest\` — assembly contract (peer-is-admin mapping for both viewer directions, unread default-zero, race-defensive null-peer filter, total-elements preservation).
- \`AdminDirectInboxControllerTest\` — happy paths for mentee/mentor/admin viewers, unauthenticated 403, pagination clamping.
- \`AdminDirectMessageControllerTest\` — 200 for participants, 404 when no conversation exists, 403 unauthenticated, mark-all-read delegation.
- \`AdminMessagingControllerTest\` — covers existing POST endpoints plus new GET/PATCH broadcast endpoints with non-admin 403s.

All four new test classes pass locally (\`mvn -Dtest='AdminDirect*,AdminMessagingControllerTest,AdminDirectInbox*' test\`).

## Out of scope
- User → admin replies through the admin-direct REST surface. Writes still flow only through the admin-only \`POST /api/admin/messages/direct/{userId}\`. Two-way DMs can be added later if/when the product calls for it.
- Frontend wiring for the new endpoints — separate web/mobile issues.

## Test plan
- [ ] CI green on the new unit/slice tests
- [ ] Manual: admin POSTs DM → recipient calls \`GET /api/conversations/admin-direct\` → sees the conversation with \`peerIsAdmin=true\`
- [ ] Manual: recipient calls \`GET /api/conversations/admin-direct/{adminId}/messages\` → sees the message
- [ ] Manual: admin POSTs broadcast → admin calls \`GET /api/admin/messages/broadcast\` → sees the message; second admin sees it too
- [ ] Manual: non-admin \`GET /api/admin/messages/broadcast\` → 403