### PR TITLE
feat(web): hybrid location entry on profile editor (#461)

### DIFF
--- a/frontend/src/components/LocationPicker.jsx
+++ b/frontend/src/components/LocationPicker.jsx
@@ -1,0 +1,238 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Location entry widget (#461). Backend stores `city`, `latitude`,
+ * `longitude` on the user profile (PATCH /api/users/me/{role}).
+ *
+ * Two parallel input paths for the user:
+ *  1. "Use my current location" — calls navigator.geolocation, reverse-
+ *     geocodes the result via Nominatim (OpenStreetMap), and fills the
+ *     city + rounded coordinates.
+ *  2. Manual search — typeahead against Nominatim's free `/search`
+ *     endpoint. Selecting a suggestion fills city + coords from the
+ *     geocoding result.
+ *
+ * Privacy: coordinates are rounded to 2 decimal places (~1 km precision)
+ * before being handed back to the parent form. Backend Bean Validation
+ * already caps lat ∈ [-90, 90] and lon ∈ [-180, 180].
+ *
+ * Props:
+ *   city / latitude / longitude — current values from parent
+ *   onChange({ city, latitude, longitude }) — fires on selection
+ *   disabled — disables interaction while the parent is saving
+ */
+
+const SEARCH_URL = 'https://nominatim.openstreetmap.org/search'
+const REVERSE_URL = 'https://nominatim.openstreetmap.org/reverse'
+
+function roundCoord(n) {
+  if (n == null || Number.isNaN(n)) return null
+  return Math.round(n * 100) / 100
+}
+
+function fmtCoords(lat, lon) {
+  if (lat == null || lon == null) return ''
+  return `${roundCoord(lat)}, ${roundCoord(lon)}`
+}
+
+function pickCityFromAddress(item) {
+  if (item.address) {
+    const addr = item.address
+    return addr.city || addr.town || addr.village || addr.hamlet || addr.county || ''
+  }
+  // Fallback: first segment of the display_name
+  return String(item.display_name || '').split(',')[0]?.trim() || ''
+}
+
+export default function LocationPicker({ city, latitude, longitude, onChange, disabled = false }) {
+  const [query, setQuery] = useState(city || '')
+  const [results, setResults] = useState([])
+  const [searchBusy, setSearchBusy] = useState(false)
+  const [searchError, setSearchError] = useState(null)
+  const [geoBusy, setGeoBusy] = useState(false)
+  const [geoError, setGeoError] = useState(null)
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef(null)
+  const debounceRef = useRef(null)
+
+  useEffect(() => {
+    setQuery(city || '')
+  }, [city])
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  function searchNominatim(q) {
+    if (q.length < 3) {
+      setResults([])
+      setOpen(false)
+      return
+    }
+    setSearchBusy(true)
+    setSearchError(null)
+    fetch(`${SEARCH_URL}?format=json&limit=6&addressdetails=1&q=${encodeURIComponent(q)}`)
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then(list => {
+        setResults(Array.isArray(list) ? list : [])
+        setOpen((list?.length || 0) > 0)
+      })
+      .catch(() => {
+        setResults([])
+        setSearchError('Search unavailable. Try again or enter coordinates manually.')
+      })
+      .finally(() => setSearchBusy(false))
+  }
+
+  function handleQueryChange(e) {
+    const v = e.target.value
+    setQuery(v)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => searchNominatim(v.trim()), 250)
+  }
+
+  function selectResult(item) {
+    const cityName = pickCityFromAddress(item)
+    const lat = roundCoord(parseFloat(item.lat))
+    const lon = roundCoord(parseFloat(item.lon))
+    setQuery(cityName || item.display_name?.split(',')[0] || '')
+    setResults([])
+    setOpen(false)
+    onChange?.({ city: cityName, latitude: lat, longitude: lon })
+  }
+
+  function useCurrentLocation() {
+    if (geoBusy || disabled) return
+    if (!navigator.geolocation) {
+      setGeoError('Your browser does not support geolocation.')
+      return
+    }
+    setGeoBusy(true)
+    setGeoError(null)
+    navigator.geolocation.getCurrentPosition(
+      async (pos) => {
+        const lat = roundCoord(pos.coords.latitude)
+        const lon = roundCoord(pos.coords.longitude)
+        try {
+          const res = await fetch(
+            `${REVERSE_URL}?format=json&zoom=10&lat=${lat}&lon=${lon}`,
+          )
+          const body = res.ok ? await res.json() : null
+          const cityName = body ? pickCityFromAddress(body) : ''
+          onChange?.({ city: cityName || '', latitude: lat, longitude: lon })
+          setQuery(cityName || '')
+        } catch {
+          // Reverse failed — still keep the rounded coords; city stays empty.
+          onChange?.({ city: '', latitude: lat, longitude: lon })
+          setQuery('')
+        } finally {
+          setGeoBusy(false)
+        }
+      },
+      (err) => {
+        setGeoBusy(false)
+        if (err.code === err.PERMISSION_DENIED) {
+          setGeoError('Permission denied. Enter your city manually.')
+        } else if (err.code === err.POSITION_UNAVAILABLE) {
+          setGeoError('Your location could not be determined.')
+        } else {
+          setGeoError('Couldn’t fetch your location. Enter it manually.')
+        }
+      },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 60000 },
+    )
+  }
+
+  function clearLocation() {
+    if (disabled) return
+    setQuery('')
+    setResults([])
+    setOpen(false)
+    onChange?.({ city: null, latitude: null, longitude: null })
+  }
+
+  const hasLocation = (city && city.length > 0) || latitude != null || longitude != null
+
+  return (
+    <div className="loc-picker" ref={wrapRef}>
+      <div className="loc-picker-row">
+        <input
+          type="text"
+          className="form-input loc-picker-input"
+          value={query}
+          onChange={handleQueryChange}
+          onFocus={() => results.length > 0 && setOpen(true)}
+          placeholder="Search a city (e.g. Istanbul)"
+          disabled={disabled}
+          maxLength={100}
+        />
+        <button
+          type="button"
+          className="action-btn"
+          onClick={useCurrentLocation}
+          disabled={disabled || geoBusy}
+        >
+          {geoBusy ? 'Locating…' : 'Use current location'}
+        </button>
+      </div>
+
+      {open && results.length > 0 && (
+        <ul className="loc-picker-results" role="listbox">
+          {results.map(r => (
+            <li key={`${r.place_id}-${r.lat}-${r.lon}`}>
+              <button
+                type="button"
+                className="loc-picker-result-btn"
+                onClick={() => selectResult(r)}
+              >
+                <span className="loc-picker-result-name">
+                  {pickCityFromAddress(r) || r.display_name}
+                </span>
+                <span className="loc-picker-result-sub">{r.display_name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {(searchError || geoError) && (
+        <div className="loc-picker-error">{searchError || geoError}</div>
+      )}
+
+      {(hasLocation || searchBusy) && (
+        <div className="loc-picker-status">
+          {searchBusy && <span>Searching…</span>}
+          {!searchBusy && hasLocation && (
+            <>
+              <span>
+                {city || 'Coordinates set'}
+                {(latitude != null || longitude != null) && (
+                  <span className="loc-picker-coords"> · {fmtCoords(latitude, longitude)}</span>
+                )}
+              </span>
+              <button
+                type="button"
+                className="loc-picker-clear"
+                onClick={clearLocation}
+                disabled={disabled}
+              >
+                Clear
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
+      <p className="loc-picker-privacy">
+        We use your location to recommend nearby mentors. Coordinates are rounded
+        to ~1 km precision before being sent to the server.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -3,6 +3,7 @@ import MainLayout from '../components/MainLayout'
 import Avatar from '../components/Avatar'
 import NotificationPreferences from '../components/NotificationPreferences'
 import MutedKeywords from '../components/MutedKeywords'
+import LocationPicker from '../components/LocationPicker'
 import usePresence from '../hooks/usePresence'
 import { useAuth } from '../context/AuthContext'
 import { useMentorship } from '../context/MentorshipContext'
@@ -15,6 +16,10 @@ function mapResponseToForm(data) {
     name: [data.firstName, data.lastName].filter(Boolean).join(' '),
     profilePhoto: data.profilePhoto || '',
     interests: (data.interests || []).join(', '),
+    // #461: shared location fields, available on both roles
+    city: data.city || '',
+    latitude: data.latitude ?? null,
+    longitude: data.longitude ?? null,
   }
   if (isMentor) {
     return {
@@ -152,6 +157,12 @@ export default function ProfilePage() {
         firstName,
         lastName,
         interests: toList(form.interests),
+        // #461: location fields are common across roles. Backend EditProfileRequest
+        // enforces pair-completeness on lat/lng via a DB CHECK constraint, so we
+        // send all three together. Null clears all three; partial null is rejected.
+        city: form.city || null,
+        latitude: form.latitude ?? null,
+        longitude: form.longitude ?? null,
         ...(isMentor ? {
           bio: form.bio || null,
           field: form.field || null,
@@ -309,6 +320,7 @@ export default function ProfilePage() {
                 <ViewField label="Field" value={form.field} />
                 <ViewField label="Expertise" value={form.expertise} />
                 <ViewField label="Affiliation" value={form.affiliation} />
+                <ViewField label="Location" value={form.city} />
                 <ViewField label="Interests" value={form.interests} chips />
                 <ViewField label="Mentoring Goals" value={form.mentoringGoals} />
                 <ViewField label="Preferred Mentee Major" value={form.preferredMenteeMajor} />
@@ -321,6 +333,7 @@ export default function ProfilePage() {
                 <ViewField label="Background" value={form.background} visible={form.profileVisible} />
                 <ViewField label="Goals" value={form.goals} visible={form.profileVisible} />
                 <ViewField label="Affiliation" value={form.affiliation} visible={form.profileVisible} />
+                <ViewField label="Location" value={form.city} visible={form.profileVisible} />
                 <ViewField label="Skills" value={form.skills} visible={form.profileVisible} chips />
                 <ViewField label="Interests" value={form.interests} visible={form.profileVisible} chips />
                 <ViewField label="Major" value={form.major} visible={form.profileVisible} />
@@ -358,6 +371,22 @@ export default function ProfilePage() {
                 onChange={e => handleChange('interests', e.target.value)}
                 placeholder="e.g. Mobile Development, AI/ML"
                 data-testid="profile-interests"
+              />
+            </div>
+
+            <div className="form-field">
+              <label className="form-label">Location</label>
+              <LocationPicker
+                city={form.city}
+                latitude={form.latitude}
+                longitude={form.longitude}
+                disabled={saving}
+                onChange={({ city, latitude, longitude }) => {
+                  // Picker hands back all three together so the pair-completeness
+                  // constraint always holds. Apply as a batch so we don't trip
+                  // any single-field validators in between.
+                  setForm(prev => ({ ...prev, city: city ?? '', latitude, longitude }))
+                }}
               />
             </div>
 

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3605,6 +3605,101 @@
   overflow: hidden;
 }
 
+/* Location picker on profile (#461). */
+.loc-picker {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.loc-picker-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+.loc-picker-input {
+  flex: 1;
+  min-width: 0;
+}
+.loc-picker-results {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  max-height: 260px;
+  overflow-y: auto;
+}
+.loc-picker-result-btn {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: 'DM Sans', sans-serif;
+  color: var(--text);
+}
+.loc-picker-result-btn:hover {
+  background: var(--green-pale);
+}
+.loc-picker-result-name {
+  font-size: 13px;
+  font-weight: 600;
+}
+.loc-picker-result-sub {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.loc-picker-error {
+  font-size: 12px;
+  color: var(--red-text, #b91c1c);
+}
+.loc-picker-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.loc-picker-coords {
+  font-variant-numeric: tabular-nums;
+}
+.loc-picker-clear {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.loc-picker-clear:hover:not(:disabled) {
+  border-color: var(--green-mid);
+  color: var(--green-dark);
+}
+.loc-picker-privacy {
+  margin: 4px 0 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
 /* Feed reposts (#542). */
 .feed-card-repost-banner {
   display: flex;


### PR DESCRIPTION
Closes #461. Replaces PR #540, which had a critical `PATCH → PUT` bug.

## Summary

This PR wires `city`, `latitude`, and `longitude` (already present server-side on `EditProfileRequest`, per #291) through the profile editor for both mentor and mentee roles.

There are two entry paths:

1. **Use current location**
   - Uses `navigator.geolocation`
   - Reverse geocodes via Nominatim
   - Fills `city` + rounded coordinates

2. **Manual typeahead**
   - Debounced (`250ms`) query against Nominatim `/search`
   - Clicking a result fills all three fields

Coordinates are rounded to **2 decimal places** (~1 km precision) before reaching the parent form.

`updateOwnProfile` remains on `PATCH`.  
The rejected PR #540 changed it to `PUT`, which does not exist on the backend. This PR keeps the existing method unchanged.

---

## Changes

### `components/LocationPicker.jsx` (new)

Self-contained widget handling:

- Geolocation
- Permission denied flow
- Position unavailable flow
- Reverse geocoding
- Debounced typeahead
- Dropdown selection
- Clear button
- Privacy note

### `pages/ProfilePage.jsx`

#### `mapResponseToForm`

- Pulls `city`, `latitude`, and `longitude` from the user response
- Applies to both mentor and mentee roles

#### Save payload

- Includes all three fields at the top level
- Works for both `MentorProfileRequest` and `MenteeProfileRequest`
- Sends them as a complete triple so the backend DB `CHECK` constraint remains satisfied

#### Edit form

- Adds a new `<LocationPicker />` block under **Interests**

#### Read-only view

- Adds a new **Location** `ViewField`
- Available for both roles
- Gated by `profileVisible` for mentees (consistent with existing mentee fields)

### `styles/main.css`

Adds `.loc-picker*` styles for:

- Typeahead dropdown
- Status row
- Privacy note

---

## What's different from PR #540

| PR #540 | This PR |
|---|---|
| Changed `updateOwnProfile` from `PATCH` to `PUT` (breaks profile save — backend has no `PUT` mapping) | ✅ Keeps `PATCH` untouched |
| Marked AC4 as ✅ but slider had no backend support | N/A (slider is out of scope) |
| Used `featuretype=city` in Nominatim query (invalid alongside `q=`) | ✅ Uses plain `q=` query |
| Set `User-Agent: 'Bounswe2026Group7-App'` (browsers silently ignore custom `User-Agent`) | ✅ Skipped |
| Displayed coordinates with `toFixed(1)` | ✅ Uses 2 decimals (~1 km precision) |

---

## Acceptance Criteria Mapping (#461)

- ✅ `MentorProfileEditPage` and `MenteeProfileEditPage` both show the location section
- ✅ “Use my current location” works on Chrome / Firefox / Safari
- ✅ Permission-denied flow falls back cleanly to manual entry with inline error messaging
- ✅ Manual entry includes autocomplete suggestions (Nominatim, debounced `250ms`)
- ✅ Saving persists through `PATCH /api/users/me/{role}` and reload renders saved location
- ✅ Privacy note is visible below the picker
- ✅ Coordinates are rounded to 2 decimal places before sending
- ✅ Empty submissions do not unintentionally clear location data
  - Existing values remain unless the user explicitly clicks **Clear**
  - Preserves expected PATCH semantics

---

## Test Plan

### Automated

- `npm run build` → clean
- `npm test` → `64/64` unit tests passing

### Manual

#### Manual search flow

1. Open `/profile`
2. Click **Edit**
3. Search for `"Istanbul"`
4. Dropdown suggestions appear
5. Select a result
6. City + coordinates populate correctly

#### Current location flow

1. Click **Use current location**
2. Browser permission prompt appears
3. Accept permission
4. City is populated via reverse geocoding

#### Permission denied flow

1. Deny browser permission
2. Inline error appears
3. Manual entry still works

#### Persistence check

1. Save profile
2. Reload page
3. Read-only view shows saved location

#### Clear flow

1. Click **Clear**
2. City + coordinates are removed
3. Save profile
4. Reload page
5. Location remains cleared