### PR TITLE
fix(test): type-annotate Mockito any() in TaskServiceTest

### DIFF
--- a/backend/src/test/java/com/group7/backend/service/TaskServiceTest.java
+++ b/backend/src/test/java/com/group7/backend/service/TaskServiceTest.java
@@ -174,7 +174,7 @@ class TaskServiceTest {
     @Test
     void submitTask_Success() {
         when(taskRepository.findByIdWithMentorship(100L)).thenReturn(Optional.of(pendingTask));
-        when(taskSubmissionRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(taskSubmissionRepository.save(any(TaskSubmission.class))).thenAnswer(i -> i.getArgument(0));
 
         TaskSubmissionRequest req = new TaskSubmissionRequest();
         req.setSubmissionText("Here is my work");


### PR DESCRIPTION
## Summary

`TaskServiceTest.submitTask_Success` at line 177 uses a bare `any()` matcher that javac 21.0.10 (Temurin) on CI cannot infer to `TaskSubmission`:

```
incompatible types: inference variable T has incompatible upper bounds
  T,S,com.group7.backend.entity.TaskSubmission,java.lang.Object
```

This blocks the backend CI on every open PR that rebases over the recent merges. The companion `any(Task.class)` call on line 83 of the same file already follows the typed-matcher pattern; aligning the submission save call with the same idiom restores the build.

One-character-class fix: `any()` → `any(TaskSubmission.class)`.

## Test plan

- [x] Local `mvn -B -q -DskipTests test-compile` against fresh checkout — clean compile.
- [ ] CI Backend pipeline on this branch — expected green.

## Backward compatibility

Test-only change; no production-code or contract impact. The matcher is functionally equivalent (`any()` and `any(TaskSubmission.class)` both match any non-null `TaskSubmission`); only the compile-time inference path differs.