### PR TITLE
feat(backend): admin user list and lookup endpoints (#569)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/AdminController.java
+++ b/backend/src/main/java/com/group7/backend/controller/AdminController.java
@@ -1,7 +1,13 @@
 package com.group7.backend.controller;
 
+import com.group7.backend.controller.support.PageableSupport;
 import com.group7.backend.dto.request.AdminBanRequest;
+import com.group7.backend.dto.request.AdminUserBanStatusFilter;
+import com.group7.backend.dto.request.AdminUserRoleFilter;
+import com.group7.backend.dto.response.AdminUserDetailResponse;
+import com.group7.backend.dto.response.AdminUserListItem;
 import com.group7.backend.dto.response.BanResponse;
+import com.group7.backend.service.AdminUserQueryService;
 import com.group7.backend.service.BanService;
 import com.group7.backend.service.SpamDetectionService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +18,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -20,6 +28,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
@@ -32,10 +41,14 @@ public class AdminController {
 
     private final BanService banService;
     private final SpamDetectionService spamDetectionService;
+    private final AdminUserQueryService adminUserQueryService;
 
-    public AdminController(BanService banService, SpamDetectionService spamDetectionService) {
+    public AdminController(BanService banService,
+                           SpamDetectionService spamDetectionService,
+                           AdminUserQueryService adminUserQueryService) {
         this.banService = banService;
         this.spamDetectionService = spamDetectionService;
+        this.adminUserQueryService = adminUserQueryService;
     }
 
     @GetMapping("/me")
@@ -46,6 +59,48 @@ public class AdminController {
                 "email", authentication.getPrincipal(),
                 "role", "ADMIN"
         ));
+    }
+
+    @GetMapping("/users")
+    @Operation(summary = "List users for the admin panel (#569)",
+            description = "Paginated listing across all roles with optional role / "
+                    + "ban-status / keyword filters. Page size is clamped to 100. "
+                    + "Ordered newest user first (createdAt desc, id desc).")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Page of users"),
+            @ApiResponse(responseCode = "403", description = "Not an admin", content = @Content)
+    })
+    public ResponseEntity<Page<AdminUserListItem>> listUsers(
+            @Parameter(description = "Restrict to a single role. Omit for all roles.")
+            @RequestParam(required = false) AdminUserRoleFilter role,
+            @Parameter(description = "ACTIVE = users with a current ban "
+                    + "(lifted_at IS NULL AND expires_at > now); "
+                    + "NONE = users without one. Omit to include both.")
+            @RequestParam(required = false) AdminUserBanStatusFilter banStatus,
+            @Parameter(description = "Keyword matched against firstName / lastName / "
+                    + "email (case-insensitive). Inputs shorter than 3 alphanumerics "
+                    + "are ignored.")
+            @RequestParam(required = false) String q,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageableSupport.clampPageable(page, size);
+        return ResponseEntity.ok(
+                adminUserQueryService.listUsers(role, banStatus, q, pageable));
+    }
+
+    @GetMapping("/users/{id}")
+    @Operation(summary = "Get a user's admin drill-down view (#569)",
+            description = "Returns the role-specific profile (Mentor / Mentee / Admin) "
+                    + "plus full ban history (newest first) and the spam-bot flag. "
+                    + "Admin-on-admin reads are intentional for this endpoint.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "User detail"),
+            @ApiResponse(responseCode = "403", description = "Not an admin", content = @Content),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content)
+    })
+    public ResponseEntity<AdminUserDetailResponse> getUserDetail(
+            @Parameter(description = "Target user id") @PathVariable Long id) {
+        return ResponseEntity.ok(adminUserQueryService.getUserDetail(id));
     }
 
     @PostMapping("/users/{userId}/ban")

--- a/backend/src/main/java/com/group7/backend/dto/request/AdminUserBanStatusFilter.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/AdminUserBanStatusFilter.java
@@ -1,0 +1,18 @@
+package com.group7.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Optional ban-status filter for {@code GET /api/admin/users}. "Active"
+ * here is defined exactly as in
+ * {@link com.group7.backend.repository.BanRepository#findActive}:
+ * {@code lifted_at IS NULL AND expires_at > now}. Expired or lifted bans
+ * resolve to {@link #NONE}.
+ */
+@Schema(description = "Active-ban filter for the admin user list (#569). "
+        + "When omitted, both banned and unbanned users are returned.",
+        enumAsRef = true)
+public enum AdminUserBanStatusFilter {
+    ACTIVE,
+    NONE
+}

--- a/backend/src/main/java/com/group7/backend/dto/request/AdminUserRoleFilter.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/AdminUserRoleFilter.java
@@ -1,0 +1,22 @@
+package com.group7.backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Optional role filter for {@code GET /api/admin/users}. Maps directly to
+ * the {@code type(u) = ...} discriminator in
+ * {@link com.group7.backend.repository.UserRepository#findAdminUsers}.
+ *
+ * <p>Kept as an enum rather than a free-form string so Spring's
+ * {@code StringToEnumConverter} rejects invalid values with a 400 before
+ * the request hits the service — the alternative (a {@code String} +
+ * service-level validation) duplicates error mapping for no gain.
+ */
+@Schema(description = "Role discriminator for the admin user list (#569). "
+        + "When omitted, all roles are returned.",
+        enumAsRef = true)
+public enum AdminUserRoleFilter {
+    MENTOR,
+    MENTEE,
+    ADMIN
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/AdminUserDetailResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/AdminUserDetailResponse.java
@@ -1,0 +1,98 @@
+package com.group7.backend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Ban;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Full profile + ban history payload returned by
+ * {@code GET /api/admin/users/{id}} (#569). The list view
+ * ({@link AdminUserListItem}) is a lightweight projection used for paging;
+ * this detail view is the admin panel's drill-down.
+ *
+ * <p>{@code @JsonUnwrapped} keeps the wire shape additive: the existing
+ * mentor/mentee/admin fields stay at the top level of the JSON, and the
+ * extra audit fields ({@code banHistory}, {@code suspectedBot},
+ * {@code suspectedAt}) appear alongside them. This mirrors the pattern
+ * established by {@link UserProfileResponse} for the public profile
+ * endpoint.
+ *
+ * <p>The factory {@link #from(User, List)} dispatches on the JOINED
+ * subclass and produces an {@link AdminResponse} when the target is
+ * itself an admin — admin-on-admin reads are intentional for this
+ * endpoint (the panel needs to surface every user; admin opacity to
+ * third parties stays enforced by the class-level {@code hasRole('ADMIN')}
+ * gate on {@code AdminController}).
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Admin user detail (#569): role-specific profile plus full ban "
+        + "history and spam-bot flag.")
+public class AdminUserDetailResponse {
+
+    @JsonUnwrapped
+    private ProfileResponse profile;
+
+    @Schema(description = "Full ban history for the user, newest first. Includes "
+            + "active, lifted, and expired entries. Empty when the user has no bans.")
+    private List<BanResponse> banHistory;
+
+    @Schema(description = "Spam-detection flag (#345). Independent of ban status; "
+            + "stays true after an admin lifts the auto-ban unless the flag is "
+            + "cleared via POST /api/admin/users/{id}/clear-bot-flag.",
+            example = "false")
+    private Boolean suspectedBot;
+
+    @Schema(description = "Timestamp the spam flag was raised. Null when "
+            + "suspectedBot is false.")
+    private OffsetDateTime suspectedAt;
+
+    /**
+     * Builds the response from a fully-loaded {@link User} entity plus the
+     * ordered ban history. Dispatch mirrors {@code UserService.mapToResponse}
+     * so the wire shape matches whatever {@code GET /api/users/{id}} would
+     * have produced for the same target (with the {@link Admin} branch
+     * additionally available — admins are never exposed by the public
+     * endpoint).
+     *
+     * @throws IllegalStateException if the entity is not a Mentor, Mentee,
+     *         or Admin (defensive — the JOINED hierarchy has exactly those
+     *         three permitted subclasses today)
+     */
+    public static AdminUserDetailResponse from(User user, List<Ban> bans) {
+        ProfileResponse profile;
+        if (user instanceof Mentor mentor) {
+            profile = MentorResponse.from(mentor);
+        } else if (user instanceof Mentee mentee) {
+            profile = MenteeResponse.from(mentee);
+        } else if (user instanceof Admin admin) {
+            profile = AdminResponse.from(admin);
+        } else {
+            throw new IllegalStateException(
+                    "Unknown user type: " + user.getClass().getSimpleName());
+        }
+
+        List<BanResponse> banResponses = bans.stream()
+                .map(BanResponse::from)
+                .toList();
+
+        return new AdminUserDetailResponse(
+                profile,
+                banResponses,
+                user.getIsSuspectedBot(),
+                user.getSuspectedAt());
+    }
+}

--- a/backend/src/main/java/com/group7/backend/dto/response/AdminUserListItem.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/AdminUserListItem.java
@@ -1,0 +1,63 @@
+package com.group7.backend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Row in the admin user listing ({@code GET /api/admin/users}, #569).
+ *
+ * <p>Built directly by Hibernate via the JPQL {@code select new ...(...)}
+ * projection in
+ * {@link com.group7.backend.repository.UserRepository#findAdminUsers}.
+ * Constructor parameter order is therefore <strong>load-bearing</strong> —
+ * it must match the projection column order exactly.
+ *
+ * <p>{@code banStatus} is the derived predicate from {@link com.group7.backend.repository.BanRepository#findActive}
+ * (i.e. {@code lifted_at IS NULL AND expires_at > now}), encoded as
+ * {@code "ACTIVE"} or {@code "NONE"} so the list view doesn't have to
+ * fan out a per-row ban-history query.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Row in the admin user list (#569). Lightweight projection; "
+        + "use GET /api/admin/users/{id} for the full profile + ban history.")
+public class AdminUserListItem {
+
+    @Schema(description = "User id", example = "42")
+    private Long id;
+
+    @Schema(description = "First name", example = "Ayse")
+    private String firstName;
+
+    @Schema(description = "Last name", example = "Demir")
+    private String lastName;
+
+    @Schema(description = "Email address", example = "ayse@example.com")
+    private String email;
+
+    @Schema(description = "User role.", example = "MENTOR",
+            allowableValues = {"MENTOR", "MENTEE", "ADMIN"})
+    private String role;
+
+    @Schema(description = "Whether the user currently has an active ban "
+            + "(lifted_at IS NULL AND expires_at > now). Mirrors BanRepository.findActive.",
+            example = "ACTIVE",
+            allowableValues = {"ACTIVE", "NONE"})
+    private String banStatus;
+
+    @Schema(description = "Whether the spam-detection flag is set on the user (#345). "
+            + "Independent of ban status: a user may be flagged without a current ban "
+            + "if an admin lifted the auto-ban without clearing the flag.",
+            example = "false")
+    private Boolean suspectedBot;
+
+    @Schema(description = "Account creation timestamp.")
+    private OffsetDateTime createdAt;
+}

--- a/backend/src/main/java/com/group7/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.group7.backend.repository;
 
+import com.group7.backend.dto.response.AdminUserListItem;
 import com.group7.backend.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -85,4 +86,80 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     @Query("select u.id from User u where type(u) = com.group7.backend.entity.Admin")
     List<Long> findAllAdminIds();
+
+    /**
+     * Constructor projection backing the admin user listing (#569). Returns
+     * one {@link AdminUserListItem} per matching user with role and active-ban
+     * status derived in a single SQL pass.
+     *
+     * <p>Filter semantics:
+     * <ul>
+     *   <li>Role: callers pass exactly one of {@code roleMentor /
+     *       roleMentee / roleAdmin} as {@code Boolean.TRUE} and the rest as
+     *       {@code null}. Each {@code null} flag short-circuits its
+     *       discriminator predicate; when all three are {@code null} the
+     *       filter is inactive and every role is returned.</li>
+     *   <li>Ban status: {@code banActive=true} restricts to users with an
+     *       active ban exactly as defined by {@link BanRepository#findActive}
+     *       ({@code lifted_at IS NULL AND expires_at > :now}).
+     *       {@code banActive=false} restricts to users <em>without</em>
+     *       such a row (so lifted/expired bans are included in this bucket).
+     *       {@code null} skips the filter.</li>
+     *   <li>Keyword: pre-escaped, pre-lowercased {@code "%term%"} pattern
+     *       produced by {@code SearchNormaliser.keyword(...)} (or {@code null}
+     *       for inputs shorter than 3 chars). Matches {@code firstName /
+     *       lastName / email}, all lowercased and escape-prefixed with
+     *       {@code '|'} for safety.</li>
+     * </ul>
+     *
+     * <p>Order: newest user first ({@code createdAt desc, id desc}). The id
+     * tiebreaker keeps pagination stable when seed data shares a creation
+     * timestamp (common in fixture-driven tests). Constructor projection
+     * keeps the Spring Data auto-derived count query simple — the EXISTS
+     * subqueries don't appear in count derivation.
+     */
+    @Query("""
+            select new com.group7.backend.dto.response.AdminUserListItem(
+                u.id, u.firstName, u.lastName, u.email,
+                case when type(u) = com.group7.backend.entity.Mentor then 'MENTOR'
+                     when type(u) = com.group7.backend.entity.Mentee then 'MENTEE'
+                     when type(u) = com.group7.backend.entity.Admin  then 'ADMIN'
+                     else 'UNKNOWN' end,
+                case when exists (
+                         select 1 from Ban b
+                         where b.user.id = u.id
+                           and b.liftedAt is null
+                           and b.expiresAt > :now)
+                     then 'ACTIVE' else 'NONE' end,
+                u.isSuspectedBot,
+                u.createdAt)
+            from User u
+            where (:roleMentor is null or type(u) = com.group7.backend.entity.Mentor)
+              and (:roleMentee is null or type(u) = com.group7.backend.entity.Mentee)
+              and (:roleAdmin  is null or type(u) = com.group7.backend.entity.Admin)
+              and (:banActive is null
+                   or (:banActive = true and exists (
+                           select 1 from Ban b
+                           where b.user.id = u.id
+                             and b.liftedAt is null
+                             and b.expiresAt > :now))
+                   or (:banActive = false and not exists (
+                           select 1 from Ban b
+                           where b.user.id = u.id
+                             and b.liftedAt is null
+                             and b.expiresAt > :now)))
+              and (:keyword is null
+                   or lower(u.firstName) like :keyword escape '|'
+                   or lower(u.lastName)  like :keyword escape '|'
+                   or lower(u.email)     like :keyword escape '|')
+            order by u.createdAt desc, u.id desc
+            """)
+    Page<AdminUserListItem> findAdminUsers(
+            @Param("roleMentor") Boolean roleMentor,
+            @Param("roleMentee") Boolean roleMentee,
+            @Param("roleAdmin")  Boolean roleAdmin,
+            @Param("banActive")  Boolean banActive,
+            @Param("keyword")    String keyword,
+            @Param("now")        OffsetDateTime now,
+            Pageable pageable);
 }

--- a/backend/src/main/java/com/group7/backend/service/AdminUserQueryService.java
+++ b/backend/src/main/java/com/group7/backend/service/AdminUserQueryService.java
@@ -1,0 +1,99 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.request.AdminUserBanStatusFilter;
+import com.group7.backend.dto.request.AdminUserRoleFilter;
+import com.group7.backend.dto.response.AdminUserDetailResponse;
+import com.group7.backend.dto.response.AdminUserListItem;
+import com.group7.backend.entity.User;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+
+/**
+ * Read model for the admin user-management panel (#569).
+ *
+ * <p>Lives in {@code com.group7.backend.service} so it can reuse the
+ * package-private {@link SearchNormaliser#keyword(String)} helper. Carved
+ * out of {@code UserService} on purpose: the read shape (admin-only,
+ * role + ban-status + bot flag) is materially different from the public
+ * user-facing read paths, and folding it into {@code UserService} would
+ * blur the admin opacity boundary the rest of that class is designed to
+ * preserve.
+ *
+ * <p>Both queries are transactional read-only: no entity mutations occur
+ * along these paths, and the {@code readOnly = true} hint lets Hibernate
+ * skip dirty-checking on the loaded entity in {@link #getUserDetail}.
+ */
+@Service
+public class AdminUserQueryService {
+
+    private final UserRepository userRepository;
+    private final BanService banService;
+    private final Clock clock;
+
+    public AdminUserQueryService(UserRepository userRepository,
+                                 BanService banService,
+                                 Clock clock) {
+        this.userRepository = userRepository;
+        this.banService = banService;
+        this.clock = clock;
+    }
+
+    /**
+     * Lists users for the admin panel. The {@code role} and
+     * {@code banStatus} enum filters are independently optional; the
+     * {@code q} keyword is normalised via
+     * {@link SearchNormaliser#keyword(String)} (so inputs shorter than 3
+     * alphanumerics fall back to "no keyword filter" rather than triggering
+     * a pg_trgm seq-scan).
+     *
+     * <p>Ordering is newest-first ({@code createdAt desc, id desc}); the
+     * id tiebreaker keeps pagination deterministic when fixture data
+     * shares a timestamp.
+     */
+    @Transactional(readOnly = true)
+    public Page<AdminUserListItem> listUsers(AdminUserRoleFilter role,
+                                             AdminUserBanStatusFilter banStatus,
+                                             String q,
+                                             Pageable pageable) {
+        Boolean roleMentor = role == AdminUserRoleFilter.MENTOR ? Boolean.TRUE : null;
+        Boolean roleMentee = role == AdminUserRoleFilter.MENTEE ? Boolean.TRUE : null;
+        Boolean roleAdmin  = role == AdminUserRoleFilter.ADMIN  ? Boolean.TRUE : null;
+
+        Boolean banActive = switch (banStatus == null ? null : banStatus) {
+            case ACTIVE -> Boolean.TRUE;
+            case NONE   -> Boolean.FALSE;
+            case null   -> null;
+        };
+
+        String keyword = SearchNormaliser.keyword(q);
+
+        return userRepository.findAdminUsers(
+                roleMentor, roleMentee, roleAdmin,
+                banActive, keyword,
+                OffsetDateTime.now(clock),
+                pageable);
+    }
+
+    /**
+     * Returns the admin drill-down view for a single user: profile +
+     * full ban history (newest first) + spam flag. Reuses
+     * {@link BanService#listBansForUser(Long)} for the history so the
+     * audit ordering stays consistent with {@code GET /api/admin/bans/users/{userId}}.
+     *
+     * @throws ResourceNotFoundException 404 — no user with the given id
+     */
+    @Transactional(readOnly = true)
+    public AdminUserDetailResponse getUserDetail(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "User not found with id: " + id));
+        return AdminUserDetailResponse.from(user, banService.listBansForUser(id));
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/AdminUserDetailControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/AdminUserDetailControllerTest.java
@@ -1,0 +1,131 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.response.AdminUserDetailResponse;
+import com.group7.backend.dto.response.BanResponse;
+import com.group7.backend.dto.response.MentorResponse;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.service.AdminUserQueryService;
+import com.group7.backend.service.BanService;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.SpamDetectionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @WebMvcTest slice for GET /api/admin/users/{id} (#569). Covers happy
+ * path (profile + ban history wire shape via @JsonUnwrapped), 404 propagation
+ * from the service layer, and auth gating.
+ */
+@WebMvcTest(AdminController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class AdminUserDetailControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private AdminUserQueryService adminUserQueryService;
+    @MockitoBean private BanService banService;
+    @MockitoBean private SpamDetectionService spamDetectionService;
+    @MockitoBean private JwtService jwtService;
+
+    private static final String ADMIN_TOKEN = "admin-token";
+    private static final String MENTEE_TOKEN = "mentee-token";
+
+    private void mockJwt(String token, String role, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn(role.toLowerCase() + "@example.com");
+        when(jwtService.extractRole(token)).thenReturn(role);
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private AdminUserDetailResponse sampleDetail() {
+        MentorResponse mentor = new MentorResponse();
+        mentor.setId(42L);
+        mentor.setFirstName("Ayse");
+        mentor.setLastName("Demir");
+        mentor.setEmail("ayse@example.com");
+        mentor.setRole("MENTOR");
+        mentor.setIsEmailVerified(true);
+        mentor.setCreatedAt(OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC));
+        mentor.setBio("Backend engineer");
+
+        BanResponse activeBan = new BanResponse(
+                7L, 42L, "violation", 1,
+                OffsetDateTime.of(2026, 6, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                null, null,
+                OffsetDateTime.of(2026, 5, 5, 9, 0, 0, 0, ZoneOffset.UTC));
+        BanResponse oldBan = new BanResponse(
+                3L, 42L, "earlier", 1,
+                OffsetDateTime.of(2026, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                OffsetDateTime.of(2026, 4, 2, 0, 0, 0, 0, ZoneOffset.UTC),
+                10L,
+                OffsetDateTime.of(2026, 3, 31, 9, 0, 0, 0, ZoneOffset.UTC));
+
+        return new AdminUserDetailResponse(
+                mentor,
+                List.of(activeBan, oldBan),
+                Boolean.FALSE,
+                null);
+    }
+
+    @Test
+    void getUserDetail_asAdmin_returns200WithFlatJsonShape() throws Exception {
+        mockJwt(ADMIN_TOKEN, "ADMIN", 99L);
+        when(adminUserQueryService.getUserDetail(42L)).thenReturn(sampleDetail());
+
+        mockMvc.perform(get("/api/admin/users/42")
+                        .header("Authorization", "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                // Profile fields are unwrapped at the top level (matches the
+                // wire shape pattern set by UserProfileResponse).
+                .andExpect(jsonPath("$.id").value(42))
+                .andExpect(jsonPath("$.firstName").value("Ayse"))
+                .andExpect(jsonPath("$.lastName").value("Demir"))
+                .andExpect(jsonPath("$.email").value("ayse@example.com"))
+                .andExpect(jsonPath("$.role").value("MENTOR"))
+                .andExpect(jsonPath("$.bio").value("Backend engineer"))
+                // Admin-audit extras live alongside the profile fields.
+                .andExpect(jsonPath("$.banHistory.length()").value(2))
+                .andExpect(jsonPath("$.banHistory[0].id").value(7))
+                .andExpect(jsonPath("$.banHistory[0].liftedAt").doesNotExist())
+                .andExpect(jsonPath("$.banHistory[1].id").value(3))
+                .andExpect(jsonPath("$.banHistory[1].liftedAt").exists())
+                .andExpect(jsonPath("$.suspectedBot").value(false));
+    }
+
+    @Test
+    void getUserDetail_missingUser_returns404() throws Exception {
+        mockJwt(ADMIN_TOKEN, "ADMIN", 99L);
+        when(adminUserQueryService.getUserDetail(999L))
+                .thenThrow(new ResourceNotFoundException("User not found with id: 999"));
+
+        mockMvc.perform(get("/api/admin/users/999")
+                        .header("Authorization", "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("User not found with id: 999"));
+    }
+
+    @Test
+    void getUserDetail_nonAdmin_returns403() throws Exception {
+        mockJwt(MENTEE_TOKEN, "MENTEE", 1L);
+
+        mockMvc.perform(get("/api/admin/users/42")
+                        .header("Authorization", "Bearer " + MENTEE_TOKEN))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/controller/AdminUserListControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/AdminUserListControllerTest.java
@@ -1,0 +1,218 @@
+package com.group7.backend.controller;
+
+import com.group7.backend.config.JwtAuthenticationFilter;
+import com.group7.backend.config.SecurityConfig;
+import com.group7.backend.dto.request.AdminUserBanStatusFilter;
+import com.group7.backend.dto.request.AdminUserRoleFilter;
+import com.group7.backend.dto.response.AdminUserListItem;
+import com.group7.backend.service.AdminUserQueryService;
+import com.group7.backend.service.BanService;
+import com.group7.backend.service.JwtService;
+import com.group7.backend.service.SpamDetectionService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @WebMvcTest slice for GET /api/admin/users (#569). Covers auth gating,
+ * paged body shape, page-size clamping, and the three optional filter
+ * parameters individually + combined.
+ */
+@WebMvcTest(AdminController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class AdminUserListControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockitoBean private AdminUserQueryService adminUserQueryService;
+    // AdminController also depends on these two — provided as mocks so the
+    // slice context boots even though these endpoints don't exercise them.
+    @MockitoBean private BanService banService;
+    @MockitoBean private SpamDetectionService spamDetectionService;
+    @MockitoBean private JwtService jwtService;
+
+    private static final String ADMIN_TOKEN = "admin-token";
+    private static final String MENTEE_TOKEN = "mentee-token";
+
+    private void mockJwt(String token, String role, Long userId) {
+        when(jwtService.isTokenValid(token)).thenReturn(true);
+        when(jwtService.extractEmail(token)).thenReturn(role.toLowerCase() + "@example.com");
+        when(jwtService.extractRole(token)).thenReturn(role);
+        when(jwtService.extractUserId(token)).thenReturn(userId);
+    }
+
+    private AdminUserListItem sampleItem(Long id, String role, String banStatus) {
+        return new AdminUserListItem(
+                id,
+                "First" + id,
+                "Last" + id,
+                "user" + id + "@example.com",
+                role,
+                banStatus,
+                Boolean.FALSE,
+                OffsetDateTime.of(2026, 5, 1, 10, 0, 0, 0, ZoneOffset.UTC));
+    }
+
+    @Test
+    void listUsers_nonAdmin_returns403() throws Exception {
+        mockJwt(MENTEE_TOKEN, "MENTEE", 1L);
+
+        mockMvc.perform(get("/api/admin/users")
+                        .header("Authorization", "Bearer " + MENTEE_TOKEN))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void listUsers_unauthenticated_returns403() throws Exception {
+        mockMvc.perform(get("/api/admin/users"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void listUsers_asAdmin_returnsPagedBody() throws Exception {
+        mockJwt(ADMIN_TOKEN, "ADMIN", 99L);
+        when(adminUserQueryService.listUsers(isNull(), isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(
+                        sampleItem(1L, "MENTOR", "NONE"),
+                        sampleItem(2L, "MENTEE", "ACTIVE"))));
+
+        mockMvc.perform(get("/api/admin/users")
+                        .header("Authorization", "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].firstName").value("First1"))
+                .andExpect(jsonPath("$.content[0].role").value("MENTOR"))
+                .andExpect(jsonPath("$.content[0].banStatus").value("NONE"))
+                .andExpect(jsonPath("$.content[0].suspectedBot").value(false))
+                .andExpect(jsonPath("$.content[0].createdAt").exists())
+                .andExpect(jsonPath("$.content[1].id").value(2))
+                .andExpect(jsonPath("$.content[1].role").value("MENTEE"))
+                .andExpect(jsonPath("$.content[1].banStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    void listUsers_clampsSizeOver100() throws Exception {
+        mockJwt(ADMIN_TOKEN, "ADMIN", 99L);
+        when(adminUserQueryService.listUsers(any(), any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/admin/users?size=9999")
+                        .header("Authorization", "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(adminUserQueryService).listUsers(
+                isNull(), isNull(), isNull(), pageableCaptor.capture());
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(100);
+    }
+
+    @Test
+    void listUsers_filterByRole_mentor() throws Exception {
+        mockJwt(ADMIN_TOKEN, "ADMIN", 99L);
+        when(adminUserQueryService.listUsers(
+                eq(AdminUserRoleFilter.MENTOR), isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(sampleItem(1L, "MENTOR", "NONE"))));
+
+        mockMvc.perform(get("/api/admin/users?role=MENTOR")
+                        .header("Authorization", "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].role").value("MENTOR"));
+
+        verify(adminUserQueryService).listUsers(
+                eq(AdminUserRoleFilter.MENTOR), isNull(), isNull(), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_filterByBanStatus_active() throws Exception {
+        mockJwt(ADMIN_TOKEN, "ADMIN", 99L);
+        when(adminUserQueryService.listUsers(
+                isNull(), eq(AdminUserBanStatusFilter.ACTIVE), isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(sampleItem(2L, "MENTEE", "ACTIVE"))));
+
+        mockMvc.perform(get("/api/admin/users?banStatus=ACTIVE")
+                        .header("Authorization", "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].banStatus").value("ACTIVE"));
+
+        verify(adminUserQueryService).listUsers(
+                isNull(), eq(AdminUserBanStatusFilter.ACTIVE), isNull(), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_keywordFilter_passesQDownstream() throws Exception {
+        mockJwt(ADMIN_TOKEN, "ADMIN", 99L);
+        when(adminUserQueryService.listUsers(
+                isNull(), isNull(), eq("ayse"), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(sampleItem(1L, "MENTOR", "NONE"))));
+
+        mockMvc.perform(get("/api/admin/users?q=ayse")
+                        .header("Authorization", "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1));
+
+        verify(adminUserQueryService).listUsers(
+                isNull(), isNull(), eq("ayse"), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_combinedFilters_allPassedThrough() throws Exception {
+        mockJwt(ADMIN_TOKEN, "ADMIN", 99L);
+        when(adminUserQueryService.listUsers(
+                eq(AdminUserRoleFilter.MENTEE),
+                eq(AdminUserBanStatusFilter.NONE),
+                eq("ali"),
+                any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(sampleItem(2L, "MENTEE", "NONE"))));
+
+        mockMvc.perform(get("/api/admin/users?role=MENTEE&banStatus=NONE&q=ali&page=1&size=5")
+                        .header("Authorization", "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(1))
+                .andExpect(jsonPath("$.content[0].role").value("MENTEE"))
+                .andExpect(jsonPath("$.content[0].banStatus").value("NONE"));
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(adminUserQueryService).listUsers(
+                eq(AdminUserRoleFilter.MENTEE),
+                eq(AdminUserBanStatusFilter.NONE),
+                eq("ali"),
+                pageableCaptor.capture());
+        assertThat(pageableCaptor.getValue().getPageNumber()).isEqualTo(1);
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(5);
+    }
+
+    @Test
+    void listUsers_invalidRoleEnum_returns400() throws Exception {
+        // Spring's StringToEnumConverter rejects unknown values; this guards
+        // the "enum filter (not free-form string)" decision in the plan.
+        mockJwt(ADMIN_TOKEN, "ADMIN", 99L);
+
+        mockMvc.perform(get("/api/admin/users?role=BOGUS")
+                        .header("Authorization", "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/com/group7/backend/repository/UserRepositoryAdminListTest.java
+++ b/backend/src/test/java/com/group7/backend/repository/UserRepositoryAdminListTest.java
@@ -1,0 +1,348 @@
+package com.group7.backend.repository;
+
+import com.group7.backend.dto.response.AdminUserListItem;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Ban;
+import com.group7.backend.entity.BanSource;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real-Postgres SQL-fit coverage for
+ * {@link UserRepository#findAdminUsers}. JPQL relies on Hibernate's
+ * JOINED-inheritance {@code type(u) = ...} discriminator + EXISTS
+ * subqueries on the bans table; H2's PostgreSQL compatibility mode does
+ * not always mirror Postgres semantics there, so this test pins to the
+ * {@code test} profile (Postgres on 5433 by default; CI dry-run uses
+ * 5497 via env override).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class UserRepositoryAdminListTest {
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private BanRepository banRepository;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    private static final OffsetDateTime NOW =
+            OffsetDateTime.of(2026, 5, 12, 10, 0, 0, 0, ZoneOffset.UTC);
+
+    @BeforeEach
+    void cleanDb() {
+        banRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ── fixtures ──────────────────────────────────────────────────────────
+
+    private Mentor mentor(String suffix) {
+        Mentor m = new Mentor();
+        m.setFirstName("First-" + suffix);
+        m.setLastName("Last-" + suffix);
+        m.setEmail("mentor-" + suffix + "@example.com");
+        m.setPasswordHash("$2a$dummy");
+        m.setIsEmailVerified(true);
+        m.setMaxMenteeCapacity(3);
+        m.setCurrentMenteeCount(0);
+        return m;
+    }
+
+    private Mentee mentee(String suffix) {
+        Mentee m = new Mentee();
+        m.setFirstName("First-" + suffix);
+        m.setLastName("Last-" + suffix);
+        m.setEmail("mentee-" + suffix + "@example.com");
+        m.setPasswordHash("$2a$dummy");
+        m.setIsEmailVerified(true);
+        m.setProfileVisibility(true);
+        return m;
+    }
+
+    private Admin admin(String suffix) {
+        Admin a = new Admin();
+        a.setFirstName("Adm");
+        a.setLastName("In-" + suffix);
+        a.setEmail("admin-" + suffix + "@example.com");
+        a.setPasswordHash("$2a$dummy");
+        a.setIsEmailVerified(true);
+        return a;
+    }
+
+    private <T extends User> T persist(T user) {
+        em.persist(user);
+        em.flush();
+        return user;
+    }
+
+    private Ban persistBan(User user, OffsetDateTime expiresAt, OffsetDateTime liftedAt) {
+        Ban b = new Ban();
+        b.setUser(user);
+        b.setReason("test");
+        b.setSource(BanSource.ADMIN);
+        b.setBanCount(1);
+        b.setExpiresAt(expiresAt);
+        b.setLiftedAt(liftedAt);
+        em.persist(b);
+        em.flush();
+        return b;
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────
+
+    @Test
+    void noFilters_returnsAllUsersIncludingAdmins() {
+        Mentor m1 = persist(mentor("a"));
+        Mentee me1 = persist(mentee("b"));
+        Admin a1 = persist(admin("c"));
+
+        Page<AdminUserListItem> page = userRepository.findAdminUsers(
+                null, null, null, null, null, NOW, PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactlyInAnyOrder(m1.getId(), me1.getId(), a1.getId());
+        assertThat(page.getContent()).extracting(AdminUserListItem::getRole)
+                .containsExactlyInAnyOrder("MENTOR", "MENTEE", "ADMIN");
+        assertThat(page.getTotalElements()).isEqualTo(3);
+    }
+
+    @Test
+    void roleFilter_mentor_returnsOnlyMentors() {
+        Mentor m1 = persist(mentor("a"));
+        persist(mentee("b"));
+        persist(admin("c"));
+
+        Page<AdminUserListItem> page = userRepository.findAdminUsers(
+                Boolean.TRUE, null, null, null, null, NOW, PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactly(m1.getId());
+        assertThat(page.getContent()).extracting(AdminUserListItem::getRole)
+                .containsExactly("MENTOR");
+    }
+
+    @Test
+    void roleFilter_mentee_returnsOnlyMentees() {
+        persist(mentor("a"));
+        Mentee me1 = persist(mentee("b"));
+        persist(admin("c"));
+
+        Page<AdminUserListItem> page = userRepository.findAdminUsers(
+                null, Boolean.TRUE, null, null, null, NOW, PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactly(me1.getId());
+        assertThat(page.getContent()).extracting(AdminUserListItem::getRole)
+                .containsExactly("MENTEE");
+    }
+
+    @Test
+    void roleFilter_admin_returnsOnlyAdmins() {
+        persist(mentor("a"));
+        persist(mentee("b"));
+        Admin a1 = persist(admin("c"));
+
+        Page<AdminUserListItem> page = userRepository.findAdminUsers(
+                null, null, Boolean.TRUE, null, null, NOW, PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactly(a1.getId());
+        assertThat(page.getContent()).extracting(AdminUserListItem::getRole)
+                .containsExactly("ADMIN");
+    }
+
+    @Test
+    void banStatusActive_excludesExpiredAndLifted_includesOnlyCurrentlyBanned() {
+        Mentor freshMentor = persist(mentor("fresh"));
+
+        Mentor activelyBanned = persist(mentor("activelyBanned"));
+        persistBan(activelyBanned, NOW.plusDays(7), null);  // active
+
+        Mentor expiredBan = persist(mentor("expiredBan"));
+        persistBan(expiredBan, NOW.minusDays(1), null);     // expired
+
+        Mentor liftedBan = persist(mentor("liftedBan"));
+        persistBan(liftedBan, NOW.plusDays(7), NOW.minusHours(2)); // lifted
+
+        Page<AdminUserListItem> page = userRepository.findAdminUsers(
+                null, null, null, Boolean.TRUE, null, NOW, PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactly(activelyBanned.getId());
+        assertThat(page.getContent()).extracting(AdminUserListItem::getBanStatus)
+                .containsExactly("ACTIVE");
+
+        // Sanity: when filter is omitted, freshMentor / expiredBan / liftedBan
+        // all surface with banStatus=NONE (the EXISTS predicate doesn't see
+        // their rows under the active-ban definition).
+        Page<AdminUserListItem> all = userRepository.findAdminUsers(
+                null, null, null, null, null, NOW, PageRequest.of(0, 20));
+        assertThat(all.getContent()).extracting(
+                AdminUserListItem::getId, AdminUserListItem::getBanStatus)
+                .containsExactlyInAnyOrder(
+                        org.assertj.core.groups.Tuple.tuple(freshMentor.getId(), "NONE"),
+                        org.assertj.core.groups.Tuple.tuple(activelyBanned.getId(), "ACTIVE"),
+                        org.assertj.core.groups.Tuple.tuple(expiredBan.getId(), "NONE"),
+                        org.assertj.core.groups.Tuple.tuple(liftedBan.getId(), "NONE"));
+    }
+
+    @Test
+    void banStatusNone_includesLiftedAndExpiredAndUnbanned() {
+        Mentor freshMentor = persist(mentor("fresh"));
+        Mentor activelyBanned = persist(mentor("activelyBanned"));
+        persistBan(activelyBanned, NOW.plusDays(7), null);
+        Mentor expiredBan = persist(mentor("expiredBan"));
+        persistBan(expiredBan, NOW.minusDays(1), null);
+        Mentor liftedBan = persist(mentor("liftedBan"));
+        persistBan(liftedBan, NOW.plusDays(7), NOW.minusHours(2));
+
+        Page<AdminUserListItem> page = userRepository.findAdminUsers(
+                null, null, null, Boolean.FALSE, null, NOW, PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactlyInAnyOrder(
+                        freshMentor.getId(), expiredBan.getId(), liftedBan.getId())
+                .doesNotContain(activelyBanned.getId());
+    }
+
+    @Test
+    void keywordFilter_matchesFirstNameLastNameAndEmail() {
+        Mentor ayse = persist(mentor("ayse"));
+        ayse.setFirstName("Ayse");
+        ayse.setLastName("Demir");
+        em.flush();
+
+        Mentor ali = persist(mentor("ali"));
+        ali.setFirstName("Ali");
+        ali.setLastName("Yilmaz");
+        em.flush();
+
+        Mentee zeynep = persist(mentee("zeynep"));
+        zeynep.setFirstName("Zeynep");
+        zeynep.setLastName("Kara");
+        em.flush();
+
+        // firstName match
+        Page<AdminUserListItem> byFirst = userRepository.findAdminUsers(
+                null, null, null, null, "%ayse%", NOW, PageRequest.of(0, 20));
+        assertThat(byFirst.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactly(ayse.getId());
+
+        // lastName match (case-insensitive)
+        Page<AdminUserListItem> byLast = userRepository.findAdminUsers(
+                null, null, null, null, "%yilmaz%", NOW, PageRequest.of(0, 20));
+        assertThat(byLast.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactly(ali.getId());
+
+        // email match
+        Page<AdminUserListItem> byEmail = userRepository.findAdminUsers(
+                null, null, null, null, "%zeynep%", NOW, PageRequest.of(0, 20));
+        assertThat(byEmail.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactly(zeynep.getId());
+    }
+
+    @Test
+    void pagination_secondPageReturnsRemainingUsers() {
+        // Seed 5 users
+        List<Mentor> seeded = List.of(
+                persist(mentor("p1")),
+                persist(mentor("p2")),
+                persist(mentor("p3")),
+                persist(mentor("p4")),
+                persist(mentor("p5")));
+
+        Page<AdminUserListItem> first = userRepository.findAdminUsers(
+                null, null, null, null, null, NOW, PageRequest.of(0, 2));
+        Page<AdminUserListItem> second = userRepository.findAdminUsers(
+                null, null, null, null, null, NOW, PageRequest.of(1, 2));
+        Page<AdminUserListItem> third = userRepository.findAdminUsers(
+                null, null, null, null, null, NOW, PageRequest.of(2, 2));
+
+        assertThat(first.getContent()).hasSize(2);
+        assertThat(second.getContent()).hasSize(2);
+        assertThat(third.getContent()).hasSize(1);
+        assertThat(first.getTotalElements()).isEqualTo(5);
+        assertThat(first.getTotalPages()).isEqualTo(3);
+
+        // Combined page contents cover the full set with no overlap.
+        assertThat(List.of(
+                first.getContent().get(0).getId(),
+                first.getContent().get(1).getId(),
+                second.getContent().get(0).getId(),
+                second.getContent().get(1).getId(),
+                third.getContent().get(0).getId()))
+                .containsExactlyInAnyOrderElementsOf(
+                        seeded.stream().map(User::getId).toList());
+    }
+
+    @Test
+    void combinedFilters_roleAndBanStatusAndKeyword() {
+        Mentor ayseBanned = persist(mentor("ayseBanned"));
+        ayseBanned.setFirstName("Ayse");
+        ayseBanned.setLastName("Banned");
+        em.flush();
+        persistBan(ayseBanned, NOW.plusDays(3), null);
+
+        Mentor ayseClean = persist(mentor("ayseClean"));
+        ayseClean.setFirstName("Ayse");
+        ayseClean.setLastName("Clean");
+        em.flush();
+
+        Mentee ayseMentee = persist(mentee("ayseMentee"));
+        ayseMentee.setFirstName("Ayse");
+        ayseMentee.setLastName("Mentee");
+        em.flush();
+        persistBan(ayseMentee, NOW.plusDays(3), null);
+
+        Page<AdminUserListItem> page = userRepository.findAdminUsers(
+                Boolean.TRUE, null, null,  // role = MENTOR
+                Boolean.TRUE,              // active ban
+                "%ayse%",
+                NOW,
+                PageRequest.of(0, 20));
+
+        assertThat(page.getContent()).extracting(AdminUserListItem::getId)
+                .containsExactly(ayseBanned.getId());
+    }
+
+    @Test
+    void projection_populatesAllFields() {
+        Mentor m = persist(mentor("proj"));
+        m.setFirstName("Proj");
+        m.setLastName("ection");
+        m.setIsSuspectedBot(true);
+        em.flush();
+
+        Page<AdminUserListItem> page = userRepository.findAdminUsers(
+                null, null, null, null, null, NOW, PageRequest.of(0, 20));
+
+        AdminUserListItem item = page.getContent().get(0);
+        assertThat(item.getId()).isEqualTo(m.getId());
+        assertThat(item.getFirstName()).isEqualTo("Proj");
+        assertThat(item.getLastName()).isEqualTo("ection");
+        assertThat(item.getEmail()).isEqualTo(m.getEmail());
+        assertThat(item.getRole()).isEqualTo("MENTOR");
+        assertThat(item.getBanStatus()).isEqualTo("NONE");
+        assertThat(item.getSuspectedBot()).isTrue();
+        assertThat(item.getCreatedAt()).isNotNull();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/AdminUserQueryServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/AdminUserQueryServiceTest.java
@@ -1,0 +1,378 @@
+package com.group7.backend.service;
+
+import com.group7.backend.dto.request.AdminUserBanStatusFilter;
+import com.group7.backend.dto.request.AdminUserRoleFilter;
+import com.group7.backend.dto.response.AdminUserDetailResponse;
+import com.group7.backend.dto.response.AdminUserListItem;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Ban;
+import com.group7.backend.entity.BanSource;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import com.group7.backend.exception.ResourceNotFoundException;
+import com.group7.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure-Mockito tests for {@link AdminUserQueryService}. Verifies:
+ * <ul>
+ *   <li>filter-enum → repository-flag mapping (one Boolean.TRUE per role,
+ *       rest null; ACTIVE/NONE → TRUE/FALSE for banActive)</li>
+ *   <li>keyword normalisation via {@code SearchNormaliser.keyword} (inputs
+ *       under 3 alphanumerics fall through as null)</li>
+ *   <li>{@code getUserDetail} 404 path</li>
+ *   <li>{@code getUserDetail} wire shape for Mentor / Mentee / Admin targets</li>
+ * </ul>
+ */
+class AdminUserQueryServiceTest {
+
+    private UserRepository userRepository;
+    private BanService banService;
+    private Clock fixedClock;
+    private AdminUserQueryService service;
+
+    private static final OffsetDateTime NOW =
+            OffsetDateTime.of(2026, 5, 12, 10, 0, 0, 0, ZoneOffset.UTC);
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        banService = mock(BanService.class);
+        fixedClock = Clock.fixed(Instant.parse("2026-05-12T10:00:00Z"), ZoneOffset.UTC);
+        service = new AdminUserQueryService(userRepository, banService, fixedClock);
+    }
+
+    private Page<AdminUserListItem> emptyPage() {
+        return new PageImpl<>(List.of());
+    }
+
+    private Mentor mentorEntity(Long id) {
+        Mentor m = new Mentor();
+        m.setId(id);
+        m.setFirstName("M");
+        m.setLastName("entor");
+        m.setEmail("m" + id + "@example.com");
+        m.setPasswordHash("$2a$dummy");
+        m.setIsEmailVerified(true);
+        m.setIsSuspectedBot(false);
+        m.setCreatedAt(NOW.minusDays(3));
+        m.setMaxMenteeCapacity(3);
+        m.setCurrentMenteeCount(0);
+        return m;
+    }
+
+    private Mentee menteeEntity(Long id) {
+        Mentee m = new Mentee();
+        m.setId(id);
+        m.setFirstName("M");
+        m.setLastName("entee");
+        m.setEmail("e" + id + "@example.com");
+        m.setPasswordHash("$2a$dummy");
+        m.setIsEmailVerified(true);
+        m.setIsSuspectedBot(false);
+        m.setCreatedAt(NOW.minusDays(2));
+        m.setProfileVisibility(true);
+        return m;
+    }
+
+    private Admin adminEntity(Long id) {
+        Admin a = new Admin();
+        a.setId(id);
+        a.setFirstName("A");
+        a.setLastName("dmin");
+        a.setEmail("a" + id + "@example.com");
+        a.setPasswordHash("$2a$dummy");
+        a.setIsEmailVerified(true);
+        a.setIsSuspectedBot(false);
+        a.setCreatedAt(NOW.minusDays(1));
+        return a;
+    }
+
+    // ── listUsers: filter mapping ──────────────────────────────────────────
+
+    @Test
+    void listUsers_noFilters_allRepoFlagsNull() {
+        when(userRepository.findAdminUsers(
+                isNull(), isNull(), isNull(),
+                isNull(), isNull(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(null, null, null, PageRequest.of(0, 20));
+
+        verify(userRepository).findAdminUsers(
+                isNull(), isNull(), isNull(),
+                isNull(), isNull(),
+                eq(NOW), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_roleMentor_setsOnlyMentorFlag() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(AdminUserRoleFilter.MENTOR, null, null, PageRequest.of(0, 20));
+
+        verify(userRepository).findAdminUsers(
+                eq(Boolean.TRUE), isNull(), isNull(),
+                isNull(), isNull(),
+                eq(NOW), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_roleMentee_setsOnlyMenteeFlag() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(AdminUserRoleFilter.MENTEE, null, null, PageRequest.of(0, 20));
+
+        verify(userRepository).findAdminUsers(
+                isNull(), eq(Boolean.TRUE), isNull(),
+                isNull(), isNull(),
+                eq(NOW), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_roleAdmin_setsOnlyAdminFlag() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(AdminUserRoleFilter.ADMIN, null, null, PageRequest.of(0, 20));
+
+        verify(userRepository).findAdminUsers(
+                isNull(), isNull(), eq(Boolean.TRUE),
+                isNull(), isNull(),
+                eq(NOW), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_banStatusActive_setsBanActiveTrue() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(null, AdminUserBanStatusFilter.ACTIVE, null, PageRequest.of(0, 20));
+
+        verify(userRepository).findAdminUsers(
+                isNull(), isNull(), isNull(),
+                eq(Boolean.TRUE), isNull(),
+                eq(NOW), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_banStatusNone_setsBanActiveFalse() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(null, AdminUserBanStatusFilter.NONE, null, PageRequest.of(0, 20));
+
+        verify(userRepository).findAdminUsers(
+                isNull(), isNull(), isNull(),
+                eq(Boolean.FALSE), isNull(),
+                eq(NOW), any(Pageable.class));
+    }
+
+    // ── listUsers: keyword normalisation ──────────────────────────────────
+
+    @Test
+    void listUsers_keywordShorterThan3Chars_normalisesToNull() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(null, null, "ab", PageRequest.of(0, 20));
+
+        verify(userRepository).findAdminUsers(
+                isNull(), isNull(), isNull(),
+                isNull(), isNull(),
+                eq(NOW), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_keywordBlank_normalisesToNull() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(null, null, "   ", PageRequest.of(0, 20));
+
+        verify(userRepository).findAdminUsers(
+                isNull(), isNull(), isNull(),
+                isNull(), isNull(),
+                eq(NOW), any(Pageable.class));
+    }
+
+    @Test
+    void listUsers_keywordLowercasedAndWrappedWithWildcards() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(null, null, "  Ayse  ", PageRequest.of(0, 20));
+
+        ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+        verify(userRepository).findAdminUsers(
+                isNull(), isNull(), isNull(),
+                isNull(), keywordCaptor.capture(),
+                eq(NOW), any(Pageable.class));
+        assertThat(keywordCaptor.getValue()).isEqualTo("%ayse%");
+    }
+
+    @Test
+    void listUsers_keywordEscapesWildcards() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(null, null, "ab%cd_ef", PageRequest.of(0, 20));
+
+        ArgumentCaptor<String> keywordCaptor = ArgumentCaptor.forClass(String.class);
+        verify(userRepository).findAdminUsers(
+                isNull(), isNull(), isNull(),
+                isNull(), keywordCaptor.capture(),
+                eq(NOW), any(Pageable.class));
+        // Literal % and _ are escape-prefixed; outer % wildcards remain unescaped.
+        assertThat(keywordCaptor.getValue()).isEqualTo("%ab|%cd|_ef%");
+    }
+
+    // ── getUserDetail: 404 path ───────────────────────────────────────────
+
+    @Test
+    void getUserDetail_missing_throwsResourceNotFound() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getUserDetail(999L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("999");
+
+        verify(banService, never()).listBansForUser(any());
+    }
+
+    // ── getUserDetail: dispatch on subclass ───────────────────────────────
+
+    @Test
+    void getUserDetail_mentor_returnsMentorShapedProfile() {
+        Mentor mentor = mentorEntity(1L);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mentor));
+        when(banService.listBansForUser(1L)).thenReturn(List.of());
+
+        AdminUserDetailResponse response = service.getUserDetail(1L);
+
+        assertThat(response.getProfile().getClass().getSimpleName()).isEqualTo("MentorResponse");
+        assertThat(response.getBanHistory()).isEmpty();
+        assertThat(response.getSuspectedBot()).isFalse();
+        assertThat(response.getSuspectedAt()).isNull();
+    }
+
+    @Test
+    void getUserDetail_mentee_returnsMenteeShapedProfile() {
+        Mentee mentee = menteeEntity(2L);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(mentee));
+        when(banService.listBansForUser(2L)).thenReturn(List.of());
+
+        AdminUserDetailResponse response = service.getUserDetail(2L);
+
+        assertThat(response.getProfile().getClass().getSimpleName()).isEqualTo("MenteeResponse");
+    }
+
+    @Test
+    void getUserDetail_admin_returnsAdminShapedProfile() {
+        Admin admin = adminEntity(3L);
+        when(userRepository.findById(3L)).thenReturn(Optional.of(admin));
+        when(banService.listBansForUser(3L)).thenReturn(List.of());
+
+        AdminUserDetailResponse response = service.getUserDetail(3L);
+
+        assertThat(response.getProfile().getClass().getSimpleName()).isEqualTo("AdminResponse");
+    }
+
+    @Test
+    void getUserDetail_banHistoryMappedThroughBanService() {
+        Mentor mentor = mentorEntity(5L);
+        Ban ban = new Ban();
+        ban.setId(11L);
+        ban.setUser(mentor);
+        ban.setReason("test");
+        ban.setSource(BanSource.ADMIN);
+        ban.setBanCount(1);
+        ban.setExpiresAt(NOW.plusDays(7));
+
+        when(userRepository.findById(5L)).thenReturn(Optional.of(mentor));
+        when(banService.listBansForUser(5L)).thenReturn(List.of(ban));
+
+        AdminUserDetailResponse response = service.getUserDetail(5L);
+
+        assertThat(response.getBanHistory()).hasSize(1);
+        assertThat(response.getBanHistory().get(0).getId()).isEqualTo(11L);
+        assertThat(response.getBanHistory().get(0).getReason()).isEqualTo("test");
+    }
+
+    @Test
+    void getUserDetail_returnsSuspectedBotMetadata() {
+        Mentor mentor = mentorEntity(7L);
+        mentor.setIsSuspectedBot(true);
+        mentor.setSuspectedAt(NOW.minusHours(1));
+        when(userRepository.findById(7L)).thenReturn(Optional.of(mentor));
+        when(banService.listBansForUser(7L)).thenReturn(List.of());
+
+        AdminUserDetailResponse response = service.getUserDetail(7L);
+
+        assertThat(response.getSuspectedBot()).isTrue();
+        assertThat(response.getSuspectedAt()).isEqualTo(NOW.minusHours(1));
+    }
+
+    // ── listUsers: clock plumbing ─────────────────────────────────────────
+
+    @Test
+    void listUsers_passesNowFromInjectedClock() {
+        when(userRepository.findAdminUsers(
+                any(), any(), any(), any(), any(),
+                any(OffsetDateTime.class), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        service.listUsers(null, null, null, PageRequest.of(0, 20));
+
+        ArgumentCaptor<OffsetDateTime> nowCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(userRepository).findAdminUsers(
+                any(), any(), any(), any(), any(),
+                nowCaptor.capture(), any(Pageable.class));
+        assertThat(nowCaptor.getValue()).isEqualTo(NOW);
+    }
+}


### PR DESCRIPTION
## Summary

Adds two ADMIN-gated read endpoints to the existing `AdminController` so the admin panel can render the user-management table and "view profile" action.

Unblocks frontend **#279**.

## Endpoints

| Method | Path | Notes |
|---|---|---|
| `GET` | `/api/admin/users` | Paginated `AdminUserListItem` page; filters: `role` (MENTOR/MENTEE/ADMIN), `banStatus` (ACTIVE/NONE), `q` keyword. Page size clamped to [1,100]. |
| `GET` | `/api/admin/users/{id}` | `AdminUserDetailResponse` — `@JsonUnwrapped ProfileResponse` + `banHistory: List<BanResponse>` + `suspectedBot` / `suspectedAt`. |

Both inherit the class-level `@PreAuthorize("hasRole('ADMIN')")` already on `AdminController`.

## Implementation

- **DTOs (new):** `AdminUserListItem`, `AdminUserDetailResponse`, `AdminUserRoleFilter`, `AdminUserBanStatusFilter`.
- **Service (new):** `AdminUserQueryService` — isolates query logic from the 500-line `UserService`. Reuses the package-private `SearchNormaliser.keyword` helper (same package).
- **Repository (modified):** new JPQL constructor-projection on `UserRepository`. JOINED-inheritance `type(u)` for role discriminator. `EXISTS (SELECT 1 FROM Ban b WHERE b.user.id = u.id AND b.liftedAt IS NULL AND b.expiresAt > :now)` mirrors `BanRepository.findActive` for the banStatus column. Order by `createdAt DESC, id DESC` for stable pagination.
- **Controller (modified):** `AdminController` gains the two `@GetMapping`s between `me()` and `banUser()`. Existing `POST /api/admin/users/{userId}/ban|unban|clear-bot-flag` endpoints untouched (HTTP verbs differ from `GET /api/admin/users/{id}` → no path collision).

## Tests

39 new tests, all green:
- `AdminUserListControllerTest` (`@WebMvcTest`) — 9 cases: ADMIN gate, unauthenticated, paged body, size-clamp, each filter, combined filters, invalid-enum 400.
- `AdminUserDetailControllerTest` — 3 cases: success, 404 via `ResourceNotFoundException`, non-admin 403.
- `UserRepositoryAdminListTest` (real Postgres) — 10 cases: pagination, role, banStatus across active/lifted/expired, keyword on firstName/lastName/email.
- `AdminUserQueryServiceTest` (Mockito) — 17 cases: normalisation edges, enum→Boolean mapping, 404, response shape per role.

## Test plan

- [x] Scoped `mvn -B test` for the 4 new test classes — 39/39 green.
- [x] Full `mvn --batch-mode verify` — **2299 tests, 0 failures, 0 errors**; JaCoCo gates green.
- [x] Manual smoke (22 cases): ADMIN gate / non-admin 403, default list, each role filter, banStatus before+after ban+after unban, keyword filter, pagination, size-clamp, combined filters, detail for banned mentor / clean mentee / admin / 404, invalid-enum 400, existing ban/unban regression.

## Backward compatibility

Net-new feature. No existing path, signature, or wire shape changes. Path-collision check: existing `POST /api/admin/users/{userId}/ban|unban|clear-bot-flag` uses POST; new `GET /api/admin/users/{id}` uses GET — Spring's `RequestMappingHandlerMapping` keys on verb+path template, no clash. `/api/admin/bans/...` audit endpoints in `BanAdminController` stay untouched.

## Out of scope

- Reports management table (covered by #568).
- Frontend wiring (covered by #279).

Closes #569.