### PR TITLE
feat(web): admin broadcast composer + inbox views + From-admin badge …

### DIFF
--- a/frontend/src/pages/AdminConsolePage.jsx
+++ b/frontend/src/pages/AdminConsolePage.jsx
@@ -8,6 +8,9 @@ import {
   clearBotFlag,
   listAdminReports,
   updateAdminReportStatus,
+  getAdminDirectInbox,
+  broadcastAdminMessage,
+  listAdminBroadcasts,
 } from '../services/api'
 import { showTransientToast } from '../utils/toast'
 import '../styles/main.css'
@@ -508,10 +511,55 @@ function pillForStatus(s) {
 // AdminConsolePage.test.jsx.
 
 function MessagesTab() {
+  // Three sub-panes: direct composer + inbox, plus broadcast composer + history.
+  // Direct composer keeps the original testids from #573 so existing
+  // AdminConsolePage tests still pass against this restructure.
+  const [view, setView] = useState('direct')
+
+  return (
+    <div data-testid="admin-messages-tab">
+      <div className="admin-subnav">
+        <button
+          type="button"
+          className={`feed-tab${view === 'direct' ? ' feed-tab--active' : ''}`}
+          onClick={() => setView('direct')}
+        >Direct</button>
+        <button
+          type="button"
+          className={`feed-tab${view === 'broadcast' ? ' feed-tab--active' : ''}`}
+          onClick={() => setView('broadcast')}
+        >Broadcast</button>
+      </div>
+
+      {view === 'direct' && <DirectMessagePane />}
+      {view === 'broadcast' && <BroadcastPane />}
+    </div>
+  )
+}
+
+function DirectMessagePane() {
   const [userId, setUserId] = useState('')
   const [content, setContent] = useState('')
   const [sending, setSending] = useState(false)
   const [error, setError] = useState('')
+
+  // #410: list the admin's existing admin-direct conversations so they can
+  // see who they've DMed before without typing the user id from memory.
+  const [inbox, setInbox] = useState([])
+  const [inboxLoading, setInboxLoading] = useState(true)
+
+  const loadInbox = useCallback(async () => {
+    setInboxLoading(true)
+    try {
+      const page = await getAdminDirectInbox(0, 50)
+      setInbox(page?.content || [])
+    } catch {
+      setInbox([])
+    } finally {
+      setInboxLoading(false)
+    }
+  }, [])
+  useEffect(() => { loadInbox() }, [loadInbox])
 
   async function handleSend(e) {
     e.preventDefault()
@@ -531,6 +579,7 @@ function MessagesTab() {
       setContent('')
       setUserId('')
       showTransientToast('Direct message delivered.')
+      loadInbox()
     } catch (err) {
       const msg = err?.message || 'Failed to send direct message.'
       setError(msg)
@@ -540,55 +589,181 @@ function MessagesTab() {
   }
 
   return (
-    <form
-      className="admin-console-form"
-      onSubmit={handleSend}
-      data-testid="admin-console-form"
-      style={{ display: 'flex', flexDirection: 'column', gap: '12px', maxWidth: '540px' }}
-    >
-      <label htmlFor="admin-console-recipient" style={{ fontWeight: 600 }}>Recipient user id</label>
-      <input
-        id="admin-console-recipient"
-        type="number"
-        min="1"
-        step="1"
-        value={userId}
-        onChange={(e) => setUserId(e.target.value)}
-        placeholder="e.g. 42"
-        data-testid="admin-console-recipient"
-        disabled={sending}
-        required
-      />
-
-      <label htmlFor="admin-console-body" style={{ fontWeight: 600 }}>Message</label>
-      <textarea
-        id="admin-console-body"
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        placeholder="Write your message…"
-        rows={6}
-        data-testid="admin-console-body"
-        disabled={sending}
-        required
-      />
-
-      {error && (
-        <div className="md-error-card" data-testid="admin-console-error">
-          <div className="md-error-title">Send failed</div>
-          <div className="md-error-sub">{error}</div>
-        </div>
-      )}
-
-      <div>
-        <button
-          type="submit"
-          className="action-btn"
+    <div className="admin-direct-pane">
+      <form
+        className="admin-console-form"
+        onSubmit={handleSend}
+        data-testid="admin-console-form"
+        style={{ display: 'flex', flexDirection: 'column', gap: '12px', maxWidth: '540px' }}
+      >
+        <label htmlFor="admin-console-recipient" style={{ fontWeight: 600 }}>Recipient user id</label>
+        <input
+          id="admin-console-recipient"
+          type="number"
+          min="1"
+          step="1"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          placeholder="e.g. 42"
+          data-testid="admin-console-recipient"
           disabled={sending}
-          data-testid="admin-console-send"
-        >
-          {sending ? 'Sending…' : 'Send message'}
-        </button>
+          required
+        />
+
+        <label htmlFor="admin-console-body" style={{ fontWeight: 600 }}>Message</label>
+        <textarea
+          id="admin-console-body"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Write your message…"
+          rows={6}
+          data-testid="admin-console-body"
+          disabled={sending}
+          required
+        />
+
+        {error && (
+          <div className="md-error-card" data-testid="admin-console-error">
+            <div className="md-error-title">Send failed</div>
+            <div className="md-error-sub">{error}</div>
+          </div>
+        )}
+
+        <div>
+          <button
+            type="submit"
+            className="action-btn"
+            disabled={sending}
+            data-testid="admin-console-send"
+          >
+            {sending ? 'Sending…' : 'Send message'}
+          </button>
+        </div>
+      </form>
+
+      <div style={{ marginTop: '24px' }}>
+        <div className="section-label" style={{ marginBottom: '8px' }}>
+          Your direct conversations
+        </div>
+        {inboxLoading ? (
+          <div className="md-loading">Loading…</div>
+        ) : inbox.length === 0 ? (
+          <div className="empty-state">No direct messages yet. Send one above to start a conversation.</div>
+        ) : (
+          <ul className="admin-inbox-list">
+            {inbox.map(c => (
+              <li key={c.conversationId} className="admin-inbox-row">
+                <span className="admin-inbox-peer">{c.peerFirstName || `User #${c.peerId}`}</span>
+                <span className="admin-inbox-preview">{c.lastMessageContent || '—'}</span>
+                <span className="admin-inbox-time">
+                  {c.lastMessageSentAt
+                    ? new Date(c.lastMessageSentAt).toLocaleString('en-GB', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })
+                    : ''}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
-    </form>
+    </div>
+  )
+}
+
+function BroadcastPane() {
+  const [content, setContent] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState('')
+  const [history, setHistory] = useState([])
+  const [historyLoading, setHistoryLoading] = useState(true)
+
+  const loadHistory = useCallback(async () => {
+    setHistoryLoading(true)
+    try {
+      const page = await listAdminBroadcasts(0, 50)
+      setHistory(page?.content || [])
+    } catch {
+      setHistory([])
+    } finally {
+      setHistoryLoading(false)
+    }
+  }, [])
+  useEffect(() => { loadHistory() }, [loadHistory])
+
+  async function handleSend(e) {
+    e.preventDefault()
+    setError('')
+    if (!content.trim()) {
+      setError('Broadcast body cannot be empty.')
+      return
+    }
+    setSending(true)
+    try {
+      await broadcastAdminMessage(content)
+      setContent('')
+      showTransientToast('Broadcast sent to all admins.')
+      loadHistory()
+    } catch (err) {
+      setError(err?.message || 'Failed to broadcast.')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  return (
+    <div className="admin-broadcast-pane">
+      <form
+        onSubmit={handleSend}
+        style={{ display: 'flex', flexDirection: 'column', gap: '12px', maxWidth: '540px' }}
+      >
+        <label htmlFor="admin-broadcast-body" style={{ fontWeight: 600 }}>Broadcast to all admins</label>
+        <textarea
+          id="admin-broadcast-body"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Note for the moderation team…"
+          rows={5}
+          disabled={sending}
+          required
+        />
+        {error && (
+          <div className="md-error-card">
+            <div className="md-error-title">Broadcast failed</div>
+            <div className="md-error-sub">{error}</div>
+          </div>
+        )}
+        <div>
+          <button type="submit" className="action-btn" disabled={sending}>
+            {sending ? 'Sending…' : 'Broadcast'}
+          </button>
+        </div>
+      </form>
+
+      <div style={{ marginTop: '24px' }}>
+        <div className="section-label" style={{ marginBottom: '8px' }}>
+          Recent broadcasts
+        </div>
+        {historyLoading ? (
+          <div className="md-loading">Loading…</div>
+        ) : history.length === 0 ? (
+          <div className="empty-state">No broadcasts yet.</div>
+        ) : (
+          <ul className="admin-broadcast-list">
+            {history.map(m => (
+              <li key={m.id} className="admin-broadcast-row">
+                <div className="admin-broadcast-head">
+                  <strong>{m.senderFirstName || `Admin #${m.senderId}`}</strong>
+                  <span className="admin-broadcast-time">
+                    {m.sentAt
+                      ? new Date(m.sentAt).toLocaleString('en-GB', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })
+                      : ''}
+                  </span>
+                </div>
+                <div className="admin-broadcast-body">{m.content}</div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
   )
 }

--- a/frontend/src/pages/MessagesPage.jsx
+++ b/frontend/src/pages/MessagesPage.jsx
@@ -14,6 +14,8 @@ import {
   getMentorPairMessages,
   sendMentorPairMessage,
   markMentorPairMessagesRead,
+  getAdminDirectInbox,
+  getAdminDirectMessages,
 } from '../services/api'
 import { uploadMessageAttachment } from '../services/attachmentService'
 import useConversationSubscription from '../hooks/useConversationSubscription'
@@ -76,6 +78,7 @@ export default function MessagesPage() {
   const [params] = useSearchParams()
   const mentorshipId = params.get('mentorshipId')
   const peerId = params.get('peerId')
+  const adminUserId = params.get('adminUserId')
   const navigate = useNavigate()
   const { role, userId } = useAuth()
   const isMentor = role === 'MENTOR'
@@ -107,8 +110,23 @@ export default function MessagesPage() {
         backLabel: '← Back to profile',
       }
     }
+    if (adminUserId) {
+      // #410: admin-direct read surface. One-way conversation (admin → user)
+      // — backend has no POST for the recipient to reply, so `send` returns
+      // a rejected promise to surface a clear error if the UI ever tries.
+      return {
+        kind: 'ADMIN_DIRECT',
+        key: adminUserId,
+        loadMessages: (k, page, size) => getAdminDirectMessages(k, page, size),
+        send: () => Promise.reject(new Error('Admin-direct conversations are read-only on this surface.')),
+        markRead: () => Promise.resolve(),
+        backHref: '/messages',
+        backLabel: '← Back to inbox',
+        readOnly: true,
+      }
+    }
     return null
-  }, [mentorshipId, peerId])
+  }, [mentorshipId, peerId, adminUserId])
 
   // Thread state
   const [messages, setMessages] = useState([])
@@ -213,9 +231,30 @@ export default function MessagesPage() {
       }
     }
 
-    Promise.all([loadMentorshipConvs(), loadMentorPairConvs()])
-      .then(([mentorships, pairs]) => {
-        const merged = [...mentorships, ...pairs]
+    async function loadAdminDirectConvs() {
+      // #410: admin-direct conversations. Surfaces in every user's inbox
+      // (a regular user sees messages from admins; an admin sees DMs to
+      // users). Backend gates by participant, so both shapes come back
+      // from the same endpoint.
+      try {
+        const inbox = await getAdminDirectInbox(0, 50)
+        return (inbox?.content || []).map(item => ({
+          kind: 'ADMIN_DIRECT',
+          id: `admin-${item.peerId}`,
+          href: `/messages?adminUserId=${item.peerId}`,
+          name: item.peerFirstName || '—',
+          preview: item.lastMessageContent || '',
+          lastAt: item.lastMessageSentAt || null,
+          fromAdmin: Boolean(item.peerIsAdmin),
+        }))
+      } catch {
+        return []
+      }
+    }
+
+    Promise.all([loadMentorshipConvs(), loadMentorPairConvs(), loadAdminDirectConvs()])
+      .then(([mentorships, pairs, adminConvs]) => {
+        const merged = [...mentorships, ...pairs, ...adminConvs]
           .sort((a, b) => new Date(b.lastAt || 0) - new Date(a.lastAt || 0))
         if (!cancelled) setConversations(merged)
       })
@@ -276,6 +315,12 @@ export default function MessagesPage() {
                       {c.kind === 'MENTOR_PAIR' && (
                         <span className="md-conv-badge">Mentor</span>
                       )}
+                      {c.kind === 'ADMIN_DIRECT' && c.fromAdmin && (
+                        <span className="md-conv-badge md-conv-badge--admin">From admin</span>
+                      )}
+                      {c.kind === 'ADMIN_DIRECT' && !c.fromAdmin && (
+                        <span className="md-conv-badge md-conv-badge--admin">Admin DM</span>
+                      )}
                       {c.lastAt && <span className="md-conv-time">{relativeTime(c.lastAt)}</span>}
                     </div>
                     <div className="md-conv-preview">{c.preview || 'No messages yet'}</div>
@@ -335,11 +380,17 @@ export default function MessagesPage() {
               )
             })}
           </div>
-          <ChatComposer
-            onSend={handleSend}
-            onUpload={uploadMessageAttachment}
-            placeholder="Type a message…"
-          />
+          {chatRoute.readOnly ? (
+            <div className="md-readonly-notice">
+              This conversation is read-only — admin announcements cannot be replied to here.
+            </div>
+          ) : (
+            <ChatComposer
+              onSend={handleSend}
+              onUpload={uploadMessageAttachment}
+              placeholder="Type a message…"
+            />
+          )}
         </>
       )}
     </MainLayout>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1061,6 +1061,44 @@ export async function sendAdminDirectMessage(userId, content) {
   return handleResponse(res)
 }
 
+// #410 / backend #561: admin-direct read paths. Inbox list is auth'd to any
+// participant (admin OR recipient user). Thread is one-way — backend exposes
+// no POST for the recipient to reply; the conversation flows admin → user.
+export async function getAdminDirectInbox(page = 0, size = 20) {
+  const params = new URLSearchParams({ page: String(page), size: String(size) })
+  const res = await fetch(`${BASE_URL}/conversations/admin-direct?${params}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+export async function getAdminDirectMessages(otherUserId, page = 0, size = 20) {
+  const params = new URLSearchParams({ page: String(page), size: String(size) })
+  const res = await fetch(`${BASE_URL}/conversations/admin-direct/${otherUserId}/messages?${params}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
+// #410 / backend #280: admin-to-admin broadcast (singleton ADMIN_BROADCAST
+// thread). Admin-only on both write and read; non-admin callers get 403.
+export async function broadcastAdminMessage(content) {
+  const res = await fetch(`${BASE_URL}/admin/messages/broadcast`, {
+    method: 'POST',
+    headers: authJsonHeaders(),
+    body: JSON.stringify({ content }),
+  })
+  return handleResponse(res)
+}
+
+export async function listAdminBroadcasts(page = 0, size = 20) {
+  const params = new URLSearchParams({ page: String(page), size: String(size) })
+  const res = await fetch(`${BASE_URL}/admin/messages/broadcast?${params}`, {
+    headers: authHeaders(),
+  })
+  return handleResponse(res)
+}
+
 // #279 / backend #569 + #280: admin user listing, drill-in, ban/unban,
 // and clear-bot-flag. All gated server-side by hasRole('ADMIN').
 export async function listAdminUsers({ role, banStatus, q, page = 0, size = 20 } = {}) {

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3389,6 +3389,72 @@
   opacity: 0.75;
 }
 
+/* Admin messaging (#410). */
+.admin-subnav {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+.admin-inbox-list,
+.admin-broadcast-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.admin-inbox-row {
+  display: grid;
+  grid-template-columns: 140px 1fr 110px;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fff;
+  font-size: 13px;
+  align-items: center;
+}
+.admin-inbox-peer { font-weight: 600; color: var(--text); }
+.admin-inbox-preview {
+  color: var(--text-muted);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.admin-inbox-time { color: var(--text-muted); font-size: 12px; text-align: right; }
+
+.admin-broadcast-row {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #fff;
+}
+.admin-broadcast-head {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 6px;
+  font-size: 13px;
+}
+.admin-broadcast-time { color: var(--text-muted); font-size: 12px; }
+.admin-broadcast-body { color: var(--text); font-size: 14px; white-space: pre-wrap; word-break: break-word; }
+
+.md-conv-badge--admin {
+  background: #ede9fe !important;
+  color: #6d28d9 !important;
+}
+
+.md-readonly-notice {
+  margin: 16px 0;
+  padding: 10px 14px;
+  background: #f3f4f6;
+  border-left: 3px solid var(--text-muted);
+  color: var(--text-muted);
+  font-size: 13px;
+  border-radius: 6px;
+}
+
 /* Admin console (#279). */
 .admin-table {
   width: 100%;


### PR DESCRIPTION
Closes #410. Builds on the AdminConsolePage seed from #279.                                                                                                                           
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Three pieces:                                                                                                                                                                         
  1. Broadcast composer + history on /admin Messages tab (new "Broadcast" sub-pane). Mobile parity — mobile ships this in profile.tsx:1026-1038.                                        
  2. Direct-conversation inbox on /admin so admins see who they've DMed without typing user ids from memory. The existing composer from #573 stays — it now also re-fires the inbox load
   after a successful send.                                                                                                                                                             
  3. Admin DMs in the user-side /messages with a "From admin" badge, opened via a new ?adminUserId=N route that renders the thread in read-only mode (backend exposes no reply endpoint 
  for recipients).                                                                                                                                                                    
                                                                                                                                                                                        
  Changes                                                                                                                                                                             
                                                                                                                                                                                        
  - services/api.js — 4 new wrappers: getAdminDirectInbox, getAdminDirectMessages, broadcastAdminMessage, listAdminBroadcasts.                                                          
  - pages/AdminConsolePage.jsx — split Messages tab into <DirectMessagePane /> + <BroadcastPane />. Direct pane shows the existing composer + the admin's existing direct conversations.
   Broadcast pane composer + history backed by /api/admin/messages/broadcast (note: "broadcast" is admin-to-admins, per backend spec — not admin-to-all-users).                         
  - pages/MessagesPage.jsx:                                 
    - Added ADMIN_DIRECT to the polymorphic chatRoute descriptor. ?adminUserId=N opens the thread; send rejects since no reply endpoint exists; readOnly: true hides the composer.      
    - Loaded admin-direct conversations alongside mentorships + mentor-pair in the conversation list.                                                                                   
    - "From admin" badge on incoming admin DMs in the conversation list; "Admin DM" badge when the admin is the viewer.                                                                 
  - styles/main.css — .admin-subnav, .admin-inbox-list, .admin-broadcast-list, .md-conv-badge--admin (purple), .md-readonly-notice.                                                     
                                                                                                                                                                                        
  Backend spec clarification                                                                                                                                                            
                                                                                                                                                                                        
  POST /api/admin/messages/broadcast is described in AdminMessagingController.java:85-104 as "Broadcast to all admins" — it posts to the singleton ADMIN_BROADCAST conversation, with   
  every current admin added as a participant. So broadcast = admin-to-admins (moderation team chat), not admin-to-all-users. The web copy reflects this ("Broadcast to all admins", "all
   admins" in the toast).                                                                                                                                                               
                                                            
  Acceptance criteria mapping (from updated #410)                                                                                                                                       
   
  - ✅ Direct composer (was already shipped) accepts a recipient user id + body → POST /api/admin/messages/direct/{userId}.                                                             
  - ✅ Broadcast composer → POST /api/admin/messages/broadcast. Confirmation toast.
  - ✅ Admin inbox lists every conversation the admin participates in (GET /api/conversations/admin-direct), newest first.                                                              
  - ✅ Admin DMs appear in the recipient-side /messages page with a "From admin" badge, accessible at /messages?adminUserId=N.                                                          
  - ✅ Admin role gate enforced server-side on all admin endpoints; client-side via the existing AdminRoute on /admin.                                                                  
                                                                                                                                                                                        
  Out of scope                                                                                                                                                                          
                                                                                                                                                                                        
  - Reply functionality for non-admin recipients — backend exposes no POST for the recipient. If conversation-style replies are wanted, that's a backend follow-up.                     
  - Broadcast targeting (admin-to-all-users, admin-to-mentors-only, etc.) — backend broadcast is to all admins; would need new endpoints.
                                                                                                                                                                                        
  Test plan                                                                                                                                                                             
                                                                                                                                                                                        
  - npm run build clean.                                                                                                                                                                
  - npm test — 84/84 unit tests pass.                       
  - Manual (admin): /admin → Messages → Direct → send a DM to user id 7 → toast + inbox list refreshes with the new conversation.                                                       
  - Manual (admin): /admin → Messages → Broadcast → write something → broadcast → confirmation toast, message appears in "Recent broadcasts" list.                                      
  - Manual (recipient user): /messages → conversation list shows the admin DM with "From admin" purple badge → click → thread opens read-only with the no-reply notice.