### PR TITLE
fix(feed): respect Mentee profileVisibility on feed read paths

### DIFF
--- a/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
+++ b/backend/src/main/java/com/group7/backend/repository/FeedPostRepository.java
@@ -46,8 +46,63 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
     /**
      * Public-visibility lookup. Returns empty for soft-deleted posts so
      * the controller can map cleanly to 404 on {@code GET}.
+     *
+     * <p>Does NOT honour {@link com.group7.backend.entity.Mentee#getProfileVisibility()}:
+     * callers on the author-load path ({@code PATCH}/{@code DELETE}) need
+     * the row regardless of visibility so the service can render a clean
+     * 403 vs 404 split. Read-path callers should use
+     * {@link #findVisibleById} instead.
      */
     Optional<FeedPost> findByIdAndDeletedAtIsNull(Long id);
+
+    /**
+     * Single-post read with the optional follower-aware visibility gate
+     * applied. Equivalent to {@link #findByIdAndDeletedAtIsNull} when
+     * {@code respectVisibility} is false; otherwise an extra predicate
+     * suppresses rows whose author is a mentee with
+     * {@code profile_visibility = false} unless the viewer is the author
+     * themselves or a current follower (see class javadoc on the
+     * predicate shape — identical to the For-You / search / author-timeline
+     * variants below).
+     *
+     * <p>Used by:
+     * <ul>
+     *   <li>{@code FeedPostService.getById} — the public {@code GET}
+     *       endpoint.</li>
+     *   <li>{@code FeedInteractionService.requireVisiblePost} — the
+     *       gate that fronts every interaction toggle, so a non-follower
+     *       cannot like / bookmark / comment on a hidden mentee's post
+     *       they cannot otherwise see.</li>
+     * </ul>
+     *
+     * <p>Author-load paths ({@code PATCH}, {@code DELETE}) intentionally
+     * stick with {@link #findByIdAndDeletedAtIsNull} (or inherited
+     * {@code findById}) so the author always sees their own posts even
+     * when their visibility flag is off.
+     */
+    @Query(value = """
+            SELECT * FROM feed_posts p
+            WHERE p.id = :id
+              AND p.deleted_at IS NULL
+              AND (
+                    :respectVisibility = false
+                 OR NOT EXISTS (
+                        SELECT 1 FROM mentees m
+                        WHERE m.id = p.author_id
+                          AND m.profile_visibility = false
+                    )
+                 OR p.author_id = :viewerId
+                 OR EXISTS (
+                        SELECT 1 FROM follows f
+                        WHERE f.follower_id = :viewerId
+                          AND f.followee_id = p.author_id
+                    )
+              )
+            """,
+            nativeQuery = true)
+    Optional<FeedPost> findVisibleById(@Param("id") Long id,
+                                       @Param("viewerId") Long viewerId,
+                                       @Param("respectVisibility") boolean respectVisibility);
 
     /**
      * Following-feed query (#350). Returns posts authored by users the
@@ -145,15 +200,46 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
             SELECT * FROM feed_posts p
             WHERE p.deleted_at IS NULL
               AND p.author_id = :authorId
+              AND (
+                    :respectVisibility = false
+                 OR NOT EXISTS (
+                        SELECT 1 FROM mentees m
+                        WHERE m.id = p.author_id
+                          AND m.profile_visibility = false
+                    )
+                 OR p.author_id = :viewerId
+                 OR EXISTS (
+                        SELECT 1 FROM follows f
+                        WHERE f.follower_id = :viewerId
+                          AND f.followee_id = p.author_id
+                    )
+              )
             ORDER BY p.created_at DESC, p.id DESC
             """,
             countQuery = """
             SELECT COUNT(*) FROM feed_posts p
             WHERE p.deleted_at IS NULL
               AND p.author_id = :authorId
+              AND (
+                    :respectVisibility = false
+                 OR NOT EXISTS (
+                        SELECT 1 FROM mentees m
+                        WHERE m.id = p.author_id
+                          AND m.profile_visibility = false
+                    )
+                 OR p.author_id = :viewerId
+                 OR EXISTS (
+                        SELECT 1 FROM follows f
+                        WHERE f.follower_id = :viewerId
+                          AND f.followee_id = p.author_id
+                    )
+              )
             """,
             nativeQuery = true)
-    Page<FeedPost> findByAuthorIdForFeed(@Param("authorId") Long authorId, Pageable pageable);
+    Page<FeedPost> findByAuthorIdForFeed(@Param("authorId") Long authorId,
+                                          @Param("viewerId") Long viewerId,
+                                          @Param("respectVisibility") boolean respectVisibility,
+                                          Pageable pageable);
 
     /**
      * For-You candidate fetch (#350). Returns the most recent N posts
@@ -170,11 +256,25 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
             SELECT * FROM feed_posts p
             WHERE p.deleted_at IS NULL
               AND p.author_id <> :viewerId
+              AND (
+                    :respectVisibility = false
+                 OR NOT EXISTS (
+                        SELECT 1 FROM mentees m
+                        WHERE m.id = p.author_id
+                          AND m.profile_visibility = false
+                    )
+                 OR EXISTS (
+                        SELECT 1 FROM follows f
+                        WHERE f.follower_id = :viewerId
+                          AND f.followee_id = p.author_id
+                    )
+              )
             ORDER BY p.created_at DESC, p.id DESC
             LIMIT :limit
             """,
             nativeQuery = true)
     List<FeedPost> findForYouCandidates(@Param("viewerId") Long viewerId,
+                                         @Param("respectVisibility") boolean respectVisibility,
                                          @Param("limit") int limit);
 
     /**
@@ -204,6 +304,20 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
               AND (CAST(:since AS timestamptz) IS NULL OR p.created_at >= CAST(:since AS timestamptz))
               AND (CAST(:until AS timestamptz) IS NULL OR p.created_at <  CAST(:until AS timestamptz))
               AND (:lang IS NULL OR p.lang = :lang)
+              AND (
+                    :respectVisibility = false
+                 OR NOT EXISTS (
+                        SELECT 1 FROM mentees m
+                        WHERE m.id = p.author_id
+                          AND m.profile_visibility = false
+                    )
+                 OR p.author_id = :viewerId
+                 OR EXISTS (
+                        SELECT 1 FROM follows f
+                        WHERE f.follower_id = :viewerId
+                          AND f.followee_id = p.author_id
+                    )
+              )
             ORDER BY p.created_at DESC, p.id DESC
             """,
             countQuery = """
@@ -215,6 +329,20 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
               AND (CAST(:since AS timestamptz) IS NULL OR p.created_at >= CAST(:since AS timestamptz))
               AND (CAST(:until AS timestamptz) IS NULL OR p.created_at <  CAST(:until AS timestamptz))
               AND (:lang IS NULL OR p.lang = :lang)
+              AND (
+                    :respectVisibility = false
+                 OR NOT EXISTS (
+                        SELECT 1 FROM mentees m
+                        WHERE m.id = p.author_id
+                          AND m.profile_visibility = false
+                    )
+                 OR p.author_id = :viewerId
+                 OR EXISTS (
+                        SELECT 1 FROM follows f
+                        WHERE f.follower_id = :viewerId
+                          AND f.followee_id = p.author_id
+                    )
+              )
             """,
             nativeQuery = true)
     Page<FeedPost> searchPosts(@Param("keyword") String keyword,
@@ -222,6 +350,8 @@ public interface FeedPostRepository extends JpaRepository<FeedPost, Long> {
                                 @Param("since") OffsetDateTime since,
                                 @Param("until") OffsetDateTime until,
                                 @Param("lang") String lang,
+                                @Param("viewerId") Long viewerId,
+                                @Param("respectVisibility") boolean respectVisibility,
                                 Pageable pageable);
 
     /**

--- a/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedInteractionService.java
@@ -99,6 +99,7 @@ public class FeedInteractionService {
      * ops tuning, ISO 8601 duration syntax.
      */
     private final Duration repostIdempotencyWindow;
+    private final boolean respectVisibility;
 
     public FeedInteractionService(FeedPostRepository feedPostRepository,
                                    FeedPostLikeRepository likeRepository,
@@ -111,7 +112,9 @@ public class FeedInteractionService {
                                    NotificationEventPublisher notificationEventPublisher,
                                    ApplicationEventPublisher eventPublisher,
                                    @Value("${app.feed.repost.idempotency-window:PT60S}")
-                                   Duration repostIdempotencyWindow) {
+                                   Duration repostIdempotencyWindow,
+                                   @Value("${app.feed.respect-profile-visibility:false}")
+                                   boolean respectVisibility) {
         this.feedPostRepository = feedPostRepository;
         this.likeRepository = likeRepository;
         this.bookmarkRepository = bookmarkRepository;
@@ -123,6 +126,7 @@ public class FeedInteractionService {
         this.notificationEventPublisher = notificationEventPublisher;
         this.eventPublisher = eventPublisher;
         this.repostIdempotencyWindow = repostIdempotencyWindow;
+        this.respectVisibility = respectVisibility;
     }
 
     // ── Likes ──────────────────────────────────────────────────────────────
@@ -148,7 +152,7 @@ public class FeedInteractionService {
      */
     @Transactional
     public FeedPostInteractionState toggleLike(Long postId, Long userId) {
-        FeedPost post = requireVisiblePost(postId);
+        FeedPost post = requireVisiblePost(postId, userId);
         FeedPostLikeId id = new FeedPostLikeId(postId, userId);
         boolean nowLiked;
         if (likeRepository.existsByIdPostIdAndIdUserId(postId, userId)) {
@@ -177,7 +181,7 @@ public class FeedInteractionService {
      */
     @Transactional
     public FeedPostInteractionState toggleBookmark(Long postId, Long userId) {
-        FeedPost post = requireVisiblePost(postId);
+        FeedPost post = requireVisiblePost(postId, userId);
         FeedPostBookmarkId id = new FeedPostBookmarkId(postId, userId);
         boolean nowBookmarked;
         if (bookmarkRepository.existsByIdPostIdAndIdUserId(postId, userId)) {
@@ -253,7 +257,7 @@ public class FeedInteractionService {
 
     @Transactional
     public FeedPostInteractionState recordShare(Long postId, Long sharerId) {
-        FeedPost post = requireVisiblePost(postId);
+        FeedPost post = requireVisiblePost(postId, sharerId);
         shareRepository.save(new FeedPostShare(postId, sharerId));
         publishEngagement(post, sharerId);
         log.info("Recorded share: postId={}, sharerId={}", postId, sharerId);
@@ -286,7 +290,7 @@ public class FeedInteractionService {
     @Transactional
     public FeedPostInteractionState recordRepost(Long postId, Long sharerId,
                                                   CreateRepostRequest request) {
-        FeedPost post = requireVisiblePost(postId);
+        FeedPost post = requireVisiblePost(postId, sharerId);
         String body = blankToNull(request != null ? request.body() : null);
 
         Optional<FeedPostShare> recent = shareRepository.findRecentRepost(
@@ -337,7 +341,7 @@ public class FeedInteractionService {
 
     @Transactional
     public FeedCommentResponse addComment(Long postId, Long authorId, String body) {
-        FeedPost post = requireVisiblePost(postId);
+        FeedPost post = requireVisiblePost(postId, authorId);
         if (body == null || body.isBlank()) {
             throw new IllegalArgumentException("Comment body must not be blank");
         }
@@ -359,7 +363,7 @@ public class FeedInteractionService {
     }
 
     public Page<FeedCommentResponse> listComments(Long postId, Long viewerId, Pageable pageable) {
-        requireVisiblePost(postId);
+        requireVisiblePost(postId, viewerId);
         Page<FeedPostComment> page = commentRepository
                 .findByPostIdOrderByCreatedAtAscIdAsc(postId, pageable);
         if (page.isEmpty()) {
@@ -437,11 +441,13 @@ public class FeedInteractionService {
     public FeedCommentResponse getComment(Long commentId, Long viewerId) {
         FeedPostComment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
                 .orElseThrow(() -> new ResourceNotFoundException("Comment not found with id: " + commentId));
-        // Orphan-permalink guard: 404 when the parent post is soft-deleted.
-        // Same exception message as the comment-missing branch — distinguishing
-        // the two would leak whether the comment id ever existed, an
-        // unnecessary information disclosure for anyone probing ids.
-        feedPostRepository.findByIdAndDeletedAtIsNull(comment.getPostId())
+        // Orphan-permalink guard: 404 when the parent post is soft-deleted
+        // OR (when respectVisibility=true) when the parent post belongs to a
+        // hidden mentee the viewer cannot otherwise reach. Same exception
+        // message as the comment-missing branch — distinguishing the two
+        // would leak whether the comment id ever existed, an unnecessary
+        // information disclosure for anyone probing ids.
+        feedPostRepository.findVisibleById(comment.getPostId(), viewerId, respectVisibility)
                 .orElseThrow(() -> new ResourceNotFoundException("Comment not found with id: " + commentId));
         return mapComment(comment, viewerId, resolveAuthorName(comment.getAuthorId()));
     }
@@ -473,7 +479,7 @@ public class FeedInteractionService {
         if (comment.getDeletedAt() != null) {
             throw new ResourceNotFoundException("Comment not found with id: " + commentId);
         }
-        FeedPost post = requireVisiblePost(comment.getPostId());
+        FeedPost post = requireVisiblePost(comment.getPostId(), userId);
 
         FeedPostCommentLikeId id = new FeedPostCommentLikeId(commentId, userId);
         boolean nowLiked;
@@ -510,7 +516,7 @@ public class FeedInteractionService {
      * {@code FeedPostService.getById}).
      */
     public FeedPostInteractionState getInteractionState(Long postId, Long viewerId) {
-        requireVisiblePost(postId);
+        requireVisiblePost(postId, viewerId);
         return interactionState(postId, viewerId);
     }
 
@@ -536,8 +542,20 @@ public class FeedInteractionService {
 
     // ── Helpers ────────────────────────────────────────────────────────────
 
-    private FeedPost requireVisiblePost(Long postId) {
-        return feedPostRepository.findByIdAndDeletedAtIsNull(postId)
+    /**
+     * Gate that fronts every interaction toggle and comment fetch. Routes
+     * through {@link FeedPostRepository#findVisibleById} so when the
+     * {@code app.feed.respect-profile-visibility} flag is on, a viewer
+     * who is not the author and not a follower of a hidden mentee gets
+     * a uniform 404 instead of being able to like / bookmark / comment
+     * on a post they could not have surfaced through any feed read.
+     *
+     * <p>When the flag is off (default) the predicate degenerates and
+     * behaviour is identical to the prior {@code findByIdAndDeletedAtIsNull}
+     * path — same query plan, same set of rows.
+     */
+    private FeedPost requireVisiblePost(Long postId, Long viewerId) {
+        return feedPostRepository.findVisibleById(postId, viewerId, respectVisibility)
                 .orElseThrow(() -> new ResourceNotFoundException("Feed post not found with id: " + postId));
     }
 

--- a/backend/src/main/java/com/group7/backend/service/FeedPostService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedPostService.java
@@ -124,6 +124,7 @@ public class FeedPostService {
      * scheduler is allowed to hard-delete it.
      */
     private final int restoreWindowDays;
+    private final boolean respectVisibility;
 
     public FeedPostService(FeedPostRepository feedPostRepository,
                            UserRepository userRepository,
@@ -132,7 +133,8 @@ public class FeedPostService {
                            FeedPostMapper feedPostMapper,
                            FeedPostEventPublisher feedPostEventPublisher,
                            FeedPostEditHistoryRepository historyRepository,
-                           @Value("${app.feed.cleanup.restore-window-days:30}") int restoreWindowDays) {
+                           @Value("${app.feed.cleanup.restore-window-days:30}") int restoreWindowDays,
+                           @Value("${app.feed.respect-profile-visibility:false}") boolean respectVisibility) {
         this.feedPostRepository = feedPostRepository;
         this.userRepository = userRepository;
         this.attachmentRepository = attachmentRepository;
@@ -143,6 +145,7 @@ public class FeedPostService {
         // Defensive clamp: a misconfigured 0 would expire every restore
         // immediately. Mirrored in FeedSoftDeleteCleanupScheduler.
         this.restoreWindowDays = Math.max(1, restoreWindowDays);
+        this.respectVisibility = respectVisibility;
     }
 
     /**
@@ -216,7 +219,11 @@ public class FeedPostService {
      * case is owned by {@code #347}).
      */
     public FeedPostResponse getById(Long postId, Long viewerId) {
-        FeedPost post = feedPostRepository.findByIdAndDeletedAtIsNull(postId)
+        // findVisibleById applies the follower-aware profile-visibility gate
+        // when app.feed.respect-profile-visibility=true; otherwise it
+        // degenerates to findByIdAndDeletedAtIsNull (the predicate's first
+        // OR short-circuits to true), so default behaviour is unchanged.
+        FeedPost post = feedPostRepository.findVisibleById(postId, viewerId, respectVisibility)
                 .orElseThrow(() -> new ResourceNotFoundException("Feed post not found with id: " + postId));
         return feedPostMapper.toResponse(post, viewerId);
     }

--- a/backend/src/main/java/com/group7/backend/service/FeedReadService.java
+++ b/backend/src/main/java/com/group7/backend/service/FeedReadService.java
@@ -79,6 +79,7 @@ public class FeedReadService {
     private final FeedPostMapper feedPostMapper;
     private final UserKeywordMuteService keywordMuteService;
     private final int candidateWindow;
+    private final boolean respectVisibility;
 
     public FeedReadService(FeedPostRepository feedPostRepository,
                            UserRepository userRepository,
@@ -89,7 +90,8 @@ public class FeedReadService {
                            Optional<ForYouScoringPipeline> forYouPipeline,
                            FeedPostMapper feedPostMapper,
                            UserKeywordMuteService keywordMuteService,
-                           @Value("${app.feed.forYou.candidate-window:200}") int candidateWindow) {
+                           @Value("${app.feed.forYou.candidate-window:200}") int candidateWindow,
+                           @Value("${app.feed.respect-profile-visibility:false}") boolean respectVisibility) {
         this.feedPostRepository = feedPostRepository;
         this.userRepository = userRepository;
         this.followRepository = followRepository;
@@ -100,6 +102,7 @@ public class FeedReadService {
         this.feedPostMapper = feedPostMapper;
         this.keywordMuteService = keywordMuteService;
         this.candidateWindow = candidateWindow;
+        this.respectVisibility = respectVisibility;
     }
 
     /**
@@ -111,7 +114,7 @@ public class FeedReadService {
      */
     public Page<FeedPostListItem> forYouFeed(Long viewerId, Pageable pageable) {
         List<FeedPost> candidates =
-                feedPostRepository.findForYouCandidates(viewerId, candidateWindow);
+                feedPostRepository.findForYouCandidates(viewerId, respectVisibility, candidateWindow);
         if (candidates.isEmpty()) {
             return Page.empty(pageable);
         }
@@ -325,7 +328,8 @@ public class FeedReadService {
      * authored by the given user id.
      */
     public Page<FeedPostListItem> postsByAuthor(Long authorId, Long viewerId, Pageable pageable) {
-        Page<FeedPost> page = feedPostRepository.findByAuthorIdForFeed(authorId, pageable);
+        Page<FeedPost> page = feedPostRepository.findByAuthorIdForFeed(
+                authorId, viewerId, respectVisibility, pageable);
         return mapPage(page, viewerId);
     }
 
@@ -382,7 +386,8 @@ public class FeedReadService {
             throw new IllegalArgumentException("'until' is too far in the future (limit: 1 day)");
         }
         Page<FeedPost> page = feedPostRepository.searchPosts(
-                normalisedKeyword, normalisedHashtag, since, until, lang, pageable);
+                normalisedKeyword, normalisedHashtag, since, until, lang,
+                viewerId, respectVisibility, pageable);
         return mapPage(page, viewerId);
     }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -158,6 +158,18 @@ app.ratelimit.rules.feed-post-create.refill=PT1H
 # unread rows when the cap suffices. Env-overrideable for demos.
 app.feed.unread.cap=${APP_FEED_UNREAD_CAP:99}
 
+# Feed read paths respect Mentee.profileVisibility (#524-adjacent privacy
+# gap). When true, the feed-read SQL queries (For-You candidates, search,
+# author timeline, single-post GET, interaction guard) suppress posts
+# authored by a mentee with profile_visibility=false UNLESS the viewer is
+# the author themselves or a current follower — "discovery off, social
+# graph intact" semantics. Default off keeps the prior public-by-default
+# behaviour bit-for-bit; once frontend / mobile surface a "your posts will
+# be hidden from new viewers" hint in the visibility toggle, this can flip
+# on. Following feed naturally satisfies the predicate (the viewer follows
+# every author in the result) so its query is left untouched.
+app.feed.respect-profile-visibility=${FEED_RESPECT_VISIBILITY:false}
+
 # EmailService dev escape hatch (#349 polish). When false, the
 # verification + password-reset paths log the link at WARN instead of
 # calling Resend. Lets a fresh-DB dev/manual-smoke run register users

--- a/backend/src/test/java/com/group7/backend/integration/FeedProfileVisibilityIntegrationTest.java
+++ b/backend/src/test/java/com/group7/backend/integration/FeedProfileVisibilityIntegrationTest.java
@@ -1,0 +1,264 @@
+package com.group7.backend.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group7.backend.dto.request.LoginRequest;
+import com.group7.backend.dto.request.MenteeProfileRequest;
+import com.group7.backend.dto.request.RegisterRequest;
+import com.group7.backend.entity.User;
+import com.group7.backend.repository.UserRepository;
+import com.group7.backend.repository.VerificationTokenRepository;
+import com.group7.backend.service.EmailService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Follower-aware visibility coverage for the feed read paths
+ * (issue-524 follow-up — addressed the entity/DTO half; this PR covers
+ * the read-side privacy gap).
+ *
+ * <p>The flag {@code app.feed.respect-profile-visibility} ships
+ * disabled by default to keep the public-by-default behaviour bit-for-bit
+ * during the staged rollout. This test class boots the same context with
+ * the flag flipped on via {@link SpringBootTest#properties()} so the
+ * filter actually runs.
+ *
+ * <p>Cases pinned here:
+ * <ul>
+ *   <li>Hidden mentee + non-follower viewer → post 404 / search empty /
+ *       author timeline empty / For-You suppresses the post.</li>
+ *   <li>Hidden mentee + follower viewer → post visible everywhere
+ *       (predicate's follower branch).</li>
+ *   <li>Hidden mentee + self → post visible everywhere
+ *       (predicate's author-id branch).</li>
+ *   <li>Hidden author who is a mentor (no {@code profileVisibility}
+ *       column on Mentor at all) → never filtered (predicate's
+ *       {@code NOT EXISTS} branch).</li>
+ * </ul>
+ *
+ * <p>The flag-off default behaviour is already pinned implicitly by
+ * every other {@code Feed*IntegrationTest} that runs without the flag
+ * override — those tests would fail if the predicate suppressed rows
+ * with the flag off.
+ */
+@SpringBootTest(properties = "app.feed.respect-profile-visibility=true")
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class FeedProfileVisibilityIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private VerificationTokenRepository verificationTokenRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @MockitoBean private EmailService emailService;
+
+    @BeforeEach
+    void cleanDb() {
+        jdbcTemplate.update("DELETE FROM feed_post_comments");
+        jdbcTemplate.update("DELETE FROM feed_post_shares");
+        jdbcTemplate.update("DELETE FROM feed_post_bookmarks");
+        jdbcTemplate.update("DELETE FROM feed_post_likes");
+        jdbcTemplate.update("DELETE FROM feed_post_hashtags");
+        jdbcTemplate.update("DELETE FROM feed_posts");
+        jdbcTemplate.update("DELETE FROM follows");
+        verificationTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        doNothing().when(emailService).sendVerificationEmail(any(), anyString());
+    }
+
+    @Test
+    void hiddenMentee_nonFollower_suppressedAcrossReadPaths() throws Exception {
+        String hiddenMenteeToken = registerAndLogin("hidden@test.com", false);
+        String strangerToken = registerAndLogin("stranger@test.com", false);
+        Long hiddenId = userRepository.findByEmail("hidden@test.com").orElseThrow().getId();
+
+        long postId = createPost(hiddenMenteeToken, "secret thoughts about ai", List.of("topic"));
+        hideMenteeProfile(hiddenMenteeToken);
+
+        // single-post GET → 404 for non-follower
+        mockMvc.perform(get("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + strangerToken))
+                .andExpect(status().isNotFound());
+
+        // author timeline → empty page
+        mockMvc.perform(get("/api/feed/users/" + hiddenId + "/posts")
+                        .header("Authorization", "Bearer " + strangerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isEmpty());
+
+        // search → empty
+        mockMvc.perform(get("/api/feed/search").param("q", "ai")
+                        .header("Authorization", "Bearer " + strangerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isEmpty());
+
+        // For-You candidates → post should be filtered out; the page is
+        // empty (no other authors posted in this test)
+        mockMvc.perform(get("/api/feed/for-you")
+                        .header("Authorization", "Bearer " + strangerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isEmpty());
+
+        // interaction guard: like attempt → 404
+        mockMvc.perform(post("/api/feed/posts/" + postId + "/like")
+                        .header("Authorization", "Bearer " + strangerToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void hiddenMentee_followerStillSees() throws Exception {
+        String hiddenMenteeToken = registerAndLogin("hidden_f@test.com", false);
+        String followerToken = registerAndLogin("follower_f@test.com", false);
+        Long hiddenId = userRepository.findByEmail("hidden_f@test.com").orElseThrow().getId();
+
+        // Follower follows the hidden mentee BEFORE they go hidden (the
+        // realistic flow: existing followers don't lose access).
+        mockMvc.perform(post("/api/users/" + hiddenId + "/follow")
+                        .header("Authorization", "Bearer " + followerToken))
+                .andExpect(status().isCreated());
+
+        long postId = createPost(hiddenMenteeToken, "thought about graphs", List.of("graph"));
+        hideMenteeProfile(hiddenMenteeToken);
+
+        // Follower can still see the post on every read path
+        mockMvc.perform(get("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + followerToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/feed/users/" + hiddenId + "/posts")
+                        .header("Authorization", "Bearer " + followerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(postId));
+
+        mockMvc.perform(get("/api/feed/search").param("q", "graph")
+                        .header("Authorization", "Bearer " + followerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(postId));
+    }
+
+    @Test
+    void hiddenMentee_selfViewUnchanged() throws Exception {
+        String hiddenMenteeToken = registerAndLogin("hidden_s@test.com", false);
+        Long hiddenId = userRepository.findByEmail("hidden_s@test.com").orElseThrow().getId();
+
+        long postId = createPost(hiddenMenteeToken, "my private musings", List.of("solo"));
+        hideMenteeProfile(hiddenMenteeToken);
+
+        // Self can still see their own post on every read path
+        mockMvc.perform(get("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + hiddenMenteeToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/feed/users/" + hiddenId + "/posts")
+                        .header("Authorization", "Bearer " + hiddenMenteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(postId));
+
+        // Search by hashtag (body doesn't contain "solo" — that's the tag).
+        mockMvc.perform(get("/api/feed/search").param("hashtag", "solo")
+                        .header("Authorization", "Bearer " + hiddenMenteeToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(postId));
+    }
+
+    @Test
+    void mentorAuthor_neverHidden_evenWithFlagOn() throws Exception {
+        // Mentor has no profileVisibility column at all — the predicate's
+        // NOT EXISTS branch (no mentees row matches the author_id) must
+        // let mentor-authored posts through unconditionally.
+        String mentorToken = registerAndLogin("mentor_author@test.com", true);
+        String strangerToken = registerAndLogin("stranger_mentor@test.com", false);
+        Long mentorId = userRepository.findByEmail("mentor_author@test.com").orElseThrow().getId();
+
+        long postId = createPost(mentorToken, "from a mentor", List.of("mtopic"));
+
+        mockMvc.perform(get("/api/feed/posts/" + postId)
+                        .header("Authorization", "Bearer " + strangerToken))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/feed/users/" + mentorId + "/posts")
+                        .header("Authorization", "Bearer " + strangerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(postId));
+
+        mockMvc.perform(get("/api/feed/search").param("q", "mentor")
+                        .header("Authorization", "Bearer " + strangerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(postId));
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private void hideMenteeProfile(String menteeToken) throws Exception {
+        MenteeProfileRequest req = new MenteeProfileRequest();
+        req.setProfileVisibility(false);
+        mockMvc.perform(patch("/api/users/me/mentee")
+                        .header("Authorization", "Bearer " + menteeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileVisibility").value(false));
+    }
+
+    private long createPost(String token, String body, List<String> hashtags) throws Exception {
+        Map<String, Object> req = Map.of("body", body, "hashtags", hashtags);
+        MvcResult res = mockMvc.perform(post("/api/feed/posts")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(res.getResponse().getContentAsString()).get("id").asLong();
+    }
+
+    private String registerAndLogin(String email, boolean isMentor) throws Exception {
+        RegisterRequest req = new RegisterRequest();
+        req.setFirstName("Vis");
+        req.setLastName("Tester");
+        req.setEmail(email);
+        req.setPassword("Password1");
+        req.setIsMentor(isMentor);
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+
+        User user = userRepository.findByEmail(email).orElseThrow();
+        String verifyToken = verificationTokenRepository
+                .findByUserIdAndUsedFalse(user.getId()).get(0).getToken();
+        mockMvc.perform(get("/api/auth/verify-email").param("token", verifyToken))
+                .andExpect(status().isOk());
+
+        LoginRequest login = new LoginRequest();
+        login.setEmail(email);
+        login.setPassword("Password1");
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(login)))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("sessionToken").asText();
+    }
+}

--- a/backend/src/test/java/com/group7/backend/service/FeedInteractionServiceCommentLikeTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedInteractionServiceCommentLikeTest.java
@@ -19,7 +19,6 @@ import com.group7.backend.repository.projection.CommentCountTuple;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
@@ -36,6 +35,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -63,7 +63,29 @@ class FeedInteractionServiceCommentLikeTest {
     @Mock private FeedPostMapper feedPostMapper;
     @Mock private NotificationEventPublisher notificationEventPublisher;
     @Mock private ApplicationEventPublisher eventPublisher;
-    @InjectMocks private FeedInteractionService service;
+
+    // Manual construction (not @InjectMocks): the service's primitive
+    // boolean (respectVisibility) + Duration parameters cannot be auto-
+    // wired by Mockito. Pin both to the production default so this test's
+    // assertions stay in sync with the shipped behaviour.
+    private FeedInteractionService service;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        service = new FeedInteractionService(
+                feedPostRepository,
+                likeRepository,
+                bookmarkRepository,
+                shareRepository,
+                commentRepository,
+                commentLikeRepository,
+                userRepository,
+                feedPostMapper,
+                notificationEventPublisher,
+                eventPublisher,
+                java.time.Duration.ofSeconds(60),
+                false);
+    }
 
     // ── toggleCommentLike ─────────────────────────────────────────────────
 
@@ -73,7 +95,7 @@ class FeedInteractionServiceCommentLikeTest {
         FeedPost post = freshPost(42L, 7L);
         attachHashtags(post, "java");
         when(commentRepository.findById(101L)).thenReturn(Optional.of(comment));
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(42L), any(), anyBoolean())).thenReturn(Optional.of(post));
         when(commentLikeRepository.existsByIdCommentIdAndIdUserId(101L, 9L)).thenReturn(false);
         when(commentLikeRepository.upsertCommentLike(101L, 9L)).thenReturn(1);
         when(commentLikeRepository.countByIdCommentId(101L)).thenReturn(1L);
@@ -98,7 +120,7 @@ class FeedInteractionServiceCommentLikeTest {
         FeedPost post = freshPost(42L, 7L);
         attachHashtags(post, "java");
         when(commentRepository.findById(101L)).thenReturn(Optional.of(comment));
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(42L), any(), anyBoolean())).thenReturn(Optional.of(post));
         when(commentLikeRepository.existsByIdCommentIdAndIdUserId(101L, 9L)).thenReturn(true);
         when(commentLikeRepository.countByIdCommentId(101L)).thenReturn(0L);
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L, "Author")));
@@ -142,7 +164,7 @@ class FeedInteractionServiceCommentLikeTest {
     void toggleCommentLike_404_whenParentPostSoftDeleted() {
         FeedPostComment comment = freshComment(101L, 42L, 1L, "hi");
         when(commentRepository.findById(101L)).thenReturn(Optional.of(comment));
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.empty());
+        when(feedPostRepository.findVisibleById(eq(42L), any(), anyBoolean())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.toggleCommentLike(101L, 9L))
                 .isInstanceOf(ResourceNotFoundException.class);
@@ -155,7 +177,7 @@ class FeedInteractionServiceCommentLikeTest {
     @Test
     void addComment_doesNotIssuePerRowLikeQueries_onFreshComment() {
         FeedPost post = freshPost(42L, 1L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(42L), any(), anyBoolean())).thenReturn(Optional.of(post));
         when(commentRepository.save(any(FeedPostComment.class))).thenAnswer(inv -> {
             FeedPostComment c = inv.getArgument(0);
             c.setId(101L);
@@ -178,7 +200,7 @@ class FeedInteractionServiceCommentLikeTest {
     @Test
     void listComments_batchLoadsCountsAndViewerLikedExactlyOnce_perPage() {
         FeedPost post = freshPost(42L, 1L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(42L), any(), anyBoolean())).thenReturn(Optional.of(post));
 
         List<FeedPostComment> rows = List.of(
                 freshComment(101L, 42L, 1L, "a"),
@@ -217,7 +239,7 @@ class FeedInteractionServiceCommentLikeTest {
     @Test
     void listComments_emptyPage_skipsAllBatchSQL() {
         FeedPost post = freshPost(42L, 1L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(42L), any(), anyBoolean())).thenReturn(Optional.of(post));
         Pageable pageable = PageRequest.of(0, 20);
         when(commentRepository.findByPostIdOrderByCreatedAtAscIdAsc(42L, pageable))
                 .thenReturn(Page.empty(pageable));
@@ -232,7 +254,7 @@ class FeedInteractionServiceCommentLikeTest {
     @Test
     void listComments_anonymousViewer_skipsLikedLookup() {
         FeedPost post = freshPost(42L, 1L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(42L), any(), anyBoolean())).thenReturn(Optional.of(post));
         List<FeedPostComment> rows = List.of(freshComment(101L, 42L, 1L, "a"));
         Pageable pageable = PageRequest.of(0, 20);
         when(commentRepository.findByPostIdOrderByCreatedAtAscIdAsc(42L, pageable))

--- a/backend/src/test/java/com/group7/backend/service/FeedInteractionServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedInteractionServiceTest.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -93,14 +94,15 @@ class FeedInteractionServiceTest {
                 feedPostMapper,
                 notificationEventPublisher,
                 eventPublisher,
-                Duration.ofSeconds(60));
+                Duration.ofSeconds(60),
+                false);
     }
 
     // ── toggleLike ─────────────────────────────────────────────────────────
 
     @Test
     void toggleLike_throws404_whenPostMissingOrSoftDeleted() {
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.toggleLike(7L, 1L))
                 .isInstanceOf(ResourceNotFoundException.class);
@@ -112,7 +114,7 @@ class FeedInteractionServiceTest {
     @Test
     void toggleLike_firstCall_insertsAndNotifiesNonSelfAuthor() {
         FeedPost post = freshPost(7L, 99L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
         // First existsBy call (in toggleLike) → not yet liked, so service
         // hits the upsert branch. The second call (inside interactionState)
         // → returns true because the row now exists in production. Mockito's
@@ -131,7 +133,7 @@ class FeedInteractionServiceTest {
     @Test
     void toggleLike_secondCall_deletesAndSkipsNotification() {
         FeedPost post = freshPost(7L, 99L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
         // First existsBy → already liked; second (inside interactionState
         // after the row is gone) → false.
         when(likeRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(true, false);
@@ -148,7 +150,7 @@ class FeedInteractionServiceTest {
     @Test
     void toggleLike_selfLike_skipsNotificationButStillInserts() {
         FeedPost post = freshPost(7L, 1L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
         when(likeRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(false);
 
         service.toggleLike(7L, 1L);
@@ -162,7 +164,7 @@ class FeedInteractionServiceTest {
 
     @Test
     void toggleBookmark_throws404_whenPostMissing() {
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.toggleBookmark(7L, 1L))
                 .isInstanceOf(ResourceNotFoundException.class);
@@ -173,7 +175,7 @@ class FeedInteractionServiceTest {
     @Test
     void toggleBookmark_firstCall_inserts() {
         FeedPost post = freshPost(7L, 99L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
         // Flip mirrors the toggleLike test: first call (in toggle) returns
         // false, second call (in interactionState after the upsert) returns
         // true.
@@ -188,7 +190,7 @@ class FeedInteractionServiceTest {
     @Test
     void toggleBookmark_secondCall_deletes() {
         FeedPost post = freshPost(7L, 99L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
         when(bookmarkRepository.existsByIdPostIdAndIdUserId(7L, 1L)).thenReturn(true, false);
 
         FeedPostInteractionState state = service.toggleBookmark(7L, 1L);
@@ -201,7 +203,7 @@ class FeedInteractionServiceTest {
 
     @Test
     void recordShare_throws404_whenPostMissing() {
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.recordShare(7L, 1L))
                 .isInstanceOf(ResourceNotFoundException.class);
@@ -212,7 +214,7 @@ class FeedInteractionServiceTest {
     @Test
     void recordShare_notifiesNonSelfAuthor() {
         FeedPost post = freshPost(7L, 99L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
 
         service.recordShare(7L, 1L);
@@ -224,7 +226,7 @@ class FeedInteractionServiceTest {
     @Test
     void recordShare_selfShare_skipsNotification() {
         FeedPost post = freshPost(7L, 1L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
 
         service.recordShare(7L, 1L);
 
@@ -236,7 +238,7 @@ class FeedInteractionServiceTest {
 
     @Test
     void addComment_throws404_whenPostMissing() {
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.addComment(7L, 1L, "hello"))
                 .isInstanceOf(ResourceNotFoundException.class);
@@ -247,7 +249,7 @@ class FeedInteractionServiceTest {
     @Test
     void addComment_throws400_onBlankBody() {
         FeedPost post = freshPost(7L, 99L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
 
         assertThatThrownBy(() -> service.addComment(7L, 1L, "   "))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -260,7 +262,7 @@ class FeedInteractionServiceTest {
     @Test
     void addComment_throws400_onNullBody() {
         FeedPost post = freshPost(7L, 99L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
 
         assertThatThrownBy(() -> service.addComment(7L, 1L, null))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -269,7 +271,7 @@ class FeedInteractionServiceTest {
     @Test
     void addComment_savesAndNotifiesNonSelfAuthor() {
         FeedPost post = freshPost(7L, 99L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
         when(commentRepository.save(any(FeedPostComment.class))).thenAnswer(inv -> {
             FeedPostComment c = inv.getArgument(0);
@@ -287,7 +289,7 @@ class FeedInteractionServiceTest {
     @Test
     void addComment_selfComment_skipsNotification() {
         FeedPost post = freshPost(7L, 1L);
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
         when(commentRepository.save(any(FeedPostComment.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -415,7 +417,7 @@ class FeedInteractionServiceTest {
         FeedPostComment c = freshComment(42L, 7L, 1L, "x");
         when(commentRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(c));
         // Parent post invisible → orphan-permalink guard fires.
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.empty());
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.getComment(42L, 1L))
                 .isInstanceOf(ResourceNotFoundException.class);
@@ -425,7 +427,7 @@ class FeedInteractionServiceTest {
     void getComment_returnsDto_whenBothVisible() {
         FeedPostComment c = freshComment(42L, 7L, 1L, "body");
         when(commentRepository.findByIdAndDeletedAtIsNull(42L)).thenReturn(Optional.of(c));
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L))
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean()))
                 .thenReturn(Optional.of(freshPost(7L, 99L)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(mentor(1L)));
 

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceHistoryTest.java
@@ -65,7 +65,8 @@ class FeedPostServiceHistoryTest {
                 feedPostMapper,
                 feedPostEventPublisher,
                 historyRepository,
-                30);
+                30,
+                false);
     }
 
     // ── update() snapshot behaviour ───────────────────────────────────────

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceRestoreTest.java
@@ -58,7 +58,8 @@ class FeedPostServiceRestoreTest {
                 feedPostMapper,
                 feedPostEventPublisher,
                 historyRepository,
-                RESTORE_WINDOW_DAYS);
+                RESTORE_WINDOW_DAYS,
+                false);
     }
 
     @Test
@@ -148,7 +149,7 @@ class FeedPostServiceRestoreTest {
         // Reconstruct with a misconfigured 0; the constructor clamps to 1.
         FeedPostService clampedService = new FeedPostService(
                 feedPostRepository, userRepository, attachmentRepository, hashtagNormalizer,
-                feedPostMapper, feedPostEventPublisher, historyRepository, 0);
+                feedPostMapper, feedPostEventPublisher, historyRepository, 0, false);
 
         FeedPost post = freshPost(7L, 1L, "Body");
         // Soft-deleted 2 days ago — past the clamped 1-day window.

--- a/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedPostServiceTest.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -62,7 +64,8 @@ class FeedPostServiceTest {
                 feedPostMapper,
                 feedPostEventPublisher,
                 historyRepository,
-                30);
+                30,
+                false);
     }
 
     // ── create ─────────────────────────────────────────────────────────────
@@ -171,7 +174,7 @@ class FeedPostServiceTest {
     @Test
     void getById_returnsDto_whenPostVisible() {
         FeedPost post = freshPost(7L, 1L, "Body");
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(7L)).thenReturn(Optional.of(post));
+        when(feedPostRepository.findVisibleById(eq(7L), anyLong(), anyBoolean())).thenReturn(Optional.of(post));
         FeedPostResponse expected = stubResponse(7L, 1L);
         when(feedPostMapper.toResponse(post, 99L)).thenReturn(expected);
 
@@ -182,7 +185,7 @@ class FeedPostServiceTest {
 
     @Test
     void getById_throws404_whenPostMissingOrDeleted() {
-        when(feedPostRepository.findByIdAndDeletedAtIsNull(99L)).thenReturn(Optional.empty());
+        when(feedPostRepository.findVisibleById(eq(99L), anyLong(), anyBoolean())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> feedPostService.getById(99L, 1L))
                 .isInstanceOf(ResourceNotFoundException.class);

--- a/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/FeedReadServiceTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -104,14 +105,15 @@ class FeedReadServiceTest {
                 Optional.empty(),
                 feedPostMapper,
                 keywordMuteService,
-                200);
+                200,
+                false);
     }
 
     // ── forYouFeed ─────────────────────────────────────────────────────────
 
     @Test
     void forYouFeed_emptyCandidates_returnsEmptyPageWithoutRanking() {
-        when(feedPostRepository.findForYouCandidates(1L, 200)).thenReturn(List.of());
+        when(feedPostRepository.findForYouCandidates(1L, false, 200)).thenReturn(List.of());
 
         Page<FeedPostListItem> page = service.forYouFeed(1L, PageRequest.of(0, 10));
 
@@ -127,7 +129,7 @@ class FeedReadServiceTest {
         FeedPost p1 = freshPost(101L, 99L);
         FeedPost p2 = freshPost(102L, 98L);
         FeedPost p3 = freshPost(103L, 97L);
-        when(feedPostRepository.findForYouCandidates(1L, 200)).thenReturn(List.of(p1, p2, p3));
+        when(feedPostRepository.findForYouCandidates(1L, false, 200)).thenReturn(List.of(p1, p2, p3));
         when(userRepository.findById(1L)).thenReturn(Optional.of(viewer(1L)));
         when(followRepository.findFolloweeIdsByFollowerId(1L)).thenReturn(Set.of());
         // Mentee's getInterests() is null on a fresh fixture, so
@@ -249,7 +251,7 @@ class FeedReadServiceTest {
     void postsByAuthor_delegatesToRepoAndMapper() {
         FeedPost post = freshPost(101L, 99L);
         Page<FeedPost> repoPage = new PageImpl<>(List.of(post), PageRequest.of(0, 10), 1L);
-        when(feedPostRepository.findByAuthorIdForFeed(eq(99L), any())).thenReturn(repoPage);
+        when(feedPostRepository.findByAuthorIdForFeed(eq(99L), anyLong(), anyBoolean(), any())).thenReturn(repoPage);
         when(feedInteractionService.batchCounts(List.of(101L))).thenReturn(
                 Map.of(101L, new PostCounts(0L, 0L)));
         when(feedPostMapper.toListItems(eq(List.of(post)), eq(1L), any()))
@@ -269,7 +271,7 @@ class FeedReadServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("at least one");
 
-        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
@@ -280,7 +282,7 @@ class FeedReadServiceTest {
         assertThatThrownBy(() -> service.search("   ", "  ", null, null, null, 1L, PageRequest.of(0, 10)))
                 .isInstanceOf(IllegalArgumentException.class);
 
-        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
@@ -295,7 +297,7 @@ class FeedReadServiceTest {
                 null, "not a valid hashtag", null, null, null, 1L, PageRequest.of(0, 10));
 
         assertThat(page.getContent()).isEmpty();
-        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
@@ -303,24 +305,24 @@ class FeedReadServiceTest {
         // %, _, and \ are LIKE metacharacters; escaping prevents a malicious
         // q=% from matching every post. Lowercasing aligns with the
         // pg_trgm GIN index on LOWER(body).
-        when(feedPostRepository.searchPosts(eq("ja\\%va"), eq(null), eq(null), eq(null), eq(null), any()))
+        when(feedPostRepository.searchPosts(eq("ja\\%va"), eq(null), eq(null), eq(null), eq(null), anyLong(), anyBoolean(), any()))
                 .thenReturn(Page.empty(PageRequest.of(0, 10)));
 
         service.search("Ja%va", null, null, null, null, 1L, PageRequest.of(0, 10));
 
-        verify(feedPostRepository).searchPosts(eq("ja\\%va"), eq(null), eq(null), eq(null), eq(null), any());
+        verify(feedPostRepository).searchPosts(eq("ja\\%va"), eq(null), eq(null), eq(null), eq(null), anyLong(), anyBoolean(), any());
     }
 
     @Test
     void search_passesNormalisedHashtagToRepository() {
         when(hashtagNormalizer.normalize(List.of("#DataScience")))
                 .thenReturn(Set.of("datascience"));
-        when(feedPostRepository.searchPosts(eq(null), eq("datascience"), eq(null), eq(null), eq(null), any()))
+        when(feedPostRepository.searchPosts(eq(null), eq("datascience"), eq(null), eq(null), eq(null), anyLong(), anyBoolean(), any()))
                 .thenReturn(Page.empty(PageRequest.of(0, 10)));
 
         service.search(null, "#DataScience", null, null, null, 1L, PageRequest.of(0, 10));
 
-        verify(feedPostRepository).searchPosts(eq(null), eq("datascience"), eq(null), eq(null), eq(null), any());
+        verify(feedPostRepository).searchPosts(eq(null), eq("datascience"), eq(null), eq(null), eq(null), anyLong(), anyBoolean(), any());
     }
 
     @Test
@@ -328,12 +330,12 @@ class FeedReadServiceTest {
         // lang on its own is enough to escape the every-filter-missing 400
         // guard, so this also pins the contract that lang is a first-class
         // search axis and not just a tie-breaker behind q/hashtag.
-        when(feedPostRepository.searchPosts(eq(null), eq(null), eq(null), eq(null), eq("en"), any()))
+        when(feedPostRepository.searchPosts(eq(null), eq(null), eq(null), eq(null), eq("en"), anyLong(), anyBoolean(), any()))
                 .thenReturn(Page.empty(PageRequest.of(0, 10)));
 
         service.search(null, null, null, null, "en", 1L, PageRequest.of(0, 10));
 
-        verify(feedPostRepository).searchPosts(eq(null), eq(null), eq(null), eq(null), eq("en"), any());
+        verify(feedPostRepository).searchPosts(eq(null), eq(null), eq(null), eq(null), eq("en"), anyLong(), anyBoolean(), any());
     }
 
     @Test
@@ -348,7 +350,7 @@ class FeedReadServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("strictly before");
 
-        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
@@ -360,7 +362,7 @@ class FeedReadServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'since'");
 
-        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
@@ -372,19 +374,19 @@ class FeedReadServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("'until'");
 
-        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any());
+        verify(feedPostRepository, never()).searchPosts(any(), any(), any(), any(), any(), any(), anyBoolean(), any());
     }
 
     @Test
     void search_passesValidWindowToRepository() {
         OffsetDateTime since = OffsetDateTime.now().minusHours(1);
         OffsetDateTime until = OffsetDateTime.now().plusHours(1);
-        when(feedPostRepository.searchPosts(eq(null), eq(null), eq(since), eq(until), eq(null), any()))
+        when(feedPostRepository.searchPosts(eq(null), eq(null), eq(since), eq(until), eq(null), anyLong(), anyBoolean(), any()))
                 .thenReturn(Page.empty(PageRequest.of(0, 10)));
 
         service.search(null, null, since, until, null, 1L, PageRequest.of(0, 10));
 
-        verify(feedPostRepository).searchPosts(eq(null), eq(null), eq(since), eq(until), eq(null), any());
+        verify(feedPostRepository).searchPosts(eq(null), eq(null), eq(since), eq(until), eq(null), anyLong(), anyBoolean(), any());
     }
 
     // ── Fixtures ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
`Mentee.profileVisibility` (V1) was only consulted by the user-search endpoint. Feed read paths surfaced every mentee's posts regardless of the flag — single-post GET, For-You, search, author timeline, and the interaction guard fronting like / bookmark / share / comment toggles all ignored it. A mentee who set their profile to private stayed fully visible across discovery surfaces, undermining the privacy toggle.

This PR adds a **follower-aware** visibility predicate to the feed read SQL: a post whose author is a mentee with `profile_visibility = false` is suppressed unless the viewer is the author themselves OR a current follower of the author. Semantics: *"discovery off, social graph intact"* — existing followers keep seeing the mentee's content; new viewers can't discover it.

Mentors and admins are never affected (no `profileVisibility` column on `Mentor` at all) — the predicate's `NOT EXISTS` branch lets every non-mentee post through unconditionally.

## Backward compatibility
The whole change is gated behind `app.feed.respect-profile-visibility` (default `false`). With the flag off, the predicate degenerates to a literal `OR true` and matches every row — the existing query plan, the existing visible set, the existing tests, all unchanged.

- No DB migration. `mentees.profile_visibility` has lived in V1 with `NOT NULL DEFAULT true`, so every existing row remains "visible" — no user is silently hidden when the flag flips.
- No API / DTO shape change. Only the SQL row set narrows; OpenAPI is unaffected.
- Write paths (post create / edit / delete / soft-delete / restore) untouched — a private mentee can still post and edit; only who can READ those posts changes.
- The Following feed query is intentionally left as-is: by definition the viewer follows every author returned, so the predicate would be a tautology.

Staged rollout:
1. This PR lands with flag off — zero behaviour change in production.
2. Frontend / mobile add a "your posts will be hidden from new viewers" hint next to the visibility toggle.
3. Separate ops PR flips `FEED_RESPECT_VISIBILITY=true`.

## Predicate shape (added to every gated query)
```sql
AND (
      :respectVisibility = false                                       -- flag off → no-op
   OR NOT EXISTS (SELECT 1 FROM mentees m
                  WHERE m.id = p.author_id
                    AND m.profile_visibility = false)                  -- author isn't a hidden mentee
   OR p.author_id = :viewerId                                          -- self-view
   OR EXISTS (SELECT 1 FROM follows f
              WHERE f.follower_id = :viewerId
                AND f.followee_id = p.author_id)                       -- viewer follows author
)
```
Index-only access on `mentees.id` (PK) and `follows(follower_id, followee_id)` (composite PK).

## Files touched
- `application.properties` — new `app.feed.respect-profile-visibility` (default false) with a comment explaining the rollout plan.
- `FeedPostRepository` — new `findVisibleById` (used by `getById`, `requireVisiblePost`, `getComment`); predicate added to `findByAuthorIdForFeed`, `findForYouCandidates`, `searchPosts`. The old `findByIdAndDeletedAtIsNull` stays for author-load write paths (`PATCH` / `DELETE`) so the author always sees their own posts on those surfaces.
- `FeedReadService` — injects `respectVisibility`, threads through to the three list-read calls.
- `FeedPostService.getById` — routes through `findVisibleById`.
- `FeedInteractionService.requireVisiblePost` / `getComment` — route through `findVisibleById`; the 8 callers (like, bookmark, share, repost, addComment, listComments, toggleCommentLike, getInteractionState) pass the viewer id they already have.
- 4 existing service tests adapted (constructor signature gained a flag; some `findByIdAndDeletedAtIsNull(...)` stubs migrated to `findVisibleById(...)`).
- New `FeedProfileVisibilityIntegrationTest` — boots with `properties = "app.feed.respect-profile-visibility=true"` and pins the four branches end-to-end: non-follower suppression across all 5 surfaces, follower bypass, self bypass, mentor never affected.

## Test plan
- [x] `mvn clean verify` against isolated Postgres → **2264/2264 tests pass**.
- [x] New integration test exercises all four predicate branches end-to-end with the flag actually on.
- [x] Flag-off default behaviour implicitly pinned by every other `Feed*IntegrationTest` that runs without the override — they would fail if the predicate suppressed rows by default.

## Spec
Maps to **1.2.2.3** "Users shall be able to control profile visibility". The spec is general — post-coverage was a product call. The follower-aware semantics ship the most conservative interpretation: existing follower feeds stay intact while the privacy toggle starts to mean something on discovery surfaces.