### PR TITLE
fix(mobile): handle banned user login response

### DIFF
--- a/mobile-app/__tests__/login.test.tsx
+++ b/mobile-app/__tests__/login.test.tsx
@@ -104,6 +104,34 @@ describe('LoginScreen', () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it('routes banned users to the blocked screen instead of showing a generic login error', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+    (apiClient.post as jest.Mock).mockRejectedValue({
+      response: {
+        status: 403,
+        data: {
+          code: 'BANNED_UNTIL',
+          reason: 'Spam activity detected',
+          expiresAt: '2026-05-20T10:30:00Z',
+        },
+      },
+    });
+
+    const { getByPlaceholderText, getByText } = render(<LoginScreen />);
+
+    fireEvent.changeText(getByPlaceholderText('ovgu@boun.edu.tr'), 'mentor@example.com');
+    fireEvent.changeText(getByPlaceholderText('••••••••'), 'secret123');
+    fireEvent.press(getByText('Sign In'));
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith('/blocked');
+    });
+
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('banReason', 'Spam activity detected');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('banExpiresAt', '2026-05-20T10:30:00Z');
+  });
+
   it('cleans up partial session state when secure storage write fails', async () => {
     const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);

--- a/mobile-app/api/client.ts
+++ b/mobile-app/api/client.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
 import { router } from 'expo-router';
+import { clearBanNotice, storeBanNotice } from '../utils/banNotice';
 
 const apiClient = axios.create({
   baseURL: 'http://192.168.37.177:8080/api',
@@ -26,6 +27,7 @@ apiClient.interceptors.request.use(
 );
 
 let isRedirectingToLogin = false;
+let isRedirectingToBlocked = false;
 
 apiClient.interceptors.response.use(
   (response) => response,
@@ -34,14 +36,38 @@ apiClient.interceptors.response.use(
     const url = error?.config?.url ?? '';
     const method = error?.config?.method?.toUpperCase();
     const data = error?.response?.data;
-    console.error(`[apiClient] ${method} ${url} → ${status}`, JSON.stringify(data));
+    const isExpectedBanResponse = status === 403 && data?.code === 'BANNED_UNTIL';
+    const logLine = `[apiClient] ${method} ${url} → ${status}`;
+    if (isExpectedBanResponse) {
+      console.warn(logLine, JSON.stringify(data));
+    } else {
+      console.error(logLine, JSON.stringify(data));
+    }
+
+    if (isExpectedBanResponse && !isRedirectingToBlocked) {
+      isRedirectingToBlocked = true;
+      await Promise.all([
+        SecureStore.deleteItemAsync('userToken'),
+        SecureStore.deleteItemAsync('userId'),
+        SecureStore.deleteItemAsync('userRole'),
+        storeBanNotice({
+          reason: typeof data?.reason === 'string' ? data.reason : null,
+          expiresAt: typeof data?.expiresAt === 'string' ? data.expiresAt : null,
+        }),
+      ]);
+      router.replace('/blocked');
+      setTimeout(() => { isRedirectingToBlocked = false; }, 3000);
+    }
 
     // Token yoksa ya da süresi dolduysa otomatik çıkış yap
     if (status === 401 && !url.includes('/auth/') && !isRedirectingToLogin) {
       isRedirectingToLogin = true;
-      await SecureStore.deleteItemAsync('userToken');
-      await SecureStore.deleteItemAsync('userId');
-      await SecureStore.deleteItemAsync('userRole');
+      await Promise.all([
+        SecureStore.deleteItemAsync('userToken'),
+        SecureStore.deleteItemAsync('userId'),
+        SecureStore.deleteItemAsync('userRole'),
+        clearBanNotice(),
+      ]);
       router.replace('/onboarding');
       setTimeout(() => { isRedirectingToLogin = false; }, 3000);
     }

--- a/mobile-app/app/blocked.tsx
+++ b/mobile-app/app/blocked.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useState } from 'react';
+import { router } from 'expo-router';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import { clearBanNotice, readBanNotice } from '../utils/banNotice';
+
+function formatExpiry(expiresAt: string | null) {
+  if (!expiresAt) return null;
+  const date = new Date(expiresAt);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString('tr-TR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function BlockedScreen() {
+  const [reason, setReason] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    readBanNotice().then((notice) => {
+      setReason(notice.reason);
+      setExpiresAt(notice.expiresAt);
+    });
+  }, []);
+
+  const goBackToLogin = async () => {
+    await clearBanNotice();
+    router.replace('/login');
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.topCircle} />
+      <View style={styles.bottomCircle} />
+
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        <View style={styles.card}>
+          <Text style={styles.eyebrow}>ACCOUNT STATUS</Text>
+          <Text style={styles.title}>Hesabiniz bloklandi</Text>
+          <Text style={styles.message}>
+            Bu hesaba erisim su anda kisitli. Ban kaldirilana kadar mobil uygulamada sadece bu uyari ekrani gosterilir.
+          </Text>
+
+          {reason ? (
+            <View style={styles.infoBox}>
+              <Text style={styles.infoLabel}>Neden</Text>
+              <Text style={styles.infoValue}>{reason}</Text>
+            </View>
+          ) : null}
+
+          {formatExpiry(expiresAt) ? (
+            <View style={styles.infoBox}>
+              <Text style={styles.infoLabel}>Bitis zamani</Text>
+              <Text style={styles.infoValue}>{formatExpiry(expiresAt)}</Text>
+            </View>
+          ) : null}
+
+          <Text style={styles.helpText}>
+            Bunun bir hata oldugunu dusunuyorsaniz sistem yoneticisiyle iletisime gecin.
+          </Text>
+
+          <TouchableOpacity style={styles.button} onPress={goBackToLogin}>
+            <Text style={styles.buttonText}>Giris ekranina don</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#4D7257',
+    overflow: 'hidden',
+  },
+  scrollContent: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    paddingVertical: 40,
+  },
+  topCircle: {
+    position: 'absolute',
+    width: 300,
+    height: 300,
+    borderRadius: 150,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+    top: -30,
+    left: -70,
+  },
+  bottomCircle: {
+    position: 'absolute',
+    width: 220,
+    height: 220,
+    borderRadius: 110,
+    backgroundColor: 'rgba(255,255,255,0.04)',
+    bottom: -20,
+    right: -40,
+  },
+  card: {
+    backgroundColor: '#F7F4EE',
+    borderRadius: 28,
+    paddingHorizontal: 24,
+    paddingVertical: 28,
+    borderWidth: 1,
+    borderColor: '#DDD5CA',
+  },
+  eyebrow: {
+    color: '#8C3E35',
+    fontSize: 12,
+    fontWeight: '800',
+    letterSpacing: 1,
+    marginBottom: 10,
+  },
+  title: {
+    color: '#23372B',
+    fontSize: 30,
+    lineHeight: 34,
+    fontWeight: '800',
+    marginBottom: 14,
+  },
+  message: {
+    color: '#5E554D',
+    fontSize: 15,
+    lineHeight: 22,
+    marginBottom: 18,
+  },
+  infoBox: {
+    backgroundColor: '#EFE8DE',
+    borderRadius: 18,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    marginBottom: 12,
+  },
+  infoLabel: {
+    color: '#7E7368',
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 0.4,
+    marginBottom: 6,
+  },
+  infoValue: {
+    color: '#23372B',
+    fontSize: 15,
+    lineHeight: 21,
+    fontWeight: '600',
+  },
+  helpText: {
+    color: '#7E7368',
+    fontSize: 13,
+    lineHeight: 20,
+    marginTop: 8,
+    marginBottom: 22,
+  },
+  button: {
+    backgroundColor: '#456B50',
+    borderRadius: 18,
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#F8F6F2',
+    fontSize: 15,
+    fontWeight: '800',
+  },
+});

--- a/mobile-app/app/login.tsx
+++ b/mobile-app/app/login.tsx
@@ -2,6 +2,7 @@
 import apiClient from '../api/client';
 import * as SecureStore from 'expo-secure-store';
 import { useRole } from '../components/RoleContext';
+import { clearBanNotice, storeBanNotice } from '../utils/banNotice';
 
 import { router } from 'expo-router';
 import React, { useMemo, useState } from 'react';
@@ -30,6 +31,7 @@ export default function LoginScreen() {
       SecureStore.deleteItemAsync('userToken'),
       SecureStore.deleteItemAsync('userId'),
       SecureStore.deleteItemAsync('userRole'),
+      clearBanNotice(),
     ]);
   };
 
@@ -40,11 +42,7 @@ export default function LoginScreen() {
     }
 
     try {
-      await Promise.all([
-        SecureStore.deleteItemAsync('userToken'),
-        SecureStore.deleteItemAsync('userId'),
-        SecureStore.deleteItemAsync('userRole'),
-      ]);
+      await clearStoredSession();
 
       const response = await apiClient.post('/auth/login', {
         email: email,
@@ -56,15 +54,21 @@ export default function LoginScreen() {
       await SecureStore.setItemAsync('userRole', role);
       setRole(role.toLowerCase());
       await SecureStore.setItemAsync('userToken', sessionToken);
+      await clearBanNotice();
 
       router.replace('/(tabs)');
 
-    } catch (error) {
-      await Promise.all([
-        SecureStore.deleteItemAsync('userToken'),
-        SecureStore.deleteItemAsync('userId'),
-        SecureStore.deleteItemAsync('userRole'),
-      ]);
+    } catch (error: any) {
+      await clearStoredSession();
+      const data = error?.response?.data;
+      if (error?.response?.status === 403 && data?.code === 'BANNED_UNTIL') {
+        await storeBanNotice({
+          reason: typeof data?.reason === 'string' ? data.reason : null,
+          expiresAt: typeof data?.expiresAt === 'string' ? data.expiresAt : null,
+        });
+        router.replace('/blocked');
+        return;
+      }
       Alert.alert("Login Failed", "Invalid email or password.");
       console.error(error);
     }

--- a/mobile-app/utils/banNotice.ts
+++ b/mobile-app/utils/banNotice.ts
@@ -1,0 +1,35 @@
+import * as SecureStore from 'expo-secure-store';
+
+const BAN_REASON_KEY = 'banReason';
+const BAN_EXPIRES_AT_KEY = 'banExpiresAt';
+
+export type BanNotice = {
+  reason: string | null;
+  expiresAt: string | null;
+};
+
+export async function storeBanNotice(notice: BanNotice) {
+  await Promise.all([
+    notice.reason
+      ? SecureStore.setItemAsync(BAN_REASON_KEY, notice.reason)
+      : SecureStore.deleteItemAsync(BAN_REASON_KEY),
+    notice.expiresAt
+      ? SecureStore.setItemAsync(BAN_EXPIRES_AT_KEY, notice.expiresAt)
+      : SecureStore.deleteItemAsync(BAN_EXPIRES_AT_KEY),
+  ]);
+}
+
+export async function readBanNotice(): Promise<BanNotice> {
+  const [reason, expiresAt] = await Promise.all([
+    SecureStore.getItemAsync(BAN_REASON_KEY),
+    SecureStore.getItemAsync(BAN_EXPIRES_AT_KEY),
+  ]);
+  return { reason, expiresAt };
+}
+
+export async function clearBanNotice() {
+  await Promise.all([
+    SecureStore.deleteItemAsync(BAN_REASON_KEY),
+    SecureStore.deleteItemAsync(BAN_EXPIRES_AT_KEY),
+  ]);
+}


### PR DESCRIPTION
## Summary
- Added blocked screen for banned users
- Treat `BANNED_UNTIL` login response as an expected blocked-user state
- Prevent Expo red error screen when banned user login is rejected
- Updated login test coverage for banned user flow

## Testing
- Updated mobile login test coverage
- Manually verified banned user should be redirected to blocked screen