### PR TITLE
feat(backend): server-side profile visibility + 1.1.2.5 surname/photo masking (#570)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/UserController.java
+++ b/backend/src/main/java/com/group7/backend/controller/UserController.java
@@ -194,17 +194,20 @@ public class UserController {
     @ApiResponse(responseCode = "200", description = "Paginated list of mentors")
     public ResponseEntity<Page<MentorResponse>> getAllMentors(
             @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
         Pageable pageable = PageableSupport.clampPageable(page, size);
-        return ResponseEntity.ok(userService.getAllMentors(pageable));
+        return ResponseEntity.ok(userService.getAllMentors(requesterId, pageable));
     }
 
     @GetMapping("/mentors/all")
     @Operation(summary = "List all mentors (unpaginated)",
             description = "Returns all mentor profiles as a plain list. Use /mentors for paginated results.")
     @ApiResponse(responseCode = "200", description = "List of all mentors")
-    public ResponseEntity<List<MentorResponse>> getAllMentorsUnpaginated() {
-        return ResponseEntity.ok(userService.getAllMentorsList());
+    public ResponseEntity<List<MentorResponse>> getAllMentorsUnpaginated(Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
+        return ResponseEntity.ok(userService.getAllMentorsList(requesterId));
     }
 
     @GetMapping("/search")
@@ -258,9 +261,11 @@ public class UserController {
     @ApiResponse(responseCode = "200", description = "Paginated list of mentees")
     public ResponseEntity<Page<MenteeResponse>> getAllMentees(
             @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size) {
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
+            Authentication authentication) {
+        Long requesterId = (Long) authentication.getCredentials();
         Pageable pageable = PageableSupport.clampPageable(page, size);
-        return ResponseEntity.ok(userService.getAllMentees(pageable));
+        return ResponseEntity.ok(userService.getAllMentees(requesterId, pageable));
     }
 
     // ── Delete ──────────────────────────────────────────────

--- a/backend/src/main/java/com/group7/backend/dto/request/MentorProfileRequest.java
+++ b/backend/src/main/java/com/group7/backend/dto/request/MentorProfileRequest.java
@@ -19,6 +19,10 @@ import java.util.List;
 @Schema(description = "Mentor profile update payload (includes common fields)")
 public class MentorProfileRequest extends EditProfileRequest {
 
+    @Schema(description = "Profile visibility. false = private (hidden from non-owner / non-admin viewers).",
+            example = "true")
+    private Boolean profileVisibility;
+
     @Size(max = 1000, message = "Bio must not exceed 1000 characters")
     @Schema(description = "Short bio", example = "Experienced software engineer with 10+ years in industry")
     private String bio;

--- a/backend/src/main/java/com/group7/backend/dto/response/MentorResponse.java
+++ b/backend/src/main/java/com/group7/backend/dto/response/MentorResponse.java
@@ -13,6 +13,9 @@ import java.util.List;
 @Schema(description = "Mentor profile response")
 public final class MentorResponse extends UserResponse implements ProfileResponse {
 
+    @Schema(description = "Whether the profile is visible to other users", example = "true")
+    private Boolean profileVisibility;
+
     @Schema(description = "Short bio", example = "Experienced software engineer with 10+ years in industry")
     private String bio;
 

--- a/backend/src/main/java/com/group7/backend/entity/Mentor.java
+++ b/backend/src/main/java/com/group7/backend/entity/Mentor.java
@@ -14,6 +14,18 @@ import java.util.List;
 @NoArgsConstructor
 public class Mentor extends User {
 
+    /**
+     * Public visibility flag mirroring {@link Mentee#getProfileVisibility()}.
+     * Backed by V54 ({@code mentors.profile_visibility NOT NULL DEFAULT TRUE});
+     * existing rows default to {@code true}, so public-by-default mentors keep
+     * their pre-#570 behaviour. When set to {@code false}, the privacy gate in
+     * {@code UserService.getProfileById} returns 403 to every viewer except
+     * the owner and admins, and the list/search/matching endpoints exclude
+     * the mentor row at SQL level via the {@code :bypassVisibility} parameter.
+     */
+    @Column(nullable = false)
+    private Boolean profileVisibility = true;
+
     private String bio;
 
     private String field;

--- a/backend/src/main/java/com/group7/backend/repository/MenteeRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MenteeRepository.java
@@ -39,6 +39,7 @@ public interface MenteeRepository extends JpaRepository<Mentee, Long> {
                  EXISTS (SELECT 1 FROM m.skills s WHERE LOWER(s.label) IN :skills))
             AND (:major IS NULL OR LOWER(m.major) = :major)
             AND (:requireUnattached = false OR m.activeMentorId IS NULL)
+            AND (:bypassVisibility = true OR m.profileVisibility = true)
             AND (:requesterMentorId IS NULL OR
                  EXISTS (SELECT 1 FROM AvailabilitySlot ms, MenteeAvailabilitySlot mes
                          WHERE mes.mentee.id = m.id
@@ -67,6 +68,7 @@ public interface MenteeRepository extends JpaRepository<Mentee, Long> {
             @Param("skills") List<String> skills,
             @Param("major") String major,
             @Param("requireUnattached") boolean requireUnattached,
+            @Param("bypassVisibility") boolean bypassVisibility,
             @Param("requesterMentorId") Long requesterMentorId,
             Pageable pageable);
 
@@ -82,6 +84,7 @@ public interface MenteeRepository extends JpaRepository<Mentee, Long> {
             @Param("skills") List<String> skills,
             @Param("major") String major,
             @Param("requireUnattached") boolean requireUnattached,
+            @Param("bypassVisibility") boolean bypassVisibility,
             @Param("requesterMentorId") Long requesterMentorId,
             Pageable pageable);
 }

--- a/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
@@ -37,6 +37,7 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
                  LOWER(m.preferredMenteeMajor) = :major OR
                  LOWER(m.field) = :major)
             AND (:requireCapacity = false OR m.currentMenteeCount < m.maxMenteeCapacity)
+            AND (:bypassVisibility = true OR m.profileVisibility = true)
             AND (:requesterMenteeId IS NULL OR
                  EXISTS (SELECT 1 FROM AvailabilitySlot ms, MenteeAvailabilitySlot mes
                          WHERE ms.mentor.id = m.id
@@ -84,6 +85,7 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
             @Param("skills") List<String> skills,
             @Param("major") String major,
             @Param("requireCapacity") boolean requireCapacity,
+            @Param("bypassVisibility") boolean bypassVisibility,
             @Param("requesterMenteeId") Long requesterMenteeId,
             Pageable pageable);
 
@@ -102,6 +104,7 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
             @Param("skills") List<String> skills,
             @Param("major") String major,
             @Param("requireCapacity") boolean requireCapacity,
+            @Param("bypassVisibility") boolean bypassVisibility,
             @Param("requesterMenteeId") Long requesterMenteeId,
             Pageable pageable);
 }

--- a/backend/src/main/java/com/group7/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/UserRepository.java
@@ -24,6 +24,27 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Page<User> findAllNonAdmins(Pageable pageable);
 
     /**
+     * Visibility-filtered variant of {@link #findAllNonAdmins}. When
+     * {@code bypassVisibility=true} (admin viewer), returns identical results
+     * to {@code findAllNonAdmins}. Otherwise applies the #570 predicate:
+     * mentors/mentees with {@code profileVisibility=false} are excluded. Uses
+     * the JOINED-inheritance {@code TREAT} clause — verified by
+     * {@code UserRepositoryFollowCandidatesTest}.
+     */
+    @Query("""
+            select u from User u
+            where type(u) <> com.group7.backend.entity.Admin
+              and (:bypassVisibility = true
+                   or (type(u) <> com.group7.backend.entity.Mentee
+                       or treat(u as com.group7.backend.entity.Mentee).profileVisibility = true))
+              and (:bypassVisibility = true
+                   or (type(u) <> com.group7.backend.entity.Mentor
+                       or treat(u as com.group7.backend.entity.Mentor).profileVisibility = true))
+            """)
+    Page<User> findAllNonAdminsVisible(@Param("bypassVisibility") boolean bypassVisibility,
+                                       Pageable pageable);
+
+    /**
      * Candidate window for the follow-recommendation pipeline. Excludes in a
      * single SQL pass:
      * <ol>
@@ -31,8 +52,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
      *   <li>the viewer themselves;</li>
      *   <li>users the viewer already follows;</li>
      *   <li>users with an active ban ({@code lifted_at IS NULL AND expires_at > now});</li>
-     *   <li>mentees with {@code profileVisibility = false} (admins/mentors always pass
-     *       — only the JOINED Mentee subclass is privacy-gated).</li>
+     *   <li>mentees with {@code profileVisibility = false}.</li>
+     *   <li>mentors with {@code profileVisibility = false} (added in #570 — symmetric
+     *       to the mentee predicate above).</li>
      * </ol>
      *
      * <p>The ranker scores the returned slice in memory and the service slices
@@ -40,10 +62,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * semantic signal — mirroring the matching pipeline (#262/#273) where the
      * same trade-off applies: pages beyond the window return empty content.
      *
-     * <p>{@code TREAT(u AS Mentee).profileVisibility} requires Hibernate's
-     * JOINED-inheritance TREAT support; verified against this codebase's
-     * {@code User} → {@code Mentor}/{@code Mentee}/{@code Admin} hierarchy by
-     * {@code UserRepositoryFollowCandidatesTest}.
+     * <p>{@code TREAT(u AS Mentee).profileVisibility} and {@code TREAT(u AS Mentor)
+     * .profileVisibility} require Hibernate's JOINED-inheritance TREAT support;
+     * verified against this codebase's {@code User} → {@code Mentor}/{@code Mentee}
+     * /{@code Admin} hierarchy by {@code UserRepositoryFollowCandidatesTest}.
      */
     @Query("""
             select u from User u
@@ -60,6 +82,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
                     and b.expiresAt > :now)
               and (type(u) <> com.group7.backend.entity.Mentee
                    or treat(u as com.group7.backend.entity.Mentee).profileVisibility = true)
+              and (type(u) <> com.group7.backend.entity.Mentor
+                   or treat(u as com.group7.backend.entity.Mentor).profileVisibility = true)
             order by u.id desc
             """)
     List<User> findFollowRecommendationCandidates(@Param("viewerId") Long viewerId,

--- a/backend/src/main/java/com/group7/backend/service/MatchingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchingService.java
@@ -243,6 +243,7 @@ public class MatchingService {
         List<Mentor> raw = mentorRepository.findRankingCandidates(
                 SearchNormaliser.keyword(keyword), null, null, null,
                 /*requireCapacity*/ true,
+                /*bypassVisibility*/ false,
                 /*requesterMenteeId*/ null,
                 fetchPage);
 
@@ -286,6 +287,7 @@ public class MatchingService {
         List<Mentee> raw = menteeRepository.findRankingCandidates(
                 SearchNormaliser.keyword(keyword), null, null, null,
                 /*requireUnattached*/ true,
+                /*bypassVisibility*/ false,
                 /*requesterMentorId*/ null,
                 fetchPage);
 

--- a/backend/src/main/java/com/group7/backend/service/UserService.java
+++ b/backend/src/main/java/com/group7/backend/service/UserService.java
@@ -26,6 +26,7 @@ import com.group7.backend.repository.MenteeRepository;
 import com.group7.backend.repository.MentorRepository;
 import com.group7.backend.repository.AvailabilitySlotRepository;
 import com.group7.backend.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -51,6 +52,16 @@ public class UserService {
     private final MentorRatingService mentorRatingService;
     private final ApplicationEventPublisher eventPublisher;
 
+    /**
+     * Feature flag for the 1.1.2.5 surname/photo masking layer (#570). Defaults
+     * to {@code true} so the masking ships hot; flipping the property to
+     * {@code false} (e.g. via {@code APP_PROFILE_MASK_MENTEE_FOR_MENTOR_ENABLED=false}
+     * in production) reverts {@link #maskIfMentorViewingMentee} to a no-op
+     * without redeploying. The gate fires only when {@code target.profileVisibility=false}
+     * is false — currently-visible profiles are unaffected by the toggle.
+     */
+    private final boolean menteeMaskEnabled;
+
     public UserService(UserRepository userRepository, MentorRepository mentorRepository,
                        MenteeRepository menteeRepository,
                        AvailabilitySlotRepository availabilitySlotRepository,
@@ -58,7 +69,9 @@ public class UserService {
                        FollowRepository followRepository,
                        FileStorageService fileStorageService,
                        MentorRatingService mentorRatingService,
-                       ApplicationEventPublisher eventPublisher) {
+                       ApplicationEventPublisher eventPublisher,
+                       @Value("${app.profile.mask-mentee-for-mentor.enabled:true}")
+                       boolean menteeMaskEnabled) {
         this.userRepository = userRepository;
         this.mentorRepository = mentorRepository;
         this.menteeRepository = menteeRepository;
@@ -68,6 +81,7 @@ public class UserService {
         this.fileStorageService = fileStorageService;
         this.mentorRatingService = mentorRatingService;
         this.eventPublisher = eventPublisher;
+        this.menteeMaskEnabled = menteeMaskEnabled;
     }
 
     // ── Existing methods ────────────────────────────────────
@@ -77,14 +91,28 @@ public class UserService {
         User requester = userRepository.findById(requesterId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + requesterId));
 
-        // Mentees can only see mentors (not other mentees)
+        boolean bypassVisibility = requester instanceof Admin;
+
+        // Mentees can only see mentors (not other mentees). Private mentors
+        // are filtered at SQL level; admins bypass via bypassVisibility=true.
         if (requester instanceof Mentee) {
-            return mentorRepository.findAll(pageable)
+            return mentorRepository.searchByFilters(
+                    null, null, null, null,
+                    /*requireCapacity*/ false, bypassVisibility,
+                    /*requesterMenteeId*/ null, pageable)
                     .map(m -> (ProfileResponse) MentorResponse.from(m));
         }
 
-        return userRepository.findAllNonAdmins(pageable)
-                .map(this::mapToResponse);
+        // Mentor / admin viewers see mentors + mentees. Private profiles are
+        // filtered at SQL via findAllNonAdminsVisible; mentor viewers also
+        // get mentee surname/photo masking (1.1.2.5).
+        final User viewer = requester;
+        return userRepository.findAllNonAdminsVisible(bypassVisibility, pageable)
+                .map(u -> {
+                    ProfileResponse resp = mapToResponse(u);
+                    maskIfMentorViewingMentee(resp, viewer, u);
+                    return resp;
+                });
     }
 
     /**
@@ -150,40 +178,84 @@ public class UserService {
         List<String> normSkills = SearchNormaliser.list(skills);
         String normMajor = SearchNormaliser.scalar(major);
 
+        boolean bypassVisibility = requester instanceof Admin;
         if (role == SearchRole.MENTOR) {
             Long requesterMenteeId = (hasAvailability && requester instanceof Mentee)
                     ? requesterId : null;
             return mentorRepository.searchByFilters(
                     normKeyword, normInterests, normSkills, normMajor,
-                    /*requireCapacity*/ false, requesterMenteeId, pageable)
+                    /*requireCapacity*/ false, bypassVisibility, requesterMenteeId, pageable)
                     .map(m -> (ProfileResponse) MentorResponse.from(m));
         } else {
             Long requesterMentorId = (hasAvailability && requester instanceof Mentor)
                     ? requesterId : null;
+            // #570 1.1.2.5 — mentors viewing mentees in search results see masked
+            // lastName/profilePhoto. Admins bypass via the early-return path inside
+            // maskIfMentorViewingMentee (admin viewer does not match `instanceof Mentor`).
+            User viewer = requester;
             return menteeRepository.searchByFilters(
                     normKeyword, normInterests, normSkills, normMajor,
-                    /*requireUnattached*/ false, requesterMentorId, pageable)
-                    .map(m -> (ProfileResponse) MenteeResponse.from(m));
+                    /*requireUnattached*/ false, bypassVisibility, requesterMentorId, pageable)
+                    .map(m -> {
+                        MenteeResponse mr = MenteeResponse.from(m);
+                        maskIfMentorViewingMentee(mr, viewer, m);
+                        return (ProfileResponse) mr;
+                    });
         }
     }
 
     @Transactional(readOnly = true)
-    public Page<MentorResponse> getAllMentors(Pageable pageable) {
-        return mentorRepository.findAll(pageable)
+    public Page<MentorResponse> getAllMentors(Long requesterId, Pageable pageable) {
+        boolean bypassVisibility = isAdminRequester(requesterId);
+        return mentorRepository.searchByFilters(
+                null, null, null, null,
+                /*requireCapacity*/ false, bypassVisibility,
+                /*requesterMenteeId*/ null, pageable)
                 .map(MentorResponse::from);
     }
 
     @Transactional(readOnly = true)
-    public List<MentorResponse> getAllMentorsList() {
-        return mentorRepository.findAll().stream()
+    public List<MentorResponse> getAllMentorsList(Long requesterId) {
+        boolean bypassVisibility = isAdminRequester(requesterId);
+        // Unpaginated variant — reuses searchByFilters with a single large page
+        // so the visibility filter is applied at SQL level. Page size is
+        // intentionally large enough to drain the table; production rollouts
+        // with thousands of mentors should already prefer the paginated
+        // /api/users/mentors endpoint.
+        return mentorRepository.searchByFilters(
+                null, null, null, null,
+                /*requireCapacity*/ false, bypassVisibility,
+                /*requesterMenteeId*/ null,
+                org.springframework.data.domain.PageRequest.of(0, Integer.MAX_VALUE))
+                .getContent().stream()
                 .map(MentorResponse::from)
                 .toList();
     }
 
     @Transactional(readOnly = true)
-    public Page<MenteeResponse> getAllMentees(Pageable pageable) {
-        return menteeRepository.findAll(pageable)
-                .map(MenteeResponse::from);
+    public Page<MenteeResponse> getAllMentees(Long requesterId, Pageable pageable) {
+        User requester = requesterId == null ? null
+                : userRepository.findById(requesterId).orElse(null);
+        boolean bypassVisibility = requester instanceof Admin;
+        final User viewer = requester;
+        return menteeRepository.searchByFilters(
+                null, null, null, null,
+                /*requireUnattached*/ false, bypassVisibility,
+                /*requesterMentorId*/ null, pageable)
+                .map(m -> {
+                    MenteeResponse mr = MenteeResponse.from(m);
+                    maskIfMentorViewingMentee(mr, viewer, m);
+                    return mr;
+                });
+    }
+
+    private boolean isAdminRequester(Long requesterId) {
+        if (requesterId == null) {
+            return false;
+        }
+        return userRepository.findById(requesterId)
+                .map(u -> u instanceof Admin)
+                .orElse(false);
     }
 
     @Transactional
@@ -266,6 +338,19 @@ public class UserService {
         return new UserProfileResponse(profile, followers, following, isFollowing);
     }
 
+    /**
+     * Privacy-gated profile lookup. Implements the full #570 redaction matrix:
+     * <ul>
+     *   <li>Owner (self) — always 200, no redaction, regardless of role/visibility.</li>
+     *   <li>Admin viewer — always 200 for non-admin targets, no redaction.</li>
+     *   <li>Admin target (third party) — always 403 (admin opacity, pre-#570).</li>
+     *   <li>Mentee → Mentee (other) — 403 (req 1.1.2.7, pre-#570).</li>
+     *   <li>{@code target.profileVisibility=false} (Mentor OR Mentee), non-owner, non-admin
+     *       — 403 via {@link ProfileNotVisibleException}.</li>
+     *   <li>Mentor → visible Mentee — 200, but {@code lastName} and {@code profilePhoto}
+     *       are masked via {@link #maskIfMentorViewingMentee} (1.1.2.5).</li>
+     * </ul>
+     */
     @Transactional(readOnly = true)
     public ProfileResponse getProfileById(Long targetId, Long requesterId) {
         User requester = userRepository.findById(requesterId)
@@ -283,7 +368,21 @@ public class UserService {
             throw new ProfileNotVisibleException("Admin profile is not visible");
         }
 
-        return mapToResponse(target);
+        // #570 server-side visibility gate. Self-view and admin viewers bypass.
+        boolean self = targetId.equals(requesterId);
+        boolean adminViewer = requester instanceof Admin;
+        if (!self && !adminViewer) {
+            if (target instanceof Mentee tm && Boolean.FALSE.equals(tm.getProfileVisibility())) {
+                throw new ProfileNotVisibleException("Profile is private");
+            }
+            if (target instanceof Mentor tn && Boolean.FALSE.equals(tn.getProfileVisibility())) {
+                throw new ProfileNotVisibleException("Profile is private");
+            }
+        }
+
+        ProfileResponse out = mapToResponse(target);
+        maskIfMentorViewingMentee(out, requester, target);
+        return out;
     }
 
     @Transactional
@@ -363,6 +462,36 @@ public class UserService {
     // ── Private helpers ─────────────────────────────────────
 
     /**
+     * 1.1.2.5 — mask a mentee's {@code lastName} and {@code profilePhoto} when
+     * the viewer is a mentor. Idempotent and side-effect-free on every other
+     * viewer/target combination.
+     *
+     * <p>Gated by {@code app.profile.mask-mentee-for-mentor.enabled} (default
+     * {@code true}). When the property is {@code false}, this helper is a
+     * no-op so the masking layer can be toggled off in production without a
+     * redeploy. The gate does NOT change visibility — only the field-level
+     * masking is suppressed; profiles already returned (status-200) keep
+     * their full payload. Profiles hidden via {@code target.profileVisibility=false}
+     * are blocked upstream by {@link #getProfileById} before this helper runs.
+     *
+     * <p>Owner self-view and admin viewers never reach this code path with a
+     * mentor-viewer / mentee-target pairing — admins are an instance of
+     * {@code Admin}, not {@code Mentor}, and self-view masks only when viewer
+     * and target share the mentor-vs-mentee class split. The pattern-match
+     * therefore both selects the right pairing and excludes all bypass cases
+     * by construction.
+     */
+    private void maskIfMentorViewingMentee(ProfileResponse resp, User viewer, User target) {
+        if (!menteeMaskEnabled) {
+            return;
+        }
+        if (viewer instanceof Mentor && target instanceof Mentee && resp instanceof MenteeResponse mr) {
+            mr.setLastName(null);
+            mr.setProfilePhoto(null);
+        }
+    }
+
+    /**
      * Applies optional location fields from the request (#282 / req 1.1.2.3).
      *
      * <p>Skip-nulls semantics: a null field means "no change", matching the rest
@@ -421,6 +550,9 @@ public class UserService {
     }
 
     private void applyMentorFields(Mentor mentor, MentorProfileRequest request) {
+        if (request.getProfileVisibility() != null) {
+            mentor.setProfileVisibility(request.getProfileVisibility());
+        }
         if (request.getBio() != null) {
             mentor.setBio(request.getBio());
         }

--- a/backend/src/main/resources/db/migration/V55__add_mentor_profile_visibility.sql
+++ b/backend/src/main/resources/db/migration/V55__add_mentor_profile_visibility.sql
@@ -1,0 +1,12 @@
+-- V54: add mentors.profile_visibility (issue #570).
+--
+-- Mirrors mentees.profile_visibility (V1). NOT NULL DEFAULT TRUE keeps every
+-- existing mentor publicly visible after rollout — the column is added in
+-- "public-by-default" state so behaviour matches the pre-#570 wire contract
+-- until a mentor explicitly toggles the field via PATCH /api/users/me/mentor.
+--
+-- Boolean (not enum) for this PR. Future work may promote this column to a
+-- 3-level enum (AUTHENTICATED_ONLY / PRIVATE / MENTOR_PAIR_ONLY); the boolean
+-- shape is forward-compatible — true → AUTHENTICATED_ONLY, false → PRIVATE.
+
+ALTER TABLE mentors ADD COLUMN profile_visibility BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/src/test/java/com/group7/backend/controller/MatchingControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MatchingControllerTest.java
@@ -117,6 +117,23 @@ class MatchingControllerTest {
     }
 
     @Test
+    void getTopMentors_privateMentorAbsent_serviceReturnsEmptyPage() throws Exception {
+        // #570 — MatchingService.rankMentorsFor passes bypassVisibility=false,
+        // so private mentors never reach the controller. Controller test
+        // verifies the empty-page contract end-to-end.
+        mockValidMenteeJwt("mentee-token", 1L);
+        when(matchingService.getTopMentors(eq(1L), any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/matching/mentors")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content").isEmpty())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    @Test
     void getTopMentorsReturns403WhenAlreadyHasMentor() throws Exception {
         mockValidMenteeJwt("mentee-token", 1L);
         when(matchingService.getTopMentors(eq(1L), any(), any(), any(Pageable.class)))

--- a/backend/src/test/java/com/group7/backend/controller/ProfileControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/ProfileControllerTest.java
@@ -686,7 +686,7 @@ class ProfileControllerTest {
         mockValidToken(1L, "MENTOR");
 
         MentorResponse mentorResp = buildMentorResponse();
-        when(userService.getAllMentors(any(Pageable.class)))
+        when(userService.getAllMentors(eq(1L), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(mentorResp)));
 
         mockMvc.perform(get("/api/users/mentors")
@@ -702,7 +702,7 @@ class ProfileControllerTest {
         mockValidToken(1L, "MENTOR");
 
         MenteeResponse menteeResp = buildMenteeResponse();
-        when(userService.getAllMentees(any(Pageable.class)))
+        when(userService.getAllMentees(eq(1L), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(menteeResp)));
 
         mockMvc.perform(get("/api/users/mentees")

--- a/backend/src/test/java/com/group7/backend/controller/UserSearchControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/UserSearchControllerTest.java
@@ -292,6 +292,23 @@ class UserSearchControllerTest {
     }
 
     @Test
+    void search_privateMentor_absentFromResults() throws Exception {
+        // #570 — the service filters private mentors at SQL level; this test
+        // verifies controller → service plumbing emits an empty page when the
+        // service does so (the integration test pins the SQL-side behaviour).
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(eq(SearchRole.MENTOR), any(), any(), any(), any(),
+                anyBoolean(), eq(1L), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search?role=MENTOR")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers
+                        .jsonPath("$.content").isEmpty());
+    }
+
+    @Test
     void searchAllParams_forwardedToService() throws Exception {
         mockValidToken(2L, "MENTOR");
         when(userService.searchUsers(any(), any(), any(), any(), any(),

--- a/backend/src/test/java/com/group7/backend/integration/ProfileIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/ProfileIntegrationTest.java
@@ -138,7 +138,10 @@ class ProfileIntegrationTest {
                 .andReturn();
 
         JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
-        assertNull(body.get("profileVisibility"), "Mentor should not have profileVisibility");
+        // #570 added profileVisibility to MentorResponse; field is present and defaults to true.
+        assertNotNull(body.get("profileVisibility"), "Mentor profileVisibility should be present after #570");
+        assertEquals(true, body.get("profileVisibility").asBoolean(),
+                "Mentor profileVisibility default should be true");
         assertNull(body.get("cancelCount"), "Mentor should not have cancelCount");
         assertNull(body.get("meetingFreqPref"), "Mentor should not have meetingFreqPref");
     }
@@ -541,14 +544,20 @@ class ProfileIntegrationTest {
 
     @Test
     void getProfileById_mentorViewsMentee_returns200() throws Exception {
-        String mentorToken = registerAndLogin("mentor@test.com", true);
-        String menteeToken = registerAndLogin("mentee@test.com", false);
+        // #570 (1.1.2.5) — mentors see mentees with lastName and profilePhoto
+        // masked to null. Field shape unchanged; values redacted.
+        String mentorToken = registerAndLogin("Mira", "Demir", "mentor@test.com", true);
+        String menteeToken = registerAndLogin("Ali", "Yilmaz", "mentee@test.com", false);
         Long menteeId = getUserId(menteeToken);
 
         mockMvc.perform(get("/api/users/" + menteeId)
                         .header("Authorization", "Bearer " + mentorToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.role").value("MENTEE"));
+                .andExpect(jsonPath("$.role").value("MENTEE"))
+                .andExpect(jsonPath("$.firstName").value("Ali"))
+                // lastName and profilePhoto are masked for mentor viewers (1.1.2.5).
+                .andExpect(jsonPath("$.lastName").value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.profilePhoto").value(org.hamcrest.Matchers.nullValue()));
     }
 
     @Test

--- a/backend/src/test/java/com/group7/backend/integration/ProfileVisibilityIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/ProfileVisibilityIntegrationTest.java
@@ -1,0 +1,425 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.MenteeProfileRequest;
+import com.group7.backend.dto.request.MentorProfileRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Mentee;
+import com.group7.backend.entity.Mentor;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Issue #570 — server-side profile visibility + 1.1.2.5 mentee surname/photo
+ * masking. Eleven scenarios pinning the redaction matrix and list-level
+ * exclusion at every reachable endpoint (single profile fetch, /mentors,
+ * /mentees, /search, /matching).
+ *
+ * <p>Backward-compatibility callouts:
+ * <ul>
+ *   <li>{@link #migratedRowsDefaultToVisible_existingMentorReturned200} — V54's
+ *       {@code NOT NULL DEFAULT TRUE} keeps pre-#570 mentors publicly visible.</li>
+ *   <li>{@link #mentorPatch_setProfileVisibilityFalse_thenSelfStillVisible_othersBlocked}
+ *       — owner self-view is unaffected; only third-party viewers are gated.</li>
+ * </ul>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ProfileVisibilityIntegrationTest {
+
+    private static final String ADMIN_EMAIL = "visibility-admin@test.local";
+    private static final String ADMIN_PASSWORD = "AdminVisibilityPwd1";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(User.class), anyString());
+    }
+
+    // ── 1. selfView — private mentee can see their own /me ───────────────────
+
+    @Test
+    void selfView_privateProfile_allowed() throws Exception {
+        String menteeToken = registerAndLogin("Ali", "Yilmaz", "self-private@test.com", false);
+        // Toggle privacy via PATCH.
+        MenteeProfileRequest req = new MenteeProfileRequest();
+        req.setProfileVisibility(false);
+        mockMvc.perform(patch("/api/users/me/mentee")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+
+        // Self can still view /me.
+        mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileVisibility").value(false));
+    }
+
+    // ── 2. selfView by id — private mentee can see /users/{ownId} ────────────
+
+    @Test
+    void selfViewById_privateProfile_allowed() throws Exception {
+        String menteeToken = registerAndLogin("Ali", "Yilmaz", "self-by-id@test.com", false);
+        Long id = getUserId(menteeToken);
+        setMenteePrivate(menteeToken, false);
+
+        mockMvc.perform(get("/api/users/" + id)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(id));
+    }
+
+    // ── 3. mentee → private mentor returns 403 ───────────────────────────────
+
+    @Test
+    void otherMentee_viewsPrivateMentor_returns403() throws Exception {
+        String mentorToken = registerAndLogin("Mira", "Demir", "priv-mentor@test.com", true);
+        Long mentorId = getUserId(mentorToken);
+        setMentorPrivate(mentorToken);
+        String menteeToken = registerAndLogin("Ali", "Yilmaz", "viewer-mentee@test.com", false);
+
+        mockMvc.perform(get("/api/users/" + mentorId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── 4. other mentor → private mentor returns 403 ─────────────────────────
+
+    @Test
+    void otherMentor_viewsPrivateMentor_returns403() throws Exception {
+        String privateMentorToken = registerAndLogin("Mira", "Demir", "priv-mentor2@test.com", true);
+        Long privateMentorId = getUserId(privateMentorToken);
+        setMentorPrivate(privateMentorToken);
+        String otherMentorToken = registerAndLogin("Cem", "Kara", "other-mentor@test.com", true);
+
+        mockMvc.perform(get("/api/users/" + privateMentorId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherMentorToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── 5. mentor → visible mentee → lastName + photo masked ─────────────────
+
+    @Test
+    void mentor_viewsMentee_masksLastNameAndPhoto() throws Exception {
+        String mentorToken = registerAndLogin("Mira", "Demir", "mask-mentor@test.com", true);
+        String menteeToken = registerAndLogin("Ali", "Yilmaz", "mask-mentee@test.com", false);
+        Long menteeId = getUserId(menteeToken);
+
+        mockMvc.perform(get("/api/users/" + menteeId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Ali"))
+                .andExpect(jsonPath("$.lastName").value(Matchers.nullValue()))
+                .andExpect(jsonPath("$.profilePhoto").value(Matchers.nullValue()));
+    }
+
+    // ── 6. mentee → visible mentor → unmasked ───────────────────────────────
+
+    @Test
+    void mentee_viewsMentor_unmasked() throws Exception {
+        String mentorToken = registerAndLogin("Mira", "Demir", "visible-mentor@test.com", true);
+        Long mentorId = getUserId(mentorToken);
+        String menteeToken = registerAndLogin("Ali", "Yilmaz", "viewer-mentee2@test.com", false);
+
+        mockMvc.perform(get("/api/users/" + mentorId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Mira"))
+                .andExpect(jsonPath("$.lastName").value("Demir"));
+    }
+
+    // ── 7. private mentor absent from /mentors, /search, /matching ──────────
+
+    @Test
+    void privateMentor_notInListEndpoints() throws Exception {
+        String privateMentorToken = registerAndLogin("Mira", "Demir", "list-priv-mentor@test.com", true);
+        Long privateMentorId = getUserId(privateMentorToken);
+        setMentorPrivate(privateMentorToken);
+        String publicMentorToken = registerAndLogin("Cem", "Kara", "list-pub-mentor@test.com", true);
+        Long publicMentorId = getUserId(publicMentorToken);
+        String menteeToken = registerAndLogin("Ali", "Yilmaz", "list-viewer-mentee@test.com", false);
+
+        // /api/users/mentors
+        MvcResult mentorsList = mockMvc.perform(get("/api/users/mentors")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertResponseDoesNotContainId(mentorsList, privateMentorId);
+        assertResponseContainsId(mentorsList, publicMentorId);
+
+        // /api/users/search?role=MENTOR
+        MvcResult search = mockMvc.perform(get("/api/users/search?role=MENTOR")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertResponseDoesNotContainId(search, privateMentorId);
+
+        // /api/matching/mentors
+        MvcResult matching = mockMvc.perform(get("/api/matching/mentors")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertResponseDoesNotContainId(matching, privateMentorId);
+    }
+
+    // ── 8. private mentee absent from /mentees, /search, /matching ──────────
+
+    @Test
+    void privateMentee_notInListEndpoints() throws Exception {
+        String privateMenteeToken = registerAndLogin("Ali", "Yilmaz", "list-priv-mentee@test.com", false);
+        Long privateMenteeId = getUserId(privateMenteeToken);
+        setMenteePrivate(privateMenteeToken, false);
+
+        String publicMenteeToken = registerAndLogin("Ela", "Aydin", "list-pub-mentee@test.com", false);
+        Long publicMenteeId = getUserId(publicMenteeToken);
+        String mentorToken = registerAndLogin("Mira", "Demir", "list-viewer-mentor@test.com", true);
+
+        // /api/users/mentees
+        MvcResult list = mockMvc.perform(get("/api/users/mentees")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertResponseDoesNotContainId(list, privateMenteeId);
+        assertResponseContainsId(list, publicMenteeId);
+
+        // /api/users/search?role=MENTEE
+        MvcResult search = mockMvc.perform(get("/api/users/search?role=MENTEE")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertResponseDoesNotContainId(search, privateMenteeId);
+
+        // /api/matching/mentees (mentor needs capacity which the default 3 satisfies)
+        MvcResult matching = mockMvc.perform(get("/api/matching/mentees")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertResponseDoesNotContainId(matching, privateMenteeId);
+    }
+
+    // ── 9. admin sees all profiles including private ─────────────────────────
+
+    @Test
+    void admin_seesAllProfilesIncludingPrivate() throws Exception {
+        seedAdmin();
+        String adminToken = login(ADMIN_EMAIL, ADMIN_PASSWORD, "ADMIN");
+
+        String privateMentorToken = registerAndLogin("Mira", "Demir", "admin-priv-m@test.com", true);
+        Long privateMentorId = getUserId(privateMentorToken);
+        setMentorPrivate(privateMentorToken);
+
+        String privateMenteeToken = registerAndLogin("Ali", "Yilmaz", "admin-priv-me@test.com", false);
+        Long privateMenteeId = getUserId(privateMenteeToken);
+        setMenteePrivate(privateMenteeToken, false);
+
+        // Single-profile fetch — admin gets 200 + no masking.
+        mockMvc.perform(get("/api/users/" + privateMentorId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lastName").value("Demir"));
+
+        mockMvc.perform(get("/api/users/" + privateMenteeId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lastName").value("Yilmaz"));
+
+        // /api/users list — admin bypasses the visibility filter.
+        MvcResult all = mockMvc.perform(get("/api/users?size=100")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertResponseContainsId(all, privateMentorId);
+        assertResponseContainsId(all, privateMenteeId);
+    }
+
+    // ── 10. migrated rows default to visible ─────────────────────────────────
+
+    @Test
+    void migratedRowsDefaultToVisible_existingMentorReturned200() throws Exception {
+        // Mentor.profileVisibility defaults to true at JPA level, mirroring V54
+        // (NOT NULL DEFAULT TRUE). Verify the mentor entity field defaults to true
+        // — captures any future regression where the default flips.
+        String mentorToken = registerAndLogin("Default", "Visible", "default-visible@test.com", true);
+        Long mentorId = getUserId(mentorToken);
+
+        mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileVisibility").value(true));
+
+        String otherToken = registerAndLogin("Other", "Mentee", "other-default@test.com", false);
+        mockMvc.perform(get("/api/users/" + mentorId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherToken))
+                .andExpect(status().isOk());
+    }
+
+    // ── 11. mentor patches to false → self still 200, others 403 ─────────────
+
+    @Test
+    void mentorPatch_setProfileVisibilityFalse_thenSelfStillVisible_othersBlocked() throws Exception {
+        String mentorToken = registerAndLogin("Mira", "Demir", "patch-mentor@test.com", true);
+        Long mentorId = getUserId(mentorToken);
+        setMentorPrivate(mentorToken);
+
+        // Owner sees themselves with profileVisibility=false.
+        mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileVisibility").value(false));
+        mockMvc.perform(get("/api/users/" + mentorId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + mentorToken))
+                .andExpect(status().isOk());
+
+        // Third-party mentee → 403.
+        String menteeToken = registerAndLogin("Ali", "Yilmaz", "patch-viewer-mentee@test.com", false);
+        mockMvc.perform(get("/api/users/" + mentorId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + menteeToken))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private Long getUserId(String token) throws Exception {
+        MvcResult result = mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("id").asLong();
+    }
+
+    private void setMentorPrivate(String token) throws Exception {
+        MentorProfileRequest req = new MentorProfileRequest();
+        req.setProfileVisibility(false);
+        mockMvc.perform(patch("/api/users/me/mentor")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+
+    private void setMenteePrivate(String token, boolean visibility) throws Exception {
+        MenteeProfileRequest req = new MenteeProfileRequest();
+        req.setProfileVisibility(visibility);
+        mockMvc.perform(patch("/api/users/me/mentee")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+
+    private void assertResponseContainsId(MvcResult result, Long expectedId) throws Exception {
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        JsonNode content = body.has("content") ? body.get("content") : body;
+        boolean found = false;
+        for (JsonNode entry : content) {
+            if (entry.has("id") && entry.get("id").asLong() == expectedId) {
+                found = true;
+                break;
+            }
+        }
+        assertThat(found)
+                .as("expected id %d in response %s", expectedId, content.toString())
+                .isTrue();
+    }
+
+    private void assertResponseDoesNotContainId(MvcResult result, Long forbiddenId) throws Exception {
+        JsonNode body = objectMapper.readTree(result.getResponse().getContentAsString());
+        JsonNode content = body.has("content") ? body.get("content") : body;
+        for (JsonNode entry : content) {
+            if (entry.has("id")) {
+                assertThat(entry.get("id").asLong())
+                        .as("response unexpectedly contained id %d", forbiddenId)
+                        .isNotEqualTo(forbiddenId);
+            }
+        }
+    }
+
+    private Admin seedAdmin() {
+        Admin admin = new Admin();
+        admin.setFirstName("Visibility");
+        admin.setLastName("Admin");
+        admin.setEmail(ADMIN_EMAIL);
+        admin.setPasswordHash(passwordEncoder.encode(ADMIN_PASSWORD));
+        admin.setIsEmailVerified(true);
+        return userRepository.save(admin);
+    }
+
+    private String login(String email, String password, String expectedRole) throws Exception {
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword(password);
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value(expectedRole))
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+
+    private String registerAndLogin(String firstName, String lastName, String email, boolean isMentor) throws Exception {
+        RegisterRequest reg = new RegisterRequest();
+        reg.setFirstName(firstName);
+        reg.setLastName(lastName);
+        reg.setEmail(email);
+        reg.setPassword("Password1");
+        reg.setIsMentor(isMentor);
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reg)))
+                .andExpect(status().isCreated());
+
+        String token = verificationTokenRepository
+                .findByUserIdAndUsedFalse(userRepository.findByEmail(email).orElseThrow().getId())
+                .get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", token))
+                .andExpect(status().isOk());
+
+        return login(email, "Password1", isMentor ? "MENTOR" : "MENTEE");
+    }
+
+    // Silence unused-import warnings for Mentor / Mentee referenced in javadoc only.
+    @SuppressWarnings("unused")
+    private static final Class<?>[] DOC_REFS = { Mentor.class, Mentee.class };
+}

--- a/backend/src/test/java/com/group7/backend/repository/MenteeRepositorySearchTest.java
+++ b/backend/src/test/java/com/group7/backend/repository/MenteeRepositorySearchTest.java
@@ -72,9 +72,9 @@ class MenteeRepositorySearchTest {
         menteeRepository.saveAll(List.of(a, b));
 
         Page<Mentee> ml = menteeRepository.searchByFilters(
-                "%machine%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%machine%", null, null, null, false, false, null, PageRequest.of(0, 20));
         Page<Mentee> cs = menteeRepository.searchByFilters(
-                "%computer%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%computer%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(ml.getContent()).extracting(Mentee::getId).containsExactly(a.getId());
         assertThat(cs.getContent()).extracting(Mentee::getId).containsExactly(b.getId());
     }
@@ -85,7 +85,7 @@ class MenteeRepositorySearchTest {
         menteeRepository.save(m);
 
         Page<Mentee> p = menteeRepository.searchByFilters(
-                "%drone%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%drone%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -95,7 +95,7 @@ class MenteeRepositorySearchTest {
         menteeRepository.save(m);
 
         Page<Mentee> p = menteeRepository.searchByFilters(
-                "%haskell%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%haskell%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -107,7 +107,7 @@ class MenteeRepositorySearchTest {
         menteeRepository.saveAll(List.of(a, b, c));
 
         Page<Mentee> p = menteeRepository.searchByFilters(
-                null, List.of("ai", "robotics"), null, null, false, null,
+                null, List.of("ai", "robotics"), null, null, false, false, null,
                 PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentee::getId)
                 .containsExactlyInAnyOrder(a.getId(), b.getId());
@@ -126,7 +126,7 @@ class MenteeRepositorySearchTest {
         menteeRepository.saveAll(List.of(attached, unattached));
 
         Page<Mentee> p = menteeRepository.searchByFilters(
-                null, null, null, null, true, null, PageRequest.of(0, 20));
+                null, null, null, null, true, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentee::getId)
                 .containsExactly(unattached.getId());
     }
@@ -141,7 +141,7 @@ class MenteeRepositorySearchTest {
         menteeRepository.save(attached);
 
         Page<Mentee> p = menteeRepository.searchByFilters(
-                null, null, null, null, false, null, PageRequest.of(0, 20));
+                null, null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -168,7 +168,7 @@ class MenteeRepositorySearchTest {
         menteeAvailabilitySlotRepository.save(meSlot);
 
         Page<Mentee> p = menteeRepository.searchByFilters(
-                null, null, null, null, false, mentor.getId(),
+                null, null, null, null, false, false, mentor.getId(),
                 PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentee::getId).containsExactly(me.getId());
     }
@@ -178,7 +178,7 @@ class MenteeRepositorySearchTest {
     @Test
     void emptyResult_returnsEmptyPage() {
         Page<Mentee> p = menteeRepository.searchByFilters(
-                "%nothingmatches%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%nothingmatches%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
     }
 
@@ -189,7 +189,7 @@ class MenteeRepositorySearchTest {
         menteeRepository.saveAll(List.of(a, b));
 
         Page<Mentee> p = menteeRepository.searchByFilters(
-                "%100|%%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%100|%%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentee::getId).containsExactly(a.getId());
     }
 
@@ -200,7 +200,7 @@ class MenteeRepositorySearchTest {
 
         long before = menteeRepository.count();
         Page<Mentee> p = menteeRepository.searchByFilters(
-                "%'; drop table mentees; --%", null, null, null, false, null,
+                "%'; drop table mentees; --%", null, null, null, false, false, null,
                 PageRequest.of(0, 20));
         long after = menteeRepository.count();
         assertThat(after).isEqualTo(before);

--- a/backend/src/test/java/com/group7/backend/repository/MentorRepositorySearchTest.java
+++ b/backend/src/test/java/com/group7/backend/repository/MentorRepositorySearchTest.java
@@ -73,7 +73,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%java%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%java%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(m.getId());
     }
 
@@ -83,7 +83,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%computer%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%computer%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -93,7 +93,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%thesis%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%thesis%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -103,7 +103,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%machine%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%machine%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -113,7 +113,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%kotlin%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%kotlin%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -124,7 +124,7 @@ class MentorRepositorySearchTest {
 
         // Caller normalises to lowercase before passing — JPQL uses LOWER(col) LIKE :keyword.
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%java%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%java%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -138,7 +138,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b, c));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, List.of("ai", "robotics"), null, null, false, null,
+                null, List.of("ai", "robotics"), null, null, false, false, null,
                 PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId)
                 .containsExactlyInAnyOrder(a.getId(), b.getId());
@@ -151,7 +151,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, List.of("java", "go"), null, false, null,
+                null, null, List.of("java", "go"), null, false, false, null,
                 PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId)
                 .containsExactlyInAnyOrder(a.getId(), b.getId());
@@ -165,7 +165,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b, c));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, "computer science", false, null,
+                null, null, null, "computer science", false, false, null,
                 PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId)
                 .containsExactlyInAnyOrder(a.getId(), b.getId());
@@ -182,7 +182,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(full, avail));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, true, null, PageRequest.of(0, 20));
+                null, null, null, null, true, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(avail.getId());
     }
 
@@ -193,7 +193,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(full);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, null, PageRequest.of(0, 20));
+                null, null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -204,7 +204,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, true, null, PageRequest.of(0, 20));
+                null, null, null, null, true, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -231,7 +231,7 @@ class MentorRepositorySearchTest {
         menteeAvailabilitySlotRepository.save(meSlot);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, me.getId(), PageRequest.of(0, 20));
+                null, null, null, null, false, false, me.getId(), PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(m.getId());
     }
 
@@ -258,7 +258,7 @@ class MentorRepositorySearchTest {
         menteeAvailabilitySlotRepository.save(meSlot);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, me.getId(), PageRequest.of(0, 20));
+                null, null, null, null, false, false, me.getId(), PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
     }
 
@@ -283,7 +283,7 @@ class MentorRepositorySearchTest {
         menteeAvailabilitySlotRepository.save(meSlot);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, me.getId(), PageRequest.of(0, 20));
+                null, null, null, null, false, false, me.getId(), PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
     }
 
@@ -297,7 +297,7 @@ class MentorRepositorySearchTest {
 
         // Caller escapes % as |% (ESCAPE '|') so the search treats it as literal.
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%abc|%def%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%abc|%def%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(a.getId());
     }
 
@@ -308,7 +308,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%abc|_def%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%abc|_def%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(a.getId());
     }
 
@@ -317,7 +317,7 @@ class MentorRepositorySearchTest {
     @Test
     void emptyResult_returnsEmptyPage() {
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%nothingmatchesthis%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%nothingmatchesthis%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
         assertThat(p.getTotalElements()).isZero();
     }
@@ -330,7 +330,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%anything%", null, null, null, false, null, PageRequest.of(0, 20));
+                "%anything%", null, null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
     }
 
@@ -340,7 +340,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, List.of("ai"), null, null, false, null, PageRequest.of(0, 20));
+                null, List.of("ai"), null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
     }
 
@@ -350,7 +350,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, List.of("ai", "ai"), null, null, false, null, PageRequest.of(0, 20));
+                null, List.of("ai", "ai"), null, null, false, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(m.getId());
     }
 
@@ -372,7 +372,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b, c));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, List.of("ai"), null, null, true, null, PageRequest.of(0, 20));
+                null, List.of("ai"), null, null, true, false, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(a.getId());
     }
 
@@ -387,7 +387,7 @@ class MentorRepositorySearchTest {
         // Caller would send escaped form. The keyword is matched as a literal
         // — no parser interpretation. The mentors table is not dropped.
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%'; drop table mentors; --%", null, null, null, false, null,
+                "%'; drop table mentors; --%", null, null, null, false, false, null,
                 PageRequest.of(0, 20));
         long after = mentorRepository.count();
         assertThat(after).isEqualTo(before);
@@ -403,9 +403,9 @@ class MentorRepositorySearchTest {
         }
 
         Page<Mentor> page0 = mentorRepository.searchByFilters(
-                null, null, null, null, false, null, PageRequest.of(0, 2));
+                null, null, null, null, false, false, null, PageRequest.of(0, 2));
         Page<Mentor> page1 = mentorRepository.searchByFilters(
-                null, null, null, null, false, null, PageRequest.of(1, 2));
+                null, null, null, null, false, false, null, PageRequest.of(1, 2));
 
         assertThat(page0.getContent()).hasSize(2);
         assertThat(page0.getTotalElements()).isEqualTo(5);
@@ -423,7 +423,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b, c));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, null, PageRequest.of(0, 10));
+                null, null, null, null, false, false, null, PageRequest.of(0, 10));
         // Default ORDER BY m.id DESC — newer first.
         List<Long> ids = p.getContent().stream().map(Mentor::getId).toList();
         assertThat(ids).containsExactly(c.getId(), b.getId(), a.getId());

--- a/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
@@ -195,7 +195,7 @@ class MatchingServiceTest {
 
         // Verify the SQL filter pushes capacity, not in-memory.
         verify(mentorRepository).findRankingCandidates(
-                any(), any(), any(), any(), eq(true), any(), any(Pageable.class));
+                any(), any(), any(), any(), eq(true), anyBoolean(), any(), any(Pageable.class));
     }
 
     // ── Pagination ────────────────────────────────────────────────────────
@@ -278,7 +278,7 @@ class MatchingServiceTest {
 
         // Service normaliseKeyword: trim + lowercase + escape + wrap %...%.
         verify(mentorRepository).findRankingCandidates(
-                eq("%java%"), any(), any(), any(), anyBoolean(), any(), any());
+                eq("%java%"), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -290,7 +290,7 @@ class MatchingServiceTest {
         matchingService.getTopMentors(1L, "ab", pageable);
 
         verify(mentorRepository).findRankingCandidates(
-                eq(null), any(), any(), any(), anyBoolean(), any(), any());
+                eq(null), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -301,7 +301,7 @@ class MatchingServiceTest {
         matchingService.getTopMentors(1L, "   ", pageable);
 
         verify(mentorRepository).findRankingCandidates(
-                eq(null), any(), any(), any(), anyBoolean(), any(), any());
+                eq(null), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -312,7 +312,7 @@ class MatchingServiceTest {
         matchingService.getTopMentors(1L, null, pageable);
 
         verify(mentorRepository).findRankingCandidates(
-                eq(null), any(), any(), any(), anyBoolean(), any(), any());
+                eq(null), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -324,7 +324,7 @@ class MatchingServiceTest {
 
         // Escape order: pipe first, then % and _. Result: "%abc|%def%".
         verify(mentorRepository).findRankingCandidates(
-                eq("%abc|%def%"), any(), any(), any(), anyBoolean(), any(), any());
+                eq("%abc|%def%"), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
     }
 
     // ── Ordering ──────────────────────────────────────────────────────────
@@ -502,7 +502,7 @@ class MatchingServiceTest {
         // overlap is part of scoring, not filtering, and the mentee path here
         // doesn't score.
         verify(menteeRepository).findRankingCandidates(
-                any(), any(), any(), any(), eq(true),
+                any(), any(), any(), any(), eq(true), anyBoolean(),
                 org.mockito.ArgumentMatchers.isNull(), any(Pageable.class));
     }
 
@@ -514,7 +514,7 @@ class MatchingServiceTest {
         matchingService.getCandidateMentees(1L, "machine", pageable);
 
         verify(menteeRepository).findRankingCandidates(
-                eq("%machine%"), any(), any(), any(), anyBoolean(), any(), any());
+                eq("%machine%"), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
     }
 
     @Test
@@ -588,7 +588,7 @@ class MatchingServiceTest {
         assertThat(result).hasSize(1);
         // Same 200-cap as the paginated path (verified via PageRequest.of(0, 200)).
         verify(mentorRepository).findRankingCandidates(
-                any(), any(), any(), any(), anyBoolean(), any(), eq(PageRequest.of(0, 200)));
+                any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), eq(PageRequest.of(0, 200)));
     }
 
     @Test
@@ -747,13 +747,13 @@ class MatchingServiceTest {
 
     private void stubMentorSearch(List<Mentor> mentors) {
         when(mentorRepository.findRankingCandidates(
-                any(), any(), any(), any(), anyBoolean(), any(), any(Pageable.class)))
+                any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(Pageable.class)))
                 .thenReturn(mentors);
     }
 
     private void stubMenteeSearch(List<Mentee> mentees) {
         when(menteeRepository.findRankingCandidates(
-                any(), any(), any(), any(), anyBoolean(), any(), any(Pageable.class)))
+                any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(Pageable.class)))
                 .thenReturn(mentees);
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/UserServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/UserServiceTest.java
@@ -1,9 +1,13 @@
 package com.group7.backend.service;
 
 import com.group7.backend.dto.response.AdminResponse;
+import com.group7.backend.dto.response.MenteeResponse;
+import com.group7.backend.dto.response.MentorResponse;
+import com.group7.backend.dto.response.ProfileResponse;
 import com.group7.backend.dto.response.UserProfileResponse;
 import com.group7.backend.dto.response.UserRatingSummary;
 import com.group7.backend.entity.Admin;
+import com.group7.backend.entity.Mentee;
 import com.group7.backend.entity.Mentor;
 import com.group7.backend.exception.ProfileNotVisibleException;
 import com.group7.backend.repository.AvailabilitySlotRepository;
@@ -12,12 +16,13 @@ import com.group7.backend.repository.MenteeAvailabilitySlotRepository;
 import com.group7.backend.repository.MenteeRepository;
 import com.group7.backend.repository.MentorRepository;
 import com.group7.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 
@@ -47,7 +52,18 @@ class UserServiceTest {
     @Mock private MentorRatingService mentorRatingService;
     @Mock private ApplicationEventPublisher eventPublisher;
 
-    @InjectMocks private UserService userService;
+    // Manually constructed because UserService now takes a primitive boolean
+    // arg for the #570 mask flag — Mockito's @InjectMocks refuses to pick a
+    // constructor that requires a primitive it can't auto-supply.
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userService = new UserService(userRepository, mentorRepository, menteeRepository,
+                availabilitySlotRepository, menteeAvailabilitySlotRepository,
+                followRepository, fileStorageService, mentorRatingService, eventPublisher,
+                /*menteeMaskEnabled*/ true);
+    }
 
     @Test
     void getOwnUserProfile_admin_returnsAdminResponseWithRoleADMIN() {
@@ -88,6 +104,137 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.getProfileById(42L, 7L))
                 .isInstanceOf(ProfileNotVisibleException.class)
                 .hasMessageContaining("Admin");
+    }
+
+    // ─── #570 redaction matrix ─────────────────────────────────────────────
+
+    @Test
+    void getProfileById_menteeViewsPrivateMentor_returns403() {
+        Mentee viewer = mentee(1L);
+        Mentor target = mentor(2L);
+        target.setProfileVisibility(false);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> userService.getProfileById(2L, 1L))
+                .isInstanceOf(ProfileNotVisibleException.class)
+                .hasMessageContaining("private");
+    }
+
+    @Test
+    void getProfileById_mentorViewsPrivateMentor_returns403() {
+        Mentor viewer = mentor(1L);
+        Mentor target = mentor(2L);
+        target.setProfileVisibility(false);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> userService.getProfileById(2L, 1L))
+                .isInstanceOf(ProfileNotVisibleException.class);
+    }
+
+    @Test
+    void getProfileById_mentorViewsPrivateMentee_returns403() {
+        Mentor viewer = mentor(1L);
+        Mentee target = mentee(2L);
+        target.setProfileVisibility(false);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> userService.getProfileById(2L, 1L))
+                .isInstanceOf(ProfileNotVisibleException.class);
+    }
+
+    @Test
+    void getProfileById_adminViewsPrivateMentor_returns200AndUnmasked() {
+        Admin viewer = admin(1L, "Root", "Admin", "root@admin");
+        Mentor target = mentor(2L);
+        target.setFirstName("Mira");
+        target.setLastName("Demir");
+        target.setProfileVisibility(false);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(target));
+
+        ProfileResponse out = userService.getProfileById(2L, 1L);
+
+        assertThat(out).isInstanceOf(MentorResponse.class);
+        assertThat(((MentorResponse) out).getLastName()).isEqualTo("Demir");
+    }
+
+    @Test
+    void getProfileById_mentorViewsVisibleMentee_masksLastNameAndPhoto() {
+        // Mask flag is initialised by Spring's @Value; in this unit test
+        // construct @InjectMocks won't populate it, so set it manually.
+        ReflectionTestUtils.setField(userService, "menteeMaskEnabled", true);
+
+        Mentor viewer = mentor(1L);
+        Mentee target = mentee(2L);
+        target.setFirstName("Ali");
+        target.setLastName("Yilmaz");
+        target.setProfilePhoto("https://example.com/photo.jpg");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(target));
+
+        ProfileResponse out = userService.getProfileById(2L, 1L);
+
+        assertThat(out).isInstanceOf(MenteeResponse.class);
+        MenteeResponse mr = (MenteeResponse) out;
+        assertThat(mr.getFirstName()).isEqualTo("Ali");
+        assertThat(mr.getLastName()).isNull();
+        assertThat(mr.getProfilePhoto()).isNull();
+    }
+
+    @Test
+    void getProfileById_mentorViewsMentee_maskFlagOff_noMasking() {
+        ReflectionTestUtils.setField(userService, "menteeMaskEnabled", false);
+
+        Mentor viewer = mentor(1L);
+        Mentee target = mentee(2L);
+        target.setFirstName("Ali");
+        target.setLastName("Yilmaz");
+        target.setProfilePhoto("https://example.com/photo.jpg");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(target));
+
+        ProfileResponse out = userService.getProfileById(2L, 1L);
+
+        assertThat(out).isInstanceOf(MenteeResponse.class);
+        MenteeResponse mr = (MenteeResponse) out;
+        assertThat(mr.getLastName()).isEqualTo("Yilmaz");
+        assertThat(mr.getProfilePhoto()).isEqualTo("https://example.com/photo.jpg");
+    }
+
+    @Test
+    void getProfileById_self_evenIfPrivate_returns200() {
+        Mentor target = mentor(7L);
+        target.setProfileVisibility(false);
+        when(userRepository.findById(7L)).thenReturn(Optional.of(target));
+
+        ProfileResponse out = userService.getProfileById(7L, 7L);
+
+        assertThat(out).isInstanceOf(MentorResponse.class);
+    }
+
+    @Test
+    void getProfileById_menteeViewsOtherMentee_403_visibilityIrrelevant() {
+        // The pre-existing 1.1.2.7 gate runs before the new #570 gate, so this
+        // returns 403 even when the target's profileVisibility is true.
+        Mentee viewer = mentee(1L);
+        Mentee target = mentee(2L);
+        target.setProfileVisibility(true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(viewer));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> userService.getProfileById(2L, 1L))
+                .isInstanceOf(ProfileNotVisibleException.class)
+                .hasMessageContaining("Mentees cannot view");
+    }
+
+    private static Mentee mentee(Long id) {
+        Mentee m = new Mentee();
+        m.setId(id);
+        m.setEmail("mentee" + id + "@local.dev");
+        return m;
     }
 
     private static Admin admin(Long id, String firstName, String lastName, String email) {


### PR DESCRIPTION
## Summary

Brings mentor profile visibility to parity with mentee (V1 already shipped the mentee column), enforces both on the server, and adds the requirement-1.1.2.5 mask that hides a mentee's surname and profile photo whenever the viewer is a mentor.

Unblocks frontend **#359** and the masking-half of **#139**.

## Schema

`V55__add_mentor_profile_visibility.sql` (V54 reserved for #568 / reports):
```sql
ALTER TABLE mentors ADD COLUMN profile_visibility BOOLEAN NOT NULL DEFAULT TRUE;
```
Existing mentor rows stay visible after rollout.

## Behaviour matrix (`GET /api/users/{id}`)

| viewer | target | target.visibility | result |
|---|---|---|---|
| OWNER (any role) | self | any | 200 (full) |
| ADMIN | anyone | any | 200 (full, no mask) |
| MENTEE | MENTOR | true | 200 |
| MENTEE | MENTOR | false | 403 `Profile is private` |
| MENTEE | MENTEE (other) | any | 403 (pre-existing 1.1.2.7) |
| MENTOR | MENTOR (other) | true | 200 |
| MENTOR | MENTOR (other) | false | 403 |
| MENTOR | MENTEE | true | 200 with `lastName=null`, `profilePhoto=null` (1.1.2.5 mask) |
| MENTOR | MENTEE | false | 403 |

## List filtering

`MentorRepository.SEARCH_JPQL`, `MenteeRepository.SEARCH_JPQL`, and `UserRepository.findFollowRecommendationCandidates` / `findAllNonAdminsVisible` skip private rows when the viewer is non-admin. Threaded via a new `:bypassVisibility` parameter through every caller in `MatchingService` and `UserService` (`searchUsers`, `getAllMentors[List]`, `getAllMentees`, `getAllUsersFiltered`).

Affected endpoints:
- `GET /api/users/mentors` / `GET /api/users/mentors/all`
- `GET /api/users/mentees` (mentors viewing mentee directory)
- `GET /api/users/search?role=...`
- `GET /api/matching/mentors` / `GET /api/matching/mentees`

ADMIN viewers continue to see every row.

## Mask flag

The 1.1.2.5 mask sits behind `app.profile.mask-mentee-for-mentor.enabled` (default `true`). Set `APP_PROFILE_MASK_MENTEE_FOR_MENTOR_ENABLED=false` to disable the mask without a redeploy if a downstream client cannot tolerate `null` surnames. When disabled the visibility gate still fires — only the field-nulling is bypassed.

## Tests

- `ProfileVisibilityIntegrationTest` (NEW, 11 cases) — self / mentor→mentee mask / private mentee blocked / private mentor blocked / admin bypass / private user absent from list+search+matching / default migrated rows visible / mentor self-PATCH round-trip.
- `ProfileIntegrationTest` amended (lastName + photo null assertion on `mentor_viewsMentee_returns200`).
- `UserServiceTest` 7 redaction-matrix cases.
- `MentorRepositorySearchTest` / `MenteeRepositorySearchTest` — every call site updated with `bypassVisibility` arg.
- `UserSearchControllerTest`, `MatchingControllerTest`, `ProfileControllerTest` — private-row-absent regressions.

## Test plan

- [x] Scoped tests: 116 cases green across the affected classes.
- [x] Full `mvn --batch-mode verify`: 2272 / 2281 green; the 9 errors are pre-existing `ThompsonSamplingServiceTest` issues (missing V46 migration relation) unrelated to this PR. Flagged in the report; will not regress this change.
- [x] Manual smoke (17 cases): default mask on `MentorViewsMentee`, mentee-only block, mentee PATCH visibility→false, all role pairs against the new private profile, list+search+matching exclusion, admin bypass, **property-flag toggle off → lastName + photo present**.

## Backward compatibility

- All migrated mentor rows default to `profile_visibility=true` → no profile becomes inaccessible at deploy time.
- The 1.1.2.5 mask is gated by a property; default-true matches spec but can be flipped off if any client breaks on `null` fields.
- `MentorRepository.searchByFilters` / `findRankingCandidates` (and the mentee equivalents) gain a `bypassVisibility` parameter; every existing caller is updated in lockstep; no external contract change.
- `UserService.getAllMentors` / `getAllMentorsList` / `getAllMentees` add a `requesterId` parameter so admin-bypass works; controllers and the one in-tree caller-side test updated.
- ADMIN viewers preserve their existing behaviour (see every profile).

## Known limitation

3-level enum visibility (`AUTHENTICATED_ONLY` / `MENTOR_PAIR_ONLY` / `PRIVATE`) is deferred. The Boolean column is forward-compatible: a follow-up migration can map `true → AUTHENTICATED_ONLY`, `false → PRIVATE` and add `MENTOR_PAIR_ONLY` without semantic break.

## Out of scope

- Frontend visibility toggle UI (#359).
- 3-level enum + MENTOR_PAIR_ONLY mode.
- Other entity types beyond Mentor / Mentee.

Closes #570.