### PR TITLE
fix(web): wire spam-bot defence on register (form-token + honeypot)

### DIFF
--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,7 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
-import { registerUser } from '../services/api'
+import { registerUser, getRegisterFormToken } from '../services/api'
 import '../styles/main.css'
 
 function validate(fields) {
@@ -35,11 +35,27 @@ export default function RegisterPage() {
     email: '',
     password: '',
     isMentor: false,
+    // #345 spam-bot defence. `website` is a honeypot — visually hidden,
+    // legitimate users never see it, autofill bots populate it and get
+    // rejected. `formToken` is fetched on mount.
+    website: '',
   })
+  const [formToken, setFormToken] = useState(null)
   const [errors, setErrors] = useState({})
   const [serverError, setServerError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [exiting, setExiting] = useState(false)
+
+  // Fetch the form-token on mount. Best-effort: if it fails (e.g. backend
+  // has the defence disabled), we submit without a token and the backend
+  // either accepts (defence off) or rejects (defence on) — same as today.
+  useEffect(() => {
+    let cancelled = false
+    getRegisterFormToken()
+      .then(r => { if (!cancelled && r?.token) setFormToken(r.token) })
+      .catch(() => { /* silent — handled by the submit error path */ })
+    return () => { cancelled = true }
+  }, [])
 
   function handleBack() {
     setExiting(true)
@@ -61,7 +77,7 @@ export default function RegisterPage() {
     }
     setIsLoading(true)
     try {
-      await registerUser(fields)
+      await registerUser({ ...fields, formToken })
       navigate('/login', { state: { registered: true } })
     } catch (err) {
       setServerError(err.message || 'Registration failed. Please try again.')
@@ -95,6 +111,26 @@ export default function RegisterPage() {
         {serverError && <div className="auth-error" data-testid="register-error">{serverError}</div>}
 
         <form onSubmit={handleSubmit} noValidate data-testid="register-form">
+          {/* #345 honeypot: visually hidden, inert to keyboard, no autocomplete.
+              Bots that auto-fill every input populate it and get rejected. */}
+          <input
+            type="text"
+            name="website"
+            tabIndex={-1}
+            autoComplete="off"
+            value={fields.website}
+            onChange={e => handleChange('website', e.target.value)}
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              left: '-9999px',
+              width: '1px',
+              height: '1px',
+              opacity: 0,
+              pointerEvents: 'none',
+            }}
+          />
+
           <label className="field-label">First Name</label>
           <input
             type="text"

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -40,12 +40,28 @@ async function handleResponse(res) {
   throw new Error(message)
 }
 
-export async function registerUser({ firstName, lastName, email, password, isMentor }) {
+export async function registerUser({ firstName, lastName, email, password, isMentor, formToken, website }) {
+  // formToken + website (honeypot) are part of the spam-bot defence (#345).
+  // Backend rejects registrations with `app.spam.enabled=true` (the default
+  // in production) unless formToken round-trips through the form, so we
+  // forward them when the caller supplies them. Older callers that omit
+  // both still work in dev / test where the defence is off.
+  const body = { firstName, lastName, email, password, isMentor }
+  if (formToken) body.formToken = formToken
+  if (website !== undefined) body.website = website
   const res = await fetch(`${BASE_URL}/auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ firstName, lastName, email, password, isMentor }),
+    body: JSON.stringify(body),
   })
+  return handleResponse(res)
+}
+
+// #345 spam-bot defence: short-lived HMAC-signed timestamp the backend
+// expects round-tripped on register. Issued by GET /api/auth/form-token,
+// TTL 15 min by default.
+export async function getRegisterFormToken() {
+  const res = await fetch(`${BASE_URL}/auth/form-token`)
   return handleResponse(res)
 }
 


### PR DESCRIPTION
 Summary                                                   
         
  Mobile (register.tsx:30, 34) and backend (#345) ship a spam-bot defence on registration: a short-lived HMAC-signed formToken fetched on render, plus a website honeypot field. Backend
   rejects with 400 when the defence is enabled (app.spam.enabled=true — the production default) and the token is missing or stale.                                                     
  
  Web's RegisterPage didn't wire either, so production web register would 400 against the live backend. Found while doing a mobile-vs-web parity audit on #139's PR.                    
                                                            
  Why no one noticed yet                                                                                                                                                                
                                                            
  backend/src/test/resources/application-test.properties:75 sets app.spam.enabled=false, so e2e + integration tests don't hit this path. CI's been green even though prod register would
   have been broken.
                                                                                                                                                                                        
  Changes                                                                                                                                                                               
   
  - services/api.js — registerUser extended to forward formToken + website when provided. New getRegisterFormToken() wrapper for GET /api/auth/form-token.                              
  - pages/RegisterPage.jsx — fetches the form-token on mount and includes it in the register payload. Added a visually-hidden honeypot input (name="website", off-screen positioning,
  tabIndex={-1}, aria-hidden="true", no autocomplete) that legitimate users never see and bots auto-fill.                                                                               
                                                            
  Acceptance criteria                                                                                                                                                                   
                                                            
  - ✅ GET /api/auth/form-token fires on RegisterPage mount.                                                                                                                            
  - ✅ Token round-trips through POST /api/auth/register body.
  - ✅ Honeypot field exists in the DOM but is invisible to humans + keyboard navigation.                                                                                               
  - ✅ Existing register tests still pass — the page is backward-compatible when formToken happens to be null (token fetch failed) or website is empty (legitimate user).               
                                                                                                                                                                                        
  Test plan                                                                                                                                                                             
                                                                                                                                                                                        
  - npm run build clean.                                                                                                                                                                
  - npm test — 84/84 unit tests pass.                       
  - Manual: visit /register → DevTools shows GET /api/auth/form-token fires → fill the form → submit → POST body contains formToken and website: "".
  - Manual: deploy to prod (where app.spam.enabled=true) → register flow succeeds (was previously 400'ing). 