### PR TITLE
feat(web): reporting trio — post + mentor + mentorship report flows (…

### DIFF
--- a/frontend/src/components/FeedPostCard.jsx
+++ b/frontend/src/components/FeedPostCard.jsx
@@ -1,10 +1,12 @@
 import { useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { MoreHorizontal, Pencil, Trash2, History, Share2, Repeat2, Bookmark, Heart, MessageCircle } from 'lucide-react'
+import { MoreHorizontal, Pencil, Trash2, History, Flag, Share2, Repeat2, Bookmark, Heart, MessageCircle } from 'lucide-react'
 import Avatar from './Avatar'
 import FeedAttachmentGrid from './FeedAttachmentGrid'
 import EditHistoryModal from './EditHistoryModal'
 import RepostModal from './RepostModal'
+import ReportModal from './ReportModal'
+import { showTransientToast } from '../utils/toast'
 import { linkify } from '../utils/linkify'
 import {
   toggleBookmarkOnPost,
@@ -62,6 +64,7 @@ export default function FeedPostCard({
   const [historyOpen, setHistoryOpen] = useState(false)
   const [repostOpen, setRepostOpen] = useState(false)
   const [repostBusy, setRepostBusy] = useState(false)
+  const [reportOpen, setReportOpen] = useState(false)
   const menuRef = useRef(null)
 
   // Local state mirrors viewer-relative interaction toggles + counts; backend
@@ -139,7 +142,9 @@ export default function FeedPostCard({
   if (!post) return null
 
   const initials = (post.authorFirstName?.[0] || '?').toUpperCase()
-  const showOverflow = isAuthor && (onEdit || onDelete || post?.isEdited)
+  // #358: every viewer can report. Authors additionally get edit/delete/history.
+  const canReport = viewerUserId != null && !isAuthor
+  const showOverflow = canReport || (isAuthor && (onEdit || onDelete || post?.isEdited))
 
   function openDetail() {
     if (clickable) navigate(`/feed/${post.id}`)
@@ -427,6 +432,16 @@ export default function FeedPostCard({
                     <Trash2 size={14} strokeWidth={1.75} /> Delete
                   </button>
                 )}
+                {canReport && (
+                  <button
+                    type="button"
+                    className="feed-card-menu-item feed-card-menu-item--danger"
+                    onClick={(e) => { e.stopPropagation(); e.preventDefault(); setMenuOpen(false); setReportOpen(true) }}
+                    role="menuitem"
+                  >
+                    <Flag size={14} strokeWidth={1.75} /> Report
+                  </button>
+                )}
               </div>
             )}
           </div>
@@ -608,18 +623,17 @@ export default function FeedPostCard({
         onConfirm={handleRepostConfirm}
         loading={repostBusy}
       />
+
+      <ReportModal
+        open={reportOpen}
+        targetType="POST"
+        targetId={post.id}
+        targetLabel="post"
+        onClose={() => setReportOpen(false)}
+        onSubmitted={() => showTransientToast('Report submitted. Admins will review it.')}
+      />
     </article>
   )
-}
-
-// Lightweight toast helper for share-link copy feedback. Avoids pulling in
-// a toast library for this single use; if more callers appear, extract.
-function showTransientToast(text) {
-  const el = document.createElement('div')
-  el.className = 'toast toast-success'
-  el.textContent = text
-  document.body.appendChild(el)
-  setTimeout(() => el.remove(), 2500)
 }
 
 function renderBody(body) {

--- a/frontend/src/components/ReportModal.jsx
+++ b/frontend/src/components/ReportModal.jsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef, useState } from 'react'
+import { submitReport } from '../services/api'
+
+/**
+ * Generic polymorphic report modal (#128 / #358 / #411). Backend
+ * (#135) accepts {targetType, targetId, problemType, description}
+ * and routes everything to the same admin queue.
+ *
+ * Props:
+ *   open
+ *   targetType    'POST' | 'MENTORSHIP' | 'USER'
+ *   targetId      numeric id of the reported entity
+ *   targetLabel   display label used in the modal header ("post", "mentor", "mentorship")
+ *   onClose()
+ *   onSubmitted(report)  — fires on 201 success
+ *
+ * Backend problem-type enum:
+ *   INAPPROPRIATE_BEHAVIOR | HARASSMENT | SPAM | MISLEADING_PROFILE | OTHER
+ * We expose all five categories regardless of targetType — the spec
+ * doesn't carve the list per target, and admin filters by problemType
+ * downstream.
+ */
+const PROBLEM_TYPES = [
+  { value: 'INAPPROPRIATE_BEHAVIOR', label: 'Inappropriate behavior' },
+  { value: 'HARASSMENT', label: 'Harassment' },
+  { value: 'SPAM', label: 'Spam' },
+  { value: 'MISLEADING_PROFILE', label: 'Misleading profile' },
+  { value: 'OTHER', label: 'Other' },
+]
+
+const DESCRIPTION_MAX = 1000
+
+export default function ReportModal({ open, targetType, targetId, targetLabel = 'this', onClose, onSubmitted }) {
+  const overlayRef = useRef(null)
+  const [problemType, setProblemType] = useState(PROBLEM_TYPES[0].value)
+  const [description, setDescription] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (open) {
+      setProblemType(PROBLEM_TYPES[0].value)
+      setDescription('')
+      setError(null)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onKey = e => { if (e.key === 'Escape' && !submitting) onClose?.() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose, submitting])
+
+  if (!open || !targetType || targetId == null) return null
+
+  const trimmed = description.trim()
+  const remaining = DESCRIPTION_MAX - description.length
+  const canSubmit = trimmed.length > 0 && !submitting
+
+  async function handleSubmit() {
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const body = await submitReport({
+        targetType,
+        targetId: Number(targetId),
+        problemType,
+        description: trimmed,
+      })
+      onSubmitted?.(body)
+      onClose?.()
+    } catch (err) {
+      const msg = err?.message || ''
+      if (msg.includes('409') || /duplicate|already/i.test(msg)) {
+        setError('You already have an open report for this. An admin will review it.')
+      } else if (msg.includes('429') || /rate.*limit/i.test(msg)) {
+        setError('Too many reports submitted. Please wait a bit before filing another.')
+      } else if (msg.includes('400') || /self/i.test(msg)) {
+        setError('That target cannot be reported.')
+      } else {
+        setError(msg || 'Failed to submit report.')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="modal-overlay"
+      ref={overlayRef}
+      onMouseDown={e => { if (e.target === overlayRef.current && !submitting) onClose?.() }}
+    >
+      <div className="modal-card" role="dialog" aria-modal="true" aria-labelledby="report-modal-title">
+        <div className="modal-header">
+          <div>
+            <h2 id="report-modal-title">Report {targetLabel}</h2>
+            <p className="modal-subtitle">
+              Reports are sent to platform admins for review. Misuse may result in restrictions
+              on your account.
+            </p>
+          </div>
+          <button type="button" className="modal-close" onClick={onClose} aria-label="Close modal">×</button>
+        </div>
+
+        <label className="section-label" style={{ marginTop: '12px', display: 'block' }} htmlFor="report-problem-type">
+          Problem category
+        </label>
+        <select
+          id="report-problem-type"
+          className="form-input"
+          value={problemType}
+          onChange={e => setProblemType(e.target.value)}
+          disabled={submitting}
+        >
+          {PROBLEM_TYPES.map(p => (
+            <option key={p.value} value={p.value}>{p.label}</option>
+          ))}
+        </select>
+
+        <label className="section-label" style={{ marginTop: '14px', display: 'block' }} htmlFor="report-description">
+          Description (required)
+        </label>
+        <textarea
+          id="report-description"
+          className="modal-textarea"
+          rows={5}
+          maxLength={DESCRIPTION_MAX}
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="Tell admins what happened. Include any context that helps with the review."
+          disabled={submitting}
+        />
+        <div style={{ fontSize: '12px', color: 'var(--text-muted)', textAlign: 'right' }}>
+          {remaining} characters left
+        </div>
+
+        {error && (
+          <div className="md-error-card" style={{ marginTop: '8px' }}>
+            <div className="md-error-sub">{error}</div>
+          </div>
+        )}
+
+        <div className="modal-actions" style={{ marginTop: '16px' }}>
+          <button type="button" className="modal-btn-secondary" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="modal-btn-primary md-danger-btn"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {submitting ? 'Submitting…' : 'Submit report'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/MentorshipDetailPage.jsx
+++ b/frontend/src/pages/MentorshipDetailPage.jsx
@@ -5,6 +5,8 @@ import Avatar from '../components/Avatar'
 import MentorshipMilestones from '../components/MentorshipMilestones'
 import MentorshipProgressTimeline from '../components/MentorshipProgressTimeline'
 import MentorMenteesProgress from '../components/MentorMenteesProgress'
+import ReportModal from '../components/ReportModal'
+import { showTransientToast } from '../utils/toast'
 import {
   getMentorshipById,
   getUserById,
@@ -572,6 +574,7 @@ export default function MentorshipDetailPage() {
   const [submittedRating, setSubmittedRating] = useState(null)
 
   const [cancelOpen, setCancelOpen] = useState(false)
+  const [reportOpen, setReportOpen] = useState(false)
   const [cancelLoading, setCancelLoading] = useState(false)
   const [cancelError, setCancelError] = useState(null)
 
@@ -1076,6 +1079,16 @@ export default function MentorshipDetailPage() {
             Cancel Mentorship
           </button>
         )}
+        {/* #411: either participant can report the mentorship — distinct from
+            reporting the other user (#128) or a feed post (#358). Visible on
+            both ACTIVE and ENDED mentorships per the issue. */}
+        <button
+          className="md-action-btn"
+          onClick={() => setReportOpen(true)}
+          title="Report this mentorship to platform admins"
+        >
+          Report Mentorship
+        </button>
       </div>
 
       {cancelError && (
@@ -1146,6 +1159,15 @@ export default function MentorshipDetailPage() {
         onSubmit={handleSaveGoal}
         loading={goalSaving}
         error={goalError}
+      />
+
+      <ReportModal
+        open={reportOpen}
+        targetType="MENTORSHIP"
+        targetId={mentorship?.id}
+        targetLabel="this mentorship"
+        onClose={() => setReportOpen(false)}
+        onSubmitted={() => showTransientToast('Report submitted. Admins will review it.')}
       />
     </MainLayout>
   )

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -3,6 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom'
 import MainLayout from '../components/MainLayout'
 import Avatar from '../components/Avatar'
 import RequestMentorshipModal from '../components/RequestMentorshipModal'
+import ReportModal from '../components/ReportModal'
+import { showTransientToast } from '../utils/toast'
 import FeedPostCard from '../components/FeedPostCard'
 import {
   getUserById,
@@ -66,6 +68,7 @@ export default function UserProfilePage() {
 
   const [modalVisible, setModalVisible] = useState(false)
   const [requestLoading, setRequestLoading] = useState(false)
+  const [reportOpen, setReportOpen] = useState(false)
   const [requestError, setRequestError] = useState('')
 
   const {
@@ -392,19 +395,39 @@ export default function UserProfilePage() {
                 const isPending = (sentRequests || []).some(r => String(r.mentorId) === String(id) && r.status === 'PENDING')
                 const hasActiveMentor = (activeMentorships || []).some(m => m.status === 'ACTIVE')
                 const isFull = profile.maxMenteeCapacity != null && (profile.currentMenteeCount ?? 0) >= profile.maxMenteeCapacity
-                
+
                 const btnDisabled = isPending || hasActiveMentor || isFull
                 const btnLabel = isPending ? '✓ Request Sent' : isFull ? 'At Capacity' : hasActiveMentor ? 'Already Mentored' : 'Send Request'
-                
+
                 return (
-                  <button
-                    className={`send-request-btn${isPending ? ' sent' : ''}${hasActiveMentor && !isPending ? ' locked' : ''}`}
-                    disabled={btnDisabled}
-                    onClick={() => !btnDisabled && setModalVisible(true)}
-                    style={{ width: '100%', height: '44px', fontSize: '14px', fontWeight: 700 }}
-                  >
-                    {btnLabel}
-                  </button>
+                  <>
+                    <button
+                      className={`send-request-btn${isPending ? ' sent' : ''}${hasActiveMentor && !isPending ? ' locked' : ''}`}
+                      disabled={btnDisabled}
+                      onClick={() => !btnDisabled && setModalVisible(true)}
+                      style={{ width: '100%', height: '44px', fontSize: '14px', fontWeight: 700 }}
+                    >
+                      {btnLabel}
+                    </button>
+                    {/* #128: mentees can report mentors. Backend rejects self-reports
+                        and duplicates; UI surfaces those errors inside the modal. */}
+                    <button
+                      type="button"
+                      onClick={() => setReportOpen(true)}
+                      style={{
+                        marginTop: '8px',
+                        background: 'transparent',
+                        border: 'none',
+                        color: 'var(--text-muted)',
+                        fontSize: '12px',
+                        fontWeight: 500,
+                        cursor: 'pointer',
+                        textDecoration: 'underline',
+                      }}
+                    >
+                      Report this mentor
+                    </button>
+                  </>
                 )
               })()}
             </div>
@@ -565,6 +588,15 @@ export default function UserProfilePage() {
           defaultMessage=""
         />
       )}
+
+      <ReportModal
+        open={reportOpen}
+        targetType="USER"
+        targetId={id}
+        targetLabel={displayName || 'this user'}
+        onClose={() => setReportOpen(false)}
+        onSubmitted={() => showTransientToast('Report submitted. Admins will review it.')}
+      />
     </MainLayout>
   )
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -819,6 +819,20 @@ export async function deleteFeedPost(id) {
   return handleResponse(res)
 }
 
+// #128 / #358 / #411 / backend #135: submit a polymorphic report.
+// targetType ∈ {POST, MENTORSHIP, USER}; the backend rejects self-reports
+// (USER target with reporter_id == target_id), non-participant mentorship
+// reports (403), and duplicate active reports (409 — same reporter +
+// same target while still-open).
+export async function submitReport({ targetType, targetId, problemType, description }) {
+  const res = await fetch(`${BASE_URL}/reports`, {
+    method: 'POST',
+    headers: authJsonHeaders(),
+    body: JSON.stringify({ targetType, targetId, problemType, description }),
+  })
+  return handleResponse(res)
+}
+
 // #356 / backend #349: feed read-state cursor + companion unread count.
 // `markFeedRead` is idempotent — backend sets the cursor to clock_timestamp.
 // `getFeedUnreadCount` returns { count, cappedAtMax } capped at 99 by default.


### PR DESCRIPTION
Closes #128, #358, #411.                                                                                                                                                              
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Three issues, one PR. Backend #574 shipped a polymorphic reporting endpoint (POST /api/reports accepting {targetType, targetId, problemType, description} for POST/MENTORSHIP/USER).  
  One shared <ReportModal /> component drives all three flows — only the target metadata differs at each trigger point.                                                                 
                                                                                                                                                                                        
  Changes                                                                                                                                                                             

  - services/api.js — submitReport(...) wrapper.
  - components/ReportModal.jsx (new) — generic modal with a 5-option problem-category dropdown, 1000-char description (validated client + server), and contextual error handling for the
   4 documented error codes (400 self-report, 403 non-participant, 409 duplicate, 429 rate-limit) — each maps to a user-readable message rather than a raw status code.                 
  - components/FeedPostCard.jsx (#358) — Report item added to the overflow menu. Menu visibility expanded: any non-author authenticated viewer can open it now (just to see Report);
  authors still see Edit / Delete / History. Removed the duplicate showTransientToast declaration that was inlined in this file before — it now imports the shared one from             
  utils/toast.js.                                                                                                                                                                     
  - pages/UserProfilePage.jsx (#128) — "Report this mentor" text-link under the Send Request button. Gated to mentees viewing a mentor profile, matching the issue's AC ("hidden for    
  mentor / admin viewers"). Self-reports are also gated server-side, but the UI doesn't render the link on own profile (since the Send Request button block is itself mentee → mentor   
  only).
  - pages/MentorshipDetailPage.jsx (#411) — "Report Mentorship" action added to the existing action grid alongside Open Messages / Meetings / My Tasks / End or Cancel. Visible to both 
  participants, in both ACTIVE and ENDED state, per the issue's AC.                                                                                                                     
  
  Acceptance criteria mapping                                                                                                                                                           
                                                            
  #128 Report mentor                                                                                                                                                                    
  
  - ✅ Button visible to mentees on mentor profiles; hidden otherwise.                                                                                                                  
  - ✅ Modal captures problem category + description (required).
  - ✅ Success toast.                                                                                                                                                                   
  - ✅ 409 duplicate path surfaces "you already have an open report" instead of raw error.
  - ⚠️  Attachment upload — backend CreateReportRequest doesn't accept attachments. Issue body called this optional; deferred until backend exposes it.                                  
                                                                                                                                                                                        
  #358 Report post                                                                                                                                                                      
                                                                                                                                                                                        
  - ✅ Report item in feed-post overflow menu.                                                                                                                                          
  - ✅ Pre-tagged for entity=POST, id=<postId>.
  - ✅ Validated category + description; success toast.                                                                                                                                 
                                                            
  #411 Report mentorship                                                                                                                                                                
                                                            
  - ✅ "Report this mentorship" action on /mentorships/:id for both participants, both ACTIVE and ENDED.                                                                                
  - ✅ Category dropdown + required description.
  - ⚠️  One-report-per-mentorship-per-reporter check — currently enforced via the modal's 409 handler rather than a pre-disabled button. Need a GET                                      
  /api/reports/me?targetType=...&targetId=... to disable the action up-front; backend has GET /api/reports/me but no filter. Could file a follow-up but the 409-as-feedback path is     
  functional.
                                                                                                                                                                                        
  Out of scope                                              

  - Reporting comments and private messages (#358 explicitly says out-of-scope).                                                                                                        
  - Admin review queue UI (#279 — separate).
  - Attachment uploads on reports (backend DTO doesn't accept them).                                                                                                                    
                                                                                                                                                                                        
  Test plan
                                                                                                                                                                                        
  - npm run build clean.                                    
  - npm test — 84/84 unit tests pass.
  - Manual (mentee → mentor profile): "Report this mentor" link → modal → category + description → submit → toast.                                                                      
  - Manual: second submission against the same mentor → 409 path renders the friendly "already have an open report" message.                                                            
  - Manual (feed): overflow on someone else's post → Report → success toast.                                                                                                            
  - Manual: try to report your own post → menu doesn't include Report (gated client-side via canReport = !isAuthor).                                                                    
  - Manual (mentorship detail, either participant): Report Mentorship → modal → submit → toast. Verify same flow works on an ENDED mentorship. 