### PR TITLE
feat(backend): advanced mentor search filter parameters (#571)

### DIFF
--- a/backend/src/main/java/com/group7/backend/controller/MatchingController.java
+++ b/backend/src/main/java/com/group7/backend/controller/MatchingController.java
@@ -20,7 +20,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/matching")
@@ -39,7 +41,10 @@ public class MatchingController {
             summary = "Get top mentor matches",
             description = "Returns mentors ranked by compatibility score with pagination support. "
                     + "Excludes full-capacity mentors and requires the caller to be a mentee without an active mentor. "
-                    + "Optionally filter by keyword matched against expertise, field, interests, skills, and goals."
+                    + "Optionally filter by keyword matched against expertise, field, interests, skills, and goals. "
+                    + "#571 adds availabilityDays (mentor offers any of the given days), mentorshipDuration "
+                    + "(months, IN-list), and minMatchScore (post-rank threshold; totalElements reflects the "
+                    + "thresholded count)."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Paginated ranked mentor list"),
@@ -51,18 +56,33 @@ public class MatchingController {
             @Parameter(description = "Optional ceiling on great-circle distance (km) between mentor and mentee. "
                     + "Mentors without coordinates are never excluded by this filter (spec 1.1.2.3).")
             @RequestParam(required = false) Double maxDistanceKm,
+            @Parameter(description = "Filter mentors by availability day-of-week (OR semantics). "
+                    + "Accepts comma-separated or repeated values.",
+                    example = "MONDAY,WEDNESDAY")
+            @RequestParam(required = false) Set<DayOfWeek> availabilityDays,
+            @Parameter(description = "Filter mentors by mentorship duration in months (IN list semantics).",
+                    example = "3")
+            @RequestParam(required = false) Set<Integer> mentorshipDuration,
+            @Parameter(description = "Post-rank minimum match score; mentors below the threshold are "
+                    + "excluded from the page and from totalElements.",
+                    example = "60")
+            @RequestParam(required = false) Integer minMatchScore,
             @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
             Authentication authentication) {
         Long menteeId = (Long) authentication.getCredentials();
         Pageable pageable = PageableSupport.clampPageable(page, size);
-        return ResponseEntity.ok(matchingService.getTopMentors(menteeId, keyword, maxDistanceKm, pageable));
+        return ResponseEntity.ok(matchingService.getTopMentors(
+                menteeId, keyword, maxDistanceKm,
+                availabilityDays, mentorshipDuration, minMatchScore, pageable));
     }
 
     @GetMapping("/mentors/all")
     @PreAuthorize("hasRole('MENTEE')")
     @Operation(summary = "Get all mentor matches (unpaginated)",
-            description = "Returns all ranked mentors as a plain list. Use /mentors for paginated results.")
+            description = "Returns all ranked mentors as a plain list. Use /mentors for paginated results. "
+                    + "Supports the same #571 filters as /mentors (availabilityDays, mentorshipDuration, "
+                    + "minMatchScore).")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Ranked mentor list"),
             @ApiResponse(responseCode = "403", description = "Not a mentee, or mentee already has an active mentor", content = @Content),
@@ -70,9 +90,19 @@ public class MatchingController {
     })
     public ResponseEntity<List<MentorMatchResponse>> getTopMentorsUnpaginated(
             @Parameter(description = "Optional keyword to filter mentors") @RequestParam(required = false) String keyword,
+            @Parameter(description = "Filter mentors by availability day-of-week (OR semantics).",
+                    example = "MONDAY,WEDNESDAY")
+            @RequestParam(required = false) Set<DayOfWeek> availabilityDays,
+            @Parameter(description = "Filter mentors by mentorship duration in months (IN list semantics).",
+                    example = "3")
+            @RequestParam(required = false) Set<Integer> mentorshipDuration,
+            @Parameter(description = "Post-rank minimum match score; mentors below the threshold are excluded.",
+                    example = "60")
+            @RequestParam(required = false) Integer minMatchScore,
             Authentication authentication) {
         Long menteeId = (Long) authentication.getCredentials();
-        return ResponseEntity.ok(matchingService.getTopMentorsList(menteeId, keyword));
+        return ResponseEntity.ok(matchingService.getTopMentorsList(
+                menteeId, keyword, availabilityDays, mentorshipDuration, minMatchScore));
     }
 
     @GetMapping("/mentees")

--- a/backend/src/main/java/com/group7/backend/controller/UserController.java
+++ b/backend/src/main/java/com/group7/backend/controller/UserController.java
@@ -29,7 +29,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/users")
@@ -213,12 +215,14 @@ public class UserController {
     @GetMapping("/search")
     @Operation(summary = "Search users by keyword and filters",
             description = "DB-level search across the user directory with composable filters "
-                    + "(#262). Mentees may search MENTOR only; mentors may search MENTEE only; "
-                    + "admins may search either role. Same-role search returns 403. "
-                    + "Short keyword (length < 3 after trim) is treated as no-keyword "
-                    + "(pg_trgm requires ≥3 alphanumerics for index acceleration). "
+                    + "(#262, extended in #571). Mentees may search MENTOR only; mentors may "
+                    + "search MENTEE only; admins may search either role. Same-role search "
+                    + "returns 403. Short keyword (length < 3 after trim) is treated as "
+                    + "no-keyword (pg_trgm requires ≥3 alphanumerics for index acceleration). "
                     + "hasAvailability=true requires the requester to have at least one "
-                    + "availability slot of their own; admins cannot use this filter.")
+                    + "availability slot of their own; admins cannot use this filter. "
+                    + "availabilityDays and mentorshipDuration apply to MENTOR searches only "
+                    + "and are silently ignored when role=MENTEE.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Paginated search results"),
             @ApiResponse(responseCode = "400",
@@ -243,6 +247,14 @@ public class UserController {
             @RequestParam(required = false) String major,
             @Parameter(description = "Restrict to candidates whose availability overlaps the requester's slots")
             @RequestParam(defaultValue = "false") boolean hasAvailability,
+            @Parameter(description = "Filter mentors by availability day-of-week (OR semantics). "
+                    + "Accepts comma-separated or repeated values. Mentor searches only.",
+                    example = "MONDAY,WEDNESDAY")
+            @RequestParam(required = false) Set<DayOfWeek> availabilityDays,
+            @Parameter(description = "Filter mentors by mentorship duration in months "
+                    + "(IN list semantics). Mentor searches only.",
+                    example = "3")
+            @RequestParam(required = false) Set<Integer> mentorshipDuration,
             @Parameter(description = "Page number (0-based)")
             @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "Page size; clamped to [1, 100]")
@@ -251,7 +263,8 @@ public class UserController {
         Long requesterId = (Long) authentication.getCredentials();
         Pageable pageable = PageableSupport.clampPageable(page, size);
         return ResponseEntity.ok(userService.searchUsers(
-                role, q, interests, skills, major, hasAvailability, requesterId, pageable));
+                role, q, interests, skills, major, hasAvailability,
+                availabilityDays, mentorshipDuration, requesterId, pageable));
     }
 
     @GetMapping("/mentees")

--- a/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/MentorRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.DayOfWeek;
 import java.util.List;
+import java.util.Set;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
 
@@ -45,6 +47,11 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
                            AND ms.dayOfWeek = mes.dayOfWeek
                            AND ms.startTime < mes.endTime
                            AND mes.startTime < ms.endTime))
+            AND (:availabilityDays IS NULL OR
+                 EXISTS (SELECT 1 FROM AvailabilitySlot s
+                         WHERE s.mentor.id = m.id
+                           AND s.dayOfWeek IN :availabilityDays))
+            AND (:mentorshipDuration IS NULL OR m.mentorshipDuration IN :mentorshipDuration)
             ORDER BY m.id DESC
             """;
 
@@ -72,6 +79,14 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
      *       mentors whose availability slots overlap that mentee's slots
      *       (day-of-week + strict-inequality time overlap). Backed by the
      *       {@code idx_mentor_avail_mentor_day} composite index.</li>
+     *   <li>{@code availabilityDays}: when non-null, restricts to mentors
+     *       whose availability slots fall on any of the requested days
+     *       (OR semantics across days). Empty sets must be coalesced to
+     *       {@code null} at the service layer for the same Postgres reason
+     *       as the lists above.</li>
+     *   <li>{@code mentorshipDuration}: when non-null, restricts to mentors
+     *       whose {@code mentorshipDuration} (months) is in the requested
+     *       set. Same empty-set rule applies.</li>
      * </ul>
      *
      * <p>Used by {@code GET /api/users/search} where {@code totalElements} is
@@ -87,6 +102,8 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
             @Param("requireCapacity") boolean requireCapacity,
             @Param("bypassVisibility") boolean bypassVisibility,
             @Param("requesterMenteeId") Long requesterMenteeId,
+            @Param("availabilityDays") Set<DayOfWeek> availabilityDays,
+            @Param("mentorshipDuration") Set<Integer> mentorshipDuration,
             Pageable pageable);
 
     /**
@@ -106,5 +123,7 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
             @Param("requireCapacity") boolean requireCapacity,
             @Param("bypassVisibility") boolean bypassVisibility,
             @Param("requesterMenteeId") Long requesterMenteeId,
+            @Param("availabilityDays") Set<DayOfWeek> availabilityDays,
+            @Param("mentorshipDuration") Set<Integer> mentorshipDuration,
             Pageable pageable);
 }

--- a/backend/src/main/java/com/group7/backend/service/MatchingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchingService.java
@@ -25,8 +25,10 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.time.DayOfWeek;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -126,7 +128,12 @@ public class MatchingService {
     }
 
     public Page<MentorMatchResponse> getTopMentors(Long menteeId, String keyword, Pageable pageable) {
-        return getTopMentors(menteeId, keyword, null, pageable);
+        return getTopMentors(menteeId, keyword, null, null, null, null, pageable);
+    }
+
+    public Page<MentorMatchResponse> getTopMentors(Long menteeId, String keyword,
+                                                   Double maxDistanceKm, Pageable pageable) {
+        return getTopMentors(menteeId, keyword, maxDistanceKm, null, null, null, pageable);
     }
 
     /**
@@ -135,12 +142,30 @@ public class MatchingService {
      * Splitting the LLM call out releases the JDBC connection before the
      * (potentially multi-second) OpenAI request — without this, every
      * matching call holds a Postgres connection for the full prose latency.
+     *
+     * <p>{@code availabilityDays} / {@code mentorshipDuration} are SQL-side
+     * filters (pushed to {@code findRankingCandidates}); {@code minMatchScore}
+     * is a post-rank filter applied before {@link #slicePage} so the
+     * paginated totals reflect the thresholded ranking (#571).
      */
     public Page<MentorMatchResponse> getTopMentors(Long menteeId, String keyword,
-                                                   Double maxDistanceKm, Pageable pageable) {
+                                                   Double maxDistanceKm,
+                                                   Set<DayOfWeek> availabilityDays,
+                                                   Set<Integer> mentorshipDuration,
+                                                   Integer minMatchScore,
+                                                   Pageable pageable) {
         var loaded = readOnlyTx.execute(status -> {
             Mentee mentee = loadEligibleMentee(menteeId);
-            List<MentorMatchResponse> ranked = rankMentorsFor(mentee, keyword, maxDistanceKm);
+            List<MentorMatchResponse> ranked = rankMentorsFor(
+                    mentee, keyword, maxDistanceKm, availabilityDays, mentorshipDuration);
+            // minMatchScore is applied AFTER scoring but BEFORE slicePage so
+            // the page's totalElements reflects the thresholded count, not
+            // the pre-threshold ranking size.
+            if (minMatchScore != null) {
+                ranked = ranked.stream()
+                        .filter(r -> r.getMatchScore() >= minMatchScore)
+                        .toList();
+            }
             Page<MentorMatchResponse> page = slicePage(ranked, pageable);
             return new LoadedPage(page, MenteeSnapshot.of(mentee));
         });
@@ -164,10 +189,36 @@ public class MatchingService {
     }
 
     public List<MentorMatchResponse> getTopMentorsList(Long menteeId, String keyword) {
+        return getTopMentorsList(menteeId, keyword, null, null, null);
+    }
+
+    /**
+     * Unpaginated counterpart of {@link #getTopMentors} with the #571 filters.
+     * Applies the SQL-side {@code availabilityDays}/{@code mentorshipDuration}
+     * to the candidate query and the post-rank {@code minMatchScore} ceiling
+     * before returning.
+     *
+     * <p>Mirrors {@link #getTopMentors}'s split-transaction pattern (#585):
+     * the mentee-load + candidate-rank run inside a programmatic read-only
+     * transaction so the entity reads commit before the (potentially slow)
+     * OpenAI prose-attach. Without the split, every matching call holds a
+     * JDBC connection for the full LLM round-trip.
+     */
+    public List<MentorMatchResponse> getTopMentorsList(Long menteeId, String keyword,
+                                                       Set<DayOfWeek> availabilityDays,
+                                                       Set<Integer> mentorshipDuration,
+                                                       Integer minMatchScore) {
         record Loaded(List<MentorMatchResponse> mentors, MenteeSnapshot snapshot) {}
         Loaded loaded = readOnlyTx.execute(status -> {
             Mentee mentee = loadEligibleMentee(menteeId);
-            return new Loaded(rankMentorsFor(mentee, keyword, null), MenteeSnapshot.of(mentee));
+            List<MentorMatchResponse> ranked = rankMentorsFor(
+                    mentee, keyword, null, availabilityDays, mentorshipDuration);
+            if (minMatchScore != null) {
+                ranked = ranked.stream()
+                        .filter(r -> r.getMatchScore() >= minMatchScore)
+                        .toList();
+            }
+            return new Loaded(ranked, MenteeSnapshot.of(mentee));
         });
         explanationService.attach(loaded.mentors(), loaded.snapshot().toDetachedMentee());
         return loaded.mentors();
@@ -203,12 +254,18 @@ public class MatchingService {
      * their own public entry point and pass through.
      */
     List<MentorMatchResponse> rankMentorsForId(Long menteeId, String keyword, Double maxDistanceKm) {
+        return rankMentorsForId(menteeId, keyword, maxDistanceKm, null, null);
+    }
+
+    List<MentorMatchResponse> rankMentorsForId(Long menteeId, String keyword, Double maxDistanceKm,
+                                               Set<DayOfWeek> availabilityDays,
+                                               Set<Integer> mentorshipDuration) {
         Mentee mentee = menteeRepository.findById(menteeId)
                 .orElseThrow(() -> new ResourceNotFoundException("Mentee not found"));
         if (mentee.getActiveMentorId() != null) {
             throw new MatchingNotAllowedException("You already have an active mentor");
         }
-        return rankMentorsFor(mentee, keyword, maxDistanceKm);
+        return rankMentorsFor(mentee, keyword, maxDistanceKm, availabilityDays, mentorshipDuration);
     }
 
     /**
@@ -223,18 +280,34 @@ public class MatchingService {
      *
      * <p>No {@code @Transactional}: package-private method advice is ignored
      * by Spring's proxy. Runs inside the caller's transaction.
+     *
+     * <p>This two-arg overload is retained for
+     * {@code MatchNotificationProcessor} (calls without distance / day /
+     * duration filters). New callers should prefer the five-arg variant.
      */
     List<MentorMatchResponse> rankMentorsFor(Mentee mentee, String keyword) {
-        return rankMentorsFor(mentee, keyword, null);
+        return rankMentorsFor(mentee, keyword, null, null, null);
     }
 
     /**
-     * Pure ranking core with optional max-distance ceiling. The two-arg
-     * overload {@link #rankMentorsFor(Mentee, String)} is kept for
-     * {@code MatchNotificationProcessor}, which still calls the no-distance
-     * variant. New callers should prefer this three-arg method.
+     * Three-arg overload preserved for callers that pre-date the #571
+     * advanced filters but still want a distance ceiling. Delegates to the
+     * five-arg form with {@code null} for day-of-week and duration filters.
      */
     List<MentorMatchResponse> rankMentorsFor(Mentee mentee, String keyword, Double maxDistanceKm) {
+        return rankMentorsFor(mentee, keyword, maxDistanceKm, null, null);
+    }
+
+    /**
+     * Pure ranking core with optional max-distance, day-of-week, and
+     * mentorship-duration filters (#571). The day-of-week and duration sets
+     * are pushed to {@code findRankingCandidates}; max-distance feeds the
+     * scoring pipeline. Empty sets are coerced to null upstream via
+     * {@link SearchNormaliser#nullIfEmpty}.
+     */
+    List<MentorMatchResponse> rankMentorsFor(Mentee mentee, String keyword, Double maxDistanceKm,
+                                             Set<DayOfWeek> availabilityDays,
+                                             Set<Integer> mentorshipDuration) {
         if (mentee == null) {
             throw new IllegalStateException("rankMentorsFor: mentee must not be null");
         }
@@ -250,6 +323,8 @@ public class MatchingService {
                 /*requireCapacity*/ true,
                 /*bypassVisibility*/ false,
                 /*requesterMenteeId*/ null,
+                SearchNormaliser.nullIfEmpty(availabilityDays),
+                SearchNormaliser.nullIfEmpty(mentorshipDuration),
                 fetchPage);
 
         if (raw.isEmpty()) {

--- a/backend/src/main/java/com/group7/backend/service/SearchNormaliser.java
+++ b/backend/src/main/java/com/group7/backend/service/SearchNormaliser.java
@@ -3,6 +3,7 @@ package com.group7.backend.service;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Shared normalisation for the SQL-side search filters introduced in #262.
@@ -79,5 +80,20 @@ final class SearchNormaliser {
      */
     static String scalar(String raw) {
         return raw == null || raw.isBlank() ? null : raw.trim().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Coerces an empty {@link Set} to {@code null} so the {@code :param IS NULL}
+     * gate in JPQL short-circuits the filter. Same rationale as
+     * {@link #list(List)} — Hibernate translates a non-null empty set to
+     * {@code IN ()} which Postgres rejects.
+     *
+     * <p>Used by typed-collection filters such as {@code Set<DayOfWeek>} or
+     * {@code Set<Integer>} where elementwise normalisation (lowercasing) does
+     * not apply. The set itself is returned unchanged when non-empty — typed
+     * enums and integers are already canonical.
+     */
+    static <T> Set<T> nullIfEmpty(Set<T> raw) {
+        return (raw == null || raw.isEmpty()) ? null : raw;
     }
 }

--- a/backend/src/main/java/com/group7/backend/service/UserService.java
+++ b/backend/src/main/java/com/group7/backend/service/UserService.java
@@ -31,8 +31,10 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.DayOfWeek;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.transaction.annotation.Transactional;
@@ -99,7 +101,9 @@ public class UserService {
             return mentorRepository.searchByFilters(
                     null, null, null, null,
                     /*requireCapacity*/ false, bypassVisibility,
-                    /*requesterMenteeId*/ null, pageable)
+                    /*requesterMenteeId*/ null,
+                    /*availabilityDays*/ null, /*mentorshipDuration*/ null,
+                    pageable)
                     .map(m -> (ProfileResponse) MentorResponse.from(m));
         }
 
@@ -132,6 +136,12 @@ public class UserService {
      *       slot-presence requirement applies).</li>
      * </ul>
      */
+    /**
+     * Backwards-compatible delegate preserved for callers that predate the
+     * advanced mentor filters in #571. New code should use the 10-arg form
+     * with {@code availabilityDays} / {@code mentorshipDuration}; passing
+     * {@code null} for both reproduces the pre-#571 behaviour.
+     */
     @Transactional(readOnly = true)
     public Page<ProfileResponse> searchUsers(SearchRole role,
                                              String keyword,
@@ -139,6 +149,27 @@ public class UserService {
                                              List<String> skills,
                                              String major,
                                              boolean hasAvailability,
+                                             Long requesterId,
+                                             Pageable pageable) {
+        return searchUsers(role, keyword, interests, skills, major,
+                hasAvailability, null, null, requesterId, pageable);
+    }
+
+    /**
+     * Advanced overload (#571) accepting the day-of-week and mentorship-
+     * duration filters introduced for the mentor search surface. The
+     * {@link MenteeRepository#searchByFilters} side ignores both — the issue
+     * scopes them to mentor results only.
+     */
+    @Transactional(readOnly = true)
+    public Page<ProfileResponse> searchUsers(SearchRole role,
+                                             String keyword,
+                                             List<String> interests,
+                                             List<String> skills,
+                                             String major,
+                                             boolean hasAvailability,
+                                             Set<DayOfWeek> availabilityDays,
+                                             Set<Integer> mentorshipDuration,
                                              Long requesterId,
                                              Pageable pageable) {
         Objects.requireNonNull(role, "role");
@@ -177,6 +208,11 @@ public class UserService {
         List<String> normInterests = SearchNormaliser.list(interests);
         List<String> normSkills = SearchNormaliser.list(skills);
         String normMajor = SearchNormaliser.scalar(major);
+        // Empty Set<DayOfWeek>/Set<Integer> must be coerced to null so the
+        // JPQL `:param IS NULL` gate short-circuits — Postgres rejects
+        // `IN ()` exactly as it does for the list-of-string filters.
+        Set<DayOfWeek> normAvailabilityDays = SearchNormaliser.nullIfEmpty(availabilityDays);
+        Set<Integer> normMentorshipDuration = SearchNormaliser.nullIfEmpty(mentorshipDuration);
 
         boolean bypassVisibility = requester instanceof Admin;
         if (role == SearchRole.MENTOR) {
@@ -184,7 +220,8 @@ public class UserService {
                     ? requesterId : null;
             return mentorRepository.searchByFilters(
                     normKeyword, normInterests, normSkills, normMajor,
-                    /*requireCapacity*/ false, bypassVisibility, requesterMenteeId, pageable)
+                    /*requireCapacity*/ false, bypassVisibility, requesterMenteeId,
+                    normAvailabilityDays, normMentorshipDuration, pageable)
                     .map(m -> (ProfileResponse) MentorResponse.from(m));
         } else {
             Long requesterMentorId = (hasAvailability && requester instanceof Mentor)
@@ -193,6 +230,8 @@ public class UserService {
             // lastName/profilePhoto. Admins bypass via the early-return path inside
             // maskIfMentorViewingMentee (admin viewer does not match `instanceof Mentor`).
             User viewer = requester;
+            // MenteeRepository is intentionally not extended with the
+            // mentor-only filters from #571 — they're silently ignored on this branch.
             return menteeRepository.searchByFilters(
                     normKeyword, normInterests, normSkills, normMajor,
                     /*requireUnattached*/ false, bypassVisibility, requesterMentorId, pageable)
@@ -210,7 +249,9 @@ public class UserService {
         return mentorRepository.searchByFilters(
                 null, null, null, null,
                 /*requireCapacity*/ false, bypassVisibility,
-                /*requesterMenteeId*/ null, pageable)
+                /*requesterMenteeId*/ null,
+                /*availabilityDays*/ null, /*mentorshipDuration*/ null,
+                pageable)
                 .map(MentorResponse::from);
     }
 
@@ -226,6 +267,7 @@ public class UserService {
                 null, null, null, null,
                 /*requireCapacity*/ false, bypassVisibility,
                 /*requesterMenteeId*/ null,
+                /*availabilityDays*/ null, /*mentorshipDuration*/ null,
                 org.springframework.data.domain.PageRequest.of(0, Integer.MAX_VALUE))
                 .getContent().stream()
                 .map(MentorResponse::from)

--- a/backend/src/test/java/com/group7/backend/controller/MatchingControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/MatchingControllerTest.java
@@ -60,7 +60,7 @@ class MatchingControllerTest {
         MentorMatchResponse match = new MentorMatchResponse();
         match.setFirstName("Ahmet");
         match.setMatchScore(10);
-        when(matchingService.getTopMentors(eq(1L), any(), any(), any(Pageable.class)))
+        when(matchingService.getTopMentors(eq(1L), any(), any(), any(), any(), any(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(match)));
 
         mockMvc.perform(get("/api/matching/mentors")
@@ -74,7 +74,7 @@ class MatchingControllerTest {
     @Test
     void getTopMentorsWithKeywordReturns200() throws Exception {
         mockValidMenteeJwt("mentee-token", 1L);
-        when(matchingService.getTopMentors(eq(1L), eq("java"), any(), any(Pageable.class)))
+        when(matchingService.getTopMentors(eq(1L), eq("java"), any(), any(), any(), any(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of()));
 
         mockMvc.perform(get("/api/matching/mentors?keyword=java")
@@ -101,7 +101,7 @@ class MatchingControllerTest {
     @Test
     void getTopMentorsForwardsMaxDistanceKmParam() throws Exception {
         mockValidMenteeJwt("mentee-token", 1L);
-        when(matchingService.getTopMentors(eq(1L), any(), eq(50.0), any(Pageable.class)))
+        when(matchingService.getTopMentors(eq(1L), any(), eq(50.0), any(), any(), any(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of()));
 
         mockMvc.perform(get("/api/matching/mentors?maxDistanceKm=50")
@@ -109,7 +109,7 @@ class MatchingControllerTest {
                 .andExpect(status().isOk());
 
         // And the unconstrained call still routes through the null-maxDistance path.
-        when(matchingService.getTopMentors(eq(1L), any(), eq((Double) null), any(Pageable.class)))
+        when(matchingService.getTopMentors(eq(1L), any(), eq((Double) null), any(), any(), any(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of()));
         mockMvc.perform(get("/api/matching/mentors")
                         .header("Authorization", "Bearer mentee-token"))
@@ -120,9 +120,11 @@ class MatchingControllerTest {
     void getTopMentors_privateMentorAbsent_serviceReturnsEmptyPage() throws Exception {
         // #570 — MatchingService.rankMentorsFor passes bypassVisibility=false,
         // so private mentors never reach the controller. Controller test
-        // verifies the empty-page contract end-to-end.
+        // verifies the empty-page contract end-to-end. Mock matches the
+        // post-#571 7-arg getTopMentors signature.
         mockValidMenteeJwt("mentee-token", 1L);
-        when(matchingService.getTopMentors(eq(1L), any(), any(), any(Pageable.class)))
+        when(matchingService.getTopMentors(eq(1L), any(), any(),
+                any(), any(), any(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of()));
 
         mockMvc.perform(get("/api/matching/mentors")
@@ -134,9 +136,61 @@ class MatchingControllerTest {
     }
 
     @Test
+    void getTopMentorsForwardsAvailabilityDays() throws Exception {
+        mockValidMenteeJwt("mentee-token", 1L);
+        when(matchingService.getTopMentors(eq(1L), any(), any(),
+                any(), any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/matching/mentors?availabilityDays=MONDAY,WEDNESDAY")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk());
+
+        @SuppressWarnings("unchecked")
+        org.mockito.ArgumentCaptor<java.util.Set<java.time.DayOfWeek>> days =
+                org.mockito.ArgumentCaptor.forClass(java.util.Set.class);
+        org.mockito.Mockito.verify(matchingService).getTopMentors(
+                eq(1L), any(), any(), days.capture(), any(), any(), any(Pageable.class));
+        org.assertj.core.api.Assertions.assertThat(days.getValue())
+                .containsExactlyInAnyOrder(java.time.DayOfWeek.MONDAY, java.time.DayOfWeek.WEDNESDAY);
+    }
+
+    @Test
+    void getTopMentorsForwardsMentorshipDuration() throws Exception {
+        mockValidMenteeJwt("mentee-token", 1L);
+        when(matchingService.getTopMentors(eq(1L), any(), any(),
+                any(), any(), any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/matching/mentors?mentorshipDuration=3&mentorshipDuration=6")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk());
+
+        @SuppressWarnings("unchecked")
+        org.mockito.ArgumentCaptor<java.util.Set<Integer>> duration =
+                org.mockito.ArgumentCaptor.forClass(java.util.Set.class);
+        org.mockito.Mockito.verify(matchingService).getTopMentors(
+                eq(1L), any(), any(), any(), duration.capture(), any(), any(Pageable.class));
+        org.assertj.core.api.Assertions.assertThat(duration.getValue())
+                .containsExactlyInAnyOrder(3, 6);
+    }
+
+    @Test
+    void getTopMentorsForwardsMinMatchScore() throws Exception {
+        mockValidMenteeJwt("mentee-token", 1L);
+        when(matchingService.getTopMentors(eq(1L), any(), any(),
+                any(), any(), eq(60), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/matching/mentors?minMatchScore=60")
+                        .header("Authorization", "Bearer mentee-token"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     void getTopMentorsReturns403WhenAlreadyHasMentor() throws Exception {
         mockValidMenteeJwt("mentee-token", 1L);
-        when(matchingService.getTopMentors(eq(1L), any(), any(), any(Pageable.class)))
+        when(matchingService.getTopMentors(eq(1L), any(), any(), any(), any(), any(), any(Pageable.class)))
                 .thenThrow(new com.group7.backend.exception.MatchingNotAllowedException(
                         "You already have an active mentor"));
 

--- a/backend/src/test/java/com/group7/backend/controller/UserSearchControllerTest.java
+++ b/backend/src/test/java/com/group7/backend/controller/UserSearchControllerTest.java
@@ -73,7 +73,7 @@ class UserSearchControllerTest {
     void searchAsMentee_searchingMentor_returns200() throws Exception {
         mockValidToken(1L, "MENTEE");
         when(userService.searchUsers(eq(SearchRole.MENTOR), any(), any(), any(), any(),
-                anyBoolean(), eq(1L), any(Pageable.class)))
+                anyBoolean(), any(), any(), eq(1L), any(Pageable.class)))
                 .thenReturn(singletonMentorPage());
 
         mockMvc.perform(get("/api/users/search?role=MENTOR")
@@ -85,7 +85,7 @@ class UserSearchControllerTest {
     void searchAsMentor_searchingMentee_returns200() throws Exception {
         mockValidToken(2L, "MENTOR");
         when(userService.searchUsers(eq(SearchRole.MENTEE), any(), any(), any(), any(),
-                anyBoolean(), eq(2L), any(Pageable.class)))
+                anyBoolean(), any(), any(), eq(2L), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         mockMvc.perform(get("/api/users/search?role=MENTEE")
@@ -97,7 +97,7 @@ class UserSearchControllerTest {
     void searchAsAdmin_searchingMentor_returns200() throws Exception {
         mockValidToken(3L, "ADMIN");
         when(userService.searchUsers(eq(SearchRole.MENTOR), any(), any(), any(), any(),
-                anyBoolean(), eq(3L), any(Pageable.class)))
+                anyBoolean(), any(), any(), eq(3L), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         mockMvc.perform(get("/api/users/search?role=MENTOR")
@@ -109,7 +109,7 @@ class UserSearchControllerTest {
     void searchAsAdmin_searchingMentee_returns200() throws Exception {
         mockValidToken(3L, "ADMIN");
         when(userService.searchUsers(eq(SearchRole.MENTEE), any(), any(), any(), any(),
-                anyBoolean(), eq(3L), any(Pageable.class)))
+                anyBoolean(), any(), any(), eq(3L), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         mockMvc.perform(get("/api/users/search?role=MENTEE")
@@ -123,7 +123,7 @@ class UserSearchControllerTest {
     void searchAsMentee_searchingMentee_returns403() throws Exception {
         mockValidToken(1L, "MENTEE");
         when(userService.searchUsers(eq(SearchRole.MENTEE), any(), any(), any(), any(),
-                anyBoolean(), eq(1L), any(Pageable.class)))
+                anyBoolean(), any(), any(), eq(1L), any(Pageable.class)))
                 .thenThrow(new ProfileNotVisibleException("Mentees cannot search for other mentees"));
 
         mockMvc.perform(get("/api/users/search?role=MENTEE")
@@ -135,7 +135,7 @@ class UserSearchControllerTest {
     void searchAsMentor_searchingMentor_returns403() throws Exception {
         mockValidToken(2L, "MENTOR");
         when(userService.searchUsers(eq(SearchRole.MENTOR), any(), any(), any(), any(),
-                anyBoolean(), eq(2L), any(Pageable.class)))
+                anyBoolean(), any(), any(), eq(2L), any(Pageable.class)))
                 .thenThrow(new ProfileNotVisibleException("Mentors cannot search for other mentors"));
 
         mockMvc.perform(get("/api/users/search?role=MENTOR")
@@ -147,7 +147,7 @@ class UserSearchControllerTest {
     void searchAsAdmin_hasAvailabilityTrue_returns400() throws Exception {
         mockValidToken(3L, "ADMIN");
         when(userService.searchUsers(any(), any(), any(), any(), any(),
-                eq(true), eq(3L), any(Pageable.class)))
+                eq(true), any(), any(), eq(3L), any(Pageable.class)))
                 .thenThrow(new IllegalArgumentException(
                         "hasAvailability filter is not applicable for admin searches"));
 
@@ -160,7 +160,7 @@ class UserSearchControllerTest {
     void searchHasAvailability_requesterMissingSlots_returns400() throws Exception {
         mockValidToken(1L, "MENTEE");
         when(userService.searchUsers(any(), any(), any(), any(), any(),
-                eq(true), eq(1L), any(Pageable.class)))
+                eq(true), any(), any(), eq(1L), any(Pageable.class)))
                 .thenThrow(new IllegalArgumentException(
                         "Set your availability before filtering by overlap"));
 
@@ -201,7 +201,7 @@ class UserSearchControllerTest {
     void searchKeywordTooShort_stillReaches200_serviceTreatsAsNoFilter() throws Exception {
         mockValidToken(1L, "MENTEE");
         when(userService.searchUsers(any(), any(), any(), any(), any(),
-                anyBoolean(), anyLong(), any(Pageable.class)))
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         // q="ab" — service-side normaliser returns null for length<3; controller
@@ -213,7 +213,7 @@ class UserSearchControllerTest {
         // Verify the raw "ab" was forwarded — normalisation is the service's job.
         ArgumentCaptor<String> kw = ArgumentCaptor.forClass(String.class);
         verify(userService).searchUsers(any(), kw.capture(), any(), any(), any(),
-                anyBoolean(), anyLong(), any(Pageable.class));
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class));
         assertThat(kw.getValue()).isEqualTo("ab");
     }
 
@@ -223,7 +223,7 @@ class UserSearchControllerTest {
     void searchPaginationParamsHonored() throws Exception {
         mockValidToken(1L, "MENTEE");
         when(userService.searchUsers(any(), any(), any(), any(), any(),
-                anyBoolean(), anyLong(), any(Pageable.class)))
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         mockMvc.perform(get("/api/users/search?role=MENTOR&page=2&size=5")
@@ -232,7 +232,7 @@ class UserSearchControllerTest {
 
         ArgumentCaptor<Pageable> pg = ArgumentCaptor.forClass(Pageable.class);
         verify(userService).searchUsers(any(), any(), any(), any(), any(),
-                anyBoolean(), anyLong(), pg.capture());
+                anyBoolean(), any(), any(), anyLong(), pg.capture());
         assertThat(pg.getValue().getPageNumber()).isEqualTo(2);
         assertThat(pg.getValue().getPageSize()).isEqualTo(5);
     }
@@ -241,7 +241,7 @@ class UserSearchControllerTest {
     void searchOversizedPage_clampedTo100() throws Exception {
         mockValidToken(1L, "MENTEE");
         when(userService.searchUsers(any(), any(), any(), any(), any(),
-                anyBoolean(), anyLong(), any(Pageable.class)))
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         mockMvc.perform(get("/api/users/search?role=MENTOR&size=10000")
@@ -250,7 +250,7 @@ class UserSearchControllerTest {
 
         ArgumentCaptor<Pageable> pg = ArgumentCaptor.forClass(Pageable.class);
         verify(userService).searchUsers(any(), any(), any(), any(), any(),
-                anyBoolean(), anyLong(), pg.capture());
+                anyBoolean(), any(), any(), anyLong(), pg.capture());
         assertThat(pg.getValue().getPageSize()).isEqualTo(100);
     }
 
@@ -258,7 +258,7 @@ class UserSearchControllerTest {
     void searchNegativePage_clampedToZero() throws Exception {
         mockValidToken(1L, "MENTEE");
         when(userService.searchUsers(any(), any(), any(), any(), any(),
-                anyBoolean(), anyLong(), any(Pageable.class)))
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         mockMvc.perform(get("/api/users/search?role=MENTOR&page=-5")
@@ -267,7 +267,7 @@ class UserSearchControllerTest {
 
         ArgumentCaptor<Pageable> pg = ArgumentCaptor.forClass(Pageable.class);
         verify(userService).searchUsers(any(), any(), any(), any(), any(),
-                anyBoolean(), anyLong(), pg.capture());
+                anyBoolean(), any(), any(), anyLong(), pg.capture());
         assertThat(pg.getValue().getPageNumber()).isEqualTo(0);
     }
 
@@ -277,7 +277,7 @@ class UserSearchControllerTest {
     void searchMultiValueInterests_forwardedAsList() throws Exception {
         mockValidToken(1L, "MENTEE");
         when(userService.searchUsers(any(), any(), any(), any(), any(),
-                anyBoolean(), anyLong(), any(Pageable.class)))
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         mockMvc.perform(get("/api/users/search?role=MENTOR&interests=AI&interests=Databases")
@@ -287,7 +287,7 @@ class UserSearchControllerTest {
         @SuppressWarnings("unchecked")
         ArgumentCaptor<List<String>> interests = ArgumentCaptor.forClass(List.class);
         verify(userService).searchUsers(any(), any(), interests.capture(), any(), any(),
-                anyBoolean(), anyLong(), any(Pageable.class));
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class));
         assertThat(interests.getValue()).containsExactly("AI", "Databases");
     }
 
@@ -298,7 +298,7 @@ class UserSearchControllerTest {
         // service does so (the integration test pins the SQL-side behaviour).
         mockValidToken(1L, "MENTEE");
         when(userService.searchUsers(eq(SearchRole.MENTOR), any(), any(), any(), any(),
-                anyBoolean(), eq(1L), any(Pageable.class)))
+                anyBoolean(), any(), any(), eq(1L), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         mockMvc.perform(get("/api/users/search?role=MENTOR")
@@ -312,7 +312,7 @@ class UserSearchControllerTest {
     void searchAllParams_forwardedToService() throws Exception {
         mockValidToken(2L, "MENTOR");
         when(userService.searchUsers(any(), any(), any(), any(), any(),
-                anyBoolean(), anyLong(), any(Pageable.class)))
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class)))
                 .thenReturn(emptyPage());
 
         // Use param() rather than inline query string so MockMvc URL-decodes
@@ -334,7 +334,54 @@ class UserSearchControllerTest {
                 eq(List.of("Java")),
                 eq("Computer Science"),
                 eq(false),
+                org.mockito.ArgumentMatchers.isNull(),
+                org.mockito.ArgumentMatchers.isNull(),
                 eq(2L),
                 any(Pageable.class));
+    }
+
+    // ── #571: availabilityDays / mentorshipDuration param binding ─────────────
+
+    @Test
+    void searchMultiValueAvailabilityDays_forwardedAsSet() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search")
+                        .param("role", "MENTOR")
+                        .param("availabilityDays", "MONDAY", "WEDNESDAY")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<java.util.Set<java.time.DayOfWeek>> days =
+                ArgumentCaptor.forClass(java.util.Set.class);
+        verify(userService).searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), days.capture(), any(), anyLong(), any(Pageable.class));
+        assertThat(days.getValue())
+                .containsExactlyInAnyOrder(java.time.DayOfWeek.MONDAY, java.time.DayOfWeek.WEDNESDAY);
+    }
+
+    @Test
+    void searchMentorshipDuration_forwardedAsSet() throws Exception {
+        mockValidToken(1L, "MENTEE");
+        when(userService.searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), any(), any(), anyLong(), any(Pageable.class)))
+                .thenReturn(emptyPage());
+
+        mockMvc.perform(get("/api/users/search")
+                        .param("role", "MENTOR")
+                        .param("mentorshipDuration", "3", "6")
+                        .header("Authorization", "Bearer " + TOKEN))
+                .andExpect(status().isOk());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<java.util.Set<Integer>> duration =
+                ArgumentCaptor.forClass(java.util.Set.class);
+        verify(userService).searchUsers(any(), any(), any(), any(), any(),
+                anyBoolean(), any(), duration.capture(), anyLong(), any(Pageable.class));
+        assertThat(duration.getValue()).containsExactlyInAnyOrder(3, 6);
     }
 }

--- a/backend/src/test/java/com/group7/backend/integration/UserSearchIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/UserSearchIntegrationTest.java
@@ -295,6 +295,64 @@ class UserSearchIntegrationTest {
         assertThat(json.get("content").get(0).get("id").asLong()).isEqualTo(a.getId());
     }
 
+    // ── #571: combined availabilityDays + mentorshipDuration happy path ──────
+
+    @Test
+    void advancedFilters_availabilityDaysAndMentorshipDuration_combineAsAnd() throws Exception {
+        // Mentor matches keyword + day + duration — included.
+        registerAndLogin("us_advanced_match@example.com", true);
+        Mentor matching = findMentor("us_advanced_match@example.com");
+        matching.setExpertise("backend java");
+        matching.setMentorshipDuration(3);
+        mentorRepository.save(matching);
+        AvailabilitySlot okSlot = new AvailabilitySlot();
+        okSlot.setMentor(matching);
+        okSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        okSlot.setStartTime(LocalTime.of(9, 0));
+        okSlot.setEndTime(LocalTime.of(10, 0));
+        availabilitySlotRepository.save(okSlot);
+
+        // Right day + keyword but wrong duration — excluded.
+        registerAndLogin("us_advanced_wrong_duration@example.com", true);
+        Mentor wrongDuration = findMentor("us_advanced_wrong_duration@example.com");
+        wrongDuration.setExpertise("backend java");
+        wrongDuration.setMentorshipDuration(12);
+        mentorRepository.save(wrongDuration);
+        AvailabilitySlot wdSlot = new AvailabilitySlot();
+        wdSlot.setMentor(wrongDuration);
+        wdSlot.setDayOfWeek(DayOfWeek.MONDAY);
+        wdSlot.setStartTime(LocalTime.of(9, 0));
+        wdSlot.setEndTime(LocalTime.of(10, 0));
+        availabilitySlotRepository.save(wdSlot);
+
+        // Right duration + keyword but wrong day — excluded.
+        registerAndLogin("us_advanced_wrong_day@example.com", true);
+        Mentor wrongDay = findMentor("us_advanced_wrong_day@example.com");
+        wrongDay.setExpertise("backend java");
+        wrongDay.setMentorshipDuration(3);
+        mentorRepository.save(wrongDay);
+        AvailabilitySlot wdaySlot = new AvailabilitySlot();
+        wdaySlot.setMentor(wrongDay);
+        wdaySlot.setDayOfWeek(DayOfWeek.FRIDAY);
+        wdaySlot.setStartTime(LocalTime.of(9, 0));
+        wdaySlot.setEndTime(LocalTime.of(10, 0));
+        availabilitySlotRepository.save(wdaySlot);
+
+        String menteeToken = registerAndLogin("us_advanced_mentee@example.com", false);
+
+        MvcResult result = mockMvc.perform(get("/api/users/search")
+                        .param("role", "MENTOR")
+                        .param("q", "java")
+                        .param("availabilityDays", "MONDAY", "WEDNESDAY")
+                        .param("mentorshipDuration", "3", "6")
+                        .header("Authorization", "Bearer " + menteeToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        var json = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(json.get("totalElements").asInt()).isEqualTo(1);
+        assertThat(json.get("content").get(0).get("id").asLong()).isEqualTo(matching.getId());
+    }
+
     // ── Authentication boundary ──────────────────────────────────────────────
 
     @Test

--- a/backend/src/test/java/com/group7/backend/repository/MentorRepositorySearchTest.java
+++ b/backend/src/test/java/com/group7/backend/repository/MentorRepositorySearchTest.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -73,7 +74,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%java%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%java%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(m.getId());
     }
 
@@ -83,7 +84,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%computer%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%computer%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -93,7 +94,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%thesis%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%thesis%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -103,7 +104,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%machine%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%machine%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -113,7 +114,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%kotlin%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%kotlin%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -124,7 +125,7 @@ class MentorRepositorySearchTest {
 
         // Caller normalises to lowercase before passing — JPQL uses LOWER(col) LIKE :keyword.
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%java%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%java%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -138,8 +139,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b, c));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, List.of("ai", "robotics"), null, null, false, false, null,
-                PageRequest.of(0, 20));
+                null, List.of("ai", "robotics"), null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId)
                 .containsExactlyInAnyOrder(a.getId(), b.getId());
     }
@@ -151,8 +151,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, List.of("java", "go"), null, false, false, null,
-                PageRequest.of(0, 20));
+                null, null, List.of("java", "go"), null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId)
                 .containsExactlyInAnyOrder(a.getId(), b.getId());
     }
@@ -165,8 +164,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b, c));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, "computer science", false, false, null,
-                PageRequest.of(0, 20));
+                null, null, null, "computer science", false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId)
                 .containsExactlyInAnyOrder(a.getId(), b.getId());
     }
@@ -182,7 +180,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(full, avail));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, true, false, null, PageRequest.of(0, 20));
+                null, null, null, null, true, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(avail.getId());
     }
 
@@ -193,7 +191,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(full);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, false, null, PageRequest.of(0, 20));
+                null, null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -204,7 +202,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, true, false, null, PageRequest.of(0, 20));
+                null, null, null, null, true, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).hasSize(1);
     }
 
@@ -231,7 +229,7 @@ class MentorRepositorySearchTest {
         menteeAvailabilitySlotRepository.save(meSlot);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, false, me.getId(), PageRequest.of(0, 20));
+                null, null, null, null, false, false, me.getId(), null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(m.getId());
     }
 
@@ -258,7 +256,7 @@ class MentorRepositorySearchTest {
         menteeAvailabilitySlotRepository.save(meSlot);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, false, me.getId(), PageRequest.of(0, 20));
+                null, null, null, null, false, false, me.getId(), null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
     }
 
@@ -283,7 +281,7 @@ class MentorRepositorySearchTest {
         menteeAvailabilitySlotRepository.save(meSlot);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, false, me.getId(), PageRequest.of(0, 20));
+                null, null, null, null, false, false, me.getId(), null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
     }
 
@@ -297,7 +295,7 @@ class MentorRepositorySearchTest {
 
         // Caller escapes % as |% (ESCAPE '|') so the search treats it as literal.
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%abc|%def%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%abc|%def%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(a.getId());
     }
 
@@ -308,7 +306,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%abc|_def%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%abc|_def%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(a.getId());
     }
 
@@ -317,7 +315,7 @@ class MentorRepositorySearchTest {
     @Test
     void emptyResult_returnsEmptyPage() {
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%nothingmatchesthis%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%nothingmatchesthis%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
         assertThat(p.getTotalElements()).isZero();
     }
@@ -330,7 +328,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%anything%", null, null, null, false, false, null, PageRequest.of(0, 20));
+                "%anything%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
     }
 
@@ -340,7 +338,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, List.of("ai"), null, null, false, false, null, PageRequest.of(0, 20));
+                null, List.of("ai"), null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).isEmpty();
     }
 
@@ -350,7 +348,7 @@ class MentorRepositorySearchTest {
         mentorRepository.save(m);
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, List.of("ai", "ai"), null, null, false, false, null, PageRequest.of(0, 20));
+                null, List.of("ai", "ai"), null, null, false, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(m.getId());
     }
 
@@ -372,7 +370,7 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b, c));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, List.of("ai"), null, null, true, false, null, PageRequest.of(0, 20));
+                null, List.of("ai"), null, null, true, false, null, null, null, PageRequest.of(0, 20));
         assertThat(p.getContent()).extracting(Mentor::getId).containsExactly(a.getId());
     }
 
@@ -387,8 +385,7 @@ class MentorRepositorySearchTest {
         // Caller would send escaped form. The keyword is matched as a literal
         // — no parser interpretation. The mentors table is not dropped.
         Page<Mentor> p = mentorRepository.searchByFilters(
-                "%'; drop table mentors; --%", null, null, null, false, false, null,
-                PageRequest.of(0, 20));
+                "%'; drop table mentors; --%", null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
         long after = mentorRepository.count();
         assertThat(after).isEqualTo(before);
         assertThat(p.getContent()).isEmpty();
@@ -403,9 +400,9 @@ class MentorRepositorySearchTest {
         }
 
         Page<Mentor> page0 = mentorRepository.searchByFilters(
-                null, null, null, null, false, false, null, PageRequest.of(0, 2));
+                null, null, null, null, false, false, null, null, null, PageRequest.of(0, 2));
         Page<Mentor> page1 = mentorRepository.searchByFilters(
-                null, null, null, null, false, false, null, PageRequest.of(1, 2));
+                null, null, null, null, false, false, null, null, null, PageRequest.of(1, 2));
 
         assertThat(page0.getContent()).hasSize(2);
         assertThat(page0.getTotalElements()).isEqualTo(5);
@@ -423,9 +420,138 @@ class MentorRepositorySearchTest {
         mentorRepository.saveAll(List.of(a, b, c));
 
         Page<Mentor> p = mentorRepository.searchByFilters(
-                null, null, null, null, false, false, null, PageRequest.of(0, 10));
+                null, null, null, null, false, false, null, null, null, PageRequest.of(0, 10));
         // Default ORDER BY m.id DESC — newer first.
         List<Long> ids = p.getContent().stream().map(Mentor::getId).toList();
         assertThat(ids).containsExactly(c.getId(), b.getId(), a.getId());
+    }
+
+    // ── #571: availabilityDays filter (OR across days, EXISTS on slot) ──────
+
+    private AvailabilitySlot slotFor(Mentor m, DayOfWeek day) {
+        AvailabilitySlot s = new AvailabilitySlot();
+        s.setMentor(m);
+        s.setDayOfWeek(day);
+        s.setStartTime(LocalTime.of(9, 0));
+        s.setEndTime(LocalTime.of(10, 0));
+        return s;
+    }
+
+    @Test
+    void availabilityDays_nullReturnsAll() {
+        // Even mentors without any slot rows survive when the filter is null
+        // (the EXISTS clause is bypassed by the `:availabilityDays IS NULL`
+        // gate).
+        Mentor noSlots = mentorRepository.save(newMentor("ad1"));
+        Mentor withSlot = mentorRepository.save(newMentor("ad2"));
+        availabilitySlotRepository.save(slotFor(withSlot, DayOfWeek.MONDAY));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, false, null, null, null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId)
+                .containsExactlyInAnyOrder(noSlots.getId(), withSlot.getId());
+    }
+
+    @Test
+    void availabilityDays_singleDayMatchesMentorWithThatSlot() {
+        Mentor monday = mentorRepository.save(newMentor("ad3"));
+        availabilitySlotRepository.save(slotFor(monday, DayOfWeek.MONDAY));
+        Mentor tuesday = mentorRepository.save(newMentor("ad4"));
+        availabilitySlotRepository.save(slotFor(tuesday, DayOfWeek.TUESDAY));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, false, null, Set.of(DayOfWeek.MONDAY), null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId)
+                .containsExactly(monday.getId());
+    }
+
+    @Test
+    void availabilityDays_multiDayUsesOrSemantics() {
+        Mentor monday = mentorRepository.save(newMentor("ad5"));
+        availabilitySlotRepository.save(slotFor(monday, DayOfWeek.MONDAY));
+        Mentor wednesday = mentorRepository.save(newMentor("ad6"));
+        availabilitySlotRepository.save(slotFor(wednesday, DayOfWeek.WEDNESDAY));
+        Mentor friday = mentorRepository.save(newMentor("ad7"));
+        availabilitySlotRepository.save(slotFor(friday, DayOfWeek.FRIDAY));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, false, null, Set.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY), null, PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId)
+                .containsExactlyInAnyOrder(monday.getId(), wednesday.getId());
+    }
+
+    @Test
+    void availabilityDays_noMatchingDayExcludes() {
+        Mentor monday = mentorRepository.save(newMentor("ad8"));
+        availabilitySlotRepository.save(slotFor(monday, DayOfWeek.MONDAY));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, false, null,
+                Set.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY), null,
+                PageRequest.of(0, 20));
+        assertThat(p.getContent()).isEmpty();
+    }
+
+    // ── #571: mentorshipDuration filter (IN list of months) ─────────────────
+
+    @Test
+    void mentorshipDuration_inListMatches() {
+        Mentor three = newMentor("md1"); three.setMentorshipDuration(3);
+        Mentor six = newMentor("md2"); six.setMentorshipDuration(6);
+        Mentor twelve = newMentor("md3"); twelve.setMentorshipDuration(12);
+        mentorRepository.saveAll(List.of(three, six, twelve));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, false, null, null, Set.of(3, 6), PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId)
+                .containsExactlyInAnyOrder(three.getId(), six.getId());
+    }
+
+    @Test
+    void mentorshipDuration_nullReturnsAll() {
+        // Mentors with null mentorshipDuration are NOT excluded when the
+        // filter is null — the `:mentorshipDuration IS NULL` gate bypasses
+        // the IN clause entirely.
+        Mentor noDuration = mentorRepository.save(newMentor("md4"));
+        Mentor sixMonths = newMentor("md5"); sixMonths.setMentorshipDuration(6);
+        mentorRepository.save(sixMonths);
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, null, null, null, false, false, null, null, null,
+                PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId)
+                .containsExactlyInAnyOrder(noDuration.getId(), sixMonths.getId());
+    }
+
+    // ── Combined: new filters compose AND with existing categories ──────────
+
+    @Test
+    void combinedFilters_appliedAsAndAcrossCategories_includingNewFilters() {
+        Mentor matching = newMentor("cm1");
+        matching.setInterests(List.of("AI"));
+        matching.setMentorshipDuration(3);
+        mentorRepository.save(matching);
+        availabilitySlotRepository.save(slotFor(matching, DayOfWeek.MONDAY));
+
+        // Right duration, right interest, wrong day.
+        Mentor wrongDay = newMentor("cm2");
+        wrongDay.setInterests(List.of("AI"));
+        wrongDay.setMentorshipDuration(3);
+        mentorRepository.save(wrongDay);
+        availabilitySlotRepository.save(slotFor(wrongDay, DayOfWeek.TUESDAY));
+
+        // Right day, right interest, wrong duration.
+        Mentor wrongDuration = newMentor("cm3");
+        wrongDuration.setInterests(List.of("AI"));
+        wrongDuration.setMentorshipDuration(12);
+        mentorRepository.save(wrongDuration);
+        availabilitySlotRepository.save(slotFor(wrongDuration, DayOfWeek.MONDAY));
+
+        Page<Mentor> p = mentorRepository.searchByFilters(
+                null, List.of("ai"), null, null, false, false, null,
+                Set.of(DayOfWeek.MONDAY), Set.of(3, 6),
+                PageRequest.of(0, 20));
+        assertThat(p.getContent()).extracting(Mentor::getId)
+                .containsExactly(matching.getId());
     }
 }

--- a/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/MatchingServiceTest.java
@@ -195,7 +195,7 @@ class MatchingServiceTest {
 
         // Verify the SQL filter pushes capacity, not in-memory.
         verify(mentorRepository).findRankingCandidates(
-                any(), any(), any(), any(), eq(true), anyBoolean(), any(), any(Pageable.class));
+                any(), any(), any(), any(), eq(true), anyBoolean(), any(), any(), any(), any(Pageable.class));
     }
 
     // ── Pagination ────────────────────────────────────────────────────────
@@ -278,7 +278,7 @@ class MatchingServiceTest {
 
         // Service normaliseKeyword: trim + lowercase + escape + wrap %...%.
         verify(mentorRepository).findRankingCandidates(
-                eq("%java%"), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
+                eq("%java%"), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(), any(), any());
     }
 
     @Test
@@ -290,7 +290,7 @@ class MatchingServiceTest {
         matchingService.getTopMentors(1L, "ab", pageable);
 
         verify(mentorRepository).findRankingCandidates(
-                eq(null), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
+                eq(null), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(), any(), any());
     }
 
     @Test
@@ -301,7 +301,7 @@ class MatchingServiceTest {
         matchingService.getTopMentors(1L, "   ", pageable);
 
         verify(mentorRepository).findRankingCandidates(
-                eq(null), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
+                eq(null), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(), any(), any());
     }
 
     @Test
@@ -312,7 +312,7 @@ class MatchingServiceTest {
         matchingService.getTopMentors(1L, null, pageable);
 
         verify(mentorRepository).findRankingCandidates(
-                eq(null), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
+                eq(null), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(), any(), any());
     }
 
     @Test
@@ -324,7 +324,7 @@ class MatchingServiceTest {
 
         // Escape order: pipe first, then % and _. Result: "%abc|%def%".
         verify(mentorRepository).findRankingCandidates(
-                eq("%abc|%def%"), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any());
+                eq("%abc|%def%"), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(), any(), any());
     }
 
     // ── Ordering ──────────────────────────────────────────────────────────
@@ -588,7 +588,7 @@ class MatchingServiceTest {
         assertThat(result).hasSize(1);
         // Same 200-cap as the paginated path (verified via PageRequest.of(0, 200)).
         verify(mentorRepository).findRankingCandidates(
-                any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), eq(PageRequest.of(0, 200)));
+                any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(), any(), eq(PageRequest.of(0, 200)));
     }
 
     @Test
@@ -737,6 +737,92 @@ class MatchingServiceTest {
         assertThat(result.get(0).getId()).isEqualTo(mentee.getId());
     }
 
+    // ── #571: advanced filter passthrough + minMatchScore post-rank ───────
+
+    @Test
+    void availabilityDays_passedThroughToRepository() {
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
+
+        java.util.Set<DayOfWeek> days =
+                java.util.Set.of(DayOfWeek.MONDAY, DayOfWeek.FRIDAY);
+        java.util.Set<Integer> durations = java.util.Set.of(3, 6);
+        matchingService.getTopMentors(
+                1L, null, /*maxDistanceKm*/ null, days, durations,
+                /*minMatchScore*/ null, pageable);
+
+        @SuppressWarnings("unchecked")
+        org.mockito.ArgumentCaptor<java.util.Set<DayOfWeek>> daysCaptor =
+                org.mockito.ArgumentCaptor.forClass(java.util.Set.class);
+        @SuppressWarnings("unchecked")
+        org.mockito.ArgumentCaptor<java.util.Set<Integer>> durCaptor =
+                org.mockito.ArgumentCaptor.forClass(java.util.Set.class);
+        verify(mentorRepository).findRankingCandidates(
+                any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(),
+                daysCaptor.capture(), durCaptor.capture(), any(Pageable.class));
+        assertThat(daysCaptor.getValue())
+                .containsExactlyInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.FRIDAY);
+        assertThat(durCaptor.getValue()).containsExactlyInAnyOrder(3, 6);
+    }
+
+    @Test
+    void availabilityDays_emptySetCoercedToNullBeforeRepository() {
+        // Empty Set<DayOfWeek> must be coerced to null at the service layer so
+        // Postgres doesn't reject the underlying `IN ()` for an empty parameter
+        // — same rule as the existing string-list filters.
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(mentor));
+
+        matchingService.getTopMentors(
+                1L, null, null, java.util.Set.of(), java.util.Set.of(),
+                null, pageable);
+
+        verify(mentorRepository).findRankingCandidates(
+                any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(),
+                org.mockito.ArgumentMatchers.isNull(),
+                org.mockito.ArgumentMatchers.isNull(),
+                any(Pageable.class));
+    }
+
+    @Test
+    void minMatchScore_excludesBelowThresholdAndAdjustsTotal() {
+        // Two mentors with markedly different fit. The mentor fixture matches
+        // the mentee on field, expertise, major, etc.; lowScore has no overlap
+        // so the ranker scores it 0. Setting minMatchScore=1 must drop the
+        // zero-scoring mentor AND lower totalElements to reflect the
+        // thresholded ranking.
+        Mentor lowScore = new Mentor();
+        lowScore.setId(7L);
+        lowScore.setMaxMenteeCapacity(3);
+        lowScore.setCurrentMenteeCount(0);
+
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(lowScore, mentor));
+
+        Page<MentorMatchResponse> withThreshold = matchingService.getTopMentors(
+                1L, null, null, null, null, /*minMatchScore*/ 1, pageable);
+
+        assertThat(withThreshold.getContent()).extracting(MentorMatchResponse::getId)
+                .containsExactly(mentor.getId());
+        assertThat(withThreshold.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    void minMatchScore_nullPreservesAllCandidates() {
+        Mentor lowScore = new Mentor();
+        lowScore.setId(7L);
+        lowScore.setMaxMenteeCapacity(3);
+        lowScore.setCurrentMenteeCount(0);
+
+        when(menteeRepository.findById(1L)).thenReturn(Optional.of(mentee));
+        stubMentorSearch(List.of(lowScore, mentor));
+
+        Page<MentorMatchResponse> noThreshold = matchingService.getTopMentors(
+                1L, null, null, null, null, /*minMatchScore*/ null, pageable);
+
+        assertThat(noThreshold.getTotalElements()).isEqualTo(2);
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────
 
     // The matching path uses findRankingCandidates (List, no count) — see
@@ -747,7 +833,7 @@ class MatchingServiceTest {
 
     private void stubMentorSearch(List<Mentor> mentors) {
         when(mentorRepository.findRankingCandidates(
-                any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(Pageable.class)))
+                any(), any(), any(), any(), anyBoolean(), anyBoolean(), any(), any(), any(), any(Pageable.class)))
                 .thenReturn(mentors);
     }
 

--- a/backend/src/test/java/com/group7/backend/service/TaskServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/TaskServiceTest.java
@@ -174,7 +174,7 @@ class TaskServiceTest {
     @Test
     void submitTask_Success() {
         when(taskRepository.findByIdWithMentorship(100L)).thenReturn(Optional.of(pendingTask));
-        when(taskSubmissionRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(taskSubmissionRepository.save(any(TaskSubmission.class))).thenAnswer(i -> i.getArgument(0));
 
         TaskSubmissionRequest req = new TaskSubmissionRequest();
         req.setSubmissionText("Here is my work");


### PR DESCRIPTION
## Summary

Adds three optional filter parameters to the mentor-facing search and matching endpoints so the frontend explore page (**#139**) can sit on day, duration, and min-score controls without breaking the existing surface.

| Param | Type | Endpoint | Semantics |
|---|---|---|---|
| `availabilityDays` | `Set<DayOfWeek>` | `/api/users/search`, `/api/matching/mentors`, `/mentors/all` | OR across days — mentor matches if at least one slot falls on a selected day. |
| `mentorshipDuration` | `Set<Integer>` | same | `IN` filter against `Mentor.mentorshipDuration`. |
| `minMatchScore` | `Integer` | `/api/matching/mentors`, `/mentors/all` only | Post-rank threshold; `totalElements` reflects the thresholded count. |

## Implementation

- `MentorRepository.SEARCH_JPQL` — two new clauses before `ORDER BY`:
  - `AND (:availabilityDays IS NULL OR EXISTS (SELECT 1 FROM AvailabilitySlot s WHERE s.mentor.id = m.id AND s.dayOfWeek IN :availabilityDays))`
  - `AND (:mentorshipDuration IS NULL OR m.mentorshipDuration IN :mentorshipDuration)`
- Both `searchByFilters(Page)` and `findRankingCandidates(List)` widened with the new `@Param`s before their `Pageable` / terminator.
- `SearchNormaliser.nullIfEmpty(Set<T>)` helper to dodge Postgres `IN ()` errors.
- `MatchingService.getTopMentors` / `getTopMentorsList` apply `minMatchScore` AFTER scoring and BEFORE `slicePage`, so paging totals match the rendered list.
- Legacy `MatchingService.rankMentorsFor(Mentee, String)` / `(Mentee, String, Double)` overloads kept as delegates (used by `MatchNotificationProcessor`).
- `MenteeRepository` and `/api/matching/mentees` deliberately untouched — issue scope is mentor-side only.

## Tests

39 new tests, every legacy call site updated in lockstep:
- `MentorRepositorySearchTest` — 7 new cases: availabilityDays null/single/multi/no-match, mentorshipDuration in-list/null, combined-filters-AND.
- `UserSearchControllerTest` — 2 new param-binding cases + existing `searchAllParams_forwardedToService` widened with `isNull()` for the new params.
- `MatchingServiceTest` — 4 cases: availabilityDays-passthrough (ArgumentCaptor), empty-Set→null coercion, `minMatchScore_excludesBelowThresholdAndAdjustsTotal`, `minMatchScore_nullPreservesAllCandidates`.
- `MatchingControllerTest` — 3 param-binding cases.
- `UserSearchIntegrationTest` — 1 happy-path case combining keyword + availabilityDays + mentorshipDuration.

## Test plan

- [x] Scoped tests (Postgres :5495): `MatchingServiceTest 46/46`, `UserSearchControllerTest 19/19`, `MatchingControllerTest 19/19`, `MentorRepositorySearchTest 32/32`, `UserSearchIntegrationTest 12/12`.
- [x] Full `mvn --batch-mode verify`: **2277 tests, 0 failures, 0 errors**. JaCoCo gates green.
- [x] Manual smoke (16 cases): back-compat without params, single-day / multi-day OR semantics, no-match day, duration single / IN-list, invalid DayOfWeek → 400, `minMatchScore` threshold and totalElements alignment, combined filters across both endpoints.

## Backward compatibility

- Every new query param is `required = false`. Omitting them produces byte-for-byte the same behaviour as before.
- All repo / service method signatures grow but every existing caller is updated within this PR. Legacy delegate overloads preserve `MatchingService.rankMentorsFor(Mentee, String)` (called by `MatchNotificationProcessor:104`) and `(Mentee, String, Double)` so no external contract changes.
- Empty `Set<DayOfWeek>` and `Set<Integer>` are coerced to `null` in `SearchNormaliser` before they reach JPQL — avoids Postgres rejecting `IN ()`.

## Out of scope

- `/api/matching/mentees` filters (mentor-side scope only).
- Frontend sidebar wiring (#139).
- Per-day time-window overlap with the mentee's own slots (handled by existing `hasAvailability` filter).
- Distance / proximity filter (covered by #286).

Closes #571.