### PR TITLE
feat(web): ESCO/ISCED-F/Wikidata taxonomy autocomplete on profile (#448)

### DIFF
--- a/frontend/src/components/TaxonomyAutocomplete.jsx
+++ b/frontend/src/components/TaxonomyAutocomplete.jsx
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Single-value taxonomy combobox (#448). Used for mentor.field (ISCED-F),
+ * mentee.major (ISCED-F), and mentee.careerInterest (ESCO).
+ *
+ * Stores both label and URI. Selecting a suggestion fills both; typing a
+ * label not in the suggestion list keeps it as free-text (URI stays
+ * empty / null), matching the backend's "URI optional, validated when
+ * present" contract.
+ *
+ * Props:
+ *   label / uri              — current single value
+ *   onChange({ label, uri }) — fires on every commit (suggestion or blur)
+ *   search                   — async fn (query, opts) → [{label, identifierUri}]
+ *   placeholder
+ *   disabled
+ */
+const DEBOUNCE_MS = 250
+const MIN_QUERY = 2
+
+export default function TaxonomyAutocomplete({
+  label = '', uri = '', onChange, search, placeholder = '', disabled = false, dataTestId,
+}) {
+  const [text, setText] = useState(label || '')
+  const [storedUri, setStoredUri] = useState(uri || '')
+  const [results, setResults] = useState([])
+  const [busy, setBusy] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [error, setError] = useState(null)
+  const wrapRef = useRef(null)
+  const debounceRef = useRef(null)
+  const lang = typeof navigator !== 'undefined' ? (navigator.language || 'en').split('-')[0] : 'en'
+
+  // Sync from parent when the controlled value changes externally (e.g. on first load).
+  useEffect(() => { setText(label || ''); setStoredUri(uri || '') }, [label, uri])
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  function runSearch(q) {
+    if (q.length < MIN_QUERY) {
+      setResults([])
+      setOpen(false)
+      return
+    }
+    setBusy(true)
+    setError(null)
+    search(q, { lang })
+      .then(list => {
+        const safe = Array.isArray(list) ? list : []
+        setResults(safe)
+        setOpen(safe.length > 0)
+      })
+      .catch(() => {
+        setResults([])
+        setError('Suggestions unavailable. Your typed value will save as free text.')
+      })
+      .finally(() => setBusy(false))
+  }
+
+  function handleTextChange(e) {
+    const v = e.target.value
+    setText(v)
+    // Typing a different value drops the linked URI — re-pick a suggestion to set it.
+    if (storedUri) {
+      setStoredUri('')
+      onChange?.({ label: v, uri: '' })
+    } else {
+      onChange?.({ label: v, uri: '' })
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => runSearch(v.trim()), DEBOUNCE_MS)
+  }
+
+  function selectHit(hit) {
+    setText(hit.label)
+    setStoredUri(hit.identifierUri || '')
+    setOpen(false)
+    onChange?.({ label: hit.label, uri: hit.identifierUri || '' })
+  }
+
+  return (
+    <div className="tax-autocomplete-wrap" ref={wrapRef}>
+      <input
+        type="text"
+        className={`form-input${storedUri ? ' tax-autocomplete-linked' : ''}`}
+        value={text}
+        onChange={handleTextChange}
+        onFocus={() => results.length > 0 && setOpen(true)}
+        placeholder={placeholder}
+        disabled={disabled}
+        data-testid={dataTestId}
+        autoComplete="off"
+        title={storedUri || undefined}
+      />
+      {open && results.length > 0 && (
+        <ul className="tax-autocomplete-results" role="listbox">
+          {results.map(hit => (
+            <li key={`${hit.identifierUri}-${hit.label}`}>
+              <button type="button" className="tax-autocomplete-result-btn" onClick={() => selectHit(hit)}>
+                {hit.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {busy && <div className="tax-autocomplete-hint">Searching…</div>}
+      {error && <div className="tax-autocomplete-error">{error}</div>}
+    </div>
+  )
+}

--- a/frontend/src/components/TaxonomyChipPicker.jsx
+++ b/frontend/src/components/TaxonomyChipPicker.jsx
@@ -1,0 +1,152 @@
+import { useEffect, useRef, useState } from 'react'
+
+/**
+ * Multi-value taxonomy combobox (#448). Used for skills (ESCO), interests
+ * / hobbies (Wikidata), and preferred-mentee-skills (ESCO). Renders an
+ * input row that turns labels into chips on add — typing followed by
+ * Enter / comma / suggestion-click commits the chip; clicking the X on a
+ * chip removes it.
+ *
+ * Free-text fallback: any chip without a matching suggestion keeps a null
+ * URI; the backend's parallel-array contract tolerates per-entry nulls so
+ * the user is never blocked.
+ *
+ * Props:
+ *   values         — [{ label, uri }]  current chips
+ *   onChange(next) — fires with the new array on every add / remove
+ *   search         — async fn (query, opts) → [{label, identifierUri}]
+ *   placeholder
+ *   disabled
+ *   max            — optional ceiling (defaults to 20, matching the
+ *                    backend @Size(max=20) on the URI lists)
+ *   dataTestId
+ */
+const DEBOUNCE_MS = 250
+const MIN_QUERY = 2
+const DEFAULT_MAX = 20
+
+export default function TaxonomyChipPicker({
+  values = [], onChange, search, placeholder = '', disabled = false, max = DEFAULT_MAX, dataTestId,
+}) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState([])
+  const [busy, setBusy] = useState(false)
+  const [open, setOpen] = useState(false)
+  const [error, setError] = useState(null)
+  const wrapRef = useRef(null)
+  const debounceRef = useRef(null)
+  const lang = typeof navigator !== 'undefined' ? (navigator.language || 'en').split('-')[0] : 'en'
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  function runSearch(q) {
+    if (q.length < MIN_QUERY) {
+      setResults([])
+      setOpen(false)
+      return
+    }
+    setBusy(true)
+    setError(null)
+    search(q, { lang })
+      .then(list => {
+        const safe = Array.isArray(list) ? list : []
+        // Hide already-picked labels from the dropdown
+        const picked = new Set(values.map(v => v.label.toLowerCase()))
+        const filtered = safe.filter(h => !picked.has(h.label.toLowerCase()))
+        setResults(filtered)
+        setOpen(filtered.length > 0)
+      })
+      .catch(() => {
+        setResults([])
+        setError('Suggestions unavailable. You can still type a value.')
+      })
+      .finally(() => setBusy(false))
+  }
+
+  function handleQueryChange(e) {
+    const v = e.target.value
+    setQuery(v)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => runSearch(v.trim()), DEBOUNCE_MS)
+  }
+
+  function addChip({ label, uri = '' }) {
+    const trimmed = label.trim()
+    if (!trimmed) return
+    if (values.length >= max) return
+    // De-duplicate case-insensitively.
+    if (values.some(v => v.label.toLowerCase() === trimmed.toLowerCase())) return
+    onChange?.([...values, { label: trimmed, uri }])
+    setQuery('')
+    setResults([])
+    setOpen(false)
+  }
+
+  function removeChip(idx) {
+    if (disabled) return
+    const next = values.slice(0, idx).concat(values.slice(idx + 1))
+    onChange?.(next)
+  }
+
+  function handleKeyDown(e) {
+    if ((e.key === 'Enter' || e.key === ',') && query.trim()) {
+      e.preventDefault()
+      addChip({ label: query.trim() })
+    } else if (e.key === 'Backspace' && !query && values.length > 0) {
+      removeChip(values.length - 1)
+    }
+  }
+
+  return (
+    <div className="tax-chips-wrap" ref={wrapRef}>
+      <div className="tax-chips-input-row">
+        {values.map((v, i) => (
+          <span key={`${v.label}-${i}`} className={`tax-chip${v.uri ? ' tax-chip--linked' : ''}`} title={v.uri || 'Free-text (no canonical URI)'}>
+            {v.label}
+            <button
+              type="button"
+              className="tax-chip-remove"
+              onClick={() => removeChip(i)}
+              disabled={disabled}
+              aria-label={`Remove ${v.label}`}
+            >×</button>
+          </span>
+        ))}
+        <input
+          type="text"
+          className="tax-chips-input"
+          value={query}
+          onChange={handleQueryChange}
+          onKeyDown={handleKeyDown}
+          onFocus={() => results.length > 0 && setOpen(true)}
+          placeholder={values.length === 0 ? placeholder : ''}
+          disabled={disabled || values.length >= max}
+          data-testid={dataTestId}
+          autoComplete="off"
+        />
+      </div>
+      {open && results.length > 0 && (
+        <ul className="tax-autocomplete-results" role="listbox">
+          {results.map(hit => (
+            <li key={`${hit.identifierUri}-${hit.label}`}>
+              <button type="button" className="tax-autocomplete-result-btn" onClick={() => addChip({ label: hit.label, uri: hit.identifierUri || '' })}>
+                {hit.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {busy && <div className="tax-autocomplete-hint">Searching…</div>}
+      {error && <div className="tax-autocomplete-error">{error}</div>}
+      {values.length >= max && (
+        <div className="tax-autocomplete-hint">Max {max} entries reached.</div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -4,18 +4,37 @@ import Avatar from '../components/Avatar'
 import NotificationPreferences from '../components/NotificationPreferences'
 import MutedKeywords from '../components/MutedKeywords'
 import LocationPicker from '../components/LocationPicker'
+import TaxonomyAutocomplete from '../components/TaxonomyAutocomplete'
+import TaxonomyChipPicker from '../components/TaxonomyChipPicker'
+import {
+  searchTaxonomySkills,
+  searchTaxonomyFields,
+  searchTaxonomyHobbies,
+} from '../services/api'
 import usePresence from '../hooks/usePresence'
 import { useAuth } from '../context/AuthContext'
 import { useMentorship } from '../context/MentorshipContext'
 import { getOwnProfile, updateOwnProfile, uploadProfilePhoto, deleteProfilePhoto } from '../services/api'
 import '../styles/main.css'
 
+// #448: zip parallel label + URI arrays into the chip-picker's {label, uri}
+// shape. Backend's contract is: URI list nullable, otherwise same length as
+// the label list, with per-entry nulls allowed.
+function zipLabelsAndUris(labels = [], uris = []) {
+  return (labels || []).map((label, i) => ({
+    label,
+    uri: uris && uris[i] != null ? uris[i] : '',
+  }))
+}
+
 function mapResponseToForm(data) {
   const isMentor = data.role === 'MENTOR'
   const base = {
     name: [data.firstName, data.lastName].filter(Boolean).join(' '),
     profilePhoto: data.profilePhoto || '',
-    interests: (data.interests || []).join(', '),
+    // #448: chip pickers manage labels + URIs together. Persist parallel
+    // arrays into a single [{label, uri}] form value per concept.
+    interests: zipLabelsAndUris(data.interests, data.interestUris),
     // #461: shared location fields, available on both roles
     city: data.city || '',
     latitude: data.latitude ?? null,
@@ -26,6 +45,7 @@ function mapResponseToForm(data) {
       ...base,
       bio: data.bio || '',
       field: data.field || '',
+      fieldUri: data.fieldUri || '',
       expertise: data.expertise || '',
       affiliation: data.affiliation || '',
       maxMenteeCapacity: data.maxMenteeCapacity != null ? String(data.maxMenteeCapacity) : '',
@@ -33,16 +53,18 @@ function mapResponseToForm(data) {
       preferredMenteeMajor: data.preferredMenteeMajor || '',
       mentoringGoals: data.mentoringGoals || '',
       mentorshipDuration: data.mentorshipDuration != null ? String(data.mentorshipDuration) : '',
-      preferredMenteeSkills: (data.preferredMenteeSkills || []).join(', '),
+      preferredMenteeSkills: zipLabelsAndUris(data.preferredMenteeSkills, data.preferredMenteeSkillUris),
     }
   }
   return {
     ...base,
     background: data.backgroundInfo || '',
     goals: data.goals || '',
-    skills: (data.skills || []).join(', '),
+    skills: zipLabelsAndUris(data.skills, data.skillUris),
     major: data.major || '',
+    majorUri: data.majorUri || '',
     careerInterest: data.careerInterest || '',
+    careerInterestUri: data.careerInterestUri || '',
     meetingFreqPref: data.meetingFreqPref || '',
     profileVisible: data.profileVisibility !== false,
   }
@@ -66,7 +88,18 @@ function PrivacyBadge({ visible }) {
 }
 
 function ViewField({ label, value, visible, chips = false }) {
-  const items = chips && value ? value.split(',').map(s => s.trim()).filter(Boolean) : []
+  // chips support three shapes: array of {label,uri} (taxonomy chips), array
+  // of strings (legacy), or a comma-separated string (back-compat).
+  let items = []
+  if (chips && value) {
+    if (Array.isArray(value)) {
+      items = value
+        .map(v => (v && typeof v === 'object' ? v.label : v))
+        .filter(Boolean)
+    } else if (typeof value === 'string') {
+      items = value.split(',').map(s => s.trim()).filter(Boolean)
+    }
+  }
   return (
     <div style={{ marginBottom: '16px' }}>
       <div style={{ display: 'flex', alignItems: 'center', marginBottom: '6px' }}>
@@ -151,12 +184,27 @@ export default function ProfilePage() {
       const firstName = nameParts[0]
       const lastName = nameParts.slice(1).join(' ') || nameParts[0]
 
-      const toList = str => str ? str.split(',').map(s => s.trim()).filter(Boolean) : null
+      // #448: chip pickers store [{label, uri}]; the backend takes two
+      // parallel arrays. Empty list → null so we don't clobber the column
+      // unintentionally. URI list is nullable on the wire — only sent when
+      // we have at least one URI to surface; per-entry nulls are kept where
+      // the user typed free text without picking a suggestion.
+      const splitChips = (chips) => {
+        if (!Array.isArray(chips) || chips.length === 0) return { labels: null, uris: null }
+        const labels = chips.map(c => c.label)
+        const uris = chips.map(c => c.uri || null)
+        const allUriNull = uris.every(u => u == null)
+        return { labels, uris: allUriNull ? null : uris }
+      }
+      const interestsSplit = splitChips(form.interests)
+      const skillsSplit = !isMentor ? splitChips(form.skills) : null
+      const prefSkillsSplit = isMentor ? splitChips(form.preferredMenteeSkills) : null
 
       const payload = {
         firstName,
         lastName,
-        interests: toList(form.interests),
+        interests: interestsSplit.labels,
+        interestUris: interestsSplit.uris,
         // #461: location fields are common across roles. Backend EditProfileRequest
         // enforces pair-completeness on lat/lng via a DB CHECK constraint, so we
         // send all three together. Null clears all three; partial null is rejected.
@@ -166,21 +214,26 @@ export default function ProfilePage() {
         ...(isMentor ? {
           bio: form.bio || null,
           field: form.field || null,
+          fieldUri: form.fieldUri || null,
           expertise: form.expertise || null,
           affiliation: form.affiliation || null,
           maxMenteeCapacity: form.maxMenteeCapacity !== '' ? parseInt(form.maxMenteeCapacity) : null,
           preferredMenteeMajor: form.preferredMenteeMajor || null,
           mentoringGoals: form.mentoringGoals || null,
           mentorshipDuration: form.mentorshipDuration !== '' ? parseInt(form.mentorshipDuration) : null,
-          preferredMenteeSkills: toList(form.preferredMenteeSkills),
+          preferredMenteeSkills: prefSkillsSplit.labels,
+          preferredMenteeSkillUris: prefSkillsSplit.uris,
         } : {
           backgroundInfo: form.background || null,
           goals: form.goals || null,
           affiliation: form.affiliation || null,
           major: form.major || null,
+          majorUri: form.majorUri || null,
           careerInterest: form.careerInterest || null,
+          careerInterestUri: form.careerInterestUri || null,
           meetingFreqPref: form.meetingFreqPref || null,
-          skills: toList(form.skills),
+          skills: skillsSplit.labels,
+          skillUris: skillsSplit.uris,
           profileVisibility: form.profileVisible,
         }),
       }
@@ -364,13 +417,13 @@ export default function ProfilePage() {
 
             <div className="form-field">
               <label className="form-label">Interests</label>
-              <input
-                className="form-input"
-                type="text"
-                value={form.interests}
-                onChange={e => handleChange('interests', e.target.value)}
-                placeholder="e.g. Mobile Development, AI/ML"
-                data-testid="profile-interests"
+              <TaxonomyChipPicker
+                values={form.interests || []}
+                onChange={(next) => handleChange('interests', next)}
+                search={searchTaxonomyHobbies}
+                placeholder="Search hobbies (Wikidata) or type your own"
+                disabled={saving}
+                dataTestId="profile-interests"
               />
             </div>
 
@@ -405,12 +458,15 @@ export default function ProfilePage() {
 
                 <div className="form-field">
                   <label className="form-label">Field</label>
-                  <input
-                    className="form-input"
-                    type="text"
-                    value={form.field}
-                    onChange={e => handleChange('field', e.target.value)}
-                    placeholder="e.g. Computer Science"
+                  <TaxonomyAutocomplete
+                    label={form.field}
+                    uri={form.fieldUri}
+                    onChange={({ label, uri }) => {
+                      setForm(prev => ({ ...prev, field: label, fieldUri: uri }))
+                    }}
+                    search={searchTaxonomyFields}
+                    placeholder="e.g. Computer Science (ISCED-F)"
+                    disabled={saving}
                   />
                 </div>
 
@@ -459,12 +515,12 @@ export default function ProfilePage() {
 
                 <div className="form-field">
                   <label className="form-label">Preferred Mentee Skills</label>
-                  <input
-                    className="form-input"
-                    type="text"
-                    value={form.preferredMenteeSkills}
-                    onChange={e => handleChange('preferredMenteeSkills', e.target.value)}
-                    placeholder="e.g. Java, Python"
+                  <TaxonomyChipPicker
+                    values={form.preferredMenteeSkills || []}
+                    onChange={(next) => handleChange('preferredMenteeSkills', next)}
+                    search={searchTaxonomySkills}
+                    placeholder="Search ESCO skills or type your own"
+                    disabled={saving}
                   />
                 </div>
 
@@ -534,34 +590,40 @@ export default function ProfilePage() {
 
                 <div className="form-field">
                   <label className="form-label">Skills</label>
-                  <input
-                    className="form-input"
-                    type="text"
-                    value={form.skills}
-                    onChange={e => handleChange('skills', e.target.value)}
-                    placeholder="e.g. JavaScript, React, Python"
+                  <TaxonomyChipPicker
+                    values={form.skills || []}
+                    onChange={(next) => handleChange('skills', next)}
+                    search={searchTaxonomySkills}
+                    placeholder="Search ESCO skills or type your own"
+                    disabled={saving}
                   />
                 </div>
 
                 <div className="form-field">
                   <label className="form-label">Major</label>
-                  <input
-                    className="form-input"
-                    type="text"
-                    value={form.major}
-                    onChange={e => handleChange('major', e.target.value)}
-                    placeholder="e.g. Computer Engineering"
+                  <TaxonomyAutocomplete
+                    label={form.major}
+                    uri={form.majorUri}
+                    onChange={({ label, uri }) => {
+                      setForm(prev => ({ ...prev, major: label, majorUri: uri }))
+                    }}
+                    search={searchTaxonomyFields}
+                    placeholder="e.g. Computer Engineering (ISCED-F)"
+                    disabled={saving}
                   />
                 </div>
 
                 <div className="form-field">
                   <label className="form-label">Career Interest</label>
-                  <input
-                    className="form-input"
-                    type="text"
-                    value={form.careerInterest}
-                    onChange={e => handleChange('careerInterest', e.target.value)}
-                    placeholder="e.g. Data Science"
+                  <TaxonomyAutocomplete
+                    label={form.careerInterest}
+                    uri={form.careerInterestUri}
+                    onChange={({ label, uri }) => {
+                      setForm(prev => ({ ...prev, careerInterest: label, careerInterestUri: uri }))
+                    }}
+                    search={searchTaxonomySkills}
+                    placeholder="e.g. Data Science (ESCO)"
+                    disabled={saving}
                   />
                 </div>
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -814,6 +814,39 @@ export async function getFeedUnreadCount() {
   return handleResponse(res)
 }
 
+// #448 / backend #320: taxonomy autocomplete endpoints. Each returns a
+// list of { label, identifierUri } pairs from a canonical source — ESCO
+// for skills, ISCED-F for fields of study, Wikidata for hobbies.
+//
+// The `lang` parameter is a BCP-47 short tag (e.g. "en", "tr") and falls
+// back to the request's Accept-Language server-side when omitted.
+export async function searchTaxonomySkills(q, { lang, limit = 10 } = {}) {
+  const params = new URLSearchParams({ q, limit: String(limit) })
+  if (lang) params.set('lang', lang)
+  const res = await fetch(`${BASE_URL}/taxonomies/skills?${params}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function searchTaxonomyFields(q, { lang, limit = 10 } = {}) {
+  const params = new URLSearchParams({ q, limit: String(limit) })
+  if (lang) params.set('lang', lang)
+  const res = await fetch(`${BASE_URL}/taxonomies/fields?${params}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function searchTaxonomyHobbies(q, { lang, limit = 10 } = {}) {
+  const params = new URLSearchParams({ q, limit: String(limit) })
+  if (lang) params.set('lang', lang)
+  const res = await fetch(`${BASE_URL}/taxonomies/hobbies?${params}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
 // #542 / backend #484: repost or quote-share a feed post. body is optional —
 // null/blank produces a bare repost, non-blank (up to 2000 chars) attaches
 // commentary. Backend dedupes repeated payloads within ~60s. Returns the

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3605,6 +3605,118 @@
   overflow: hidden;
 }
 
+/* Taxonomy autocomplete + chip picker (#448). */
+.tax-autocomplete-wrap {
+  position: relative;
+}
+.tax-autocomplete-results {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  max-height: 240px;
+  overflow-y: auto;
+}
+.tax-autocomplete-result-btn {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: var(--text);
+}
+.tax-autocomplete-result-btn:hover {
+  background: var(--green-pale);
+}
+.tax-autocomplete-linked {
+  border-color: var(--green-mid, #b6d8bd);
+  background: #fafdfb;
+}
+.tax-autocomplete-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+.tax-autocomplete-error {
+  font-size: 12px;
+  color: var(--red-text, #b91c1c);
+  margin-top: 4px;
+}
+
+.tax-chips-wrap {
+  position: relative;
+}
+.tax-chips-input-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fff;
+  font-family: 'DM Sans', sans-serif;
+}
+.tax-chips-input-row:focus-within {
+  border-color: var(--green-mid);
+  box-shadow: 0 0 0 3px var(--green-pale);
+}
+.tax-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 4px 3px 10px;
+  border-radius: 999px;
+  background: #f1f5ee;
+  border: 1px solid #e2e8d8;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 500;
+}
+.tax-chip--linked {
+  background: var(--green-pale, #ecf6ee);
+  border-color: var(--green-mid, #b6d8bd);
+  color: var(--green-dark, #2e7d4f);
+}
+.tax-chip-remove {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  color: currentColor;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.6;
+}
+.tax-chip-remove:hover:not(:disabled) { opacity: 1; }
+.tax-chips-input {
+  flex: 1;
+  min-width: 120px;
+  border: none;
+  outline: none;
+  padding: 4px 6px;
+  font-family: inherit;
+  font-size: 13px;
+  background: transparent;
+  color: var(--text);
+}
+
 /* Location picker on profile (#461). */
 .loc-picker {
   position: relative;


### PR DESCRIPTION
Closes #448.

## Summary

This PR wires the controlled-vocabulary taxonomy endpoints (#320, backend `TaxonomyController`) into the profile editor.

Six text inputs are converted into typeahead comboboxes backed by:

- **ESCO** → skills
- **ISCED-F** → fields of study
- **Wikidata** → hobbies

Selecting a suggestion stores both:

- the human-readable label
- the canonical taxonomy URI

Typing a value that does not exist in the suggestion list preserves the label and stores a `null` URI, matching the backend contract:

> URI is optional, but validated when present.

---

## Inputs Wired

| Field | Role | Endpoint |
|---|---|---|
| Interests | both | `/api/taxonomies/hobbies` (Wikidata) |
| Skills | mentee | `/api/taxonomies/skills` (ESCO) |
| Preferred Mentee Skills | mentor | `/api/taxonomies/skills` (ESCO) |
| Field | mentor | `/api/taxonomies/fields` (ISCED-F) |
| Major | mentee | `/api/taxonomies/fields` (ISCED-F) |
| Career Interest | mentee | `/api/taxonomies/skills` (ESCO) |

---

## Changes

### `services/api.js`

Adds:

- `searchTaxonomySkills`
- `searchTaxonomyFields`
- `searchTaxonomyHobbies`

Each wrapper:

- accepts `{ lang, limit }`
- defaults language to the browser locale stripped to the base BCP-47 tag

---

### `components/TaxonomyAutocomplete.jsx` (new)

Single-value combobox used for:

- Field
- Major
- Career Interest

Behavior:

- Stores `{ label, uri }`
- Typing free text updates state to `{ label, '' }`
- Selecting a suggestion stores the linked URI
- Displays a subtle green border when linked to a taxonomy URI

---

### `components/TaxonomyChipPicker.jsx` (new)

Multi-value combobox used for:

- Interests
- Skills
- Preferred Mentee Skills

Behavior:

- Chip-style multi-entry UI
- Linked entries render green
- Free-text entries render gray
- `Enter` or `,` commits free text
- Clicking a suggestion commits `{ label, uri }`
- Enforces backend `@Size(max = 20)` limit

---

### `pages/ProfilePage.jsx`

#### `mapResponseToForm`

Zips:

- `interests + interestUris`
- `skills + skillUris`
- `preferredMenteeSkills + preferredMenteeSkillUris`

into unified form objects:

```js
[{ label, uri }]
````

---

#### Save payload

Splits the form state back into the parallel arrays expected by the backend.

Example:

```js
interests[]
interestUris[]
```

URI arrays are:

* sent only when at least one entry contains a URI
* otherwise sent as `null`

This avoids unintentionally clobbering URI columns when the user only uses free text.

---

#### Single-value taxonomy fields

Adds URI siblings to form state:

* `fieldUri`
* `majorUri`
* `careerInterestUri`

---

#### `ViewField`

Extended to support:

```js
[{ label, uri }]
```

in addition to legacy comma-separated string chips for backward compatibility.

---

### `styles/main.css`

Adds:

* `.tax-autocomplete-*`
* `.tax-chips-*`

Styling behavior:

* Linked chips render green
* Free-text chips remain gray

This provides a subtle indication of which entries contribute to taxonomy-based matching.

---

## Acceptance Criteria Mapping (#448)

* ✅ Skills / field-of-study / hobbies inputs are now typeahead comboboxes backed by taxonomy endpoints
* ✅ Selecting a suggestion stores the taxonomy URI on the profile
* ✅ Free-text fallback works for values not present in suggestions
* ✅ Suggestions debounce at `250ms`
* ✅ Suggestions respect endpoint limit (default `10`)
* ✅ Mentor “preferred mentee criteria” reuses the same chip picker component

---

## Out of Scope

* Migrating existing free-text values into taxonomy URIs
* Admin taxonomy curation
* Read-only profile indicators showing linked vs free-text entries

---

## Test Plan

### Automated

* `npm run build` → clean
* `npm test` → `64/64` unit tests passing

---

### Manual

#### Mentor skills flow

1. Open `/profile`
2. Click **Edit**
3. Type `"java"` in Skills
4. ESCO suggestions appear
5. Select `"Java"`
6. Chip turns green and URI is linked
7. Save profile
8. Reload page
9. Chip remains green

---

#### Free-text fallback

1. Type a non-taxonomy value (e.g. `"underwater basket weaving"`) into Interests
2. Press `Enter`
3. Gray chip appears without a URI
4. Save profile
5. Reload page
6. Chip remains gray

---

#### Max chip limit

1. Add 20 interest chips
2. Attempt to add a 21st
3. Input becomes disabled
4. `"Max 20 entries reached."` hint appears

---

#### Mentee major flow

1. Open mentee profile edit view
2. Select Major = `"Computer Engineering"` from ISCED-F suggestions
3. Field displays linked (green) styling
4. Backend persists `majorUri` alongside `major`

`