### PR TITLE
chore(env): document Neo4j vars + follow-graph flags in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,35 @@ FRONTEND_PORT=8000
 OPENAI_API_KEY=
 # Enable the advanced ranker (otherwise the legacy bag-of-words ranker is used).
 MENTOR_ADVANCED_RANKER=false
+
+# ---- Neo4j (Follow-graph mirror, #437) ----
+# The follow-graph mirror writes every Postgres follow/unfollow into Neo4j
+# (after the SQL commit) so the Personalized PageRank signal on the
+# advanced follow ranker has a real graph to walk. docker-compose.yml runs
+# a custom Neo4j 5 + GDS 2.13.4 image (backend/docker/neo4j-gds) on
+# service `neo4j`, and the backend service `depends_on` it.
+#
+# Local dev: defaults below match docker-compose's :- fallbacks, so plain
+# `docker compose up` works without setting any of these. They are listed
+# here for discoverability and so prod operators don't ship insecure
+# defaults to a real deploy.
+#
+# Production: NEO4J_PASSWORD must be a strong non-default value
+# (`openssl rand -base64 24`). The other values map to the bolt URI / auth
+# username your managed Neo4j (e.g. Aura) gives you.
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USERNAME=neo4j
+NEO4J_PASSWORD=group7pass
+NEO4J_HTTP_PORT=7474
+NEO4J_BOLT_PORT=7687
+# Flips on FollowGraphSyncListener (real-time PG→Neo4j writes), the
+# nightly FollowGraphResyncJob retry sweep, the dual TX manager, and the
+# startup FollowGraphBootstrap mirror. `false` means the Bolt driver is
+# never opened — backend boots whether or not Neo4j is reachable, and the
+# legacy follow ranker still serves recommendations.
+FOLLOW_GRAPH_SYNC_ENABLED=true
+# Selects between the legacy rule-based follow ranker and the multi-signal
+# AdvancedFollowRanker (which includes PersonalizedPageRank — needs Neo4j).
+# Leave `legacy` until Neo4j is reachable AND OPENAI_API_KEY is set if you
+# want the SemanticAffinity signal active.
+FOLLOW_RANKER=legacy


### PR DESCRIPTION
## Summary
`docker-compose.yml` already references every Neo4j knob (`NEO4J_URI`, `NEO4J_USERNAME`, `NEO4J_PASSWORD`, `NEO4J_HTTP_PORT`, `NEO4J_BOLT_PORT`) and the `FOLLOW_GRAPH_SYNC_ENABLED` master flag with `:-default` fallbacks, so plain `docker compose up` works without any of them being declared in `.env`. But `.env.example` shipped none of them, which left two real gaps:

1. **Discoverability** — a prod operator copying `.env.example` had no signal that Neo4j was wired in at all, and could easily miss the `NEO4J_PASSWORD` override required for a non-insecure deploy.
2. **The compose default `NEO4J_PASSWORD=group7pass`** is identical to the Postgres default — without a prompt in `.env.example` it silently ships to production.

This PR adds a Neo4j block at the end of `.env.example` with the same defaults compose already uses, plus comments explaining the "defaults work for local dev / production must override" split. Also exposes `FOLLOW_GRAPH_SYNC_ENABLED` (gates the entire sync layer) and `FOLLOW_RANKER` (legacy vs advanced — the latter needs Neo4j) so all the related toggles live together.

## What this does NOT change
- No code or compose changes — pure documentation in `.env.example`.
- Local `docker compose up` behaviour is identical (the same `:-default` fallbacks resolve to the same values).
- No `docker-compose.prod.yml` change — production deployments already pass these through verbatim from the runtime `.env`.

## Test plan
- [x] `docker compose up` without an `.env` still works (compose defaults).
- [x] `cp .env.example .env && docker compose up` works and brings the Neo4j sync online (`FOLLOW_GRAPH_SYNC_ENABLED=true` by default).
- [ ] Reviewer / ops: confirm production deploy guide (`backend/DEPLOYMENT.md`) sections "Neo4j follow-graph" and "Pre-production checklist" align with the new env block (they do — same keys, same semantics).