### PR TITLE
feat(web): admin console — user moderation + report queue (#279)

### DIFF
--- a/frontend/src/pages/AdminConsolePage.jsx
+++ b/frontend/src/pages/AdminConsolePage.jsx
@@ -1,21 +1,513 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import MainLayout from '../components/MainLayout'
-import { sendAdminDirectMessage } from '../services/api'
+import {
+  sendAdminDirectMessage,
+  listAdminUsers,
+  banAdminUser,
+  unbanAdminUser,
+  clearBotFlag,
+  listAdminReports,
+  updateAdminReportStatus,
+} from '../services/api'
+import { showTransientToast } from '../utils/toast'
 import '../styles/main.css'
 
-// AT-15 surface B. Minimal admin console — just the direct-message form for now.
-// Toast pattern mirrors HomePage / ExplorePage: an absolutely-positioned DOM
-// node injected into body for ~3.5s, then removed. Keeps us off a toast lib.
+/**
+ * Admin console (#279). Three tabs:
+ *  1. Users — paginated list with role / ban / keyword filters, drill-in
+ *     actions (ban, unban, clear bot flag).
+ *  2. Reports — moderation queue with status / target-type filters, drill-in
+ *     status transitions.
+ *  3. Messages — direct-message composer (shipped earlier via #573).
+ *
+ * Page is gated server-side by hasRole('ADMIN') on every endpoint and
+ * client-side by AdminRoute. Existing test IDs preserved for the unit
+ * tests added in #573.
+ */
 
-function showToast(message, type = 'success') {
-  const el = document.createElement('div')
-  el.className = `toast toast-${type}`
-  el.textContent = message
-  document.body.appendChild(el)
-  setTimeout(() => el.remove(), 3500)
-}
+const TABS = [
+  { key: 'users', label: 'Users' },
+  { key: 'reports', label: 'Reports' },
+  { key: 'messages', label: 'Messages' },
+]
 
 export default function AdminConsolePage() {
+  const [tab, setTab] = useState('users')
+
+  return (
+    <MainLayout>
+      <div className="page-header">
+        <div>
+          <div className="page-title">Admin Console</div>
+          <div className="page-sub">User moderation, report review, and admin messaging.</div>
+        </div>
+      </div>
+
+      <div className="feed-tabs" role="tablist" aria-label="Admin sections">
+        {TABS.map(t => (
+          <button
+            key={t.key}
+            type="button"
+            role="tab"
+            aria-selected={tab === t.key}
+            className={`feed-tab${tab === t.key ? ' feed-tab--active' : ''}`}
+            onClick={() => setTab(t.key)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'users' && <UsersTab />}
+      {tab === 'reports' && <ReportsTab />}
+      {tab === 'messages' && <MessagesTab />}
+    </MainLayout>
+  )
+}
+
+// ── Users tab ─────────────────────────────────────────────────────────
+
+function UsersTab() {
+  const [roleFilter, setRoleFilter] = useState('')
+  const [banFilter, setBanFilter] = useState('')
+  const [q, setQ] = useState('')
+  const [draftQ, setDraftQ] = useState('')
+  const [page, setPage] = useState(0)
+  const [data, setData] = useState({ content: [], totalPages: 1, totalElements: 0 })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [busyUserId, setBusyUserId] = useState(null)
+  const [banTarget, setBanTarget] = useState(null) // { id, name }
+  const [banReason, setBanReason] = useState('')
+  const [banHours, setBanHours] = useState(168)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await listAdminUsers({
+        role: roleFilter || undefined,
+        banStatus: banFilter || undefined,
+        q: q || undefined,
+        page,
+        size: 20,
+      })
+      setData(res || { content: [], totalPages: 1, totalElements: 0 })
+    } catch (err) {
+      setError(err?.message || 'Failed to load users.')
+      setData({ content: [], totalPages: 1, totalElements: 0 })
+    } finally {
+      setLoading(false)
+    }
+  }, [roleFilter, banFilter, q, page])
+
+  useEffect(() => { load() }, [load])
+
+  function applySearch(e) {
+    e.preventDefault()
+    setPage(0)
+    setQ(draftQ.trim())
+  }
+
+  function openBanModal(u) {
+    setBanTarget({ id: u.id, name: [u.firstName, u.lastName].filter(Boolean).join(' ') || `user ${u.id}` })
+    setBanReason('')
+    setBanHours(168)
+  }
+
+  async function confirmBan() {
+    if (!banTarget) return
+    if (!banReason.trim() || !Number.isFinite(Number(banHours)) || Number(banHours) < 1) return
+    setBusyUserId(banTarget.id)
+    try {
+      await banAdminUser(banTarget.id, { reason: banReason.trim(), durationHours: Number(banHours) })
+      showTransientToast(`${banTarget.name} banned for ${banHours}h.`)
+      setBanTarget(null)
+      load()
+    } catch (err) {
+      showTransientToast(err?.message || 'Failed to ban user.')
+    } finally {
+      setBusyUserId(null)
+    }
+  }
+
+  async function handleUnban(u) {
+    const name = [u.firstName, u.lastName].filter(Boolean).join(' ') || `user ${u.id}`
+    if (!window.confirm(`Lift the active ban for ${name}?`)) return
+    setBusyUserId(u.id)
+    try {
+      await unbanAdminUser(u.id)
+      showTransientToast(`${name} unbanned.`)
+      load()
+    } catch (err) {
+      showTransientToast(err?.message || 'Failed to unban user.')
+    } finally {
+      setBusyUserId(null)
+    }
+  }
+
+  async function handleClearBot(u) {
+    const name = [u.firstName, u.lastName].filter(Boolean).join(' ') || `user ${u.id}`
+    setBusyUserId(u.id)
+    try {
+      await clearBotFlag(u.id)
+      showTransientToast(`Suspected-bot flag cleared for ${name}.`)
+      load()
+    } catch (err) {
+      showTransientToast(err?.message || 'Failed to clear flag.')
+    } finally {
+      setBusyUserId(null)
+    }
+  }
+
+  return (
+    <div data-testid="admin-users-tab">
+      <form
+        className="feed-search"
+        onSubmit={applySearch}
+        style={{ marginBottom: '12px' }}
+      >
+        <input
+          type="text"
+          className="feed-search-input"
+          placeholder="Search by name or email…"
+          value={draftQ}
+          onChange={(e) => setDraftQ(e.target.value)}
+        />
+        <select
+          className="feed-search-input"
+          style={{ flex: '0 0 130px' }}
+          value={roleFilter}
+          onChange={(e) => { setPage(0); setRoleFilter(e.target.value) }}
+        >
+          <option value="">All roles</option>
+          <option value="MENTOR">Mentor</option>
+          <option value="MENTEE">Mentee</option>
+          <option value="ADMIN">Admin</option>
+        </select>
+        <select
+          className="feed-search-input"
+          style={{ flex: '0 0 140px' }}
+          value={banFilter}
+          onChange={(e) => { setPage(0); setBanFilter(e.target.value) }}
+        >
+          <option value="">Any status</option>
+          <option value="ACTIVE">Currently banned</option>
+          <option value="NONE">Not banned</option>
+        </select>
+        <button type="submit" className="action-btn">Search</button>
+      </form>
+
+      {error && (
+        <div className="md-error-card" style={{ marginBottom: '12px' }}>
+          <div className="md-error-title">Couldn’t load users</div>
+          <div className="md-error-sub">{error}</div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="md-loading">Loading users…</div>
+      ) : (data.content || []).length === 0 ? (
+        <div className="empty-state">No users match these filters.</div>
+      ) : (
+        <table className="admin-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Role</th>
+              <th>Status</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.content.map(u => {
+              const fullName = [u.firstName, u.lastName].filter(Boolean).join(' ') || '—'
+              const busy = busyUserId === u.id
+              const banned = u.banStatus === 'ACTIVE'
+              const isBot = u.isSuspectedBot
+              return (
+                <tr key={u.id}>
+                  <td>{u.id}</td>
+                  <td>{fullName}</td>
+                  <td>{u.email}</td>
+                  <td>{u.role}</td>
+                  <td>
+                    {banned && <span className="admin-pill admin-pill--danger">Banned</span>}
+                    {isBot && <span className="admin-pill admin-pill--warn">Bot flagged</span>}
+                    {!banned && !isBot && <span className="admin-pill admin-pill--ok">Active</span>}
+                  </td>
+                  <td style={{ whiteSpace: 'nowrap' }}>
+                    {banned ? (
+                      <button
+                        type="button"
+                        className="action-btn"
+                        onClick={() => handleUnban(u)}
+                        disabled={busy}
+                      >Unban</button>
+                    ) : u.role !== 'ADMIN' ? (
+                      <button
+                        type="button"
+                        className="action-btn action-btn--danger"
+                        onClick={() => openBanModal(u)}
+                        disabled={busy}
+                      >Ban</button>
+                    ) : null}
+                    {isBot && (
+                      <button
+                        type="button"
+                        className="action-btn"
+                        style={{ marginLeft: '6px' }}
+                        onClick={() => handleClearBot(u)}
+                        disabled={busy}
+                      >Clear bot flag</button>
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      )}
+
+      {!loading && !error && data.totalPages > 1 && (
+        <div className="follow-pagination" style={{ marginTop: '16px' }}>
+          <button
+            type="button"
+            className="action-btn"
+            onClick={() => setPage(p => Math.max(0, p - 1))}
+            disabled={page === 0}
+          >Previous</button>
+          <div className="follow-page-indicator">Page {page + 1} of {data.totalPages}</div>
+          <button
+            type="button"
+            className="action-btn"
+            onClick={() => setPage(p => Math.min(data.totalPages - 1, p + 1))}
+            disabled={page >= data.totalPages - 1}
+          >Next</button>
+        </div>
+      )}
+
+      {banTarget && (
+        <div className="modal-overlay" onMouseDown={e => { if (e.target === e.currentTarget && !busyUserId) setBanTarget(null) }}>
+          <div className="modal-card" role="dialog" aria-modal="true">
+            <div className="modal-header">
+              <h2>Ban {banTarget.name}</h2>
+              <button type="button" className="modal-close" onClick={() => setBanTarget(null)} aria-label="Close">×</button>
+            </div>
+            <label className="section-label" style={{ marginTop: '12px', display: 'block' }}>Reason (required)</label>
+            <textarea
+              className="modal-textarea"
+              rows={4}
+              maxLength={1000}
+              value={banReason}
+              onChange={e => setBanReason(e.target.value)}
+              placeholder="Explain why this ban is being imposed."
+            />
+            <label className="section-label" style={{ marginTop: '12px', display: 'block' }}>Duration (hours)</label>
+            <input
+              type="number"
+              className="form-input"
+              min="1"
+              step="1"
+              value={banHours}
+              onChange={e => setBanHours(e.target.value)}
+            />
+            <div className="modal-actions" style={{ marginTop: '16px' }}>
+              <button type="button" className="modal-btn-secondary" onClick={() => setBanTarget(null)}>Cancel</button>
+              <button
+                type="button"
+                className="modal-btn-primary md-danger-btn"
+                onClick={confirmBan}
+                disabled={!banReason.trim() || busyUserId === banTarget.id}
+              >
+                {busyUserId === banTarget.id ? 'Banning…' : 'Ban user'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Reports tab ───────────────────────────────────────────────────────
+
+const REPORT_STATUSES = [
+  { value: '', label: 'All statuses' },
+  { value: 'OPEN', label: 'Open' },
+  { value: 'UNDER_REVIEW', label: 'Under review' },
+  { value: 'RESOLVED', label: 'Resolved' },
+  { value: 'DISMISSED', label: 'Dismissed' },
+]
+const REPORT_TARGET_TYPES = [
+  { value: '', label: 'All targets' },
+  { value: 'POST', label: 'Post' },
+  { value: 'MENTORSHIP', label: 'Mentorship' },
+  { value: 'USER', label: 'User' },
+]
+
+function ReportsTab() {
+  const [status, setStatus] = useState('OPEN')
+  const [targetType, setTargetType] = useState('')
+  const [page, setPage] = useState(0)
+  const [data, setData] = useState({ content: [], totalPages: 1 })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [busy, setBusy] = useState(null) // report id being transitioned
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await listAdminReports({
+        status: status || undefined,
+        targetType: targetType || undefined,
+        page,
+        size: 20,
+      })
+      setData(res || { content: [], totalPages: 1 })
+    } catch (err) {
+      setError(err?.message || 'Failed to load reports.')
+      setData({ content: [], totalPages: 1 })
+    } finally {
+      setLoading(false)
+    }
+  }, [status, targetType, page])
+
+  useEffect(() => { load() }, [load])
+
+  async function transition(report, nextStatus) {
+    setBusy(report.id)
+    try {
+      await updateAdminReportStatus(report.id, nextStatus)
+      showTransientToast(`Report ${report.id} → ${nextStatus.replace('_', ' ').toLowerCase()}.`)
+      load()
+    } catch (err) {
+      showTransientToast(err?.message || 'Failed to update report.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  function nextActions(report) {
+    switch (report.status) {
+      case 'OPEN':
+        return ['UNDER_REVIEW', 'RESOLVED', 'DISMISSED']
+      case 'UNDER_REVIEW':
+        return ['RESOLVED', 'DISMISSED']
+      default:
+        return []
+    }
+  }
+
+  return (
+    <div data-testid="admin-reports-tab">
+      <div className="feed-search" style={{ marginBottom: '12px' }}>
+        <select
+          className="feed-search-input"
+          value={status}
+          onChange={(e) => { setPage(0); setStatus(e.target.value) }}
+        >
+          {REPORT_STATUSES.map(s => (
+            <option key={s.value || 'any'} value={s.value}>{s.label}</option>
+          ))}
+        </select>
+        <select
+          className="feed-search-input"
+          value={targetType}
+          onChange={(e) => { setPage(0); setTargetType(e.target.value) }}
+        >
+          {REPORT_TARGET_TYPES.map(t => (
+            <option key={t.value || 'any'} value={t.value}>{t.label}</option>
+          ))}
+        </select>
+      </div>
+
+      {error && (
+        <div className="md-error-card" style={{ marginBottom: '12px' }}>
+          <div className="md-error-title">Couldn’t load reports</div>
+          <div className="md-error-sub">{error}</div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="md-loading">Loading reports…</div>
+      ) : (data.content || []).length === 0 ? (
+        <div className="empty-state">No reports match these filters.</div>
+      ) : (
+        <ul className="admin-report-list">
+          {data.content.map(r => (
+            <li key={r.id} className="admin-report-card">
+              <div className="admin-report-head">
+                <span className="admin-report-id">#{r.id}</span>
+                <span className={`admin-pill admin-pill--${pillForStatus(r.status)}`}>{r.status}</span>
+                <span className="admin-pill admin-pill--neutral">{r.targetType}</span>
+                <span className="admin-pill admin-pill--neutral">{r.problemType}</span>
+              </div>
+              <div className="admin-report-summary">
+                <strong>{r.reporterFirstName || `User #${r.reporterId}`}</strong> reported{' '}
+                <strong>{r.targetSummary || `${r.targetType.toLowerCase()} #${r.targetId}`}</strong>
+              </div>
+              <p className="admin-report-desc">{r.description}</p>
+              {nextActions(r).length > 0 && (
+                <div className="admin-report-actions">
+                  {nextActions(r).map(s => (
+                    <button
+                      key={s}
+                      type="button"
+                      className="action-btn"
+                      onClick={() => transition(r, s)}
+                      disabled={busy === r.id}
+                    >
+                      {s === 'UNDER_REVIEW' ? 'Mark Under Review' : s === 'RESOLVED' ? 'Resolve' : 'Dismiss'}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!loading && !error && data.totalPages > 1 && (
+        <div className="follow-pagination" style={{ marginTop: '16px' }}>
+          <button
+            type="button"
+            className="action-btn"
+            onClick={() => setPage(p => Math.max(0, p - 1))}
+            disabled={page === 0}
+          >Previous</button>
+          <div className="follow-page-indicator">Page {page + 1} of {data.totalPages}</div>
+          <button
+            type="button"
+            className="action-btn"
+            onClick={() => setPage(p => Math.min(data.totalPages - 1, p + 1))}
+            disabled={page >= data.totalPages - 1}
+          >Next</button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function pillForStatus(s) {
+  switch (s) {
+    case 'OPEN': return 'danger'
+    case 'UNDER_REVIEW': return 'warn'
+    case 'RESOLVED': return 'ok'
+    case 'DISMISSED': return 'neutral'
+    default: return 'neutral'
+  }
+}
+
+// ── Messages tab ──────────────────────────────────────────────────────
+// Direct-message composer originally shipped in PR #573. Preserved here
+// unchanged so its existing testids continue to satisfy
+// AdminConsolePage.test.jsx.
+
+function MessagesTab() {
   const [userId, setUserId] = useState('')
   const [content, setContent] = useState('')
   const [sending, setSending] = useState(false)
@@ -38,75 +530,65 @@ export default function AdminConsolePage() {
       await sendAdminDirectMessage(numericId, content)
       setContent('')
       setUserId('')
-      showToast('Direct message delivered.', 'success')
+      showTransientToast('Direct message delivered.')
     } catch (err) {
       const msg = err?.message || 'Failed to send direct message.'
       setError(msg)
-      showToast('Unable to send message.', 'error')
     } finally {
       setSending(false)
     }
   }
 
   return (
-    <MainLayout>
-      <div className="page-header">
-        <div>
-          <div className="page-title">Admin Console</div>
-          <div className="page-sub">Send a direct message to any user as an administrator.</div>
+    <form
+      className="admin-console-form"
+      onSubmit={handleSend}
+      data-testid="admin-console-form"
+      style={{ display: 'flex', flexDirection: 'column', gap: '12px', maxWidth: '540px' }}
+    >
+      <label htmlFor="admin-console-recipient" style={{ fontWeight: 600 }}>Recipient user id</label>
+      <input
+        id="admin-console-recipient"
+        type="number"
+        min="1"
+        step="1"
+        value={userId}
+        onChange={(e) => setUserId(e.target.value)}
+        placeholder="e.g. 42"
+        data-testid="admin-console-recipient"
+        disabled={sending}
+        required
+      />
+
+      <label htmlFor="admin-console-body" style={{ fontWeight: 600 }}>Message</label>
+      <textarea
+        id="admin-console-body"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder="Write your message…"
+        rows={6}
+        data-testid="admin-console-body"
+        disabled={sending}
+        required
+      />
+
+      {error && (
+        <div className="md-error-card" data-testid="admin-console-error">
+          <div className="md-error-title">Send failed</div>
+          <div className="md-error-sub">{error}</div>
         </div>
+      )}
+
+      <div>
+        <button
+          type="submit"
+          className="action-btn"
+          disabled={sending}
+          data-testid="admin-console-send"
+        >
+          {sending ? 'Sending…' : 'Send message'}
+        </button>
       </div>
-
-      <form
-        className="admin-console-form"
-        onSubmit={handleSend}
-        data-testid="admin-console-form"
-        style={{ display: 'flex', flexDirection: 'column', gap: '12px', maxWidth: '540px' }}
-      >
-        <label htmlFor="admin-console-recipient" style={{ fontWeight: 600 }}>Recipient user id</label>
-        <input
-          id="admin-console-recipient"
-          type="number"
-          min="1"
-          step="1"
-          value={userId}
-          onChange={(e) => setUserId(e.target.value)}
-          placeholder="e.g. 42"
-          data-testid="admin-console-recipient"
-          disabled={sending}
-          required
-        />
-
-        <label htmlFor="admin-console-body" style={{ fontWeight: 600 }}>Message</label>
-        <textarea
-          id="admin-console-body"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          placeholder="Write your message…"
-          rows={6}
-          data-testid="admin-console-body"
-          disabled={sending}
-          required
-        />
-
-        {error && (
-          <div className="md-error-card" data-testid="admin-console-error">
-            <div className="md-error-title">Send failed</div>
-            <div className="md-error-sub">{error}</div>
-          </div>
-        )}
-
-        <div>
-          <button
-            type="submit"
-            className="action-btn"
-            disabled={sending}
-            data-testid="admin-console-send"
-          >
-            {sending ? 'Sending…' : 'Send message'}
-          </button>
-        </div>
-      </form>
-    </MainLayout>
+    </form>
   )
 }

--- a/frontend/src/pages/__tests__/AdminConsolePage.test.jsx
+++ b/frontend/src/pages/__tests__/AdminConsolePage.test.jsx
@@ -18,6 +18,12 @@ describe('AdminConsolePage', () => {
     api.getActiveMentorships.mockResolvedValue([])
     api.getReceivedMentorshipRequests.mockResolvedValue({ content: [] })
     api.getOwnProfile.mockResolvedValue({})
+    // #279: AdminConsolePage is now a tabbed surface. The Users tab is the
+    // default and fires `listAdminUsers` on mount; auto-mocked it returns
+    // undefined which would crash the page. Resolve with an empty page so
+    // the tests for the Messages tab can navigate cleanly to it.
+    api.listAdminUsers.mockResolvedValue({ content: [], totalPages: 1, totalElements: 0 })
+    api.listAdminReports.mockResolvedValue({ content: [], totalPages: 1, totalElements: 0 })
   })
 
   async function renderConsole() {
@@ -54,6 +60,15 @@ describe('AdminConsolePage', () => {
     api.sendAdminDirectMessage.mockResolvedValue({ id: 42 })
     await renderConsole()
 
+    // #279: tabbed surface. Messages tab is not the default; switch to it
+    // before exercising the composer.
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /messages/i })).toBeInTheDocument()
+    })
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: /messages/i }))
+    })
+
     await waitFor(() => {
       expect(screen.getByTestId('admin-console-send')).toBeInTheDocument()
     })
@@ -74,6 +89,15 @@ describe('AdminConsolePage', () => {
     AuthContext.useAuth.mockReturnValue({ token: 'tok', role: 'ADMIN', userId: '1', isLoading: false })
     api.sendAdminDirectMessage.mockRejectedValue(new Error('boom'))
     await renderConsole()
+
+    // #279: tabbed surface. Messages tab is not the default; switch to it
+    // before exercising the composer.
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: /messages/i })).toBeInTheDocument()
+    })
+    await act(async () => {
+      await userEvent.click(screen.getByRole('tab', { name: /messages/i }))
+    })
 
     await waitFor(() => {
       expect(screen.getByTestId('admin-console-send')).toBeInTheDocument()

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1061,6 +1061,81 @@ export async function sendAdminDirectMessage(userId, content) {
   return handleResponse(res)
 }
 
+// #279 / backend #569 + #280: admin user listing, drill-in, ban/unban,
+// and clear-bot-flag. All gated server-side by hasRole('ADMIN').
+export async function listAdminUsers({ role, banStatus, q, page = 0, size = 20 } = {}) {
+  const params = new URLSearchParams({ page: String(page), size: String(size) })
+  if (role) params.set('role', role)
+  if (banStatus) params.set('banStatus', banStatus)
+  if (q) params.set('q', q)
+  const res = await fetch(`${BASE_URL}/admin/users?${params}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function getAdminUserDetail(id) {
+  const res = await fetch(`${BASE_URL}/admin/users/${id}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function banAdminUser(userId, { reason, durationHours }) {
+  const res = await fetch(`${BASE_URL}/admin/users/${userId}/ban`, {
+    method: 'POST',
+    headers: authJsonHeaders(),
+    body: JSON.stringify({ reason, durationHours }),
+  })
+  return handleResponse(res)
+}
+
+export async function unbanAdminUser(userId) {
+  const res = await fetch(`${BASE_URL}/admin/users/${userId}/unban`, {
+    method: 'POST',
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function clearBotFlag(userId) {
+  const res = await fetch(`${BASE_URL}/admin/users/${userId}/clear-bot-flag`, {
+    method: 'POST',
+    headers: authHeaders(),
+  })
+  if (res.status === 204) return null
+  return handleResponse(res)
+}
+
+// #279 / backend #135: admin report queue + status transitions.
+// Allowed transitions: OPEN → UNDER_REVIEW / RESOLVED / DISMISSED;
+// UNDER_REVIEW → RESOLVED / DISMISSED. Terminal states reject with 400.
+export async function listAdminReports({ status, targetType, page = 0, size = 20 } = {}) {
+  const params = new URLSearchParams({ page: String(page), size: String(size) })
+  if (status) params.set('status', status)
+  if (targetType) params.set('targetType', targetType)
+  const res = await fetch(`${BASE_URL}/admin/reports?${params}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function getAdminReport(id) {
+  const res = await fetch(`${BASE_URL}/admin/reports/${id}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function updateAdminReportStatus(id, status) {
+  const res = await fetch(`${BASE_URL}/admin/reports/${id}`, {
+    method: 'PATCH',
+    headers: authJsonHeaders(),
+    body: JSON.stringify({ status }),
+  })
+  return handleResponse(res)
+}
+
 export async function getMenteeAvailability() {
   const res = await fetch(`${BASE_URL}/mentee-availability`, {
     headers: authHeaders(),

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3389,6 +3389,105 @@
   opacity: 0.75;
 }
 
+/* Admin console (#279). */
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+}
+.admin-table th,
+.admin-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+.admin-table th {
+  background: #fafaf9;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+.admin-table tbody tr:last-child td { border-bottom: none; }
+.admin-table tbody tr:hover { background: var(--green-pale); }
+
+.admin-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  margin-right: 4px;
+  white-space: nowrap;
+}
+.admin-pill--ok      { background: #d1fae5; color: #047857; }
+.admin-pill--warn    { background: #fef3c7; color: #b45309; }
+.admin-pill--danger  { background: #fee2e2; color: #b91c1c; }
+.admin-pill--neutral { background: #e5e7eb; color: #374151; }
+
+.action-btn--danger {
+  background: #fee2e2;
+  color: #b91c1c;
+  border-color: #fecaca;
+}
+.action-btn--danger:hover:not(:disabled) {
+  background: #fecaca;
+}
+
+.admin-report-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.admin-report-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px 16px;
+}
+.admin-report-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.admin-report-id {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-muted);
+  margin-right: 4px;
+}
+.admin-report-summary {
+  font-size: 14px;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+.admin-report-desc {
+  margin: 6px 0 12px;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.admin-report-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 /* My Mentorships list (#408). */
 .ml-list {
   list-style: none;


### PR DESCRIPTION
Closes #279.                                              
                                                                                                                                                                                        
  Summary                                                   

  Replaces the seed AdminConsolePage from PR #573 (just the direct-message composer) with a full tabbed admin surface. Users, Reports, Messages — all backed by endpoints that already  
  exist on dev (/api/admin/users from #569, /api/admin/reports from #574, /api/admin/messages/direct/{id} from #561).
                                                                                                                                                                                        
  Changes                                                   

  - services/api.js — 8 admin wrappers: listAdminUsers (paginated with role / banStatus / q filters), getAdminUserDetail, banAdminUser, unbanAdminUser, clearBotFlag, listAdminReports  
  (filtered by status + targetType), getAdminReport, updateAdminReportStatus.
  - pages/AdminConsolePage.jsx — completely rewritten as a tabbed surface, splitting into <UsersTab />, <ReportsTab />, <MessagesTab />. Messages tab preserves the existing composer   
  (and its test IDs) verbatim.                                                                                                                                                          
  - pages/__tests__/AdminConsolePage.test.jsx — added mocks for listAdminUsers + listAdminReports so the Users tab doesn't crash on mount. Tests now click the Messages tab before
  exercising the composer.                                                                                                                                                              
  - styles/main.css — .admin-table, .admin-pill--ok/warn/danger/neutral, .admin-report-card, .action-btn--danger.
                                                                                                                                                                                        
  Acceptance criteria mapping (from #279 — "Admin Panel — User Management and Report Review")                                                                                           
                                                                                                                                                                                        
  - ✅ Users tab — paginated list of all users, filterable by role / ban status / keyword. Each row shows ID / name / email / role / status + per-row action buttons.                   
  - ✅ Ban modal — reason (required) + duration (hours), submits to POST /api/admin/users/{id}/ban.
  - ✅ Unban — confirm prompt, submits to POST /api/admin/users/{id}/unban.                                                                                                             
  - ✅ Clear bot flag — single-click action on rows where isSuspectedBot=true, submits to POST /api/admin/users/{id}/clear-bot-flag.                                                    
  - ✅ Reports tab — paginated queue filtered by status + targetType.                                                                                                                   
  - ✅ Status transitions per the backend state machine: OPEN → UNDER_REVIEW / RESOLVED / DISMISSED; UNDER_REVIEW → RESOLVED / DISMISSED. Terminal states (RESOLVED, DISMISSED) show no 
  action buttons.                                                                                                                                                                       
  - ✅ Admin role gate — server-side @PreAuthorize("hasRole('ADMIN')") on every endpoint; client-side via the existing AdminRoute.
                                                                                                                                                                                        
  Mobile parity                                             
                                                                                                                                                                                        
  Mobile's admin section sits inside the profile tab (mobile-app/app/(tabs)/profile.tsx:974-1024). Web's dedicated /admin route is a more conventional surface. Functional parity for   
  users + ban/unban; web additionally gets the reports queue that mobile doesn't have.
                                                                                                                                                                                        
  Out of scope (handled separately by updated #410)                                                                                                                                     
   
  - Admin broadcast messaging composer                                                                                                                                                  
  - Admin inbox list + thread view                          
  - "From admin" badge on the recipient-side /messages page
                                                                                                                                                                                        
  Test plan
                                                                                                                                                                                        
  - npm run build clean.                                    
  - npm test — 84/84 unit tests pass.
  - Manual (admin): navigate /admin → Users tab loads with first page. Search "bob" → results filter. Click Ban on a user → modal opens → enter reason + 24 hours → Ban → user row      
  reflects new status.                                                                                                                                                                  
  - Manual (admin): switch to Reports tab → see queue with OPEN reports → click Mark Under Review on one → row reflects new state.                                                      
  - Manual (non-admin): navigate /admin → redirected to /home.