### PR TITLE
feat(seed+docs): data seeding + default credentials (#423)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,15 @@ PASSWORD_RESET_MAX_REQUESTS_PER_HOUR=5
 # ---- Frontend ----
 FRONTEND_PORT=8000
 
+# ---- Follow-graph Neo4j mirror (#437) ----
+# When true, FollowGraphSyncListener mirrors every Postgres follow/unfollow
+# into Neo4j after the SQL commit so the Personalized PageRank ranker has
+# data. The neo4j service in docker-compose.yml is brought up alongside the
+# backend, so leaving this on is safe in the default docker-compose flow.
+# Switch to false to disable the mirror (the legacy follow ranker continues
+# to work without Neo4j).
+FOLLOW_GRAPH_SYNC_ENABLED=true
+
 # ---- Admin bootstrap ----
 # Creates a default ADMIN account on first backend startup against an empty
 # users table. After the admin exists the seeder no-ops on every subsequent

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,17 @@ PASSWORD_RESET_MAX_REQUESTS_PER_HOUR=5
 # ---- Frontend ----
 FRONTEND_PORT=8000
 
+# ---- Admin bootstrap ----
+# Creates a default ADMIN account on first backend startup against an empty
+# users table. After the admin exists the seeder no-ops on every subsequent
+# boot (it matches on email). For a production install, change the password
+# immediately after first login and flip ENABLED back to false.
+APP_ADMIN_BOOTSTRAP_ENABLED=true
+APP_ADMIN_BOOTSTRAP_EMAIL=admin@group7.com
+APP_ADMIN_BOOTSTRAP_PASSWORD=Admin1234!
+APP_ADMIN_BOOTSTRAP_FIRST_NAME=System
+APP_ADMIN_BOOTSTRAP_LAST_NAME=Admin
+
 # ---- OpenAI / Spring AI (advanced mentor recommendation, #436) ----
 # API key used by Spring AI for both embeddings (text-embedding-3-small) and
 # chat completions (gpt-4o-mini) in the advanced mentor ranker + LLM prose

--- a/README.md
+++ b/README.md
@@ -90,9 +90,12 @@ python3 seed_personas.py
 
 The script is idempotent (re-runnable on an existing database) and creates:
 
-- **50 personas** — a mix of mentors and mentees with varied locations, interests, and capacity. All seeded accounts share the password `Seed1234!`. Emails follow the pattern `<slugified-first>.<slugified-last>.<id>@seed.test` (e.g. `Dr. Ahmet Bulut` with persona id `2` becomes `dr.ahmet.bulut.2@seed.test`).
-- **Mentorship edges** — a handful of accepted, pending, and rejected mentorship requests so the matching, request, and dashboard surfaces all have something to show.
-- **Demo ecosystem** — mentorship messages, tasks with due dates, meetings (including a pending reschedule request), and feed posts with hashtags so the social feed, calendar, and notification surfaces aren't empty on launch.
+- **~137 personas** — 50 hand-curated named personas (including six explicitly cross-domain ones in Music Production, Sports Performance, Public Speaking, and Management) plus ~80 bulk-generated personas across tech, design, finance, research, and career-coaching tracks, plus the admin fixture. All seeded accounts share the password `Seed1234!`. Emails follow the pattern `<slugified-first>.<slugified-last>.<id>@seed.test` (e.g. `Dr. Ahmet Bulut` with persona id `2` becomes `dr.ahmet.bulut.2@seed.test`).
+- **Mentorship edges** — accepted requests for the showcase mentee Elif Yilmaz (id=1) with both an *active* mentor (Dr. Ahmet Bulut, id=2) and a gracefully *completed* past mentor (Fikret Ersoy, id=19) so the mentee dashboard renders both current and historical mentorships. Plus eight more accepted mentorships across the rest of the persona pool.
+- **Engagement graph around Elif** — Elif follows her active + past mentors, additional Data Science mentors, peers in her own field, and the new Music / Sports / Public Speaking / Management mentors and peers. Several personas follow her back. She likes and comments on cross-domain feed posts; other personas like and comment on hers. The Following feed, For-You feed, post-detail comment threads, and inbox surfaces are all populated for her account.
+- **Demo ecosystem** — mentorship messages, tasks with due dates, meetings (including a pending reschedule request), and feed posts with hashtags across Data Science, Music, Sports, Public Speaking, Management, and the existing tech/career tracks.
+
+On startup the script also verifies that the bootstrapped admin can log in and prints a clear warning if not.
 
 The seeder also writes `scripts/personas.json` — a flat fixture used by the mobile/web QA acceptance flows.
 
@@ -123,9 +126,13 @@ The bootstrap admin is created on first backend startup against an empty `users`
 | Role | Email | Password | Notes |
 |------|-------|----------|-------|
 | Admin | `admin@group7.com` | `Admin1234!` | Created on first backend startup from `.env.example`. Set `APP_ADMIN_BOOTSTRAP_ENABLED=false` after first login on a production install and change the password immediately. |
-| Mentor (Data Science) | `dr.ahmet.bulut.2@seed.test` | `Seed1234!` | Verified mentor; one of his active mentees is Elif (below). |
-| Mentee (Data Science) | `elif.yilmaz.1@seed.test` | `Seed1234!` | Verified mentee actively paired with Dr. Ahmet Bulut. |
-| Mentee (banned fixture) | `eren.kilic.5@seed.test` | `Seed1234!` | Marked banned in `personas.json`; the ban flag itself is set via the admin ban endpoint (the seeder does not apply it automatically). |
+| Mentee (showcase) | `elif.yilmaz.1@seed.test` | `Seed1234!` | The richest seeded account. Active mentor (Dr. Ahmet) and a completed past mentor (Fikret). Diverse interests: Data Science, Machine Learning, Music, Sociology, Photography. Follows mentors and peers across all those tracks; has authored posts, has likes and comments on her posts, and has liked / commented on others' posts. |
+| Mentor (Data Science, active) | `dr.ahmet.bulut.2@seed.test` | `Seed1234!` | Email-verified mentor. Elif's *active* mentor; also has open feed posts and a pending reschedule request from another mentee. |
+| Mentor (Music, cross-domain) | `defne.aksu.132@seed.test` | `Seed1234!` | Email-verified mentor in Music Production / Songwriting — populates a non-tech feed track that Elif follows. |
+| Mentor (Management) | `tolga.erdem.135@seed.test` | `Seed1234!` | Email-verified mentor in Engineering Management / 1:1 Coaching. |
+| Mentee (banned fixture) | `eren.kilic.5@seed.test` | `Seed1234!` | Marked banned in `personas.json`; the ban itself is set via the admin ban endpoint (the seeder does not apply it automatically). |
 | Mentee (unverified) | `ayse.kaya.6@seed.test` | n/a | Fixture for the unverified / verification-prompt surface. The account exists but cannot log in until verification is completed. |
 
-The full 50-persona list is in `scripts/personas.json` after the seeder runs.
+> "Email-verified" simply means the account completed the email-verification flow (the User entity's `isEmailVerified` flag is `true`). There is no separate admin-approval or trust-badge field in the backend.
+
+The full ~137-persona list (50 hand-curated, 80 bulk-generated, 1 admin, 6 cross-domain) is in `scripts/personas.json` after the seeder runs.

--- a/README.md
+++ b/README.md
@@ -76,3 +76,56 @@ npm run dev
 ```
 
 Frontend will be available at http://localhost:5173 and proxies `/api` requests to the backend at port 8080.
+
+---
+
+## Seeding mock data
+
+A fresh database has no users beyond the bootstrapped admin (see [Default credentials](#default-credentials)). To populate the system with realistic personas, mentorships, tasks, meetings, and feed posts, run the persona seeder against the running backend:
+
+```bash
+cd scripts
+python3 seed_personas.py
+```
+
+The script is idempotent (re-runnable on an existing database) and creates:
+
+- **50 personas** — a mix of mentors and mentees with varied locations, interests, and capacity. All seeded accounts share the password `Seed1234!`. Emails follow the pattern `<slugified-first>.<slugified-last>.<id>@seed.test` (e.g. `Dr. Ahmet Bulut` with persona id `2` becomes `dr.ahmet.bulut.2@seed.test`).
+- **Mentorship edges** — a handful of accepted, pending, and rejected mentorship requests so the matching, request, and dashboard surfaces all have something to show.
+- **Demo ecosystem** — mentorship messages, tasks with due dates, meetings (including a pending reschedule request), and feed posts with hashtags so the social feed, calendar, and notification surfaces aren't empty on launch.
+
+The seeder also writes `scripts/personas.json` — a flat fixture used by the mobile/web QA acceptance flows.
+
+### Prerequisites for seeding
+
+1. Backend reachable at `http://localhost:8080` (either via `docker compose up` or `mvn spring-boot:run`).
+2. MailHog reachable at `http://localhost:8025` (the seeder uses MailHog's REST API to fetch verification tokens automatically — included in `docker compose`).
+3. Python 3.10+ (stdlib only — no `pip install` step required).
+
+If verification tokens are missing (e.g., emails went to a real SMTP server in production), the script falls back to logging the failure for that persona and continues with the rest.
+
+### Resetting before re-seeding
+
+To start from a clean database:
+
+```bash
+docker compose down -v        # drops the postgres volume
+docker compose up -d          # backend boots, bootstraps the admin
+cd scripts && python3 seed_personas.py
+```
+
+---
+
+## Default credentials
+
+The bootstrap admin is created on first backend startup against an empty `users` table — controlled by the `APP_ADMIN_BOOTSTRAP_*` variables in `.env.example`. Every persona created by `seed_personas.py` shares the same seed password.
+
+| Role | Email | Password | Notes |
+|------|-------|----------|-------|
+| Admin | `admin@group7.com` | `Admin1234!` | Created on first backend startup from `.env.example`. Set `APP_ADMIN_BOOTSTRAP_ENABLED=false` after first login on a production install and change the password immediately. |
+| Mentor (Data Science) | `dr.ahmet.bulut.2@seed.test` | `Seed1234!` | Verified mentor; one of his active mentees is Elif (below). |
+| Mentee (Data Science) | `elif.yilmaz.1@seed.test` | `Seed1234!` | Verified mentee actively paired with Dr. Ahmet Bulut. |
+| Mentee (banned fixture) | `eren.kilic.5@seed.test` | `Seed1234!` | Marked banned in `personas.json`; the ban flag itself is set via the admin ban endpoint (the seeder does not apply it automatically). |
+| Mentee (unverified) | `ayse.kaya.6@seed.test` | n/a | Fixture for the unverified / verification-prompt surface. The account exists but cannot log in until verification is completed. |
+
+The full 50-persona list is in `scripts/personas.json` after the seeder runs.

--- a/README.md
+++ b/README.md
@@ -93,9 +93,16 @@ The script is idempotent (re-runnable on an existing database) and creates:
 - **~137 personas** — 50 hand-curated named personas (including six explicitly cross-domain ones in Music Production, Sports Performance, Public Speaking, and Management) plus ~80 bulk-generated personas across tech, design, finance, research, and career-coaching tracks, plus the admin fixture. All seeded accounts share the password `Seed1234!`. Emails follow the pattern `<slugified-first>.<slugified-last>.<id>@seed.test` (e.g. `Dr. Ahmet Bulut` with persona id `2` becomes `dr.ahmet.bulut.2@seed.test`).
 - **Mentorship edges** — accepted requests for the showcase mentee Elif Yilmaz (id=1) with both an *active* mentor (Dr. Ahmet Bulut, id=2) and a gracefully *completed* past mentor (Fikret Ersoy, id=19) so the mentee dashboard renders both current and historical mentorships. Plus eight more accepted mentorships across the rest of the persona pool.
 - **Engagement graph around Elif** — Elif follows her active + past mentors, additional Data Science mentors, peers in her own field, and the new Music / Sports / Public Speaking / Management mentors and peers. Several personas follow her back. She likes and comments on cross-domain feed posts; other personas like and comment on hers. The Following feed, For-You feed, post-detail comment threads, and inbox surfaces are all populated for her account.
+- **Conversation history** — a 4-message thread in Elif's *active* mentorship with Dr. Ahmet, a 5-message thread in Elif's *past* mentorship with Fikret (so the closed mentorship's chat history is browseable), three admin DMs (admin → Elif, admin → the banned-fixture mentee, admin → another mentee), and two admin-broadcast messages so every admin's broadcast inbox is non-empty on first log-in.
 - **Demo ecosystem** — mentorship messages, tasks with due dates, meetings (including a pending reschedule request), and feed posts with hashtags across Data Science, Music, Sports, Public Speaking, Management, and the existing tech/career tracks.
 
-On startup the script also verifies that the bootstrapped admin can log in and prints a clear warning if not.
+On startup the script also verifies that the bootstrapped admin can log in and prints a clear warning if not. The admin session token is then used to seed the admin DMs and broadcast messages above.
+
+### Neo4j follow-graph mirror
+
+The follow-graph mirror is wired by default. `FOLLOW_GRAPH_SYNC_ENABLED=true` in `.env.example` flips on `FollowGraphSyncListener`, which writes every Postgres follow/unfollow into the `neo4j` service after the SQL commit so the Personalized PageRank ranker has data to walk. The `neo4j` service is part of `docker-compose.yml` and the backend `depends_on` it, so the default `docker compose up` flow brings Neo4j up before the backend starts — the seeded follow edges propagate automatically.
+
+If `FOLLOW_GRAPH_SYNC_ENABLED=false` (or Neo4j is unreachable), the legacy follow ranker continues to work; failed sync events are queued and replayed by the nightly `FollowGraphResyncJob`.
 
 The seeder also writes `scripts/personas.json` — a flat fixture used by the mobile/web QA acceptance flows.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,12 @@ services:
       # off until the impression-tracking follow-up PR lands.
       FEED_ADVANCED_RANKER: ${FEED_ADVANCED_RANKER:-false}
       FEED_BANDIT_ENABLED: ${FEED_BANDIT_ENABLED:-false}
+      # Follow-graph Neo4j mirror (#437). When true, FollowGraphSyncListener
+      # writes every follow/unfollow into Neo4j after the SQL commit so the
+      # Personalized PageRank ranker has data to walk. The neo4j service in
+      # this compose file is required when this is true; .env.example
+      # defaults this to true so a fresh-clone seed populates Neo4j.
+      FOLLOW_GRAPH_SYNC_ENABLED: ${FOLLOW_GRAPH_SYNC_ENABLED:-false}
       # E2E / Playwright fixtures rely on /api/test/* seed-and-reset
       # endpoints and on the spam-bot defences being off so registrations
       # don't need a real form-token round-trip. Default off in production;

--- a/scripts/seed_personas.py
+++ b/scripts/seed_personas.py
@@ -1338,6 +1338,22 @@ def login_admin(email: str, password: str):
     return http_post(f"{BASE}/auth/login", {"email": email, "password": password})
 
 
+def send_admin_dm(target_user_id: int, token: str, content: str):
+    return http_post(
+        f"{BASE}/admin/messages/direct/{target_user_id}",
+        {"content": content},
+        token,
+    )
+
+
+def send_admin_broadcast(token: str, content: str):
+    return http_post(
+        f"{BASE}/admin/messages/broadcast",
+        {"content": content},
+        token,
+    )
+
+
 def process_persona(persona: dict, index: int) -> Optional[dict]:
     email = build_email(persona)
     print(f"[{index + 1:2}/{len(PERSONAS)}] {persona['first_name']} {persona['last_name']} ({email})", end=" ... ", flush=True)
@@ -1422,7 +1438,7 @@ def seed_mentorship_edges(persona_tokens: dict):
     return created_mentorships
 
 
-def seed_demo_ecosystem(persona_tokens: dict, mentorships: dict):
+def seed_demo_ecosystem(persona_tokens: dict, mentorships: dict, admin_token: Optional[str] = None):
     elif_ahmet = mentorships.get((1, 2))
     mert_ahmet = mentorships.get((7, 2))
 
@@ -1501,11 +1517,29 @@ def seed_demo_ecosystem(persona_tokens: dict, mentorships: dict):
     else:
         print("[DEMO][meeting] skipped because no Dr. Ahmet mentorship exists for another mentee")
 
-    # ── Past mentor for Elif: end the (1, 19) Fikret mentorship gracefully ──
-    # so the mentee dashboard surfaces a "previous mentorships" timeline with
-    # a real COMPLETED row, not just the active Ahmet one.
+    # ── Past mentor for Elif: seed a short chat history with Fikret, then
+    # end the (1, 19) mentorship gracefully so the mentee dashboard surfaces
+    # a "previous mentorships" timeline with both messages and a COMPLETED
+    # status row, not just the active Ahmet one.
     elif_fikret = mentorships.get((1, 19))
     if elif_fikret:
+        past_thread = [
+            (1, "Thanks for taking me on. I want to apply for graduate study within 2 years and would love a realistic roadmap."),
+            (19, "Good. Let's narrow your research interest first — pick one paper this week and write a 1-page summary, including the dataset and the limitation you spot."),
+            (1, "Sent the summary draft. The limitation I keep coming back to is the lack of held-out evaluation."),
+            (19, "Solid catch. That's the kind of observation reviewers reward. Next: read the paper that cites this one most often and compare assumptions."),
+            (1, "Wrapping up the comparison this weekend; my next step is the technical depth side with Dr. Ahmet. Thanks for the early planning push."),
+        ]
+        for sender_id, content in past_thread:
+            sender = persona_tokens.get(sender_id)
+            if not sender:
+                continue
+            status, resp = send_mentorship_message(elif_fikret["mentorship_id"], sender["token"], content)
+            if status not in (200, 201):
+                print(f"[DEMO][messages] past-mentor message failed ({status}): {resp}")
+            else:
+                print(f"[DEMO][messages] seeded past-mentor message {resp.get('id')}")
+
         end_status, end_resp = end_mentorship_gracefully(
             elif_fikret["mentorship_id"],
             persona_tokens[19]["token"],
@@ -1691,26 +1725,63 @@ def seed_demo_ecosystem(persona_tokens: dict, mentorships: dict):
             if comment_body:
                 comment_on_post(post_id, elif_token["token"], comment_body)
 
+    # ── Admin messaging surfaces (#280, #410, #561). One DM to the showcase
+    # mentee Elif, one DM to the banned-fixture mentee Eren (so the
+    # admin → user DM-after-ban surface has real content), and one broadcast
+    # so every admin's broadcast inbox isn't empty on first log-in.
+    if admin_token:
+        admin_messages = [
+            (1,  "Welcome to the platform — let us know via the report flow if anything looks off in your mentor matches."),
+            (5,  "Your account is currently restricted following a community-guidelines review. Reach out here with any questions."),
+            (7,  "Quick check: please confirm your portfolio review link in your profile is still the latest. Thanks!"),
+        ]
+        for target_persona_id, content in admin_messages:
+            target = persona_tokens.get(target_persona_id)
+            if not target:
+                continue
+            status, resp = send_admin_dm(target["user_id"], admin_token, content)
+            if status in (200, 201):
+                print(f"[DEMO][admin-dm] admin → persona {target_persona_id} (msg {resp.get('id')})")
+            else:
+                print(f"[DEMO][admin-dm] admin → persona {target_persona_id} failed ({status}): {resp}")
 
-def verify_admin_exists() -> None:
-    """Verify the AdminBootstrapper created the default admin. If the
-    expected credentials don't log in, print a clear warning with remediation
-    instructions but don't abort — the rest of the seed can still run."""
+        admin_broadcasts = [
+            "Reminder: this week's moderation queue closes at EOD Friday. Please review pending reports before then.",
+            "Heads-up: the new admin-direct read endpoints are live — recipients can now see and reply to your DMs through the standard inbox.",
+        ]
+        for content in admin_broadcasts:
+            status, resp = send_admin_broadcast(admin_token, content)
+            if status in (200, 201):
+                print(f"[DEMO][admin-broadcast] seeded broadcast msg {resp.get('id')}")
+            else:
+                print(f"[DEMO][admin-broadcast] failed ({status}): {resp}")
+    else:
+        print("[DEMO][admin-dm] skipped — no admin token (verify .env.example admin bootstrap)")
+
+
+def verify_admin_exists() -> Optional[str]:
+    """Verify the AdminBootstrapper created the default admin and return a
+    session token for it. If the expected credentials don't log in, print a
+    clear warning with remediation instructions and return None — the rest
+    of the seed can still run, only admin-specific surfaces (DMs, broadcast)
+    are skipped."""
     status, resp = login_admin("admin@group7.com", "Admin1234!")
     if status == 200 and "sessionToken" in resp:
         print("[ADMIN] verified: admin@group7.com is logged-in-able")
-    else:
-        print(f"[ADMIN][WARN] could not log in as admin@group7.com (status={status}). "
-              "Confirm the backend started with APP_ADMIN_BOOTSTRAP_ENABLED=true "
-              "and a matching APP_ADMIN_BOOTSTRAP_PASSWORD (see .env.example). The "
-              "rest of the seed will continue; persona accounts are unaffected.")
+        return resp["sessionToken"]
+    print(f"[ADMIN][WARN] could not log in as admin@group7.com (status={status}). "
+          "Confirm the backend started with APP_ADMIN_BOOTSTRAP_ENABLED=true "
+          "and a matching APP_ADMIN_BOOTSTRAP_PASSWORD (see .env.example). The "
+          "rest of the seed will continue; persona accounts are unaffected; "
+          "admin DMs and the broadcast thread will not be seeded.")
+    return None
 
 
 def main() -> None:
     export_personas()
     print(f"Exported {len(PERSONAS)} personas to {OUTPUT_PATH}")
 
-    verify_admin_exists()
+    admin_token = verify_admin_exists()
 
     persona_tokens = {}
     for index, persona in enumerate(PERSONAS):
@@ -1721,7 +1792,7 @@ def main() -> None:
         persona_tokens[persona["id"]] = auth
 
     mentorships = seed_mentorship_edges(persona_tokens)
-    seed_demo_ecosystem(persona_tokens, mentorships or {})
+    seed_demo_ecosystem(persona_tokens, mentorships or {}, admin_token=admin_token)
 
 
 if __name__ == "__main__":

--- a/scripts/seed_personas.py
+++ b/scripts/seed_personas.py
@@ -27,11 +27,13 @@ PERSONAS = [   {   'id': 1,
         'location': 'Istanbul',
         'capacity_current': 0,
         'capacity_max': 0,
-        'interests': ['Data Science', 'Machine Learning'],
+        'interests': ['Data Science', 'Machine Learning', 'Music', 'Sociology', 'Photography'],
         'is_banned': False,
-        'background': 'Academic or professional background in Data Science.',
-        'goals': 'Transitioning into data science and looking for roadmap advice, project ideas, and a realistic study '
-                 'plan.'},
+        'background': 'Computer science undergrad with a part-time interest in qualitative '
+                      'research methods; plays classical guitar and shoots film photography on the side.',
+        'goals': 'Transitioning into data science with a long-term interest in computational '
+                 'social science. Looking for roadmap advice, project ideas, and a realistic '
+                 'study plan that leaves room for non-technical hobbies.'},
     {   'id': 2,
         'first_name': 'Dr. Ahmet',
         'last_name': 'Bulut',
@@ -954,11 +956,111 @@ PERSONAS.append(
     }
 )
 
+# Non-tech / cross-domain personas — explicit named mentors and mentees in
+# fields the bulk-generator pool doesn't surface clearly (Music, Sports,
+# Public Speaking, Management). They give the showcase user (Elif) a
+# realistic graph of varied interests to follow and engage with.
+PERSONAS.extend([
+    {
+        "id": 132,
+        "first_name": "Defne",
+        "last_name": "Aksu",
+        "role": "MENTOR",
+        "status": "VERIFIED",
+        "location": "Beyoglu, Istanbul",
+        "capacity_current": 1,
+        "capacity_max": 3,
+        "interests": ["Music Production", "Songwriting", "Audio Engineering"],
+        "bio": "Helps emerging musicians develop a release-ready workflow, from arrangement and "
+               "production to mixing and distribution. Background in classical training plus a decade in indie studios.",
+        "is_banned": False,
+        "mentoring_goals": "Aims to support mentees in turning unfinished demos into shipped tracks.",
+    },
+    {
+        "id": 133,
+        "first_name": "Cem",
+        "last_name": "Demir",
+        "role": "MENTOR",
+        "status": "VERIFIED",
+        "location": "Ankara",
+        "capacity_current": 0,
+        "capacity_max": 4,
+        "interests": ["Sports Performance", "Strength & Conditioning", "Sports Psychology"],
+        "bio": "Strength coach for amateur and student athletes. Builds programs that balance "
+               "academic schedules, training load, and recovery so people don't burn out mid-season.",
+        "is_banned": False,
+        "mentoring_goals": "Aims to help mentees build sustainable athletic habits alongside study and work.",
+    },
+    {
+        "id": 134,
+        "first_name": "Yasemin",
+        "last_name": "Kara",
+        "role": "MENTOR",
+        "status": "VERIFIED",
+        "location": "Kadikoy, Istanbul",
+        "capacity_current": 2,
+        "capacity_max": 4,
+        "interests": ["Public Speaking", "Storytelling", "Executive Presence"],
+        "bio": "Speaker coach for engineers and researchers preparing conference talks, interview "
+               "panels, and academic defenses. Focus on narrative structure over slide polish.",
+        "is_banned": False,
+        "mentoring_goals": "Aims to help mentees deliver a clear, confident technical story in 10 minutes or less.",
+    },
+    {
+        "id": 135,
+        "first_name": "Tolga",
+        "last_name": "Erdem",
+        "role": "MENTOR",
+        "status": "VERIFIED",
+        "location": "Sisli, Istanbul",
+        "capacity_current": 1,
+        "capacity_max": 3,
+        "interests": ["Management", "Team Leadership", "1:1 Coaching"],
+        "bio": "Engineering manager turned coach. Helps individual contributors transitioning "
+               "into their first management role build a steady cadence of 1:1s, feedback, and review.",
+        "is_banned": False,
+        "mentoring_goals": "Aims to help mentees grow into managers without losing their craft.",
+    },
+    {
+        "id": 136,
+        "first_name": "Mira",
+        "last_name": "Yalcin",
+        "role": "MENTEE",
+        "status": "VERIFIED",
+        "location": "Beyoglu, Istanbul",
+        "capacity_current": 0,
+        "capacity_max": 0,
+        "interests": ["Music Production", "Songwriting", "Photography"],
+        "is_banned": False,
+        "background": "Self-taught producer balancing a day job and weekend recording sessions.",
+        "goals": "Wants help finishing the first EP and developing a consistent release rhythm.",
+    },
+    {
+        "id": 137,
+        "first_name": "Burak",
+        "last_name": "Ozdemir",
+        "role": "MENTEE",
+        "status": "VERIFIED",
+        "location": "Bursa",
+        "capacity_current": 0,
+        "capacity_max": 0,
+        "interests": ["Sports Performance", "Public Speaking", "Time Management"],
+        "is_banned": False,
+        "background": "University student-athlete training competitively while studying engineering.",
+        "goals": "Wants a training program that respects exam crunch periods and improves "
+                 "post-game interview confidence.",
+    },
+])
+
 PERSONAS = [normalize_persona(persona) for persona in PERSONAS]
 
 
 MENTORSHIP_EDGE_CASES = [
     {"mentee_id": 1, "mentor_id": 2, "duration": 3, "message": "I would like guidance on data science foundations and a practical roadmap."},
+    # Elif's past mentor — completed gracefully in seed_demo_ecosystem so the
+    # mentee dashboard surfaces a populated "previous mentorships" timeline,
+    # not just a single active row.
+    {"mentee_id": 1, "mentor_id": 19, "duration": 3, "message": "I am preparing to apply for graduate study with a research focus; would like roadmap help."},
     {"mentee_id": 7, "mentor_id": 2, "duration": 3, "message": "I need help planning my data science portfolio and first project."},
     {"mentee_id": 8, "mentor_id": 3, "duration": 3, "message": "I want mentorship on finance and startup strategy."},
     {"mentee_id": 11, "mentor_id": 3, "duration": 3, "message": "I am exploring startup thinking and product-first finance basics."},
@@ -1210,6 +1312,32 @@ def create_feed_post(token: str, content: str, hashtags):
     )
 
 
+def like_post(post_id: int, token: str):
+    return http_post(f"{BASE}/feed/posts/{post_id}/like", {}, token)
+
+
+def comment_on_post(post_id: int, token: str, body: str):
+    return http_post(f"{BASE}/feed/posts/{post_id}/comments", {"body": body}, token)
+
+
+def follow_user(user_id: int, token: str):
+    return http_post(f"{BASE}/users/{user_id}/follow", {}, token)
+
+
+def end_mentorship_gracefully(mentorship_id: int, token: str, reason: str = ""):
+    return http_patch(
+        f"{BASE}/mentorships/{mentorship_id}/end",
+        {"reason": reason},
+        token,
+    )
+
+
+def login_admin(email: str, password: str):
+    """Lightweight admin liveness check — used by main() to confirm the
+    AdminBootstrapper actually ran. Returns (status, body)."""
+    return http_post(f"{BASE}/auth/login", {"email": email, "password": password})
+
+
 def process_persona(persona: dict, index: int) -> Optional[dict]:
     email = build_email(persona)
     print(f"[{index + 1:2}/{len(PERSONAS)}] {persona['first_name']} {persona['last_name']} ({email})", end=" ... ", flush=True)
@@ -1373,39 +1501,216 @@ def seed_demo_ecosystem(persona_tokens: dict, mentorships: dict):
     else:
         print("[DEMO][meeting] skipped because no Dr. Ahmet mentorship exists for another mentee")
 
-    elif_post_status, elif_post_resp = create_feed_post(
-        persona_tokens[1]["token"],
-        "Working on a new data cleaning routine and comparing feature choices with my mentor today. #DataScience #MachineLearning",
-        ["DataScience", "MachineLearning"],
-    )
-    if elif_post_status not in (200, 201):
-        print(f"[DEMO][feed] post creation skipped/failed ({elif_post_status}): {elif_post_resp}")
-    else:
-        print(f"[DEMO][feed] seeded post {elif_post_resp.get('id')} for Elif")
-
-    mentor_posts = [
-        (
-            persona_tokens[2]["token"],
-            "A good mentorship plan starts with one small experiment and a clear review loop. #DataScience #MachineLearning",
-            ["DataScience", "MachineLearning"],
-        ),
-        (
-            persona_tokens[2]["token"],
-            "Strong growth comes from consistent practice, feedback, and a focused portfolio story. #CareerGrowth #Mentorship",
-            ["CareerGrowth", "Mentorship"],
-        ),
-    ]
-    for token, content, hashtags in mentor_posts:
-        status, resp = create_feed_post(token, content, hashtags)
-        if status not in (200, 201):
-            print(f"[DEMO][feed] mentor post skipped/failed ({status}): {resp}")
+    # ── Past mentor for Elif: end the (1, 19) Fikret mentorship gracefully ──
+    # so the mentee dashboard surfaces a "previous mentorships" timeline with
+    # a real COMPLETED row, not just the active Ahmet one.
+    elif_fikret = mentorships.get((1, 19))
+    if elif_fikret:
+        end_status, end_resp = end_mentorship_gracefully(
+            elif_fikret["mentorship_id"],
+            persona_tokens[19]["token"],
+            "Roadmap planning wrapped — Elif starting CS coursework. Continue with Dr. Ahmet for data science depth.",
+        )
+        if end_status not in (200, 201):
+            print(f"[DEMO][mentorship] past-mentor close failed ({end_status}): {end_resp}")
         else:
-            print(f"[DEMO][feed] seeded post {resp.get('id')}")
+            print(f"[DEMO][mentorship] closed past mentorship {elif_fikret['mentorship_id']} (Elif ↔ Fikret)")
+    else:
+        print("[DEMO][mentorship] past-mentor edge (1, 19) missing; skipping graceful close")
+
+    # ── Feed posts: track ids so we can wire engagement around them ─────────
+    feed_post_ids = {}
+
+    feed_post_seed = [
+        # (key, author_persona_id, content, hashtags)
+        ("elif_data", 1,
+         "Working on a new data cleaning routine and comparing feature choices "
+         "with my mentor today. #DataScience #MachineLearning",
+         ["DataScience", "MachineLearning"]),
+        ("elif_music", 1,
+         "Took a break to learn a new piece on classical guitar — and noticed "
+         "the same iterative practice mindset transfers to debugging notebooks. "
+         "#Music #LearningInPublic",
+         ["Music", "LearningInPublic"]),
+        ("elif_sociology", 1,
+         "Started reading on computational social science. Quantitative methods "
+         "+ qualitative grounding feel underrated as a combo. #Sociology #DataScience",
+         ["Sociology", "DataScience"]),
+        ("ahmet_plan", 2,
+         "A good mentorship plan starts with one small experiment and a clear "
+         "review loop. #DataScience #MachineLearning",
+         ["DataScience", "MachineLearning"]),
+        ("ahmet_growth", 2,
+         "Strong growth comes from consistent practice, feedback, and a focused "
+         "portfolio story. #CareerGrowth #Mentorship",
+         ["CareerGrowth", "Mentorship"]),
+        ("fikret_research", 19,
+         "Research-track careers reward depth on a narrow question early on; "
+         "breadth comes from collaborators, not your own reading list. #Research #AcademicCareer",
+         ["Research", "AcademicCareer"]),
+        ("mert_portfolio", 7,
+         "Finishing a portfolio rewrite — focusing on three projects with clear "
+         "before/after impact instead of ten weak ones. #Frontend #PortfolioReview",
+         ["Frontend", "PortfolioReview"]),
+    ]
+    for key, author_id, content, hashtags in feed_post_seed:
+        author = persona_tokens.get(author_id)
+        if not author:
+            continue
+        status, resp = create_feed_post(author["token"], content, hashtags)
+        if status not in (200, 201):
+            print(f"[DEMO][feed] post '{key}' skipped/failed ({status}): {resp}")
+            continue
+        post_id = resp.get("id")
+        feed_post_ids[key] = post_id
+        print(f"[DEMO][feed] seeded post {post_id} ({key}) by persona {author_id}")
+
+    # ── Likes: Elif likes the posts that align with her interests, and a
+    # handful of other personas like Elif's posts so her engagement graph is
+    # populated for the dashboard surfaces (recent likers, like counts).
+    engagement_likes = [
+        # (post_key, liker_persona_id)
+        ("ahmet_plan", 1), ("ahmet_plan", 7), ("ahmet_plan", 8),
+        ("ahmet_growth", 1), ("ahmet_growth", 7),
+        ("fikret_research", 1), ("fikret_research", 8),
+        ("mert_portfolio", 1), ("mert_portfolio", 12),
+        ("elif_data", 2), ("elif_data", 7), ("elif_data", 8), ("elif_data", 19),
+        ("elif_music", 2), ("elif_music", 7),
+        ("elif_sociology", 2), ("elif_sociology", 19), ("elif_sociology", 8),
+    ]
+    for post_key, liker_id in engagement_likes:
+        post_id = feed_post_ids.get(post_key)
+        liker = persona_tokens.get(liker_id)
+        if not post_id or not liker:
+            continue
+        status, _ = like_post(post_id, liker["token"])
+        if status in (200, 201):
+            print(f"[DEMO][feed] persona {liker_id} liked post {post_id} ({post_key})")
+
+    # ── Comments: Elif comments on others' posts (showing engagement), and
+    # other personas comment on Elif's posts (so her detail page renders a
+    # real thread).
+    engagement_comments = [
+        # (post_key, commenter_persona_id, body)
+        ("ahmet_plan", 1, "This is exactly what I have been trying to set up with you — small experiments first."),
+        ("ahmet_plan", 7, "Saving this. The review-loop framing fixes 80% of where I get stuck."),
+        ("fikret_research", 1, "Thanks again for the early roadmap — I am applying the depth-over-breadth advice now."),
+        ("mert_portfolio", 1, "Cutting from ten to three was the hardest part for me too — but the signal got so much stronger."),
+        ("elif_data", 2, "Great progress, Elif. Note the assumptions in the README so future-you can rerun cleanly."),
+        ("elif_data", 7, "Curious which features you ended up dropping after the correlation pass."),
+        ("elif_music", 2, "Cross-domain practice transfer is real — keep both habits."),
+        ("elif_sociology", 19, "Welcome to the rabbit hole. Start with Salganik's Bit by Bit if you have not yet."),
+    ]
+    for post_key, commenter_id, body in engagement_comments:
+        post_id = feed_post_ids.get(post_key)
+        commenter = persona_tokens.get(commenter_id)
+        if not post_id or not commenter:
+            continue
+        status, resp = comment_on_post(post_id, commenter["token"], body)
+        if status in (200, 201):
+            print(f"[DEMO][feed] persona {commenter_id} commented on post {post_id} ({post_key}) -> {resp.get('id')}")
+
+    # ── Follow graph centred on Elif: she follows her active and past mentors
+    # plus a few peers across her interest mix (technical, music, sociology,
+    # photography), and a handful of personas follow her back so the network
+    # surfaces (followers/following counts, Following feed) aren't empty for
+    # the showcase mentee.
+    follow_edges = [
+        # (follower_persona_id, target_persona_id)
+        (1, 2),    # Elif → Dr. Ahmet (active mentor)
+        (1, 19),   # Elif → Fikret (past mentor)
+        (1, 50),   # Elif → Ali Bicakci (additional ML mentor)
+        (1, 7),    # Elif → Mert (peer mentee)
+        (1, 8),    # Elif → Selin (peer mentee, ML/Data)
+        (1, 12),   # Elif → Derya (peer mentee, UI/UX — cross-interest)
+        (1, 132),  # Elif → Defne (music mentor — matches Elif's Music interest)
+        (1, 133),  # Elif → Cem (sports mentor — wellness/life-balance interest)
+        (1, 134),  # Elif → Yasemin (public speaking — research-presentation prep)
+        (1, 136),  # Elif → Mira (music mentee — peer cross-interest)
+        (1, 137),  # Elif → Burak (sports mentee — cross-interest)
+        (2, 1),    # Dr. Ahmet → Elif (mentor follows mentee back)
+        (19, 1),   # Fikret → Elif
+        (7, 1),    # Mert → Elif
+        (8, 1),    # Selin → Elif
+        (132, 1),  # Defne → Elif (cross-domain peer engagement)
+        (136, 1),  # Mira → Elif
+        # A few edges that don't involve Elif so the broader graph isn't a star.
+        (136, 132), # Mira → Defne (mentee in music follows music mentor)
+        (137, 133), # Burak → Cem (sports mentee follows sports coach)
+        (137, 134), # Burak → Yasemin (sports mentee follows public-speaking coach)
+        (7, 135),   # Mert → Tolga (frontend mentee follows management mentor)
+    ]
+    for follower_id, target_id in follow_edges:
+        follower = persona_tokens.get(follower_id)
+        target = persona_tokens.get(target_id)
+        if not follower or not target:
+            continue
+        status, _ = follow_user(target["user_id"], follower["token"])
+        if status in (200, 201, 204):
+            print(f"[DEMO][follow] persona {follower_id} → persona {target_id}")
+
+    # ── Cross-domain feed posts from the new mentors + likes from Elif to
+    # surface non-tech content on her dashboard.
+    cross_domain_posts = [
+        (132, "Mixing tip of the week: leave the kick at -6 dB and carve a 3 kHz dip in the bass for clarity. "
+              "Small EQ moves outrank fancy plugins. #MusicProduction #Audio",
+         ["MusicProduction", "Audio"]),
+        (133, "Block your training into 6-week cycles aligned with your school term. Deload during exam week — "
+              "the recovery shows up two weeks later, not the next session. #Sports #Training",
+         ["Sports", "Training"]),
+        (134, "Your slides aren't the story. Open with the question your work answers, close with what to do "
+              "differently on Monday. Everything in between is supporting evidence. #PublicSpeaking",
+         ["PublicSpeaking"]),
+        (135, "First-time managers: protect your 1:1 calendar like prod traffic. Cancelled 1:1s compound silently "
+              "into surprise resignations 4 months later. #Management #Leadership",
+         ["Management", "Leadership"]),
+    ]
+    for author_id, content, hashtags in cross_domain_posts:
+        author = persona_tokens.get(author_id)
+        if not author:
+            continue
+        status, resp = create_feed_post(author["token"], content, hashtags)
+        if status not in (200, 201):
+            print(f"[DEMO][feed] cross-domain post by persona {author_id} skipped ({status}): {resp}")
+            continue
+        post_id = resp.get("id")
+        print(f"[DEMO][feed] seeded cross-domain post {post_id} by persona {author_id}")
+
+        # Elif likes + comments on each cross-domain post so the showcase
+        # account has a populated cross-interest engagement history.
+        elif_token = persona_tokens.get(1)
+        if elif_token:
+            like_post(post_id, elif_token["token"])
+            elif_comments = {
+                132: "This is exactly the kind of practical mixing note I was looking for — saving for the weekend session.",
+                133: "Calibrating my training around exam blocks has been my biggest unsolved problem; trying this.",
+                134: "Reframing slides as supporting evidence makes the prep so much less stressful.",
+                135: "Reading this as a soon-to-be tech lead — the 1:1 cadence point is the one I keep underrating.",
+            }
+            comment_body = elif_comments.get(author_id)
+            if comment_body:
+                comment_on_post(post_id, elif_token["token"], comment_body)
+
+
+def verify_admin_exists() -> None:
+    """Verify the AdminBootstrapper created the default admin. If the
+    expected credentials don't log in, print a clear warning with remediation
+    instructions but don't abort — the rest of the seed can still run."""
+    status, resp = login_admin("admin@group7.com", "Admin1234!")
+    if status == 200 and "sessionToken" in resp:
+        print("[ADMIN] verified: admin@group7.com is logged-in-able")
+    else:
+        print(f"[ADMIN][WARN] could not log in as admin@group7.com (status={status}). "
+              "Confirm the backend started with APP_ADMIN_BOOTSTRAP_ENABLED=true "
+              "and a matching APP_ADMIN_BOOTSTRAP_PASSWORD (see .env.example). The "
+              "rest of the seed will continue; persona accounts are unaffected.")
 
 
 def main() -> None:
     export_personas()
     print(f"Exported {len(PERSONAS)} personas to {OUTPUT_PATH}")
+
+    verify_admin_exists()
 
     persona_tokens = {}
     for index, persona in enumerate(PERSONAS):


### PR DESCRIPTION
Addresses the §6 \"Data Seeding\" and \"Default Credentials\" deliverables from #423 (Final Software Release & Setup).

## What this PR ships

**`.env.example`** — adds the `APP_ADMIN_BOOTSTRAP_*` block so a fresh-clone-and-run flow (`cp .env.example .env && docker compose up`) creates a logged-in-able admin (`admin@group7.com` / `Admin1234!`) on first boot. The bootstrap is already wired in docker-compose; only the env was missing.

**`README.md`** — two new sections:
- *Seeding mock data*: how to run `scripts/seed_personas.py`, what it creates (~137 personas + mentorships + engagement graph), prerequisites, and reset flow.
- *Default credentials*: a table with the admin, the showcase mentee (Elif), her active and past mentors, the new Music + Management mentors, and the banned/unverified fixtures.

**`scripts/seed_personas.py`** — substantial extension so the seeded data is the realistic, populated demo a reviewer expects:

- *Showcase mentee* Elif Yilmaz (id=1) now has a cross-domain interest profile (Data Science, Machine Learning, Music, Sociology, Photography). She gets:
  - An **active mentor** (Dr. Ahmet Bulut, id=2) and a **past mentor** (Fikret Ersoy, id=19) — the new (1, 19) mentorship is created and immediately closed via `PATCH /api/mentorships/{id}/end` so the mentee dashboard renders both current and historical mentorships.
  - A **follow graph** spanning her two mentors, additional ML mentors, peer mentees, and the new cross-domain mentors. Several personas follow her back so followers/following counts and the Following feed aren't empty.
  - **Feed engagement**: she likes and comments on others' posts; several personas like and comment on hers. Cross-domain posts (Music, Sports, Public Speaking, Management) all have her engagement.

- *New cross-domain personas* (ids 132–137) so the platform isn't a tech-only directory:
  - Mentors: 132 Defne Aksu (Music Production), 133 Cem Demir (Sports Performance), 134 Yasemin Kara (Public Speaking), 135 Tolga Erdem (Management).
  - Mentees: 136 Mira Yalcin (Music + Photography), 137 Burak Ozdemir (Sports + Public Speaking).
  - Each new mentor seeds one feed post in their domain.

- *New API helpers*: `like_post`, `comment_on_post`, `follow_user`, `end_mentorship_gracefully`, `login_admin`.

- *Admin verification at startup*: `verify_admin_exists()` runs before persona processing and turns a silent `.env` misconfiguration into a visible WARN.

## Test plan
- [ ] `cp .env.example .env && docker compose up -d` boots cleanly; backend logs show `Admin bootstrap: created admin userId=...`.
- [ ] `cd scripts && python3 seed_personas.py` prints `[ADMIN] verified: admin@group7.com is logged-in-able`.
- [ ] Seed completes; 137 lines of `personas.json` show up; backend logs show mentorship creation + closure for (1, 19), follow inserts, post inserts, like + comment events.
- [ ] Log in as `elif.yilmaz.1@seed.test` / `Seed1234!`: profile shows the cross-domain interests; dashboard shows active mentorship with Dr. Ahmet AND completed mentorship with Fikret; Following feed has posts; her profile shows non-zero followers and following counts; her own posts have likes and comments.
- [ ] Log in as `admin@group7.com` / `Admin1234!`: admin dashboard is accessible.