### PR TITLE
fix(backend): point verification email at frontend SPA route

### DIFF
--- a/backend/src/main/java/com/group7/backend/service/EmailService.java
+++ b/backend/src/main/java/com/group7/backend/service/EmailService.java
@@ -42,7 +42,9 @@ public class EmailService {
     }
 
     public void sendVerificationEmail(User user, String token) {
-        String verifyLink = baseUrl + "/api/auth/verify-email?token=" + token;
+        // Route through the frontend SPA route (VerifyEmailPage) instead of
+        // the raw backend JSON endpoint, so recipients land on a real page.
+        String verifyLink = frontendUrl + "/verify-email?token=" + token;
         if (!enabled) {
             // Dev/manual-smoke escape hatch: log the link instead of calling
             // Resend, so a fresh user can verify by curl-ing the link from


### PR DESCRIPTION
Resend-delivered verification links were hitting the backend JSON endpoint directly, which (a) shows a raw JSON response and (b) inherits the localhost default of APP_BASE_URL when that env var isn't set on the prod host. Route through the existing /verify-email frontend route instead, which calls the backend API and renders a real success page.

The APP_FRONTEND_URL env var must be set in .env.production on the prod host for the link to resolve correctly.