### PR TITLE
feat(web): feed reposts and quote-shares with attribution rendering (…

### DIFF
--- a/frontend/src/components/FeedPostCard.jsx
+++ b/frontend/src/components/FeedPostCard.jsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { MoreHorizontal, Pencil, Trash2, History, Share2, Bookmark, Heart, MessageCircle } from 'lucide-react'
+import { MoreHorizontal, Pencil, Trash2, History, Share2, Repeat2, Bookmark, Heart, MessageCircle } from 'lucide-react'
 import Avatar from './Avatar'
 import FeedAttachmentGrid from './FeedAttachmentGrid'
 import EditHistoryModal from './EditHistoryModal'
+import RepostModal from './RepostModal'
 import { linkify } from '../utils/linkify'
 import {
   toggleBookmarkOnPost,
@@ -13,6 +14,7 @@ import {
   getPostComments,
   addCommentToPost,
   toggleLikeOnComment,
+  repostPost,
 } from '../services/api'
 
 /**
@@ -58,6 +60,8 @@ export default function FeedPostCard({
   const navigate = useNavigate()
   const [menuOpen, setMenuOpen] = useState(false)
   const [historyOpen, setHistoryOpen] = useState(false)
+  const [repostOpen, setRepostOpen] = useState(false)
+  const [repostBusy, setRepostBusy] = useState(false)
   const menuRef = useRef(null)
 
   // Local state mirrors viewer-relative interaction toggles + counts; backend
@@ -281,6 +285,29 @@ export default function FeedPostCard({
     }
   }
 
+  async function handleRepostConfirm(body) {
+    if (repostBusy) return
+    setRepostBusy(true)
+    try {
+      const state = await repostPost(post.id, body)
+      // Backend returns the original post's updated interaction state; bump
+      // the share count locally so the count next to the Share button matches.
+      if (state?.shareCount != null) setShareCount(state.shareCount)
+      onShared?.(state)
+      setRepostOpen(false)
+    } catch (err) {
+      window.alert(err?.message || 'Failed to repost')
+    } finally {
+      setRepostBusy(false)
+    }
+  }
+
+  function openRepost(e) {
+    e.stopPropagation()
+    e.preventDefault()
+    setRepostOpen(true)
+  }
+
   async function handleShare(e) {
     e.stopPropagation()
     e.preventDefault()
@@ -310,11 +337,31 @@ export default function FeedPostCard({
     }
   }
 
+  // #542: when the Following-feed surfaces a repost, the FeedPostListItem
+  // carries sharedById / sharedByFirstName / commentary / sharedAt. Render
+  // a small "Reposted by X" attribution above the original-post body and,
+  // for quote-shares, a commentary block between the attribution and body.
+  const isRepostSurface = post?.sharedById != null
+
   return (
     <article
       className={`feed-card${clickable ? ' feed-card--clickable' : ''}`}
       onClick={openDetail}
     >
+      {isRepostSurface && (
+        <div className="feed-card-repost-banner">
+          <Repeat2 size={13} strokeWidth={2} />
+          <span>
+            Reposted by <strong>{post.sharedByFirstName || 'someone'}</strong>
+            {post.sharedAt && <span className="feed-card-repost-time"> · {formatPostTime(post.sharedAt)}</span>}
+          </span>
+        </div>
+      )}
+
+      {isRepostSurface && post.commentary && (
+        <div className="feed-card-repost-commentary">{post.commentary}</div>
+      )}
+
       <div className="feed-card-header">
         <button
           type="button"
@@ -414,6 +461,16 @@ export default function FeedPostCard({
           <span>{commentCount}</span>
         </button>
         <span className="feed-card-action-spacer" aria-hidden="true" />
+        <button
+          type="button"
+          className="feed-card-action-btn"
+          onClick={openRepost}
+          disabled={repostBusy}
+          aria-label="Repost or quote-share"
+          title="Repost"
+        >
+          <Repeat2 size={16} strokeWidth={1.75} />
+        </button>
         <button
           type="button"
           className="feed-card-action-btn"
@@ -527,6 +584,14 @@ export default function FeedPostCard({
         open={historyOpen}
         postId={post.id}
         onClose={() => setHistoryOpen(false)}
+      />
+
+      <RepostModal
+        open={repostOpen}
+        post={post}
+        onClose={() => !repostBusy && setRepostOpen(false)}
+        onConfirm={handleRepostConfirm}
+        loading={repostBusy}
       />
     </article>
   )

--- a/frontend/src/components/RepostModal.jsx
+++ b/frontend/src/components/RepostModal.jsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from 'react'
+
+const COMMENTARY_MAX = 2000
+
+/**
+ * Repost / quote-share modal (#542 / backend #484). Submits an empty body
+ * for a bare repost (button labelled "Repost without commentary") or the
+ * trimmed text for a quote-share. The original post is shown in a compact
+ * embed inside the modal so the user remembers what they're resharing.
+ *
+ * Props:
+ *   open       — visibility
+ *   post       — the original FeedPostListItem / FeedPostResponse
+ *   onClose()  — close handler
+ *   onConfirm(body)  — async; body is "" for bare repost, trimmed string
+ *                     for quote-share. Caller is responsible for surfacing
+ *                     errors and closing the modal on success.
+ *   loading    — disables submit while in flight
+ */
+export default function RepostModal({ open, post, onClose, onConfirm, loading }) {
+  const overlayRef = useRef(null)
+  const [body, setBody] = useState('')
+
+  useEffect(() => {
+    if (open) setBody('')
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onKey = e => { if (e.key === 'Escape' && !loading) onClose?.() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose, loading])
+
+  if (!open || !post) return null
+
+  const trimmed = body.trim()
+  const remaining = COMMENTARY_MAX - body.length
+
+  return (
+    <div
+      className="modal-overlay"
+      ref={overlayRef}
+      onMouseDown={e => { if (e.target === overlayRef.current && !loading) onClose?.() }}
+    >
+      <div className="modal-card" role="dialog" aria-modal="true" aria-labelledby="repost-title">
+        <div className="modal-header">
+          <div>
+            <h2 id="repost-title">Repost</h2>
+            <p className="modal-subtitle">
+              Reshare this post into your followers' feeds. Add optional commentary to
+              quote-share, or leave it empty for a bare repost.
+            </p>
+          </div>
+          <button type="button" className="modal-close" onClick={onClose} aria-label="Close modal">×</button>
+        </div>
+
+        <label className="section-label" style={{ marginTop: '12px', display: 'block' }} htmlFor="repost-body">
+          Your commentary (optional)
+        </label>
+        <textarea
+          id="repost-body"
+          className="modal-textarea"
+          rows={4}
+          maxLength={COMMENTARY_MAX}
+          value={body}
+          onChange={e => setBody(e.target.value)}
+          placeholder="What's your take on this?"
+          disabled={loading}
+        />
+        <div style={{ fontSize: '12px', color: 'var(--text-muted)', textAlign: 'right' }}>
+          {remaining} characters left
+        </div>
+
+        <div className="repost-embed" aria-label="Original post">
+          <div className="repost-embed-head">
+            <span className="repost-embed-author">{post.authorFirstName || 'User'}</span>
+          </div>
+          <div className="repost-embed-body">{post.body}</div>
+        </div>
+
+        <div className="modal-actions" style={{ marginTop: '16px' }}>
+          <button type="button" className="modal-btn-secondary" onClick={onClose} disabled={loading}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="modal-btn-primary"
+            onClick={() => onConfirm?.(trimmed)}
+            disabled={loading}
+            title={trimmed ? 'Quote-share with commentary' : 'Bare repost without commentary'}
+          >
+            {loading
+              ? 'Reposting…'
+              : trimmed
+                ? 'Quote-share'
+                : 'Repost without commentary'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -814,6 +814,21 @@ export async function getFeedUnreadCount() {
   return handleResponse(res)
 }
 
+// #542 / backend #484: repost or quote-share a feed post. body is optional —
+// null/blank produces a bare repost, non-blank (up to 2000 chars) attaches
+// commentary. Backend dedupes repeated payloads within ~60s. Returns the
+// updated FeedPostInteractionState for the original post so the share count
+// can refresh in place.
+export async function repostPost(postId, body) {
+  const payload = body && body.trim() ? { body: body.trim() } : {}
+  const res = await fetch(`${BASE_URL}/feed/posts/${postId}/reposts`, {
+    method: 'POST',
+    headers: authJsonHeaders(),
+    body: JSON.stringify(payload),
+  })
+  return handleResponse(res)
+}
+
 // #544 / backend #487: restore a soft-deleted post within the 30-day window.
 // 410 means the window expired; surfaced as a regular Error from handleResponse.
 export async function restoreFeedPost(id) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3605,6 +3605,65 @@
   overflow: hidden;
 }
 
+/* Feed reposts (#542). */
+.feed-card-repost-banner {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  font-weight: 600;
+}
+.feed-card-repost-banner strong {
+  color: var(--text);
+  font-weight: 600;
+}
+.feed-card-repost-time {
+  font-weight: 400;
+}
+.feed-card-repost-commentary {
+  padding: 10px 12px;
+  margin-bottom: 10px;
+  background: var(--green-pale, #ecf6ee);
+  border-left: 3px solid var(--green-mid, #b6d8bd);
+  border-radius: 8px;
+  font-size: 14px;
+  color: var(--text);
+  font-style: italic;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.repost-embed {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fafaf9;
+}
+.repost-embed-head {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+.repost-embed-author {
+  font-weight: 600;
+  color: var(--text);
+}
+.repost-embed-body {
+  font-size: 13px;
+  color: var(--text);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* Feed real-time UI (#356). */
 .feed-new-pill {
   display: block;


### PR DESCRIPTION
Closes #542.                                                                                                                                                                          
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Wires the enhanced-sharing flow that shipped in backend PR #531. Two surfaces:                                                                                                        
                                                                                                                                                                                        
  1. Repost action — new Repeat2 icon on every post card, between Comments and Share. Opens a modal with an embedded preview of the original post and an optional commentary textarea   
  (max 2000 chars to match the backend @Size). Bare repost when commentary is empty, quote-share when not.                                                                            
  2. Repost attribution — when the Following feed surfaces a repost (FeedPostListItem.sharedById != null), the card renders a "Reposted by X · 2h ago" banner above the author header,  
  plus the quote-share commentary in a green block above the original-post body.                                                                                                        
   
  Changes                                                                                                                                                                               
                                                                                                                                                                                      
  - services/api.js — repostPost(postId, body) wrapper. Trims commentary client-side; empty/whitespace becomes {} (bare repost) so the backend's "blank = bare repost" semantics fire   
  correctly.
  - components/RepostModal.jsx (new) — modal with optional commentary input, compact original-post embed, dynamic submit-button label ("Quote-share" with content, "Repost without      
  commentary" empty).                                                                                                                                                                   
  - components/FeedPostCard.jsx:
    - Added repostOpen / repostBusy state + handleRepostConfirm and openRepost handlers.                                                                                                
    - New Repost button in the action row (next to Share). On success, bumps the local shareCount from the returned FeedPostInteractionState and calls the existing onShared callback so
   parents update their lists.                                                                                                                                                          
    - "Reposted by X" attribution banner + commentary block render above the existing author header when post.sharedById != null (Following-feed only — other surfaces still carry the  
  field as null).                                                                                                                                                                       
    - Mount the new modal alongside the existing edit-history modal.
  - styles/main.css — .feed-card-repost-banner, .feed-card-repost-commentary, .repost-embed* for the modal's original-post preview (4-line clamp to keep the modal tight).              
                                                                                                                                                                                        
  Acceptance criteria mapping (from #542)                                                                                                                                               
                                                                                                                                                                                        
  - ✅ Repost button visible on every post card with an icon distinct from Share (Repeat2 vs Share2).                                                                                   
  - ✅ Repost modal accepts optional quote text; submitting creates a repost via the reposts endpoint.
  - ✅ New repost appears in the viewer's Following feed (backend fans out via STOMP /topic/feed.{userId}; the #356 PR already subscribes to that topic, so the "X new posts" pill fires
   on follower clients).                                                                                                                                                                
  - ✅ Original-post-embed renders inside the repost via FeedPostListItem.sharedBy* / commentary fields.                                                                                
                                                                                                                                                                                        
  Out of scope                                              
                                                                                                                                                                                        
  - A "Quote" button separate from "Repost" — single button + optional commentary covers both paths and matches backend semantics (one endpoint, optional body).                        
  - Editing or deleting a quote-share's commentary after the fact — backend doesn't expose this.
  - Live like/comment counts on visible reposts — covered by #563 / backend #562 follow-ups.                                                                                            
                                                                                                                                                                                        
  Test plan                                                                                                                                                                             
                                                                                                                                                                                        
  - npm run build clean.                                                                                                                                                                
  - npm test — 64/64 unit tests pass.
  - Manual: open /feed → click the Repeat2 icon on someone else's post → modal opens with their post embedded → click "Repost without commentary" → success, share count next to the    
  Share button increments by 1.                                                                                                                                                         
  - Manual: same flow but add commentary → submit "Quote-share" → success.
  - Manual: log in as a follower of the reposter → visit Following tab → the reposted post appears at the top with "Reposted by X" attribution; if quote-share, the commentary shows    
  above the original-post body.                                                                                                                                                         
  - Manual: try to repost the same post twice within 60s → backend dedupes silently (no error toast, no double-increment). 