### PR TITLE
feat(web): live like/comment/share count updates on visible feed post…

### DIFF
--- a/frontend/src/hooks/useFeedSubscription.js
+++ b/frontend/src/hooks/useFeedSubscription.js
@@ -4,16 +4,17 @@ import { getStompClient } from '../services/stompClient'
 /**
  * Subscribe to live feed pushes on `/topic/feed.{userId}` (#349).
  *
- * Backend (FeedFanoutListener) publishes two payload shapes to this topic
- * after a post or share commits in the viewer's follow graph:
- *   - FeedPostPushPayload  : { postId, authorId, authorFirstName, createdAt }
- *   - FeedSharePushPayload : { shareId, postId, sharerId, sharerFirstName,
- *                              commentary, sharedAt }
+ * Backend (FeedFanoutListener) publishes three payload shapes to this
+ * topic, all routed to followers of the relevant author/sharer:
+ *   - FeedPostPushPayload       : { postId, authorId, authorFirstName, createdAt }
+ *   - FeedSharePushPayload      : { shareId, postId, sharerId, sharerFirstName,
+ *                                   commentary, sharedAt }
+ *   - FeedEngagementPushPayload : { postId, likeCount, commentCount, shareCount,
+ *                                   updatedAt }  -- has neither authorId nor sharerId
  *
- * The two shapes are distinguished by presence of `sharerId` (share) vs.
- * `authorId` (original post). Callers pass `onPost` and / or `onShare`;
- * frames are routed by the discriminator without the caller having to
- * write the JSON.parse + try/catch boilerplate.
+ * Callers pass `onPost`, `onShare`, and/or `onEngagement`; frames are
+ * routed by the discriminator without the caller writing JSON.parse +
+ * try/catch boilerplate.
  *
  * Lifecycle mirrors `useConversationSubscription` — the singleton STOMP
  * client survives unmounts so navigating between pages doesn't churn the
@@ -21,11 +22,13 @@ import { getStompClient } from '../services/stompClient'
  *
  * The latest callbacks are stored in refs so callers don't need to memoize.
  */
-export default function useFeedSubscription(userId, { onPost, onShare } = {}) {
+export default function useFeedSubscription(userId, { onPost, onShare, onEngagement } = {}) {
   const postRef = useRef(onPost)
   const shareRef = useRef(onShare)
+  const engagementRef = useRef(onEngagement)
   postRef.current = onPost
   shareRef.current = onShare
+  engagementRef.current = onEngagement
 
   useEffect(() => {
     if (!userId) return undefined
@@ -41,8 +44,11 @@ export default function useFeedSubscription(userId, { onPost, onShare } = {}) {
               const payload = JSON.parse(frame.body)
               if (payload.sharerId != null) {
                 shareRef.current?.(payload)
-              } else {
+              } else if (payload.authorId != null) {
                 postRef.current?.(payload)
+              } else if (payload.postId != null) {
+                // Engagement payload — has neither authorId nor sharerId.
+                engagementRef.current?.(payload)
               }
             } catch {
               // Backend always sends JSON; bad frames are ignored.

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -144,6 +144,25 @@ export default function FeedPage() {
       if (activeSearch || loading) return
       setNewPostsCount(c => c + 1)
     },
+    // #563: patch like / comment / share counts on visible posts in place.
+    // Counts are authoritative (not deltas), so we overwrite — a missed
+    // frame self-heals on the next received one.
+    onEngagement: (payload) => {
+      setPosts(prev => {
+        let changed = false
+        const next = prev.map(p => {
+          if (String(p.id) !== String(payload.postId)) return p
+          changed = true
+          return {
+            ...p,
+            likeCount: payload.likeCount,
+            commentCount: payload.commentCount,
+            shareCount: payload.shareCount,
+          }
+        })
+        return changed ? next : prev
+      })
+    },
   })
 
   // #356: mark the feed read whenever the page loads with results. Cheap on

--- a/frontend/src/pages/FeedPostDetailPage.jsx
+++ b/frontend/src/pages/FeedPostDetailPage.jsx
@@ -6,6 +6,7 @@ import FeedImageUploader from '../components/FeedImageUploader'
 import { getFeedPostById, updateFeedPost, deleteFeedPost, restoreFeedPost } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import { showUndoToast } from '../utils/toast'
+import useFeedSubscription from '../hooks/useFeedSubscription'
 import '../styles/main.css'
 
 export default function FeedPostDetailPage() {
@@ -16,6 +17,22 @@ export default function FeedPostDetailPage() {
   const [post, setPost] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+
+  // #563: subscribe to the viewer's feed topic so a like / comment / share
+  // on the post being viewed updates the counts in place. Engagement frames
+  // for other posts are ignored. New-post and repost frames are ignored on
+  // the detail surface — there's no list to insert them into.
+  useFeedSubscription(userId, {
+    onEngagement: (payload) => {
+      if (!post || String(post.id) !== String(payload.postId)) return
+      setPost(prev => prev ? {
+        ...prev,
+        likeCount: payload.likeCount,
+        commentCount: payload.commentCount,
+        shareCount: payload.shareCount,
+      } : prev)
+    },
+  })
 
   // Edit modal state — same pattern as FeedPage; would extract a shared
   // <EditPostModal /> if/when a third caller appears.


### PR DESCRIPTION
Closes #563. Builds on the STOMP hook from #356.

  Summary

  Wires the FeedEngagementPushPayload that shipped in backend #566 into the existing useFeedSubscription hook. When another user likes, comments on, or shares a post the viewer can
  see, the like / comment / share counts update in place within ~1s — no refresh, no polling. Finishes the "live counts" AC that #356 had to scope out.

  Changes

  - hooks/useFeedSubscription.js — added onEngagement callback to the dispatch table. Discriminator: payload has neither authorId (post) nor sharerId (share), only postId — engagement.
   Existing onPost / onShare paths unchanged.
  - pages/FeedPage.jsx — onEngagement patches the matching post in posts in place; non-matching frames are ignored without re-rendering. Counts are written authoritatively (not deltas)
   so a dropped STOMP frame self-heals on the next received one — matches the backend's contract.
  - pages/FeedPostDetailPage.jsx — same subscription with onEngagement only (no list to insert new posts into). Patches the single visible post's counts.

  FeedPostCard.jsx needs no changes — its existing useEffect (lines 101-118) already re-seeds local state from the post prop, so when FeedPage swaps in a post with updated counts the
  card re-renders cleanly.

  Acceptance criteria mapping (from #563)

  - ✅ On /feed, another user's like on a visible post updates count + heart fill within ~1s without refresh (the heart fill follows naturally from the card's re-seed on prop change).
  - ✅ Comment count and share count update the same way.
  - ✅ Off-screen / not-in-list posts ignored (the prev.map short-circuits via changed and returns the previous reference unchanged, so no wasted re-render).
  - ✅ No regression to the new-posts pill, unread badge, or mark-read flow.

  Test plan

  - npm run build clean.
  - npm test — 64/64 unit tests pass.
  - Manual: log in as User A and B in two tabs. A views the feed and sees one of B's posts. B likes a post → A's count next to that post increments within ~1s.
  - Manual: A is on /feed/123. B comments on post 123 → A's comment count increments. B comments on post 456 → A's view doesn't change.
  - Manual: dropped frame (DevTools: close the STOMP socket briefly while engagement fires) — next received frame brings counts back into sync (no stale +1 leftover).