### PR TITLE
Feature/139 advanced mentor search

### DIFF
--- a/frontend/src/components/MentorCompareModal.jsx
+++ b/frontend/src/components/MentorCompareModal.jsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Side-by-side mentor comparison view (#139). Up to 3 mentors. Closes
+ * via overlay click, the × button, or Escape.
+ *
+ * Backend's MentorMatchResponse carries everything we display: firstName,
+ * expertise, affiliation, city, distanceKm, matchScore, factors,
+ * mentorshipDuration, maxMenteeCapacity, currentMenteeCount, averageRating,
+ * ratingCount. We render whatever's available and skip missing fields
+ * gracefully — a mentor with no rating just shows "—" in that row.
+ */
+
+const ROWS = [
+  { key: 'expertise', label: 'Expertise' },
+  { key: 'affiliation', label: 'Affiliation' },
+  { key: 'city', label: 'City' },
+  { key: 'distanceKm', label: 'Distance', format: v => v != null ? `${Number(v).toFixed(1)} km` : '' },
+  { key: 'matchScore', label: 'Match score', format: v => v != null ? `${v}` : '' },
+  { key: 'mentorshipDuration', label: 'Duration', format: v => v != null ? `${v} month${v !== 1 ? 's' : ''}` : '' },
+  {
+    key: 'capacity',
+    label: 'Capacity',
+    format: (_, m) => m.maxMenteeCapacity != null
+      ? `${m.currentMenteeCount ?? 0} / ${m.maxMenteeCapacity}`
+      : '',
+  },
+  {
+    key: 'rating',
+    label: 'Rating',
+    format: (_, m) => m.averageRating != null
+      ? `★ ${Number(m.averageRating).toFixed(1)} (${m.ratingCount ?? 0})`
+      : '',
+  },
+]
+
+export default function MentorCompareModal({ open, mentors = [], onClose, onRemove }) {
+  const overlayRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onKey = e => { if (e.key === 'Escape') onClose?.() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open || mentors.length === 0) return null
+
+  return (
+    <div
+      className="modal-overlay"
+      ref={overlayRef}
+      onMouseDown={e => { if (e.target === overlayRef.current) onClose?.() }}
+    >
+      <div className="modal-card mentor-compare-card" role="dialog" aria-modal="true" aria-labelledby="mentor-compare-title">
+        <div className="modal-header">
+          <div>
+            <h2 id="mentor-compare-title">Compare mentors</h2>
+            <p className="modal-subtitle">
+              Up to 3 mentors side by side. Remove from the selection with the × on a column.
+            </p>
+          </div>
+          <button type="button" className="modal-close" onClick={onClose} aria-label="Close comparison">×</button>
+        </div>
+
+        <div className="mentor-compare-grid" style={{ gridTemplateColumns: `160px repeat(${mentors.length}, minmax(0, 1fr))` }}>
+          <div /> {/* row-label column header is empty */}
+          {mentors.map(m => (
+            <div key={m.id} className="mentor-compare-col-head">
+              <div className="mentor-compare-name">{m.firstName || `Mentor #${m.id}`}</div>
+              <button
+                type="button"
+                className="mentor-compare-remove"
+                onClick={() => onRemove?.(m.id)}
+                aria-label={`Remove ${m.firstName || 'mentor'} from comparison`}
+              >×</button>
+            </div>
+          ))}
+
+          {ROWS.map(row => (
+            <CompareRow key={row.key} row={row} mentors={mentors} />
+          ))}
+
+          {/* Factors are arrays, so we render them as a separate row of chips */}
+          <div className="mentor-compare-row-label">Top factors</div>
+          {mentors.map(m => (
+            <div key={`${m.id}-factors`} className="mentor-compare-cell">
+              {Array.isArray(m.factors) && m.factors.length > 0 ? (
+                <div className="mentor-compare-factors">
+                  {m.factors.slice(0, 6).map((f, i) => (
+                    <span key={i} className="mentor-compare-factor">{f}</span>
+                  ))}
+                </div>
+              ) : (
+                <span className="mentor-compare-empty">—</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function CompareRow({ row, mentors }) {
+  return (
+    <>
+      <div className="mentor-compare-row-label">{row.label}</div>
+      {mentors.map(m => {
+        const raw = row.key === 'capacity' || row.key === 'rating' ? null : m[row.key]
+        const value = row.format ? row.format(raw, m) : (raw ?? '')
+        return (
+          <div key={`${m.id}-${row.key}`} className="mentor-compare-cell">
+            {value !== '' && value != null
+              ? <span>{value}</span>
+              : <span className="mentor-compare-empty">—</span>}
+          </div>
+        )
+      })}
+    </>
+  )
+}

--- a/frontend/src/components/MentorFilterSidebar.jsx
+++ b/frontend/src/components/MentorFilterSidebar.jsx
@@ -1,0 +1,119 @@
+/**
+ * Advanced mentor filter sidebar (#139). Three filter dimensions backed
+ * by the matching API's #571 params:
+ *  - availabilityDays: multi-select of weekdays
+ *  - mentorshipDuration: multi-select of 1/3/6 month options
+ *  - minMatchScore: slider, 0-100
+ *
+ * Controlled component. Parent owns the state; this just renders the
+ * controls and emits onChange on every interaction. Reset clears the
+ * three filters back to their initial empty state.
+ */
+
+const DAYS = [
+  { value: 'MONDAY', label: 'Mon' },
+  { value: 'TUESDAY', label: 'Tue' },
+  { value: 'WEDNESDAY', label: 'Wed' },
+  { value: 'THURSDAY', label: 'Thu' },
+  { value: 'FRIDAY', label: 'Fri' },
+  { value: 'SATURDAY', label: 'Sat' },
+  { value: 'SUNDAY', label: 'Sun' },
+]
+
+const DURATIONS = [1, 3, 6]
+
+export default function MentorFilterSidebar({
+  availabilityDays = [], mentorshipDuration = [], minMatchScore = 0,
+  onChange,
+  onReset,
+}) {
+  function toggleDay(day) {
+    const next = availabilityDays.includes(day)
+      ? availabilityDays.filter(d => d !== day)
+      : [...availabilityDays, day]
+    onChange?.({ availabilityDays: next })
+  }
+
+  function toggleDuration(n) {
+    const next = mentorshipDuration.includes(n)
+      ? mentorshipDuration.filter(d => d !== n)
+      : [...mentorshipDuration, n]
+    onChange?.({ mentorshipDuration: next })
+  }
+
+  function setMinScore(v) {
+    onChange?.({ minMatchScore: Number(v) })
+  }
+
+  const hasAny = availabilityDays.length > 0 || mentorshipDuration.length > 0 || minMatchScore > 0
+
+  return (
+    <aside className="mentor-filter-sidebar" aria-label="Advanced mentor filters">
+      <div className="mentor-filter-head">
+        <span className="section-label" style={{ margin: 0 }}>Filters</span>
+        {hasAny && (
+          <button type="button" className="mentor-filter-reset" onClick={onReset}>
+            Reset
+          </button>
+        )}
+      </div>
+
+      <div className="mentor-filter-block">
+        <div className="mentor-filter-label">Availability days</div>
+        <div className="mentor-filter-days">
+          {DAYS.map(d => {
+            const selected = availabilityDays.includes(d.value)
+            return (
+              <button
+                key={d.value}
+                type="button"
+                className={`mentor-filter-day${selected ? ' mentor-filter-day--active' : ''}`}
+                aria-pressed={selected}
+                onClick={() => toggleDay(d.value)}
+              >
+                {d.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="mentor-filter-block">
+        <div className="mentor-filter-label">Mentorship duration</div>
+        <div className="mentor-filter-durations">
+          {DURATIONS.map(n => {
+            const selected = mentorshipDuration.includes(n)
+            return (
+              <button
+                key={n}
+                type="button"
+                className={`mentor-filter-duration${selected ? ' mentor-filter-duration--active' : ''}`}
+                aria-pressed={selected}
+                onClick={() => toggleDuration(n)}
+              >
+                {n} month{n !== 1 ? 's' : ''}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="mentor-filter-block">
+        <div className="mentor-filter-label">
+          Minimum match score
+          <span className="mentor-filter-score-value">{minMatchScore || 0}+</span>
+        </div>
+        <input
+          type="range"
+          min="0"
+          max="100"
+          step="5"
+          value={minMatchScore}
+          onChange={(e) => setMinScore(e.target.value)}
+          className="mentor-filter-slider"
+          aria-label="Minimum match score"
+        />
+      </div>
+    </aside>
+  )
+}

--- a/frontend/src/pages/ExplorePage.jsx
+++ b/frontend/src/pages/ExplorePage.jsx
@@ -315,17 +315,20 @@ export default function ExplorePage() {
     setFilters({ availabilityDays: [], mentorshipDuration: [], minMatchScore: 0 })
   }
 
+  // Backends mix numeric and string ids in JSON payloads, so we coerce to
+  // String once at the boundary. Lookups elsewhere do the same.
   function toggleCompare(mentorId) {
+    const key = String(mentorId)
     setCompareIds(prev => {
       const next = new Set(prev)
-      if (next.has(mentorId)) {
-        next.delete(mentorId)
+      if (next.has(key)) {
+        next.delete(key)
       } else {
         if (next.size >= 3) {
           showTransientToast('You can compare up to 3 mentors at a time.')
           return prev
         }
-        next.add(mentorId)
+        next.add(key)
       }
       return next
     })
@@ -336,8 +339,8 @@ export default function ExplorePage() {
   // match across surfaces.
   const compareMentors = (() => {
     const pool = new Map()
-    for (const m of mentors) pool.set(m.id, m)
-    for (const m of matches) pool.set(m.id, m)
+    for (const m of mentors) pool.set(String(m.id), m)
+    for (const m of matches) pool.set(String(m.id), m)
     return [...compareIds].map(id => pool.get(id)).filter(Boolean)
   })()
 
@@ -568,7 +571,7 @@ export default function ExplorePage() {
                   <label className="mentor-compare-toggle" title="Add to comparison (up to 3)">
                     <input
                       type="checkbox"
-                      checked={compareIds.has(m.id)}
+                      checked={compareIds.has(String(m.id))}
                       onChange={() => toggleCompare(m.id)}
                       aria-label={`Add ${m.firstName} to comparison`}
                     />
@@ -635,7 +638,7 @@ export default function ExplorePage() {
         onClose={() => setCompareOpen(false)}
         onRemove={(id) => setCompareIds(prev => {
           const next = new Set(prev)
-          next.delete(id)
+          next.delete(String(id))
           if (next.size === 0) setCompareOpen(false)
           return next
         })}

--- a/frontend/src/pages/ExplorePage.jsx
+++ b/frontend/src/pages/ExplorePage.jsx
@@ -4,6 +4,9 @@ import MainLayout from '../components/MainLayout'
 import Avatar from '../components/Avatar'
 import RequestMentorshipModal from '../components/RequestMentorshipModal'
 import { getAllMentors, getMatchingMentors, getMatchingMentees, getActiveMentorships, getSentMentorshipRequests, createMentorshipRequest } from '../services/api'
+import MentorFilterSidebar from '../components/MentorFilterSidebar'
+import MentorCompareModal from '../components/MentorCompareModal'
+import { showTransientToast } from '../utils/toast'
 import { useAuth } from '../context/AuthContext'
 import '../styles/main.css'
 
@@ -225,6 +228,21 @@ export default function ExplorePage() {
   const [showMatches, setShowMatches] = useState(false)
   const matchSectionRef = useRef(null)
 
+  // #139: advanced filters. State lives here; controls in MentorFilterSidebar.
+  // Filters are passed straight through to the matching API which has been
+  // accepting them since backend #571. The selection is also applied client-
+  // side when the AI Match panel isn't open (i.e., to the regular mentor
+  // grid which comes from getAllMentors — that endpoint doesn't take the
+  // same filter params).
+  const [filters, setFilters] = useState({
+    availabilityDays: [],
+    mentorshipDuration: [],
+    minMatchScore: 0,
+  })
+  // #139: compare mode. Selection is a Set of mentor ids, capped at 3.
+  const [compareIds, setCompareIds] = useState(() => new Set())
+  const [compareOpen, setCompareOpen] = useState(false)
+
   useEffect(() => {
     async function init() {
       setLoading(true)
@@ -271,7 +289,14 @@ export default function ExplorePage() {
     }
     setAiState('loading')
     try {
-      const data = await getMatchingMentors()
+      // #139: forward the advanced filters to the matching endpoint. None of
+      // them are required — empty arrays / zero score are sent as nothing,
+      // so this is backward compatible with the no-filter case.
+      const data = await getMatchingMentors(null, {
+        availabilityDays: filters.availabilityDays,
+        mentorshipDuration: filters.mentorshipDuration,
+        minMatchScore: filters.minMatchScore > 0 ? filters.minMatchScore : undefined,
+      })
       const list = Array.isArray(data) ? data.slice(0, 5) : []
       setMatches(list)
       setAiState('done')
@@ -281,6 +306,40 @@ export default function ExplorePage() {
       setAiState('idle')
     }
   }
+
+  function updateFilters(patch) {
+    setFilters(prev => ({ ...prev, ...patch }))
+  }
+
+  function resetFilters() {
+    setFilters({ availabilityDays: [], mentorshipDuration: [], minMatchScore: 0 })
+  }
+
+  function toggleCompare(mentorId) {
+    setCompareIds(prev => {
+      const next = new Set(prev)
+      if (next.has(mentorId)) {
+        next.delete(mentorId)
+      } else {
+        if (next.size >= 3) {
+          showTransientToast('You can compare up to 3 mentors at a time.')
+          return prev
+        }
+        next.add(mentorId)
+      }
+      return next
+    })
+  }
+
+  // Mentor objects currently selected for comparison. Combines the AI
+  // matches list and the regular all-mentors list so a user can mix-and-
+  // match across surfaces.
+  const compareMentors = (() => {
+    const pool = new Map()
+    for (const m of mentors) pool.set(m.id, m)
+    for (const m of matches) pool.set(m.id, m)
+    return [...compareIds].map(id => pool.get(id)).filter(Boolean)
+  })()
 
   const filtered = isMentee
     ? mentors.filter(m => {
@@ -389,8 +448,36 @@ export default function ExplorePage() {
             data-testid="explore-search-input"
           />
         </div>
+        {/* #139: open compare modal. Disabled when no mentor selected. */}
+        {isMentee && (
+          <button
+            type="button"
+            className="action-btn"
+            disabled={compareIds.size === 0}
+            onClick={() => setCompareOpen(true)}
+            data-testid="explore-compare-btn"
+            title={compareIds.size === 0 ? 'Select up to 3 mentors to compare' : `Compare ${compareIds.size} selected`}
+            style={{ whiteSpace: 'nowrap' }}
+          >
+            Compare ({compareIds.size}/3)
+          </button>
+        )}
       </div>
 
+      <div className={`explore-body${isMentee ? ' explore-body--with-sidebar' : ''}`}>
+        {/* #139: mentor-side filter sidebar. Mentees only — backend matching
+            API is mentee-only too, so showing it on mentor view would be moot. */}
+        {isMentee && (
+          <MentorFilterSidebar
+            availabilityDays={filters.availabilityDays}
+            mentorshipDuration={filters.mentorshipDuration}
+            minMatchScore={filters.minMatchScore}
+            onChange={updateFilters}
+            onReset={resetFilters}
+          />
+        )}
+
+      <div className="explore-main">
       <div className="chips">
         {FILTERS.map(f => (
           <div key={f} className={`chip${activeFilter === f ? ' active' : ''}`} onClick={() => setActiveFilter(f)}>
@@ -478,6 +565,15 @@ export default function ExplorePage() {
                 )}
                 {m.bio && <div className="mc-bio">{m.bio}</div>}
                 <div className="mc-footer">
+                  <label className="mentor-compare-toggle" title="Add to comparison (up to 3)">
+                    <input
+                      type="checkbox"
+                      checked={compareIds.has(m.id)}
+                      onChange={() => toggleCompare(m.id)}
+                      aria-label={`Add ${m.firstName} to comparison`}
+                    />
+                    Compare
+                  </label>
                   <div className="mentor-actions">
                     <button
                       className={`send-request-btn${alreadySent ? ' sent' : ''}${hasActiveMentor && !alreadySent ? ' locked' : ''}`}
@@ -530,6 +626,20 @@ export default function ExplorePage() {
           })}
         </div>
       )}
+      </div> {/* /explore-main */}
+      </div> {/* /explore-body */}
+
+      <MentorCompareModal
+        open={compareOpen}
+        mentors={compareMentors}
+        onClose={() => setCompareOpen(false)}
+        onRemove={(id) => setCompareIds(prev => {
+          const next = new Set(prev)
+          next.delete(id)
+          if (next.size === 0) setCompareOpen(false)
+          return next
+        })}
+      />
     </MainLayout>
   )
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -95,9 +95,27 @@ export async function resetPassword({ token, newPassword }) {
   return handleResponse(res)
 }
 
-export async function getMatchingMentors(keyword) {
-  const url = keyword
-    ? `${BASE_URL}/matching/mentors/all?keyword=${encodeURIComponent(keyword)}`
+// #139 / backend #571: matching/mentors/all accepts a bunch of optional
+// filters. Keyword stays positional for backward compatibility with the
+// existing call sites that pass just a string. Extra filters go into the
+// second options object so adding more never grows the signature again.
+export async function getMatchingMentors(keyword, options = {}) {
+  const params = new URLSearchParams()
+  if (keyword) params.set('keyword', keyword)
+  const { maxDistanceKm, availabilityDays, mentorshipDuration, minMatchScore } = options
+  if (maxDistanceKm != null) params.set('maxDistanceKm', String(maxDistanceKm))
+  // Sets are serialised as repeated keys (?availabilityDays=MONDAY&availabilityDays=TUESDAY)
+  // which Spring binds into a Set<DayOfWeek> via its standard collection binder.
+  if (Array.isArray(availabilityDays)) {
+    for (const d of availabilityDays) if (d) params.append('availabilityDays', d)
+  }
+  if (Array.isArray(mentorshipDuration)) {
+    for (const n of mentorshipDuration) if (n != null) params.append('mentorshipDuration', String(n))
+  }
+  if (minMatchScore != null) params.set('minMatchScore', String(minMatchScore))
+  const qs = params.toString()
+  const url = qs
+    ? `${BASE_URL}/matching/mentors/all?${qs}`
     : `${BASE_URL}/matching/mentors/all`
   const res = await fetch(url, { headers: authHeaders() })
   return handleResponse(res)

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3389,6 +3389,182 @@
   opacity: 0.75;
 }
 
+/* Mentor filter sidebar + compare mode (#139). */
+.explore-body {
+  display: block;
+}
+.explore-body--with-sidebar {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+.explore-main {
+  min-width: 0;
+}
+
+.mentor-filter-sidebar {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  position: sticky;
+  top: 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  font-family: 'DM Sans', sans-serif;
+}
+.mentor-filter-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.mentor-filter-reset {
+  background: transparent;
+  border: none;
+  color: var(--green-dark);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+.mentor-filter-reset:hover { text-decoration: underline; }
+.mentor-filter-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.mentor-filter-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.mentor-filter-score-value {
+  font-weight: 700;
+  color: var(--green-dark);
+}
+.mentor-filter-days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+}
+.mentor-filter-day {
+  font-size: 11px;
+  padding: 6px 2px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: #fff;
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  color: var(--text);
+}
+.mentor-filter-day:hover { border-color: var(--green-mid); }
+.mentor-filter-day--active {
+  background: var(--green-pale);
+  border-color: var(--green-dark);
+  color: var(--green-dark);
+  font-weight: 600;
+}
+.mentor-filter-durations {
+  display: flex;
+  gap: 6px;
+}
+.mentor-filter-duration {
+  flex: 1;
+  font-size: 12px;
+  padding: 8px 6px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: #fff;
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  color: var(--text);
+}
+.mentor-filter-duration:hover { border-color: var(--green-mid); }
+.mentor-filter-duration--active {
+  background: var(--green-pale);
+  border-color: var(--green-dark);
+  color: var(--green-dark);
+  font-weight: 600;
+}
+.mentor-filter-slider {
+  width: 100%;
+}
+
+.mentor-compare-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+  margin-right: auto;
+}
+.mentor-compare-toggle input { margin: 0; }
+
+.mentor-compare-card {
+  max-width: 900px;
+}
+.mentor-compare-grid {
+  display: grid;
+  gap: 6px 12px;
+  margin-top: 12px;
+  align-items: start;
+}
+.mentor-compare-col-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 8px 10px;
+  background: var(--green-pale);
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--green-dark);
+}
+.mentor-compare-remove {
+  background: transparent;
+  border: none;
+  color: var(--green-dark);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+.mentor-compare-row-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  padding: 8px 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.mentor-compare-cell {
+  padding: 8px 4px;
+  font-size: 13px;
+  color: var(--text);
+  border-top: 1px solid var(--border);
+}
+.mentor-compare-empty { color: var(--text-muted); }
+.mentor-compare-factors {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.mentor-compare-factor {
+  background: #f1f5ee;
+  border: 1px solid #e2e8d8;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: var(--text);
+}
+
 /* Admin messaging (#410). */
 .admin-subnav {
   display: flex;

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -3399,6 +3399,16 @@
   gap: 20px;
   align-items: start;
 }
+@media (max-width: 880px) {
+  .explore-body--with-sidebar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  /* On narrow viewports collapse the sticky sidebar into the document
+     flow so it doesn't trap the user's scroll. */
+  .mentor-filter-sidebar {
+    position: static;
+  }
+}
 .explore-main {
   min-width: 0;
 }


### PR DESCRIPTION
Closes #139.                                                                                                                                                                          
                                                                                                                                                                                        
  Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Three of the four ACs in #139 are now backed by backend params (#571 / PR #580): availability days, mentorship duration, minimum match score. The fourth (compare mode) is a pure     
  frontend feature. Web shipping this means web is now the most-featured client — mobile's Explore screen has only a keyword search, no advanced filters or compare.                    
                                                                                                                                                                                        
  Changes                                                                                                                                                                             

  - services/api.js — getMatchingMentors(keyword, options) extended to accept { maxDistanceKm, availabilityDays, mentorshipDuration, minMatchScore }. Keyword stays positional for      
  backward compatibility with existing call sites in HomePage + tests. Set values serialise as repeated query keys (Spring's standard Set<T> binder).
  - components/MentorFilterSidebar.jsx (new) — controlled sidebar with three filter blocks: 7-day toggle grid, 1/3/6-month duration toggles, min-score 0-100 slider. Reset button when  
  anything is non-default.                                                                                                                                                              
  - components/MentorCompareModal.jsx (new) — side-by-side table of up to 3 mentors. 8 comparison rows: expertise / affiliation / city / distance / match score / duration / capacity /
  rating, plus a Top Factors chips row. Per-column × removes a mentor from the comparison.                                                                                              
  - pages/ExplorePage.jsx:                                  
    - Added filters + compareIds state.                                                                                                                                                 
    - Wrapped the body in a two-column explore-body--with-sidebar grid (mentees only — mentor view doesn't have the matching API in scope, so the sidebar makes no sense there).
    - Threaded filters into handleAiClick → getMatchingMentors. Empty filters serialise to nothing, so the no-filter case is byte-identical to before.                                  
    - Added a "Compare (N/3)" button next to the search box. Disabled when nothing selected.                                                                                            
    - Added a Compare checkbox to each mentor card on the regular grid. Mentee-only.                                                                                                    
    - Mounted <MentorCompareModal /> at page root.                                                                                                                                      
  - styles/main.css — sidebar styles, compare-modal grid styles, compare checkbox styling, two-column layout.                                                                           
                                                                                                                                                                                        
  Mobile-vs-web parity                                                                                                                                                                  
                                                                                                                                                                                        
  Mobile Explore is just a keyword search box with client-side filtering on name/role/tags. Web after this PR has: keyword + topic chips + availability multi-select + duration         
  multi-select + min-score slider + side-by-side compare. Web is intentionally ahead of mobile here.
                                                                                                                                                                                        
  What's NOT changed (compatibility-conscious)              

  - MatchCard component untouched. muhammetsami's open #286 PR rewrites this for explanation cards + diverse-pick + proximity slider. When that PR rebases on top of mine, the only     
  collision will be in getMatchingMentors's signature — and even there my options-object form should accommodate his maxDistanceKm without further work (it's already in my options
  shape).                                                                                                                                                                               
  - Topic chips (FILTERS array ['All', 'Backend', ...]) untouched — they remain a separate orthogonal filter layer.
  - Keyword search untouched — still client-side filters mentors by name/expertise/interests, doesn't go through the matching API.                                                      
  - AI Match flow untouched except for passing filters to the API.                                                                                                                      
                                   