### PR TITLE
Feat/web readme and local seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 uml-diagrams/
 
+# Local seed output (regenerated on every run of scripts/seed_local.py)
+scripts/seed_local_credentials.txt
+
+# Python bytecode
+__pycache__/
+*.pyc
+
 # Backend - Spring Boot
 backend/target/
 backend/*.class

--- a/README.md
+++ b/README.md
@@ -2,72 +2,91 @@
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
-## Running with Docker
+## Web Application
 
-Make sure you have [Docker](https://docs.docker.com/get-docker/) and Docker Compose installed.
+The web app is a React + Vite frontend backed by a Spring Boot REST API and a
+PostgreSQL + Neo4j data layer. Everything below assumes you are at the repo
+root.
 
-### Environment variables
+### Quick start (development, Docker)
 
-Create a `.env` file in the project root (see `.env.example`):
+Make sure you have [Docker](https://docs.docker.com/get-docker/) and Docker
+Compose installed.
 
 ```bash
 cp .env.example .env
-```
-
-You can keep defaults for local development.
-
-### Start all services
-
-```bash
 docker compose up --build
 ```
 
-This starts three containers:
+This starts four services:
 
-| Service  | URL                          | Description              |
-|----------|------------------------------|--------------------------|
-| Frontend | http://localhost:5174        | React + Vite dev server  |
-| Backend  | http://localhost:8080        | Spring Boot REST API     |
-| Swagger  | http://localhost:8080/swagger-ui.html | API docs        |
-| MailHog  | http://localhost:8025        | Local email inbox (dev)  |
-| Database | localhost:5433               | PostgreSQL               |
+| Service  | URL                                   | Description                                |
+|----------|---------------------------------------|--------------------------------------------|
+| Frontend | http://localhost:8000                 | React + Vite dev server                    |
+| Backend  | http://localhost:8080                 | Spring Boot REST API                       |
+| Swagger  | http://localhost:8080/swagger-ui.html | API docs                                   |
+| Neo4j    | http://localhost:7474                 | Follow-graph mirror (GDS plugin)           |
+| Database | `localhost:5433`                      | PostgreSQL (managed via Flyway migrations) |
 
-> **Note:** Port 5174 is used for the Docker frontend. If you run the frontend locally (`npm run dev`), it runs on 5173.
+Defaults in `.env.example` are good enough for local development — no editing
+required.
 
-### Stop all services
+Stop the stack with `docker compose down`. Add `-v` to also drop the Postgres
+and Neo4j volumes if you want a fully clean reset on the next boot.
+
+### Seed local data
+
+Right after a fresh `docker compose up`, the app is empty. The seed script
+populates Postgres directly (bypassing email verification, Resend, and the
+spam-bot defences) with **1 admin + 40 mentors + 60 mentees**, each with
+realistic interests, bios, and goals.
 
 ```bash
-docker compose down
+pip install -r scripts/requirements-seed.txt
+python3 scripts/seed_local.py
 ```
 
-To also remove the database volume:
+Every run is destructive-but-scoped: it deletes all prior `@seed.local` users
+first, then re-inserts the roster. Real users you registered through the web
+UI are never touched. Run it again whenever you want a clean demo dataset.
 
-```bash
-docker compose down -v
-```
+The script prints a credentials block to stdout (sample users per role) and
+writes the full list — including each mentor's field and each mentee's major —
+to `scripts/seed_local_credentials.txt`.
 
----
+### Default credentials (after seeding)
 
-## Running locally (without Docker)
+All seeded passwords are deterministic. Sample accounts:
 
-### Prerequisites
+| Role   | Email                                            | Password      |
+|--------|--------------------------------------------------|---------------|
+| Admin  | `admin@seed.local`                               | `Admin1234!`  |
+| Mentor | `mentor.<first>.<last>.<n>@seed.local` (40 total) | `Mentor1234!` |
+| Mentee | `mentee.<first>.<last>.<n>@seed.local` (60 total) | `Mentee1234!` |
+
+The first 5 mentors and 5 mentees are echoed when the script finishes; the
+remaining accounts live in `scripts/seed_local_credentials.txt`.
+
+### Quick start (development, without Docker)
+
+Prerequisites:
 
 - Java 21
 - Maven
 - Node.js 18+
-- PostgreSQL running on port 5433 with:
-  - Database: `group7db`
-  - Username: `group7`
-  - Password: `group7pass`
+- PostgreSQL running on port 5433 with database `group7db`, user `group7`,
+  password `group7pass` (matching `.env.example`)
+- Neo4j running on `bolt://localhost:7687` with user `neo4j` / `group7pass`
+  (only required when `FOLLOW_GRAPH_SYNC_ENABLED=true`, the default)
 
-### Backend
+Backend:
 
 ```bash
 cd backend
 mvn spring-boot:run
 ```
 
-### Frontend
+Frontend:
 
 ```bash
 cd frontend
@@ -75,7 +94,32 @@ npm install
 npm run dev
 ```
 
-Frontend will be available at http://localhost:5173 and proxies `/api` requests to the backend at port 8080.
+Frontend will be available at http://localhost:8000 and proxies `/api`
+requests to the backend at port 8080.
+
+End-to-end tests, including how to enable the `/api/test/**` fixture endpoints
+used by Playwright, are documented in [frontend/README.md](frontend/README.md).
+
+### Production deployment
+
+Production uses a separate compose file (`docker-compose.prod.yml`) that
+expects a managed Postgres and reads secrets from `.env.production`.
+
+```bash
+cp .env.production.example .env.production
+# edit .env.production: set NEO4J_PASSWORD, JWT_SECRET, SPRING_DATASOURCE_URL,
+# SPRING_DATASOURCE_USERNAME, SPRING_DATASOURCE_PASSWORD, RESEND_API_KEY,
+# APP_BASE_URL, APP_FRONTEND_URL, APP_CORS_ALLOWED_ORIGINS
+docker compose --env-file .env.production -f docker-compose.prod.yml up --build -d
+```
+
+The prod compose runs the backend, frontend, and Neo4j in-stack and binds the
+frontend to host port 80 by default (override with `FRONTEND_PORT`). It does
+not bring up a Postgres service — point `SPRING_DATASOURCE_URL` at your
+managed database.
+
+See [PRODUCTION_CHECKLIST.md](PRODUCTION_CHECKLIST.md) for the broader
+deployment checklist (TLS, backups, secret rotation).
 
 ---
 

--- a/scripts/requirements-seed.txt
+++ b/scripts/requirements-seed.txt
@@ -1,0 +1,2 @@
+psycopg[binary]>=3.1
+bcrypt>=4.0

--- a/scripts/seed_data.py
+++ b/scripts/seed_data.py
@@ -1,0 +1,175 @@
+"""Shared mock-data constants for the local seed scripts.
+
+Extracted from `seed_personas.py` so both that script and the lightweight
+`seed_local.py` (direct-DB seed for `docker compose` users) can share the same
+pools without copy-paste drift.
+"""
+
+from __future__ import annotations
+
+
+TURKISH_FIRST_NAMES = [
+    "Ali", "Ayse", "Can", "Ceren", "Deniz", "Derya", "Ece", "Emre", "Eren", "Ezgi",
+    "Fikret", "Gamze", "Gul", "Hakan", "Hale", "Haluk", "Ipek", "Kaan", "Kerem", "Levent",
+    "Merve", "Mert", "Mina", "Murat", "Naz", "Neslihan", "Nihat", "Nil", "Oguz", "Onur",
+    "Pelin", "Pinar", "Riza", "Selcuk", "Selin", "Serdar", "Seda", "Sule", "Sude", "Tayfun",
+    "Tolga", "Yusuf", "Zeynep", "Bora", "Baris", "Buse", "Asli", "Damla", "Burak", "Yagmur",
+]
+
+TURKISH_LAST_NAMES = [
+    "Acar", "Aksu", "Aksoy", "Arslan", "Aydin", "Basaran", "Balci", "Bayer", "Bicakci", "Bozkurt",
+    "Cetin", "Colak", "Demir", "Dogan", "Ekinci", "Eren", "Erkmen", "Ersoy", "Gok", "Gunes",
+    "Karaca", "Kara", "Kilic", "Kilicoglu", "Korkmaz", "Kurt", "Mert", "Ozturk", "Polat", "Sahin",
+    "Sezer", "Sari", "Sonmez", "Tan", "Tekin", "Turan", "Tufekci", "Ural", "Uysal", "Yalcin",
+]
+
+LOCATIONS = [
+    "Kadikoy, Istanbul", "Sisli, Istanbul", "Besiktas, Istanbul", "Uskudar, Istanbul", "Bakirkoy, Istanbul",
+    "Maltepe, Istanbul", "Beyoglu, Istanbul", "Ankara", "Cankaya, Ankara", "Izmir", "Karşıyaka, Izmir",
+    "Bursa", "Antalya", "Konya", "Eskişehir", "Adana", "Gaziantep", "Kayseri", "Trabzon", "Mersin",
+]
+
+MENTEE_INTEREST_SETS = [
+    ["Frontend Development", "React", "Portfolio Review"],
+    ["Backend Development", "System Design", "Interview Prep"],
+    ["Machine Learning", "Data Science", "Python"],
+    ["Digital Marketing", "Content Strategy", "SEO"],
+    ["Career Switch", "Communication Skills", "Business Analysis"],
+    ["UI/UX Design", "Figma", "Design Systems"],
+    ["iOS Development", "Swift", "Mobile Development"],
+    ["Entrepreneurship", "Finance", "Pitch Deck"],
+    ["Research", "Academic Career", "Study Abroad"],
+    ["Product Management", "User Research", "Leadership"],
+    ["Cyber Security", "Ethical Hacking", "Internship Hunt"],
+    ["Game Development", "Unity", "3D Modeling"],
+    ["Blockchain", "Smart Contracts", "Web3"],
+    ["DevOps", "Docker", "Cloud Fundamentals"],
+    ["QA Automation", "Selenium", "Test Strategy"],
+    ["Data Engineering", "ETL", "SQL"],
+    ["Cloud Engineering", "AWS", "Certification Prep"],
+    ["Mobile App Development", "Flutter", "Startup Ideas"],
+    ["Algorithms", "Competitive Programming", "Problem Solving"],
+    ["Public Speaking", "Leadership", "Confidence"],
+    ["Time Management", "Study Habits", "Focus"],
+    ["English Writing", "Technical Blogging", "Personal Branding"],
+    ["Machine Learning Operations", "Model Deployment", "Cloud"],
+    ["Computer Vision", "OpenCV", "Research Papers"],
+    ["Full Stack Development", "Node.js", "MongoDB"],
+    ["FinTech", "Risk Analysis", "Data Visualization"],
+    ["Game Design", "Level Design", "Storytelling"],
+    ["AI Ethics", "Prompting", "Responsible AI"],
+    ["Digital Product Thinking", "Roadmapping", "Stakeholder Communication"],
+    ["Study Abroad", "GRE Prep", "Campus Networking"],
+    ["Bootcamp Graduate", "First Job", "Portfolio Building"],
+]
+
+MENTOR_INTEREST_SETS = [
+    ["Frontend Architecture", "React", "Accessibility"],
+    ["Backend Engineering", "Java", "Spring Boot"],
+    ["Machine Learning", "Data Science", "Python"],
+    ["Digital Marketing", "Brand Strategy", "Analytics"],
+    ["Career Development", "Interview Prep", "Leadership"],
+    ["UI/UX Strategy", "Product Design", "Figma"],
+    ["iOS Engineering", "Swift", "Mobile Development"],
+    ["Entrepreneurship", "Finance", "Startup Operations"],
+    ["Research Leadership", "Academic Career", "Public Speaking"],
+    ["Cloud Architecture", "DevOps", "System Design"],
+    ["Engineering Management", "Team Growth", "Hiring"],
+    ["Angel Investing", "Startup Strategy", "Mentorship"],
+    ["Career Transition", "Coaching", "Personal Growth"],
+    ["Retirement Planning", "Financial Literacy", "Life Design"],
+    ["Security Architecture", "Threat Modeling", "Zero Trust"],
+    ["Data Platform Design", "Streaming", "Governance"],
+    ["Agile Leadership", "Scrum", "Cross-Functional Collaboration"],
+    ["MLOps", "Model Deployment", "Operational Excellence"],
+    ["Platform Engineering", "Observability", "Reliability"],
+    ["Startup Founding", "Fundraising", "Go-to-Market"],
+    ["Technical Writing", "Documentation", "Developer Experience"],
+    ["Open Source", "Community Building", "Code Review"],
+    ["FinTech", "Payments", "Regulatory Compliance"],
+    ["HealthTech", "Privacy", "Clinical Workflows"],
+    ["EdTech", "Curriculum Design", "Learning Science"],
+    ["Game Industry", "Production", "Live Operations"],
+    ["Embedded Systems", "Firmware", "Hardware Debugging"],
+    ["AI Governance", "Model Risk", "Responsible Innovation"],
+    ["Customer Success", "B2B Growth", "Retention"],
+    ["Sales Engineering", "Discovery Calls", "Solution Design"],
+    ["Mentoring First-Gen Talent", "Inclusive Hiring", "Career Growth"],
+]
+
+BIO_TEMPLATES = {
+    "MENTEE": [
+        "Seeking practical guidance in {interest1} and steady progress through small, well-defined projects.",
+        "Transitioning toward {interest1} and looking for a realistic roadmap with clear milestones.",
+        "Open to feedback on a {interest1} portfolio, with a strong focus on interview preparation and professional polish.",
+        "Working to connect a current background with {interest1} and would value a structured mentorship plan.",
+        "Building confidence in {interest1} while strengthening {interest2} through consistent practice and support.",
+        "Early in a tech journey and focused on learning {interest1} alongside stronger {interest2} habits.",
+        "Preparing for an internship and aiming to grow in {interest1} while becoming more effective at {interest2}.",
+        "Recently completed a bootcamp and now looking to apply {interest1} in real-world projects with stronger {interest2} skills.",
+        "Exploring a career shift into {interest1} and seeking practical advice on {interest2} and next steps.",
+        "Aiming to improve both {interest1} and {interest2} with mentorship that is direct, supportive, and actionable.",
+        "Eager to build a stronger foundation in {interest1} and learn how professionals approach {interest2}.",
+        "Balancing studies and personal projects while developing {interest1} and better {interest2} habits.",
+        "Focused on turning curiosity about {interest1} into a serious path, with extra attention on {interest2}.",
+        "Looking for guidance that can turn practice in {interest1} into measurable progress and stronger {interest2}.",
+        "Preparing for study abroad and building skills in {interest1} while improving {interest2} for collaboration.",
+        "Working toward a first role in tech and aiming to sharpen {interest1} as well as {interest2}.",
+        "Interested in {interest1} and eager to become more disciplined in {interest2} through mentorship.",
+        "Developing a portfolio around {interest1} and hoping to present work more confidently through {interest2}.",
+        "Learning {interest1} from scratch while building the communication and planning habits needed for {interest2}.",
+        "Committed to long-term growth in {interest1} and seeking a mentor who can help refine {interest2}.",
+    ],
+    "MENTOR": [
+        "Bringing years of hands-on experience in {interest1} and {interest2}, with a focus on practical, measurable growth.",
+        "Supporting mentees who want to translate theory in {interest1} into real-world results and stronger {interest2} habits.",
+        "Guiding professionals through career growth in {interest1}, with additional emphasis on communication and {interest2}.",
+        "Working across {interest1} and {interest2}, and helping people build confidence through clear milestones.",
+        "Focused on helping ambitious learners develop strong foundations in {interest1} while improving {interest2}.",
+        "Offering mentorship shaped by experience in {interest1}, leadership, and practical decision-making around {interest2}.",
+        "Actively mentoring people who are preparing for their next step in {interest1} and want to become stronger in {interest2}.",
+        "Providing thoughtful feedback to mentees exploring {interest1} and building professional habits around {interest2}.",
+        "Helping people navigate growth in {interest1} with realistic planning, accountability, and better {interest2}.",
+        "Bringing a startup and product perspective to conversations about {interest1} and {interest2}.",
+        "Sharing lessons from senior roles in {interest1}, with an emphasis on clarity, systems thinking, and {interest2}.",
+        "Mentoring with a balance of empathy and structure for people building skills in {interest1} and {interest2}.",
+        "Supporting learners who are moving from early exploration to confident execution in {interest1} and {interest2}.",
+        "Drawing from experience in architecture, delivery, and team growth to mentor around {interest1} and {interest2}.",
+        "Helping mentees connect technical depth in {interest1} with the professional habits needed for {interest2}.",
+        "Offering practical mentorship for those pursuing growth in {interest1}, especially when paired with stronger {interest2}.",
+        "Guiding the next generation of builders in {interest1} with a strong focus on feedback, iteration, and {interest2}.",
+        "Bringing cross-industry experience to mentorship in {interest1} and {interest2}, especially for people navigating change.",
+        "Mentoring people who want to grow beyond the basics of {interest1} and develop more confident {interest2} skills.",
+        "Sharing a long-term perspective on careers in {interest1} and {interest2}, with advice that is calm, practical, and clear.",
+    ],
+}
+
+MENTEE_BACKGROUND_TEMPLATES = [
+    "I am currently studying computer engineering and trying to apply my knowledge to real-world problems.",
+    "I have been learning about {interest1} through online courses and bootcamps.",
+    "My background is in a different field, but I have recently started exploring tech and {interest2}.",
+    "I work as a junior professional and want to dive deeper into {interest1}.",
+    "I have some academic experience in {interest1} but I lack practical industry experience.",
+    "I recently graduated and am actively looking for opportunities to use my skills in {interest1}.",
+    "I have been a hobbyist programmer for a few years, mostly focusing on {interest2}.",
+    "I am transitioning from a non-technical role and have completed several projects in {interest1}.",
+    "I am an undergraduate student with a strong passion for {interest1} and {interest2}.",
+    "I have been self-taught in {interest1} for the past year and want to take it to the next level.",
+    "Currently exploring different career paths in technology, with a particular focus on {interest1}.",
+    "I have built a few small projects using {interest2} and want to learn enterprise standards.",
+]
+
+MENTOR_GOALS_TEMPLATES = [
+    "Aims to share industry experience and guide mentees in {interest1} and {interest2}.",
+    "Focuses on providing practical insights and career guidance for those interested in {interest1}.",
+    "Passionate about helping juniors navigate the complexities of {interest1} and build confidence.",
+    "Dedicated to mentoring aspiring professionals in {interest1}, helping them achieve their career milestones.",
+    "Wants to support mentees by sharing real-world lessons in {interest1} and {interest2}.",
+    "Committed to fostering growth in {interest1} through structured feedback and regular check-ins.",
+    "Looks forward to helping mentees overcome obstacles in {interest1} and develop strong foundations.",
+    "Interested in guiding early-career talents through the challenges of {interest1}.",
+    "Aims to bridge the gap between academic knowledge and practical application in {interest1}.",
+    "Enthusiastic about empowering the next generation of leaders in {interest1} and {interest2}.",
+    "Focuses on career strategy, portfolio building, and technical growth in {interest1}.",
+    "Dedicated to offering actionable advice and support for mentees navigating {interest1}.",
+]

--- a/scripts/seed_local.py
+++ b/scripts/seed_local.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Local data seed for a freshly-started `docker compose up` stack.
+
+Writes 1 admin + 40 mentors + 60 mentees directly into Postgres (bypassing the
+HTTP API, Resend, email verification, and the spam-bot defences), then prints
+login credentials for several users of each role plus the full roster to
+`scripts/seed_local_credentials.txt`.
+
+Every run is destructive-but-scoped: all rows whose user email matches
+`%@seed.local` are deleted before the fresh roster is inserted. Users created
+through the web UI are never touched.
+
+Usage:
+    pip install -r scripts/requirements-seed.txt
+    python3 scripts/seed_local.py
+
+Connection defaults match `docker-compose.yml` (Postgres exposed on host
+:5433). Override with the standard PG* env vars or DATABASE_URL if needed.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import bcrypt
+    import psycopg
+except ImportError as exc:
+    sys.stderr.write(
+        f"Missing dependency: {exc.name}.\n"
+        "Install with: pip install -r scripts/requirements-seed.txt\n"
+    )
+    sys.exit(1)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from seed_data import (  # noqa: E402  (sys.path tweak above)
+    BIO_TEMPLATES,
+    LOCATIONS,
+    MENTEE_BACKGROUND_TEMPLATES,
+    MENTEE_INTEREST_SETS,
+    MENTOR_GOALS_TEMPLATES,
+    MENTOR_INTEREST_SETS,
+    TURKISH_FIRST_NAMES,
+    TURKISH_LAST_NAMES,
+)
+
+SEED_EMAIL_DOMAIN = "seed.local"
+ADMIN_PASSWORD = "Admin1234!"
+MENTOR_PASSWORD = "Mentor1234!"
+MENTEE_PASSWORD = "Mentee1234!"
+NUM_MENTORS = 40
+NUM_MENTEES = 60
+CREDS_OUTPUT = SCRIPT_DIR / "seed_local_credentials.txt"
+SAMPLE_PER_ROLE = 5  # how many of each role to echo to stdout
+
+RNG = random.Random(20260513)  # deterministic roster across runs
+
+
+@dataclass
+class SeedUser:
+    first_name: str
+    last_name: str
+    email: str
+    password: str
+    role: str  # "ADMIN" | "MENTOR" | "MENTEE"
+    city: str
+    bio: str
+    interests: list[str]
+    extra_skills: list[str]
+    field: str
+    affiliation: str
+    max_capacity: int
+    mentoring_goals: str
+    mentorship_duration: int
+    goals: str
+    major: str
+    career_interest: str
+    background_info: str
+
+
+def build_dsn() -> str:
+    if "DATABASE_URL" in os.environ:
+        return os.environ["DATABASE_URL"]
+    user = os.environ.get("POSTGRES_USER", "group7")
+    password = os.environ.get("POSTGRES_PASSWORD", "group7pass")
+    db = os.environ.get("POSTGRES_DB", "group7db")
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    port = os.environ.get("DB_PORT", os.environ.get("POSTGRES_PORT", "5433"))
+    return f"postgresql://{user}:{password}@{host}:{port}/{db}"
+
+
+def bcrypt_hash(plain: str) -> str:
+    # Spring Security's BCryptPasswordEncoder defaults to cost=10 and $2a$ —
+    # see backend/.../config/SecurityConfig.java.
+    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt(rounds=10)).decode()
+
+
+def email_for(role: str, first: str, last: str, index: int | None = None) -> str:
+    prefix = role.lower()
+    base = f"{prefix}.{first.lower()}.{last.lower()}"
+    if index is not None:
+        base = f"{base}.{index}"
+    return f"{base}@{SEED_EMAIL_DOMAIN}"
+
+
+def pick(items: list, i: int):
+    return items[i % len(items)]
+
+
+def generate_mentor(i: int) -> SeedUser:
+    first = pick(TURKISH_FIRST_NAMES, i * 7 + 3)
+    last = pick(TURKISH_LAST_NAMES, i * 11 + 5)
+    interests = pick(MENTOR_INTEREST_SETS, i)
+    bio_template = pick(BIO_TEMPLATES["MENTOR"], i)
+    goal_template = pick(MENTOR_GOALS_TEMPLATES, i)
+    city = pick(LOCATIONS, i)
+    return SeedUser(
+        first_name=first,
+        last_name=last,
+        email=email_for("mentor", first, last, i),
+        password=MENTOR_PASSWORD,
+        role="MENTOR",
+        city=city,
+        bio=bio_template.format(interest1=interests[0], interest2=interests[1]),
+        interests=interests,
+        extra_skills=interests[:3],
+        field=interests[0],
+        affiliation=city,
+        max_capacity=2 + (i % 5),  # 2..6
+        mentoring_goals=goal_template.format(interest1=interests[0], interest2=interests[1]),
+        mentorship_duration=[3, 6, 12][i % 3],
+        goals="",
+        major="",
+        career_interest="",
+        background_info="",
+    )
+
+
+def generate_mentee(i: int) -> SeedUser:
+    first = pick(TURKISH_FIRST_NAMES, i * 5 + 1)
+    last = pick(TURKISH_LAST_NAMES, i * 13 + 2)
+    interests = pick(MENTEE_INTEREST_SETS, i)
+    bio_template = pick(BIO_TEMPLATES["MENTEE"], i)
+    background_template = pick(MENTEE_BACKGROUND_TEMPLATES, i)
+    city = pick(LOCATIONS, i + 3)
+    return SeedUser(
+        first_name=first,
+        last_name=last,
+        email=email_for("mentee", first, last, i),
+        password=MENTEE_PASSWORD,
+        role="MENTEE",
+        city=city,
+        bio="",
+        interests=interests,
+        extra_skills=interests[:3],
+        field="",
+        affiliation="",
+        max_capacity=0,
+        mentoring_goals="",
+        mentorship_duration=0,
+        goals=bio_template.format(interest1=interests[0], interest2=interests[1]),
+        major=interests[0],
+        career_interest=interests[0],
+        background_info=background_template.format(interest1=interests[0], interest2=interests[1]),
+    )
+
+
+def admin_user() -> SeedUser:
+    return SeedUser(
+        first_name="Deniz",
+        last_name="Admin",
+        email=f"admin@{SEED_EMAIL_DOMAIN}",
+        password=ADMIN_PASSWORD,
+        role="ADMIN",
+        city="Istanbul",
+        bio="",
+        interests=[],
+        extra_skills=[],
+        field="",
+        affiliation="",
+        max_capacity=0,
+        mentoring_goals="",
+        mentorship_duration=0,
+        goals="",
+        major="",
+        career_interest="",
+        background_info="",
+    )
+
+
+def build_roster() -> list[SeedUser]:
+    roster: list[SeedUser] = [admin_user()]
+    seen_emails = {roster[0].email}
+    i = 0
+    while sum(1 for u in roster if u.role == "MENTOR") < NUM_MENTORS:
+        candidate = generate_mentor(i)
+        i += 1
+        if candidate.email in seen_emails:
+            continue
+        seen_emails.add(candidate.email)
+        roster.append(candidate)
+    j = 0
+    while sum(1 for u in roster if u.role == "MENTEE") < NUM_MENTEES:
+        candidate = generate_mentee(j)
+        j += 1
+        if candidate.email in seen_emails:
+            continue
+        seen_emails.add(candidate.email)
+        roster.append(candidate)
+    return roster
+
+
+def wipe_existing_seed(cur) -> int:
+    """Delete every row whose user.email ends in @seed.local.
+
+    Mentor/mentee/admin FKs from V1 do not cascade, so children must go first.
+    Other tables that reference users.id (feed_posts, mentorships, ...) all
+    declare ON DELETE CASCADE on more recent migrations and clear themselves
+    when the underlying mentor/mentee/users row is removed.
+    """
+    seed_id_filter = (
+        "IN (SELECT id FROM users WHERE email LIKE %s)",
+        (f"%@{SEED_EMAIL_DOMAIN}",),
+    )
+    pre_count_sql = "SELECT COUNT(*) FROM users WHERE email LIKE %s"
+    cur.execute(pre_count_sql, (f"%@{SEED_EMAIL_DOMAIN}",))
+    existing = cur.fetchone()[0]
+    if existing == 0:
+        return 0
+
+    for table, column in [
+        ("mentor_interests", "mentor_id"),
+        ("mentor_preferred_mentee_skills", "mentor_id"),
+        ("mentee_interests", "mentee_id"),
+        ("mentee_skills", "mentee_id"),
+    ]:
+        cur.execute(
+            f"DELETE FROM {table} WHERE {column} {seed_id_filter[0]}",
+            seed_id_filter[1],
+        )
+
+    # active_mentor_id on mentees points back at mentors — clear before deleting mentors.
+    cur.execute(
+        f"UPDATE mentees SET active_mentor_id = NULL WHERE active_mentor_id {seed_id_filter[0]}",
+        seed_id_filter[1],
+    )
+
+    for table in ("admins", "mentors", "mentees"):
+        cur.execute(
+            f"DELETE FROM {table} WHERE id {seed_id_filter[0]}",
+            seed_id_filter[1],
+        )
+
+    cur.execute("DELETE FROM users WHERE email LIKE %s", (f"%@{SEED_EMAIL_DOMAIN}",))
+    return existing
+
+
+def insert_user(cur, user: SeedUser) -> int:
+    cur.execute(
+        """
+        INSERT INTO users (
+            first_name, last_name, email, password_hash,
+            is_email_verified, timezone, is_suspected_bot, version,
+            city, created_at
+        )
+        VALUES (%s, %s, %s, %s, TRUE, 'UTC', FALSE, 0, %s, NOW())
+        RETURNING id
+        """,
+        (
+            user.first_name,
+            user.last_name,
+            user.email,
+            bcrypt_hash(user.password),
+            user.city,
+        ),
+    )
+    return cur.fetchone()[0]
+
+
+def insert_admin(cur, user_id: int) -> None:
+    cur.execute("INSERT INTO admins (id) VALUES (%s)", (user_id,))
+
+
+def insert_mentor(cur, user_id: int, user: SeedUser) -> None:
+    cur.execute(
+        """
+        INSERT INTO mentors (
+            id, profile_visibility, bio, field, expertise, affiliation,
+            max_mentee_capacity, current_mentee_count, preferred_mentee_major,
+            mentoring_goals, mentorship_duration
+        )
+        VALUES (%s, TRUE, %s, %s, %s, %s, %s, 0, %s, %s, %s)
+        """,
+        (
+            user_id,
+            user.bio,
+            user.field,
+            user.field,
+            user.affiliation,
+            user.max_capacity,
+            user.field,
+            user.mentoring_goals,
+            user.mentorship_duration,
+        ),
+    )
+    for interest in user.interests:
+        cur.execute(
+            "INSERT INTO mentor_interests (mentor_id, interest) VALUES (%s, %s)",
+            (user_id, interest),
+        )
+    for skill in user.extra_skills:
+        cur.execute(
+            "INSERT INTO mentor_preferred_mentee_skills (mentor_id, skill) VALUES (%s, %s)",
+            (user_id, skill),
+        )
+
+
+def insert_mentee(cur, user_id: int, user: SeedUser) -> None:
+    cur.execute(
+        """
+        INSERT INTO mentees (
+            id, profile_visibility, goals, major, career_interest,
+            meeting_freq_pref, background_info, cancel_count
+        )
+        VALUES (%s, TRUE, %s, %s, %s, %s, %s, 0)
+        """,
+        (
+            user_id,
+            user.goals,
+            user.major,
+            user.career_interest,
+            "Weekly",
+            user.background_info,
+        ),
+    )
+    for interest in user.interests:
+        cur.execute(
+            "INSERT INTO mentee_interests (mentee_id, interest) VALUES (%s, %s)",
+            (user_id, interest),
+        )
+    for skill in user.extra_skills:
+        cur.execute(
+            "INSERT INTO mentee_skills (mentee_id, skill) VALUES (%s, %s)",
+            (user_id, skill),
+        )
+
+
+def reset_user_sequence(cur) -> None:
+    # Postgres won't auto-bump the IDENTITY sequence if a future test inserts a
+    # higher id manually; align it with the current MAX so UI registrations
+    # don't collide with seed rows.
+    cur.execute("SELECT setval(pg_get_serial_sequence('users', 'id'), COALESCE((SELECT MAX(id) FROM users), 1))")
+
+
+def write_credentials_file(roster: list[SeedUser]) -> None:
+    # Pipe-separated so city values that contain a comma (e.g. "Kadikoy,
+    # Istanbul") survive grep/cut workflows unmangled.
+    lines = [
+        "# Local seed credentials (regenerated on every run of scripts/seed_local.py)",
+        "# Format: role|email|password|first_name|last_name|city",
+        "",
+    ]
+    for user in roster:
+        lines.append(
+            "|".join(
+                [
+                    user.role,
+                    user.email,
+                    user.password,
+                    user.first_name,
+                    user.last_name,
+                    user.city,
+                ]
+            )
+        )
+    CREDS_OUTPUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def echo_summary(roster: list[SeedUser], deleted: int) -> None:
+    admin = next(u for u in roster if u.role == "ADMIN")
+    mentors = [u for u in roster if u.role == "MENTOR"]
+    mentees = [u for u in roster if u.role == "MENTEE"]
+
+    bar = "=" * 70
+    print(bar)
+    if deleted:
+        print(f"Cleared {deleted} previous @{SEED_EMAIL_DOMAIN} user(s).")
+    print(
+        f"Local seed complete — created {len(roster)} users "
+        f"(1 admin, {len(mentors)} mentors, {len(mentees)} mentees)."
+    )
+    print()
+    print(f"ADMIN (1) — password: {ADMIN_PASSWORD}")
+    print(f"  {admin.email}")
+    print()
+    print(f"MENTORS (showing {SAMPLE_PER_ROLE} of {len(mentors)}) — password: {MENTOR_PASSWORD}")
+    for u in mentors[:SAMPLE_PER_ROLE]:
+        print(f"  {u.email:<46} {u.first_name} {u.last_name} — {u.field}")
+    print()
+    print(f"MENTEES (showing {SAMPLE_PER_ROLE} of {len(mentees)}) — password: {MENTEE_PASSWORD}")
+    for u in mentees[:SAMPLE_PER_ROLE]:
+        print(f"  {u.email:<46} {u.first_name} {u.last_name} — {u.major}")
+    print()
+    print(f"Full roster written to {CREDS_OUTPUT.relative_to(SCRIPT_DIR.parent)}")
+    print(bar)
+
+
+def main() -> int:
+    dsn = build_dsn()
+    safe_dsn = dsn.split("@", 1)[-1] if "@" in dsn else dsn
+    print(f"Connecting to {safe_dsn} ...")
+    try:
+        conn = psycopg.connect(dsn)
+    except psycopg.OperationalError as e:
+        sys.stderr.write(
+            f"Could not connect to Postgres: {e}\n"
+            "Is the docker-compose stack running? (docker compose up -d)\n"
+        )
+        return 1
+
+    roster = build_roster()
+    with conn:
+        with conn.cursor() as cur:
+            deleted = wipe_existing_seed(cur)
+            for user in roster:
+                user_id = insert_user(cur, user)
+                if user.role == "ADMIN":
+                    insert_admin(cur, user_id)
+                elif user.role == "MENTOR":
+                    insert_mentor(cur, user_id, user)
+                else:
+                    insert_mentee(cur, user_id, user)
+            reset_user_sequence(cur)
+
+    write_credentials_file(roster)
+    echo_summary(roster, deleted)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_personas.py
+++ b/scripts/seed_personas.py
@@ -5,12 +5,25 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 import time
 from datetime import datetime, timedelta
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from seed_data import (  # noqa: E402  (sys.path tweak above)
+    BIO_TEMPLATES,
+    LOCATIONS,
+    MENTEE_BACKGROUND_TEMPLATES,
+    MENTEE_INTEREST_SETS,
+    MENTOR_GOALS_TEMPLATES,
+    MENTOR_INTEREST_SETS,
+    TURKISH_FIRST_NAMES,
+    TURKISH_LAST_NAMES,
+)
 
 
 BASE = "http://localhost:8080/api"
@@ -657,173 +670,6 @@ PERSONAS = [   {   'id': 1,
         'is_banned': False,
         'mentoring_goals': 'Aims to support and guide mentees in Machine Learning.'}]
 
-
-
-TURKISH_FIRST_NAMES = [
-    "Ali", "Ayse", "Can", "Ceren", "Deniz", "Derya", "Ece", "Emre", "Eren", "Ezgi",
-    "Fikret", "Gamze", "Gul", "Hakan", "Hale", "Haluk", "Ipek", "Kaan", "Kerem", "Levent",
-    "Merve", "Mert", "Mina", "Murat", "Naz", "Neslihan", "Nihat", "Nil", "Oguz", "Onur",
-    "Pelin", "Pinar", "Riza", "Selcuk", "Selin", "Serdar", "Seda", "Sule", "Sude", "Tayfun",
-    "Tolga", "Yusuf", "Zeynep", "Bora", "Baris", "Buse", "Asli", "Damla", "Burak", "Yagmur",
-]
-
-TURKISH_LAST_NAMES = [
-    "Acar", "Aksu", "Aksoy", "Arslan", "Aydin", "Basaran", "Balci", "Bayer", "Bicakci", "Bozkurt",
-    "Cetin", "Colak", "Demir", "Dogan", "Ekinci", "Eren", "Erkmen", "Ersoy", "Gok", "Gunes",
-    "Karaca", "Kara", "Kilic", "Kilicoglu", "Korkmaz", "Kurt", "Mert", "Ozturk", "Polat", "Sahin",
-    "Sezer", "Sari", "Sonmez", "Tan", "Tekin", "Turan", "Tufekci", "Ural", "Uysal", "Yalcin",
-]
-
-LOCATIONS = [
-    "Kadikoy, Istanbul", "Sisli, Istanbul", "Besiktas, Istanbul", "Uskudar, Istanbul", "Bakirkoy, Istanbul",
-    "Maltepe, Istanbul", "Beyoglu, Istanbul", "Ankara", "Cankaya, Ankara", "Izmir", "Karşıyaka, Izmir",
-    "Bursa", "Antalya", "Konya", "Eskişehir", "Adana", "Gaziantep", "Kayseri", "Trabzon", "Mersin",
-]
-
-MENTEE_INTEREST_SETS = [
-    ["Frontend Development", "React", "Portfolio Review"],
-    ["Backend Development", "System Design", "Interview Prep"],
-    ["Machine Learning", "Data Science", "Python"],
-    ["Digital Marketing", "Content Strategy", "SEO"],
-    ["Career Switch", "Communication Skills", "Business Analysis"],
-    ["UI/UX Design", "Figma", "Design Systems"],
-    ["iOS Development", "Swift", "Mobile Development"],
-    ["Entrepreneurship", "Finance", "Pitch Deck"],
-    ["Research", "Academic Career", "Study Abroad"],
-    ["Product Management", "User Research", "Leadership"],
-    ["Cyber Security", "Ethical Hacking", "Internship Hunt"],
-    ["Game Development", "Unity", "3D Modeling"],
-    ["Blockchain", "Smart Contracts", "Web3"],
-    ["DevOps", "Docker", "Cloud Fundamentals"],
-    ["QA Automation", "Selenium", "Test Strategy"],
-    ["Data Engineering", "ETL", "SQL"],
-    ["Cloud Engineering", "AWS", "Certification Prep"],
-    ["Mobile App Development", "Flutter", "Startup Ideas"],
-    ["Algorithms", "Competitive Programming", "Problem Solving"],
-    ["Public Speaking", "Leadership", "Confidence"],
-    ["Time Management", "Study Habits", "Focus"],
-    ["English Writing", "Technical Blogging", "Personal Branding"],
-    ["Machine Learning Operations", "Model Deployment", "Cloud"],
-    ["Computer Vision", "OpenCV", "Research Papers"],
-    ["Full Stack Development", "Node.js", "MongoDB"],
-    ["FinTech", "Risk Analysis", "Data Visualization"],
-    ["Game Design", "Level Design", "Storytelling"],
-    ["AI Ethics", "Prompting", "Responsible AI"],
-    ["Digital Product Thinking", "Roadmapping", "Stakeholder Communication"],
-    ["Study Abroad", "GRE Prep", "Campus Networking"],
-    ["Bootcamp Graduate", "First Job", "Portfolio Building"],
-]
-
-MENTOR_INTEREST_SETS = [
-    ["Frontend Architecture", "React", "Accessibility"],
-    ["Backend Engineering", "Java", "Spring Boot"],
-    ["Machine Learning", "Data Science", "Python"],
-    ["Digital Marketing", "Brand Strategy", "Analytics"],
-    ["Career Development", "Interview Prep", "Leadership"],
-    ["UI/UX Strategy", "Product Design", "Figma"],
-    ["iOS Engineering", "Swift", "Mobile Development"],
-    ["Entrepreneurship", "Finance", "Startup Operations"],
-    ["Research Leadership", "Academic Career", "Public Speaking"],
-    ["Cloud Architecture", "DevOps", "System Design"],
-    ["Engineering Management", "Team Growth", "Hiring"],
-    ["Angel Investing", "Startup Strategy", "Mentorship"],
-    ["Career Transition", "Coaching", "Personal Growth"],
-    ["Retirement Planning", "Financial Literacy", "Life Design"],
-    ["Security Architecture", "Threat Modeling", "Zero Trust"],
-    ["Data Platform Design", "Streaming", "Governance"],
-    ["Agile Leadership", "Scrum", "Cross-Functional Collaboration"],
-    ["MLOps", "Model Deployment", "Operational Excellence"],
-    ["Platform Engineering", "Observability", "Reliability"],
-    ["Startup Founding", "Fundraising", "Go-to-Market"],
-    ["Technical Writing", "Documentation", "Developer Experience"],
-    ["Open Source", "Community Building", "Code Review"],
-    ["FinTech", "Payments", "Regulatory Compliance"],
-    ["HealthTech", "Privacy", "Clinical Workflows"],
-    ["EdTech", "Curriculum Design", "Learning Science"],
-    ["Game Industry", "Production", "Live Operations"],
-    ["Embedded Systems", "Firmware", "Hardware Debugging"],
-    ["AI Governance", "Model Risk", "Responsible Innovation"],
-    ["Customer Success", "B2B Growth", "Retention"],
-    ["Sales Engineering", "Discovery Calls", "Solution Design"],
-    ["Mentoring First-Gen Talent", "Inclusive Hiring", "Career Growth"],
-]
-
-BIO_TEMPLATES = {
-    "MENTEE": [
-        "Seeking practical guidance in {interest1} and steady progress through small, well-defined projects.",
-        "Transitioning toward {interest1} and looking for a realistic roadmap with clear milestones.",
-        "Open to feedback on a {interest1} portfolio, with a strong focus on interview preparation and professional polish.",
-        "Working to connect a current background with {interest1} and would value a structured mentorship plan.",
-        "Building confidence in {interest1} while strengthening {interest2} through consistent practice and support.",
-        "Early in a tech journey and focused on learning {interest1} alongside stronger {interest2} habits.",
-        "Preparing for an internship and aiming to grow in {interest1} while becoming more effective at {interest2}.",
-        "Recently completed a bootcamp and now looking to apply {interest1} in real-world projects with stronger {interest2} skills.",
-        "Exploring a career shift into {interest1} and seeking practical advice on {interest2} and next steps.",
-        "Aiming to improve both {interest1} and {interest2} with mentorship that is direct, supportive, and actionable.",
-        "Eager to build a stronger foundation in {interest1} and learn how professionals approach {interest2}.",
-        "Balancing studies and personal projects while developing {interest1} and better {interest2} habits.",
-        "Focused on turning curiosity about {interest1} into a serious path, with extra attention on {interest2}.",
-        "Looking for guidance that can turn practice in {interest1} into measurable progress and stronger {interest2}.",
-        "Preparing for study abroad and building skills in {interest1} while improving {interest2} for collaboration.",
-        "Working toward a first role in tech and aiming to sharpen {interest1} as well as {interest2}.",
-        "Interested in {interest1} and eager to become more disciplined in {interest2} through mentorship.",
-        "Developing a portfolio around {interest1} and hoping to present work more confidently through {interest2}.",
-        "Learning {interest1} from scratch while building the communication and planning habits needed for {interest2}.",
-        "Committed to long-term growth in {interest1} and seeking a mentor who can help refine {interest2}.",
-    ],
-    "MENTOR": [
-        "Bringing years of hands-on experience in {interest1} and {interest2}, with a focus on practical, measurable growth.",
-        "Supporting mentees who want to translate theory in {interest1} into real-world results and stronger {interest2} habits.",
-        "Guiding professionals through career growth in {interest1}, with additional emphasis on communication and {interest2}.",
-        "Working across {interest1} and {interest2}, and helping people build confidence through clear milestones.",
-        "Focused on helping ambitious learners develop strong foundations in {interest1} while improving {interest2}.",
-        "Offering mentorship shaped by experience in {interest1}, leadership, and practical decision-making around {interest2}.",
-        "Actively mentoring people who are preparing for their next step in {interest1} and want to become stronger in {interest2}.",
-        "Providing thoughtful feedback to mentees exploring {interest1} and building professional habits around {interest2}.",
-        "Helping people navigate growth in {interest1} with realistic planning, accountability, and better {interest2}.",
-        "Bringing a startup and product perspective to conversations about {interest1} and {interest2}.",
-        "Sharing lessons from senior roles in {interest1}, with an emphasis on clarity, systems thinking, and {interest2}.",
-        "Mentoring with a balance of empathy and structure for people building skills in {interest1} and {interest2}.",
-        "Supporting learners who are moving from early exploration to confident execution in {interest1} and {interest2}.",
-        "Drawing from experience in architecture, delivery, and team growth to mentor around {interest1} and {interest2}.",
-        "Helping mentees connect technical depth in {interest1} with the professional habits needed for {interest2}.",
-        "Offering practical mentorship for those pursuing growth in {interest1}, especially when paired with stronger {interest2}.",
-        "Guiding the next generation of builders in {interest1} with a strong focus on feedback, iteration, and {interest2}.",
-        "Bringing cross-industry experience to mentorship in {interest1} and {interest2}, especially for people navigating change.",
-        "Mentoring people who want to grow beyond the basics of {interest1} and develop more confident {interest2} skills.",
-        "Sharing a long-term perspective on careers in {interest1} and {interest2}, with advice that is calm, practical, and clear.",
-    ],
-}
-
-MENTEE_BACKGROUND_TEMPLATES = [
-    "I am currently studying computer engineering and trying to apply my knowledge to real-world problems.",
-    "I have been learning about {interest1} through online courses and bootcamps.",
-    "My background is in a different field, but I have recently started exploring tech and {interest2}.",
-    "I work as a junior professional and want to dive deeper into {interest1}.",
-    "I have some academic experience in {interest1} but I lack practical industry experience.",
-    "I recently graduated and am actively looking for opportunities to use my skills in {interest1}.",
-    "I have been a hobbyist programmer for a few years, mostly focusing on {interest2}.",
-    "I am transitioning from a non-technical role and have completed several projects in {interest1}.",
-    "I am an undergraduate student with a strong passion for {interest1} and {interest2}.",
-    "I have been self-taught in {interest1} for the past year and want to take it to the next level.",
-    "Currently exploring different career paths in technology, with a particular focus on {interest1}.",
-    "I have built a few small projects using {interest2} and want to learn enterprise standards.",
-]
-
-MENTOR_GOALS_TEMPLATES = [
-    "Aims to share industry experience and guide mentees in {interest1} and {interest2}.",
-    "Focuses on providing practical insights and career guidance for those interested in {interest1}.",
-    "Passionate about helping juniors navigate the complexities of {interest1} and build confidence.",
-    "Dedicated to mentoring aspiring professionals in {interest1}, helping them achieve their career milestones.",
-    "Wants to support mentees by sharing real-world lessons in {interest1} and {interest2}.",
-    "Committed to fostering growth in {interest1} through structured feedback and regular check-ins.",
-    "Looks forward to helping mentees overcome obstacles in {interest1} and develop strong foundations.",
-    "Interested in guiding early-career talents through the challenges of {interest1}.",
-    "Aims to bridge the gap between academic knowledge and practical application in {interest1}.",
-    "Enthusiastic about empowering the next generation of leaders in {interest1} and {interest2}.",
-    "Focuses on career strategy, portfolio building, and technical growth in {interest1}.",
-    "Dedicated to offering actionable advice and support for mentees navigating {interest1}.",
-]
 
 
 def pick(items, index: int):


### PR DESCRIPTION
What changed (3 commits on feat/web-readme-and-local-seed):                                                                                                                           
                                                                                                                                                                                        
  1. refactor(scripts): extract seed data constants into seed_data.py — pulls names/locations/interests/templates out of seed_personas.py into a shared seed_data.py module;            
  seed_personas.py behaviour unchanged.                                                                                                                                                 
  2. feat(scripts): add seed_local.py for offline docker-compose data seeding — direct-DB seed (psycopg + bcrypt, no HTTP/Resend/MailHog) that wipes all @seed.local rows then writes 1 
  admin + 40 mentors + 60 mentees with realistic profiles. Prints sample credentials, writes the full list to a (gitignored) scripts/seed_local_credentials.txt.                        
  3. docs(readme): rewrite Web Application section with dev/seed/prod flows — fresh structure mirroring the Mobile section, fixes the wrong :5174 frontend port (now :8000), drops the  
  dead MailHog row, adds a prod-deployment subsection. Mobile section untouched.                                                                                                        
                                                                                                                                                                                      
  Verified end-to-end against a live docker compose up stack (Flyway V55): seed run succeeded, 101 rows in users / 1 in admins / 40 in mentors / 60 in mentees, and POST /api/auth/login
   against the real Spring backend returned 200 + correct role for admin, a mentor, and a mentee account. Re-run with a synthetic non-seed user present kept that user intact and       
  reseeded cleanly.