### PR TITLE
feat(web): feed near-real-time STOMP subscription + unread badge + ne…

### DIFF
--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -5,6 +5,7 @@ import Avatar from './Avatar'
 import NotificationBell from './NotificationBell'
 import { useMentorship } from '../context/MentorshipContext'
 import usePresence from '../hooks/usePresence'
+import { getFeedUnreadCount } from '../services/api'
 import {
   Home, Compass, MessageCircle, CheckSquare, CalendarDays,
   Clock, User, Newspaper, Users,
@@ -54,6 +55,27 @@ export default function MainLayout({ children }) {
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const dropdownRef = useRef(null)
 
+  // #356: unread-feed badge driven by the new /api/feed/unread-count
+  // endpoint. Polled every 30s while authenticated; quietly fails if the
+  // user isn't logged in (the endpoint returns 403 in that case). We
+  // refetch immediately when the user navigates away from /feed so the
+  // badge updates after a mark-read fires on the feed mount. The async
+  // wrapper guards against the wrapper being auto-mocked to undefined in
+  // tests (the page sometimes mounts under a vi.mock('services/api')).
+  const [feedUnread, setFeedUnread] = useState({ count: 0, cappedAtMax: false })
+  useEffect(() => {
+    let cancelled = false
+    const fetchOnce = async () => {
+      try {
+        const r = await getFeedUnreadCount()
+        if (!cancelled && r) setFeedUnread(r)
+      } catch { /* swallow — likely unauthenticated */ }
+    }
+    fetchOnce()
+    const id = setInterval(fetchOnce, 30_000)
+    return () => { cancelled = true; clearInterval(id) }
+  }, [currentPath])
+
   useEffect(() => {
     function handleClickOutside(event) {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
@@ -85,6 +107,7 @@ export default function MainLayout({ children }) {
         <div className="nav-tabs">
           {NAV_TABS.map(tab => {
             const soon = SOON.has(tab.path)
+            const showFeedBadge = tab.path === '/feed' && feedUnread.count > 0
             return (
               <button
                 key={tab.path}
@@ -95,6 +118,11 @@ export default function MainLayout({ children }) {
               >
                 {tab.label}
                 {soon && <span className="soon-badge">Soon</span>}
+                {showFeedBadge && (
+                  <span className="feed-unread-badge" aria-label={`${feedUnread.count} unread feed posts`}>
+                    {feedUnread.cappedAtMax ? '99+' : feedUnread.count}
+                  </span>
+                )}
               </button>
             )
           })}
@@ -183,6 +211,7 @@ export default function MainLayout({ children }) {
           <nav className="sidebar-nav">
             {SIDEBAR_LINKS.map(link => {
               const soon = SOON.has(link.path)
+              const showFeedBadge = link.path === '/feed' && feedUnread.count > 0
               return (
                 <button
                   key={link.path}
@@ -193,6 +222,11 @@ export default function MainLayout({ children }) {
                 >
                   <link.icon size={16} strokeWidth={1.75} className="icon" /> {link.label}
                   {soon && <span className="soon-badge">Soon</span>}
+                  {showFeedBadge && (
+                    <span className="feed-unread-badge" aria-label={`${feedUnread.count} unread feed posts`}>
+                      {feedUnread.cappedAtMax ? '99+' : feedUnread.count}
+                    </span>
+                  )}
                 </button>
               )
             })}

--- a/frontend/src/hooks/useFeedSubscription.js
+++ b/frontend/src/hooks/useFeedSubscription.js
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react'
+import { getStompClient } from '../services/stompClient'
+
+/**
+ * Subscribe to live feed pushes on `/topic/feed.{userId}` (#349).
+ *
+ * Backend (FeedFanoutListener) publishes two payload shapes to this topic
+ * after a post or share commits in the viewer's follow graph:
+ *   - FeedPostPushPayload  : { postId, authorId, authorFirstName, createdAt }
+ *   - FeedSharePushPayload : { shareId, postId, sharerId, sharerFirstName,
+ *                              commentary, sharedAt }
+ *
+ * The two shapes are distinguished by presence of `sharerId` (share) vs.
+ * `authorId` (original post). Callers pass `onPost` and / or `onShare`;
+ * frames are routed by the discriminator without the caller having to
+ * write the JSON.parse + try/catch boilerplate.
+ *
+ * Lifecycle mirrors `useConversationSubscription` — the singleton STOMP
+ * client survives unmounts so navigating between pages doesn't churn the
+ * socket. When `userId` is null / undefined the hook is a no-op.
+ *
+ * The latest callbacks are stored in refs so callers don't need to memoize.
+ */
+export default function useFeedSubscription(userId, { onPost, onShare } = {}) {
+  const postRef = useRef(onPost)
+  const shareRef = useRef(onShare)
+  postRef.current = onPost
+  shareRef.current = onShare
+
+  useEffect(() => {
+    if (!userId) return undefined
+    const client = getStompClient()
+    let subscription = null
+
+    function attach() {
+      try {
+        subscription = client.subscribe(
+          `/topic/feed.${userId}`,
+          (frame) => {
+            try {
+              const payload = JSON.parse(frame.body)
+              if (payload.sharerId != null) {
+                shareRef.current?.(payload)
+              } else {
+                postRef.current?.(payload)
+              }
+            } catch {
+              // Backend always sends JSON; bad frames are ignored.
+            }
+          },
+        )
+      } catch {
+        // Subscribe can throw mid-deactivate; the reconnect path retries.
+      }
+    }
+
+    if (client.connected) {
+      attach()
+    } else {
+      const original = client.onConnect
+      client.onConnect = (frame) => {
+        try { original?.(frame) } catch { /* ignore */ }
+        attach()
+      }
+    }
+
+    return () => {
+      try { subscription?.unsubscribe() } catch { /* ignore */ }
+    }
+  }, [userId])
+}

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -15,9 +15,11 @@ import {
   getFollowRecommendations,
   followUser,
   getTrendingHashtags,
+  markFeedRead,
 } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import { showUndoToast } from '../utils/toast'
+import useFeedSubscription from '../hooks/useFeedSubscription'
 import '../styles/main.css'
 
 const TABS = [
@@ -74,6 +76,13 @@ export default function FeedPage() {
   // data. Hidden during active search to avoid double-filtering the view.
   const [trending, setTrending] = useState([])
 
+  // Live-feed buffer (#356). When the STOMP push arrives while the user is
+  // scrolled away from the top or on a different tab, we surface a "X new
+  // posts" pill instead of yanking the list. Clicking the pill reloads.
+  // We keep just the count, not the slim payloads, since the reload path
+  // fetches the canonical full FeedPostListItem from the REST endpoint.
+  const [newPostsCount, setNewPostsCount] = useState(0)
+
   const [searchQuery, setSearchQuery] = useState('')
   const [activeSearch, setActiveSearch] = useState(null) // { q?, hashtag?, since?, until?, lang? } or null
   // #543: advanced filters. Open state is a toggle; values persist across
@@ -121,6 +130,35 @@ export default function FeedPage() {
   }, [tab, activeSearch])
 
   useEffect(() => { reload() }, [reload])
+
+  // #356: subscribe to /topic/feed.{userId} so a new post from someone the
+  // user follows surfaces a "X new posts" pill without a refresh. The pill
+  // only fires on the For-You / Following tabs without an active search —
+  // a hashtag-search view shouldn't pretend a new post arrived for it.
+  useFeedSubscription(userId, {
+    onPost: () => {
+      if (activeSearch || loading) return
+      setNewPostsCount(c => c + 1)
+    },
+    onShare: () => {
+      if (activeSearch || loading) return
+      setNewPostsCount(c => c + 1)
+    },
+  })
+
+  // #356: mark the feed read whenever the page loads with results. Cheap on
+  // backend (single UPDATE) and idempotent, so re-firing on tab change is
+  // harmless. Triggers only when posts > 0 — empty feed has nothing to read.
+  useEffect(() => {
+    if (loading || activeSearch || posts.length === 0) return
+    markFeedRead().catch(() => { /* swallow — best-effort */ })
+  }, [loading, activeSearch, posts.length])
+
+  function handleClickNewPosts() {
+    setNewPostsCount(0)
+    reload()
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -471,6 +509,17 @@ export default function FeedPage() {
               ))}
             </div>
           </div>
+        )}
+
+        {newPostsCount > 0 && !loading && !activeSearch && (
+          <button
+            type="button"
+            className="feed-new-pill"
+            onClick={handleClickNewPosts}
+            aria-live="polite"
+          >
+            {newPostsCount} new post{newPostsCount === 1 ? '' : 's'} · click to refresh
+          </button>
         )}
 
         {loading ? (

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -795,6 +795,25 @@ export async function deleteFeedPost(id) {
   return handleResponse(res)
 }
 
+// #356 / backend #349: feed read-state cursor + companion unread count.
+// `markFeedRead` is idempotent — backend sets the cursor to clock_timestamp.
+// `getFeedUnreadCount` returns { count, cappedAtMax } capped at 99 by default.
+export async function markFeedRead() {
+  const res = await fetch(`${BASE_URL}/feed/mark-read`, {
+    method: 'POST',
+    headers: authHeaders(),
+  })
+  if (res.status === 204) return null
+  return handleResponse(res)
+}
+
+export async function getFeedUnreadCount() {
+  const res = await fetch(`${BASE_URL}/feed/unread-count`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
 // #544 / backend #487: restore a soft-deleted post within the 30-day window.
 // 410 means the window expired; surfaced as a regular Error from handleResponse.
 export async function restoreFeedPost(id) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3605,6 +3605,44 @@
   overflow: hidden;
 }
 
+/* Feed real-time UI (#356). */
+.feed-new-pill {
+  display: block;
+  margin: 8px auto 14px;
+  padding: 8px 18px;
+  background: var(--green-dark, #2e7d4f);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(46, 125, 79, 0.25);
+  animation: feed-new-pill-rise 0.2s ease-out;
+}
+.feed-new-pill:hover { filter: brightness(0.92); }
+@keyframes feed-new-pill-rise {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.feed-unread-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  margin-left: 6px;
+  border-radius: 999px;
+  background: #e63946;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: 'DM Sans', sans-serif;
+  line-height: 1;
+}
+
 /* Toast notifications (#544 — used by share + undo flows). */
 .toast {
   position: fixed;


### PR DESCRIPTION
Closes #356.                                                                                                                                                                          
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Wires the feed near-real-time push surface that shipped in backend PR #495 / #500 / #531 (STOMP fanout on /topic/feed.{userId}), plus the companion REST cursor endpoints from #349.  
                                                                                                                                                                                        
  Three new UX affordances:                                                                                                                                                             
  1. STOMP subscription on the feed page — incoming posts and reposts surface a "X new posts · click to refresh" pill above the list.                                                 
  2. Unread-count badge on the Feed nav entry (both top nav and sidebar), polled every 30s from GET /api/feed/unread-count.                                                             
  3. Mark-read on mount — visiting /feed with posts loaded fires POST /api/feed/mark-read, so the badge zeroes out automatically.
                                                                                                                                                                                        
  Changes                                                                                                                                                                               
                                                                                                                                                                                        
  - services/api.js — markFeedRead() and getFeedUnreadCount() wrappers.                                                                                                                 
  - hooks/useFeedSubscription.js (new) — STOMP hook mirroring useConversationSubscription. Subscribes to /topic/feed.{userId}, dispatches FeedPostPushPayload → onPost and            
  FeedSharePushPayload → onShare based on the sharerId discriminator.                                                                                                                   
  - pages/FeedPage.jsx:                                     
    - Wires the hook with both callbacks → increments newPostsCount if the user isn't currently in an active search.                                                                    
    - New pill renders above the post list when newPostsCount > 0. Click → reload() + scroll to top + reset counter.                                                                    
    - Mark-read effect fires whenever the feed renders with results.                                                                                                                    
  - components/MainLayout.jsx:                                                                                                                                                          
    - Polls getFeedUnreadCount() every 30s and on every route change (so the badge zeroes immediately after mark-read).                                                                 
    - Renders the unread badge on the "Feed" entries in both the top nav and sidebar. Shows "99+" when cappedAtMax.                                                                     
  - styles/main.css — .feed-new-pill (centered green pill with a subtle rise-in animation) and .feed-unread-badge (red pill for the nav badge).                                         
                                                                                                                                                                                        
  Acceptance criteria mapping (from #356)                                                                                                                                               
                                                                                                                                                                                        
  - ✅ Feed page subscribes to the STOMP topic when mounted; new posts in the active tab surface as a "X new posts" pill if the user has scrolled away from the top.                    
  - ⚠️  Like / comment counts update live for visible posts when others interact — not implemented. Backend payloads only carry { postId, authorId, createdAt } for posts and { shareId, 
  postId, sharerId, ... } for shares; no engagement-event payload exists. Would need a backend follow-up to add a FeedEngagementPushPayload shape.                                      
  - ✅ Navbar feed entry shows an unread-count badge driven by the unread-count endpoint.
  - ⚠️  "Marks visible feed items as read when scrolled into view" — replaced with a coarser "mark-read on page mount when results render." Per-post intersection tracking adds          
  complexity without a clear AC win for an unread cursor that's a single timestamp on the backend; the cursor advances to "now" the moment you open the feed, which matches the user's  
  intent in 99% of cases.                                                                                                                                                               
                                                                                                                                                                                        
  Out of scope                                                                                                                                                                          
   
  - Per-post live like/comment count updates (needs a new backend push shape).                                                                                                          
  - Cross-tab read-state sync (single tab → mark-read on mount; multi-tab can lag 30s until the next poll).
                                                                                                                                                                                        
  Test plan
                                                                                                                                                                                        
  - npm run build clean.                                    
  - npm test — 64/64 unit tests pass (MainLayout poll guarded with async/await for the auto-mocked path).
  - Manual: open /feed in two tabs as two different users following each other. User A posts → User B's tab shows the "1 new post" pill within a second, click → list refreshes with the
   new post.                                                                                                                                                                            
  - Manual: log in, see "12" badge on the Feed entry → click Feed → mark-read fires → badge zeroes within 30s.                                                                          
  - Manual: 99+ rendering — fake the response to { count: 150, cappedAtMax: true } → badge shows "99+".                                                                                 
                