### PR TITLE
feat(backend): live engagement push payload for /topic/feed.{userId} (#562)

### DIFF
--- a/backend/src/main/java/com/group7/backend/dto/response/FeedEngagementPushPayload.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/FeedEngagementPushPayload.java
@@ -1,0 +1,43 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Slim engagement-update push payload broadcast over the
+ * {@code /topic/feed.{userId}} STOMP destination so visible feed cards
+ * can update like / comment / share counts without polling.
+ *
+ * <p>Discriminator: this payload has neither {@code authorId} nor
+ * {@code sharerId} (cf. {@link FeedPostPushPayload} /
+ * {@link FeedSharePushPayload}); the post is identified by id only.
+ *
+ * <p>Routing: the broadcast reaches every follower of the post's author
+ * <em>plus</em> the author themselves, so the author also sees live
+ * counts on their own post. Non-follower viewers (search, For-You
+ * discovery, direct link) fall back to polling on next interaction.
+ *
+ * <p>Counts are <em>authoritative</em>, not deltas — the frontend sets
+ * {@code likeCount = N} (rather than {@code += 1}), so a dropped STOMP
+ * frame self-heals on the next received one.
+ */
+@Schema(description = "Engagement-counts push over /topic/feed.{userId} STOMP. " +
+        "Authoritative absolute counts, not deltas — frontend sets the value to self-heal dropped frames.")
+public record FeedEngagementPushPayload(
+        @Schema(description = "Post id whose counts changed", example = "42")
+        Long postId,
+
+        @Schema(description = "Total likes on the post", example = "12")
+        long likeCount,
+
+        @Schema(description = "Total non-deleted comments on the post", example = "3")
+        long commentCount,
+
+        @Schema(description = "Total shares + reposts of the post", example = "5")
+        long shareCount,
+
+        @Schema(description = "Server-side timestamp of this engagement change")
+        OffsetDateTime updatedAt
+) {
+}

--- a/backend/src/main/java/com/group7/backend/event/FeedFanoutListener.java
+++ b/backend/src/main/java/com/group7/backend/event/FeedFanoutListener.java
@@ -1,6 +1,7 @@
 package com.group7.backend.event;
 
 import com.group7.backend.dto.feed.FeedTopics;
+import com.group7.backend.dto.response.FeedEngagementPushPayload;
 import com.group7.backend.dto.response.FeedPostPushPayload;
 import com.group7.backend.dto.response.FeedSharePushPayload;
 import com.group7.backend.repository.FollowRepository;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -115,6 +117,39 @@ public class FeedFanoutListener {
         } catch (RuntimeException ex) {
             log.error("Share fanout aborted: shareId={}, sharerId={}: {}",
                     event.shareId(), event.sharerId(), ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Engagement-counts fanout. Mirrors {@link #onFeedPostShared}'s
+     * follower-set snapshot pattern, but adds the post author to the
+     * recipients so the author also sees live counts on their own post.
+     * Non-follower viewers (search, For-You discovery, direct link) are
+     * not in the recipient set and fall back to polling on next
+     * interaction — a documented v1 limitation.
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onFeedPostEngagementChanged(FeedPostEngagementChangedEvent event) {
+        try {
+            Set<Long> recipients = new HashSet<>(
+                    followRepository.findFollowerIdsByFolloweeId(event.authorId()));
+            recipients.add(event.authorId());
+            if (recipients.isEmpty()) {
+                return;
+            }
+            FeedEngagementPushPayload payload = new FeedEngagementPushPayload(
+                    event.postId(),
+                    event.likeCount(),
+                    event.commentCount(),
+                    event.shareCount(),
+                    event.updatedAt());
+            int delivered = broadcastTo(recipients, payload, event.postId());
+            log.info("Engagement fanout: postId={}, authorId={}, recipients={}, delivered={}",
+                    event.postId(), event.authorId(), recipients.size(), delivered);
+        } catch (RuntimeException ex) {
+            log.error("Engagement fanout aborted: postId={}, authorId={}: {}",
+                    event.postId(), event.authorId(), ex.getMessage(), ex);
         }
     }
 

--- a/backend/src/main/java/com/group7/backend/event/FeedPostEngagementChangedEvent.java
+++ b/backend/src/main/java/com/group7/backend/event/FeedPostEngagementChangedEvent.java
@@ -1,0 +1,31 @@
+package com.group7.backend.event;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Published whenever an engagement mutation on a feed post changes the
+ * post's visible counts (like / comment / share / repost) <em>or</em>
+ * fires as a heartbeat for downstream views (comment-like).
+ * {@link FeedFanoutListener} subscribes via
+ * {@code @TransactionalEventListener(AFTER_COMMIT)} and broadcasts a
+ * {@link com.group7.backend.dto.response.FeedEngagementPushPayload} to
+ * the author's followers plus the author themselves.
+ *
+ * <p>Carries the post id and author id so the listener can resolve
+ * recipients without re-loading the entity, plus the post-flush
+ * authoritative counts so the wire payload is a self-contained snapshot
+ * (frontend assigns absolute values rather than computing deltas).
+ *
+ * <p>Mirrors {@link FeedPostCreatedEvent} / {@link FeedPostSharedEvent}'s
+ * all-values record shape so the {@code @Async} listener never crosses
+ * a thread boundary with a managed entity.
+ */
+public record FeedPostEngagementChangedEvent(
+        Long postId,
+        Long authorId,
+        long likeCount,
+        long commentCount,
+        long shareCount,
+        OffsetDateTime updatedAt
+) {
+}

--- a/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
@@ -13,6 +13,7 @@ import com.group7.backend.entity.FeedPostShare;
 import com.group7.backend.entity.User;
 import com.group7.backend.entity.FeedPostHashtag;
 import com.group7.backend.event.FeedEngagementEvent;
+import com.group7.backend.event.FeedPostEngagementChangedEvent;
 import com.group7.backend.event.FeedPostSharedEvent;
 import com.group7.backend.exception.ResourceNotFoundException;
 import com.group7.backend.repository.FeedPostBookmarkRepository;
@@ -159,6 +160,7 @@ public class FeedInteractionService {
             nowLiked = true;
             publishEngagement(post, userId);
         }
+        publishEngagementChanged(post);
         log.info("Toggle like: postId={}, userId={}, nowLiked={}", postId, userId, nowLiked);
         if (nowLiked && !userId.equals(post.getAuthorId())) {
             notificationEventPublisher.publishFeedLike(
@@ -256,6 +258,7 @@ public class FeedInteractionService {
         FeedPost post = requireVisiblePost(postId);
         shareRepository.save(new FeedPostShare(postId, sharerId));
         publishEngagement(post, sharerId);
+        publishEngagementChanged(post);
         log.info("Recorded share: postId={}, sharerId={}", postId, sharerId);
         if (!sharerId.equals(post.getAuthorId())) {
             notificationEventPublisher.publishFeedShare(
@@ -319,6 +322,7 @@ public class FeedInteractionService {
                 OffsetDateTime.now()));
 
         publishEngagement(post, sharerId);
+        publishEngagementChanged(post);
         log.info("Recorded repost: postId={}, sharerId={}, hasCommentary={}",
                 postId, sharerId, body != null);
 
@@ -347,6 +351,7 @@ public class FeedInteractionService {
         comment.setUpdatedAt(now);
         FeedPostComment saved = commentRepository.save(comment);
         publishEngagement(post, authorId);
+        publishEngagementChanged(post);
         log.info("Created comment: id={}, postId={}, authorId={}", saved.getId(), postId, authorId);
         String actorFirstName = resolveAuthorName(authorId);
         if (!authorId.equals(post.getAuthorId())) {
@@ -414,6 +419,10 @@ public class FeedInteractionService {
         }
         comment.setDeletedAt(OffsetDateTime.now());
         commentRepository.save(comment);
+        // Parent may have been soft-deleted concurrently — skip the push in
+        // that case because no follower has the post visible anyway.
+        feedPostRepository.findByIdAndDeletedAtIsNull(comment.getPostId())
+                .ifPresent(this::publishEngagementChanged);
         log.info("Soft-deleted comment: id={}, authorId={}", commentId, requesterId);
     }
 
@@ -488,6 +497,10 @@ public class FeedInteractionService {
             // Mirrors the contract documented on publishEngagement.
             publishEngagement(post, userId);
         }
+        // Engagement push fires on both branches as a heartbeat — post.commentCount
+        // is unchanged, but the frontend uses the push to refresh comment-likes
+        // on an open post-detail view.
+        publishEngagementChanged(post);
         log.info("Toggle comment like: commentId={}, postId={}, userId={}, nowLiked={}",
                 commentId, comment.getPostId(), userId, nowLiked);
         return mapComment(
@@ -564,6 +577,32 @@ public class FeedInteractionService {
         if (!hashtags.isEmpty()) {
             eventPublisher.publishEvent(new FeedEngagementEvent(viewerId, hashtags));
         }
+    }
+
+    /**
+     * Publishes a {@link FeedPostEngagementChangedEvent} carrying the
+     * post-flush authoritative counts. The {@code @TransactionalEventListener}
+     * subscriber broadcasts a {@link com.group7.backend.dto.response.FeedEngagementPushPayload}
+     * to the author's followers plus the author themselves so visible
+     * feed cards can refresh counts without polling.
+     *
+     * <p>Counts are queried via {@link #interactionState} inside the same
+     * {@code @Transactional} boundary as the mutating write — Hibernate
+     * flushes before the SELECTs, so the counts include the just-written
+     * row. {@code viewerId} is {@code null} because the listener fans out
+     * to many viewers and per-viewer toggle flags aren't part of the push
+     * contract.
+     */
+    private void publishEngagementChanged(FeedPost post) {
+        if (post == null) return;
+        FeedPostInteractionState state = interactionState(post.getId(), null);
+        eventPublisher.publishEvent(new FeedPostEngagementChangedEvent(
+                post.getId(),
+                post.getAuthorId(),
+                state.likeCount(),
+                state.commentCount(),
+                state.shareCount(),
+                OffsetDateTime.now()));
     }
 
     /**

--- a/backend/src/test/java/com/group7/backend/integration/FeedRealtimeIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedRealtimeIntegrationTest.java
@@ -3,6 +3,7 @@ package com.group7.backend.integration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.group7.backend.dto.request.LoginRequest;
 import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.dto.response.FeedEngagementPushPayload;
 import com.group7.backend.dto.response.FeedPostPushPayload;
 import com.group7.backend.dto.response.FeedSharePushPayload;
 import com.group7.backend.dto.response.FeedUnreadCountResponse;
@@ -49,6 +50,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -329,7 +331,350 @@ class FeedRealtimeIntegrationTest {
         assertThat(third.getBody().count()).isZero();
     }
 
+    // ── Engagement push payload (#562) ────────────────────────────────────────
+
+    @Test
+    void followerReceivesEngagementPush_onLike() throws Exception {
+        EngagementFixture fx = setupEngagementFixture("like");
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        // Actor likes the author's post; the push fires to the author's
+        // followers (and the author themselves).
+        ResponseEntity<String> resp = restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/like",
+                HttpMethod.POST, authedJson(fx.actorToken(), null), String.class);
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+
+        FeedEngagementPushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered.postId()).isEqualTo(fx.postId());
+        assertThat(delivered.likeCount()).isEqualTo(1L);
+        assertThat(delivered.commentCount()).isZero();
+        assertThat(delivered.shareCount()).isZero();
+        assertThat(delivered.updatedAt()).isNotNull();
+
+        session.disconnect();
+    }
+
+    @Test
+    void followerReceivesEngagementPush_onUnlike() throws Exception {
+        EngagementFixture fx = setupEngagementFixture("unlike");
+        // Actor likes BEFORE the follower subscribes — that first push is
+        // dropped by the broker. Subscribe, then actor unlikes; the unlike
+        // push must arrive with likeCount=0.
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/like",
+                HttpMethod.POST, authedJson(fx.actorToken(), null), String.class);
+
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/like",
+                HttpMethod.POST, authedJson(fx.actorToken(), null), String.class);
+
+        FeedEngagementPushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered.likeCount()).isZero();
+
+        session.disconnect();
+    }
+
+    @Test
+    void followerReceivesEngagementPush_onComment() throws Exception {
+        EngagementFixture fx = setupEngagementFixture("comment");
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/comments",
+                HttpMethod.POST,
+                authedJson(fx.actorToken(), Map.of("body", "engagement comment")),
+                String.class);
+
+        FeedEngagementPushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered.commentCount()).isEqualTo(1L);
+        assertThat(delivered.likeCount()).isZero();
+        assertThat(delivered.shareCount()).isZero();
+
+        session.disconnect();
+    }
+
+    @Test
+    void followerReceivesEngagementPush_onCommentDelete() throws Exception {
+        EngagementFixture fx = setupEngagementFixture("comment-delete");
+        // Comment exists BEFORE the follower subscribes (creation push is dropped).
+        ResponseEntity<String> commentResp = restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/comments",
+                HttpMethod.POST,
+                authedJson(fx.actorToken(), Map.of("body", "to be deleted")),
+                String.class);
+        Long commentId = objectMapper.readTree(commentResp.getBody()).get("id").asLong();
+
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/comments/" + commentId,
+                HttpMethod.DELETE, authedJson(fx.actorToken(), null), String.class);
+
+        FeedEngagementPushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        // Soft-deleted comments fall out of the visible commentCount.
+        assertThat(delivered.commentCount()).isZero();
+
+        session.disconnect();
+    }
+
+    @Test
+    void followerReceivesEngagementPush_onShare() throws Exception {
+        EngagementFixture fx = setupEngagementFixture("share");
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/share",
+                HttpMethod.POST, authedJson(fx.actorToken(), null), String.class);
+
+        FeedEngagementPushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered.shareCount()).isEqualTo(1L);
+
+        session.disconnect();
+    }
+
+    @Test
+    void followerReceivesEngagementPush_onRepost() throws Exception {
+        EngagementFixture fx = setupEngagementFixture("repost");
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        // Actor (no followers) reposts; FeedSharePushPayload fanout finds zero
+        // recipients, so only the engagement push reaches the follower.
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/reposts",
+                HttpMethod.POST, authedJson(fx.actorToken(), Map.of()), String.class);
+
+        FeedEngagementPushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered.shareCount()).isEqualTo(1L);
+
+        session.disconnect();
+    }
+
+    @Test
+    void followerReceivesEngagementPush_onCommentLike() throws Exception {
+        EngagementFixture fx = setupEngagementFixture("comment-like");
+        // Author writes a comment so the actor has something to like. This
+        // addComment fires a push that is dropped (no subscriber yet).
+        ResponseEntity<String> commentResp = restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/comments",
+                HttpMethod.POST,
+                authedJson(fx.authorToken(), Map.of("body", "comment by author")),
+                String.class);
+        Long commentId = objectMapper.readTree(commentResp.getBody()).get("id").asLong();
+
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/comments/" + commentId + "/like",
+                HttpMethod.POST, authedJson(fx.actorToken(), null), String.class);
+
+        // Heartbeat: post.commentCount is unchanged (1), but the push still
+        // fires so the frontend's comment-detail view can refresh comment-likes.
+        FeedEngagementPushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered.postId()).isEqualTo(fx.postId());
+        assertThat(delivered.commentCount()).isEqualTo(1L);
+        assertThat(delivered.likeCount()).isZero();
+
+        session.disconnect();
+    }
+
+    @Test
+    void authorAlsoReceivesEngagementPush_onOwnPostLiked() throws Exception {
+        // Author isn't in their own follower set (you can't follow yourself),
+        // so the routing rule explicitly adds the author. Verifies that branch.
+        EngagementFixture fx = setupEngagementFixture("author-self");
+        StompSession session = connect(fx.authorToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.authorId());
+        Thread.sleep(2000);
+
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/like",
+                HttpMethod.POST, authedJson(fx.actorToken(), null), String.class);
+
+        FeedEngagementPushPayload delivered = received.poll(5, TimeUnit.SECONDS);
+        assertThat(delivered).isNotNull();
+        assertThat(delivered.likeCount()).isEqualTo(1L);
+
+        session.disconnect();
+    }
+
+    @Test
+    void engagementPush_carriesAuthoritativeCounts() throws Exception {
+        // Three different likers in sequence — each push must carry the
+        // absolute count (1, then 2, then 3), not a delta.
+        EngagementFixture fx = setupEngagementFixture("authoritative");
+        String liker2Token = registerAndLogin("ws_engage_liker2_authoritative@test.com", false, "Liker2");
+        String liker3Token = registerAndLogin("ws_engage_liker3_authoritative@test.com", false, "Liker3");
+
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        for (String token : java.util.List.of(fx.actorToken(), liker2Token, liker3Token)) {
+            ResponseEntity<String> resp = restTemplate.exchange(
+                    "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/like",
+                    HttpMethod.POST, authedJson(token, null), String.class);
+            assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        }
+
+        FeedEngagementPushPayload first = received.poll(5, TimeUnit.SECONDS);
+        FeedEngagementPushPayload second = received.poll(5, TimeUnit.SECONDS);
+        FeedEngagementPushPayload third = received.poll(5, TimeUnit.SECONDS);
+        assertThat(first).isNotNull();
+        assertThat(second).isNotNull();
+        assertThat(third).isNotNull();
+        assertThat(first.likeCount()).isEqualTo(1L);
+        assertThat(second.likeCount()).isEqualTo(2L);
+        assertThat(third.likeCount()).isEqualTo(3L);
+
+        session.disconnect();
+    }
+
+    @Test
+    void engagementPush_skippedOnEditComment() throws Exception {
+        // Comment edit changes updatedAt but no count — must NOT push. We
+        // confirm by editing first, then triggering a known like push and
+        // asserting only one frame arrives (the like) with commentCount=1.
+        EngagementFixture fx = setupEngagementFixture("edit-comment-skip");
+        ResponseEntity<String> commentResp = restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/comments",
+                HttpMethod.POST,
+                authedJson(fx.actorToken(), Map.of("body", "original")),
+                String.class);
+        Long commentId = objectMapper.readTree(commentResp.getBody()).get("id").asLong();
+
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        // Edit — no push expected. mockMvc because the default
+        // TestRestTemplate request factory rejects PATCH.
+        mockMvc.perform(patch("/api/feed/comments/" + commentId)
+                        .header("Authorization", "Bearer " + fx.actorToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("body", "edited"))))
+                .andExpect(status().isOk());
+
+        // Forcing a known push.
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/like",
+                HttpMethod.POST, authedJson(fx.actorToken(), null), String.class);
+
+        FeedEngagementPushPayload first = received.poll(5, TimeUnit.SECONDS);
+        assertThat(first).isNotNull();
+        assertThat(first.likeCount()).isEqualTo(1L);
+        assertThat(first.commentCount()).isEqualTo(1L);
+        // No second frame from the earlier edit.
+        FeedEngagementPushPayload extra = received.poll(1, TimeUnit.SECONDS);
+        assertThat(extra).isNull();
+
+        session.disconnect();
+    }
+
+    @Test
+    void engagementPush_skippedOnBookmark() throws Exception {
+        // Bookmark is private-state; per the issue's "(bookmark is optional)"
+        // caveat we deliberately don't fire the push. Same two-phase shape as
+        // the edit-comment-skip test.
+        EngagementFixture fx = setupEngagementFixture("bookmark-skip");
+        StompSession session = connect(fx.followerToken());
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = subscribeEngagement(session, fx.followerId());
+        Thread.sleep(2000);
+
+        // Bookmark — no push expected.
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/bookmark",
+                HttpMethod.POST, authedJson(fx.actorToken(), null), String.class);
+
+        // Forcing a known push.
+        restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts/" + fx.postId() + "/like",
+                HttpMethod.POST, authedJson(fx.actorToken(), null), String.class);
+
+        FeedEngagementPushPayload first = received.poll(5, TimeUnit.SECONDS);
+        assertThat(first).isNotNull();
+        assertThat(first.likeCount()).isEqualTo(1L);
+        FeedEngagementPushPayload extra = received.poll(1, TimeUnit.SECONDS);
+        assertThat(extra).isNull();
+
+        session.disconnect();
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────────
+
+    private record EngagementFixture(String authorToken, String followerToken, String actorToken,
+                                      Long authorId, Long followerId, Long actorId,
+                                      Long postId) {
+    }
+
+    /**
+     * Standard fixture for engagement-push tests: author + follower (follows
+     * the author) + actor (the third party who performs the engagement) +
+     * a freshly-created post by the author. The post is created BEFORE any
+     * STOMP subscription so the post-creation FeedPostPushPayload broadcast
+     * is dropped by the broker and does not contaminate engagement assertions.
+     */
+    private EngagementFixture setupEngagementFixture(String suffix) throws Exception {
+        String authorToken = registerAndLogin("ws_engage_author_" + suffix + "@test.com", true, "Author");
+        String followerToken = registerAndLogin("ws_engage_follower_" + suffix + "@test.com", false, "Follower");
+        String actorToken = registerAndLogin("ws_engage_actor_" + suffix + "@test.com", false, "Actor");
+        Long authorId = userRepository.findByEmail("ws_engage_author_" + suffix + "@test.com").orElseThrow().getId();
+        Long followerId = userRepository.findByEmail("ws_engage_follower_" + suffix + "@test.com").orElseThrow().getId();
+        Long actorId = userRepository.findByEmail("ws_engage_actor_" + suffix + "@test.com").orElseThrow().getId();
+
+        ResponseEntity<String> followResp = restTemplate.exchange(
+                "http://localhost:" + port + "/api/users/" + authorId + "/follow",
+                HttpMethod.POST, authedJson(followerToken, null), String.class);
+        assertThat(followResp.getStatusCode().is2xxSuccessful()).isTrue();
+
+        ResponseEntity<String> createResp = restTemplate.exchange(
+                "http://localhost:" + port + "/api/feed/posts",
+                HttpMethod.POST,
+                authedJson(authorToken, Map.of("body", "engagement post " + suffix, "hashtags", java.util.List.of())),
+                String.class);
+        assertThat(createResp.getStatusCode().value()).isEqualTo(201);
+        Long postId = objectMapper.readTree(createResp.getBody()).get("id").asLong();
+
+        return new EngagementFixture(authorToken, followerToken, actorToken,
+                authorId, followerId, actorId, postId);
+    }
+
+    private LinkedBlockingDeque<FeedEngagementPushPayload> subscribeEngagement(StompSession session,
+                                                                                Long topicUserId) {
+        LinkedBlockingDeque<FeedEngagementPushPayload> received = new LinkedBlockingDeque<>();
+        session.subscribe("/topic/feed." + topicUserId, new StompFrameHandler() {
+            @Override public Type getPayloadType(StompHeaders headers) { return FeedEngagementPushPayload.class; }
+            @Override public void handleFrame(StompHeaders headers, Object payload) {
+                if (payload instanceof FeedEngagementPushPayload p) {
+                    received.add(p);
+                }
+            }
+        });
+        return received;
+    }
 
     private record Pair(String authorToken, String followerToken,
                          Long authorId, Long followerId) {


### PR DESCRIPTION
## Summary

Closes the gap web's #356 left open: like / comment / share counts on visible feed cards still required polling because the existing STOMP fanout (`FeedPostPushPayload` / `FeedSharePushPayload`) only carries timeline entries, not engagement state.

This PR adds a third payload — `FeedEngagementPushPayload` — broadcast over `/topic/feed.{userId}` whenever an engagement mutation commits, so visible cards update without polling.

## Wire shape

| Payload | Discriminator | Routing |
| --- | --- | --- |
| `FeedPostPushPayload` | has `authorId`, no `sharerId` | author's followers |
| `FeedSharePushPayload` | has `sharerId` | sharer's followers |
| `FeedEngagementPushPayload` *(new)* | has neither, only `postId` + counts | author's followers ∪ {authorId} |

```json
{ "postId": 42, "likeCount": 12, "commentCount": 3, "shareCount": 5, "updatedAt": "..." }
```

Counts are absolute (not deltas), so a dropped STOMP frame self-heals on the next received one.

## Fires on

- `toggleLike` — both insert and delete branches
- `recordShare` — `/share` endpoint
- `recordRepost` — fresh-insert only (idempotency-window collapses skip the push)
- `addComment`
- `deleteComment` — soft-delete; skipped if the parent post is itself soft-deleted
- `toggleCommentLike` — both branches, as a heartbeat for an open post-detail view

## Deliberately skipped

- **`toggleBookmark`** — bookmark is private-state per the issue's "(bookmark is optional)" caveat; live broadcast adds STOMP noise with no UX value.
- **`editComment`** — body change without count change.

## Routing decision

Author's followers plus the author themselves (a user can't follow themselves, so the union is explicit). Non-follower viewers (search, For-You discovery, direct link) fall back to polling on next interaction — documented as a known v1 limitation. Per-post topics would close that gap but add frontend subscription-lifecycle complexity for a marginal reach gain.

## Test coverage

Eleven new STOMP integration tests in `FeedRealtimeIntegrationTest`:

1. `followerReceivesEngagementPush_onLike`
2. `followerReceivesEngagementPush_onUnlike` *(DELETE branch regression)*
3. `followerReceivesEngagementPush_onComment`
4. `followerReceivesEngagementPush_onCommentDelete`
5. `followerReceivesEngagementPush_onShare`
6. `followerReceivesEngagementPush_onRepost`
7. `followerReceivesEngagementPush_onCommentLike` *(heartbeat: post `commentCount` unchanged)*
8. `authorAlsoReceivesEngagementPush_onOwnPostLiked` *(routing regression: author + followers)*
9. `engagementPush_carriesAuthoritativeCounts` *(three likers → counts 1, 2, 3)*
10. `engagementPush_skippedOnEditComment` *(forces a known like push afterward, asserts only one frame arrives)*
11. `engagementPush_skippedOnBookmark` *(same pattern)*

Scoped run: `FeedRealtimeIntegrationTest` 16/16 green (5 pre-existing + 11 new).
Full `mvn --batch-mode verify`: 2237/2238 green; the single failure is the pre-existing flaky `EndToEndWorkflowTest.rejectionPathSendsNotification` (notification-event race, unrelated to this PR).

## Implementation notes

- `FeedInteractionService.publishEngagementChanged` queries `interactionState(postId, null)` inside the same `@Transactional` boundary as the mutating write — Hibernate's flush-on-query mode ensures the SELECTs see the just-inserted/deleted row.
- `FeedFanoutListener.onFeedPostEngagementChanged` reuses the existing `broadcastTo(Set<Long>, Object, Long)` helper (already untyped after the share-fanout work in #484).
- No DB migration, no controller change, no SecurityConfig change.

## Known limitations

- Non-follower viewers (search, For-You discovery, direct profile link) miss live updates. Polling remains the fallback.
- High-engagement burst on a popular author with N followers fires N+1 STOMP frames per engagement. Spring's in-memory `SimpleBroker` handles this comfortably at class-project scale; production scale would warrant per-post topics, a STOMP relay broker, or a debounce window — out of scope for v1.
- Comment-like heartbeat reuses the post-level payload (`commentCount` unchanged); a richer `FeedCommentEngagementPushPayload` with `commentId` + `commentLikeCount` is a follow-up if comment-level live updates become a hot UX path.

## Out of scope

- Bookmark engagement push (issue marks bookmark optional).
- Edit-comment push (no count change).
- Per-post topic routing (`/topic/feed.post.{postId}`).
- Coalescing / debounce for engagement bursts.
- Frontend integration — a parallel web PR threads this payload through to `useFeedSubscription`'s `onEngagement` branch.

Closes #562