### PR TITLE
fix(backend): run explanation service outside read-only transaction

### DIFF
--- a/backend/src/main/java/com/group7/backend/service/MatchingService.java
+++ b/backend/src/main/java/com/group7/backend/service/MatchingService.java
@@ -163,9 +163,14 @@ public class MatchingService {
         return mentee;
     }
 
-    @Transactional(readOnly = true)
     public List<MentorMatchResponse> getTopMentorsList(Long menteeId, String keyword) {
-        return rankMentorsForId(menteeId, keyword, null);
+        record Loaded(List<MentorMatchResponse> mentors, MenteeSnapshot snapshot) {}
+        Loaded loaded = readOnlyTx.execute(status -> {
+            Mentee mentee = loadEligibleMentee(menteeId);
+            return new Loaded(rankMentorsFor(mentee, keyword, null), MenteeSnapshot.of(mentee));
+        });
+        explanationService.attach(loaded.mentors(), loaded.snapshot().toDetachedMentee());
+        return loaded.mentors();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
Separates the OpenAI explanation call from the @Transactional(readOnly)
scope so the LLM round-trip does not hold a DB connection open. Uses a
manual readOnlyTx.execute block for the DB work, then calls
explanationService.attach() on the detached mentee snapshot.