### PR TITLE
feat(web): profile visibility toggle for mentors + private-profile st…

### DIFF
--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -44,6 +44,10 @@ function mapResponseToForm(data) {
     latitude: data.latitude ?? null,
     longitude: data.longitude ?? null,
   }
+  // #359 / backend #579: profileVisibility now exists on both Mentor and
+  // Mentee. Lifted onto the shared base so both branches save/load it the
+  // same way. Default true on a missing value (matches backend default).
+  base.profileVisible = data.profileVisibility !== false
   if (isMentor) {
     return {
       ...base,
@@ -69,7 +73,6 @@ function mapResponseToForm(data) {
     careerInterest: data.careerInterest || '',
     careerInterestUri: data.careerInterestUri || '',
     meetingFreqPref: data.meetingFreqPref || '',
-    profileVisible: data.profileVisibility !== false,
   }
 }
 
@@ -215,8 +218,11 @@ export default function ProfilePage() {
         latitude: form.latitude ?? null,
         longitude: form.longitude ?? null,
         // Shared between both roles (backend MentorProfileRequest and
-        // MenteeProfileRequest both expose it via the shared EditProfileRequest).
+        // MenteeProfileRequest both expose them via the shared EditProfileRequest).
         affiliation: form.affiliation || null,
+        // #359 / backend #579: profileVisibility lives on both Mentor and
+        // Mentee request DTOs now; send it from the shared base.
+        profileVisibility: form.profileVisible,
         ...(isMentor ? {
           bio: form.bio || null,
           field: form.field || null,
@@ -238,7 +244,6 @@ export default function ProfilePage() {
           meetingFreqPref: form.meetingFreqPref || null,
           skills: skillsSplit.labels,
           skillUris: skillsSplit.uris,
-          profileVisibility: form.profileVisible,
         }),
       }
 
@@ -646,25 +651,31 @@ export default function ProfilePage() {
                   </select>
                 </div>
 
-                <div className="divider" />
-
-                <div className="section-label">Privacy Settings</div>
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 0' }}>
-                  <div>
-                    <div style={{ fontSize: '14px', fontWeight: 500 }}>Profile Visibility</div>
-                    <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '2px' }}>
-                      {form.profileVisible ? 'Your profile is visible to matched users' : 'Your profile is hidden'}
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    className={`toggle${form.profileVisible ? '' : ' off'}`}
-                    onClick={() => handleChange('profileVisible', !form.profileVisible)}
-                    aria-label="Toggle profile visibility"
-                  />
-                </div>
               </>
             )}
+
+            {/* #359 / backend #579: shared by both roles now. Private profiles
+                return 403 to non-owner non-admin viewers and the masking matrix
+                redacts mentee surname + photo when a mentor views them. */}
+            <div className="divider" />
+
+            <div className="section-label">Privacy Settings</div>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 0' }}>
+              <div>
+                <div style={{ fontSize: '14px', fontWeight: 500 }}>Profile Visibility</div>
+                <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '2px' }}>
+                  {form.profileVisible
+                    ? 'Public — other authenticated users can see your profile.'
+                    : 'Private — your profile is hidden from non-admin viewers.'}
+                </div>
+              </div>
+              <button
+                type="button"
+                className={`toggle${form.profileVisible ? '' : ' off'}`}
+                onClick={() => handleChange('profileVisible', !form.profileVisible)}
+                aria-label="Toggle profile visibility"
+              />
+            </div>
 
             {saveSuccess && (
               <div data-testid="profile-save-success" style={{ color: 'var(--green-dark)', fontSize: '13px', marginBottom: '8px' }}>

--- a/frontend/src/pages/UserProfilePage.jsx
+++ b/frontend/src/pages/UserProfilePage.jsx
@@ -105,7 +105,18 @@ export default function UserProfilePage() {
         setLoading(false)
       })
       .catch(err => {
-        setError(err.message || 'Failed to load profile.')
+        // #359 / backend #579: server returns 403 "Profile is private" when
+        // the target's profileVisibility=false and the viewer isn't the
+        // owner or an admin. Mentees can also be hidden from each other
+        // entirely (req 1.1.2.7). Map both to a friendly private-profile
+        // state so the page doesn't render a generic error card.
+        const msg = err?.message || ''
+        const isPrivate = /private/i.test(msg) || /not visible/i.test(msg)
+        if (isPrivate) {
+          setError('This profile is private.')
+        } else {
+          setError(msg || 'Failed to load profile.')
+        }
         setLoading(false)
       })
 
@@ -266,15 +277,26 @@ export default function UserProfilePage() {
   }
 
   if (error) {
-    const is403 = error.includes('403') || error.toLowerCase().includes('not allowed') || error.toLowerCase().includes('cannot view')
+    const lower = error.toLowerCase()
+    const isPrivate = lower.includes('private')
+    const is403 = !isPrivate && (error.includes('403') || lower.includes('not allowed') || lower.includes('cannot view') || lower.includes('not visible'))
+    let title = 'User not found'
+    let body = 'This user does not exist.'
+    if (isPrivate) {
+      title = 'This profile is private'
+      body = 'The owner has chosen to hide their profile from other users.'
+    } else if (is403) {
+      title = 'Profile not available'
+      body = 'You do not have permission to view this profile.'
+    }
     return (
       <MainLayout>
         <div style={{ padding: '40px', textAlign: 'center' }}>
           <div style={{ fontSize: '18px', fontWeight: 600, marginBottom: '8px' }}>
-            {is403 ? 'Profile not available' : 'User not found'}
+            {title}
           </div>
           <div style={{ color: 'var(--text-muted)', marginBottom: '24px' }}>
-            {is403 ? 'You do not have permission to view this profile.' : 'This user does not exist.'}
+            {body}
           </div>
           <button className="action-btn" onClick={() => navigate(-1)}>Go Back</button>
         </div>


### PR DESCRIPTION
Closes #359. Backend dependency #579 just merged.                                                                                                                                     
                                                            
  Summary

  Wires the now-shared profileVisibility field on both Mentor and Mentee through the profile editor, and surfaces a friendly "This profile is private" state on /users/:id when backend 
  returns 403 ProfileNotVisibleException.
                                                                                                                                                                                        
  Backend now covers what was previously "out of scope"     

  When #359 was filed, the issue body listed several blockers:
  - ❌ Mentor profile visibility — backend now has Mentor.profileVisibility
  - ❌ Server-side redaction — backend now returns 403 for private profiles                                                                                                             
  - ❌ Mentee surname/photo masking (1.1.2.5) — backend now masks via maskIfMentorViewingMentee
                                                                                                                                                                                        
  All three are addressed in backend #579. This PR delivers the corresponding web work.                                                                                                 
                                                                                                                                                                                        
  Changes                                                                                                                                                                               
                                                                                                                                                                                        
  - pages/ProfilePage.jsx:                                  
    - mapResponseToForm lifts profileVisible out of the mentee-only branch onto the shared base. Backend exposes the field on both roles' responses now.
    - Save payload lifts profileVisibility to the shared layer so both PATCH /api/users/me/mentor and PATCH /api/users/me/mentee get it.                                                
    - Privacy Settings block moved out of the mentee-only edit section to be shared. Updated the description to match the new server-side semantics (Public = visible to authenticated  
  viewers, Private = 403 to non-owner non-admin).                                                                                                                                       
  - pages/UserProfilePage.jsx:                                                                                                                                                          
    - 403 handler in the load useEffect now distinguishes private from other forbidden cases by parsing the backend error message.                                                      
    - Error renderer shows three distinct states: "User not found" (404), "Profile not available" (other 403), "This profile is private" (visibility 403). Each gets the right copy.    
   
  Acceptance criteria mapping (from #359)                                                                                                                                               
                                                            
  - ✅ Mentee /profile has a visibility toggle (was already there; now also on mentor).                                                                                                 
  - ✅ Saved value round-trips via PATCH.
  - ✅ Public profile page renders private-profile placeholder when backend says it's hidden.                                                                                           
  - ✅ Control shown for both roles (originally mentee-only because of the backend gap; now resolved).                                                                                  
  - ✅ Pre-existing enforcement of 1.1.2.6/1.1.2.7 unaffected.                                                                                                                          
                                                                                                                                                                                        
  What was previously "out of scope" and is now covered                                                                                                                                 
                                                                                                                                                                                        
  - ✅ Mentor profile visibility (backend #579 added the field)                                                                                                                         
  - ✅ Server-side redaction (backend ProfileNotVisibleException returns 403)
  - ✅ 1.1.2.5 mentee surname/photo masking (backend maskIfMentorViewingMentee returns nulls; existing frontend renders [firstName, lastName].filter(Boolean).join(' ') so the masked   
  state shows just the first name gracefully)                                                                                                                                           
                                                                                                                                                                                        
  Out of scope (still)                                                                                                                                                                  
                                                            
  - 3-level enum (Public / Authenticated only / Mentor pair only) — backend field is still a Boolean. Would need migration.                                                             
  - Hide private profiles from mentor search / matching results — orthogonal to the view-time gate; needs MatchingService filter.
                                                                                                                                                                                        
  Test plan                                                 
                                                                                                                                                                                        
  - npm run build clean.                                                                                                                                                                
  - npm test — 84/84 unit tests pass.
  - Manual (mentor): /profile → Privacy Settings toggle is visible, flips Public ↔ Private, save persists across reload.                                                                
  - Manual: User A sets profile to Private → User B visits /users/A → sees "This profile is private" with Go Back button, not the generic error card.                                   
  - Manual (mentor viewing mentee): backend masks lastName + profilePhoto → mentor card shows just the mentee's first name + initials avatar, no broken state.