### PR TITLE
ci(deploy): bump SSH command_timeout to 30m

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: root
           key: ${{ secrets.DEPLOY_SSH_KEY }}
+          # Default is 10m; cold Maven rebuild (~7m) + Neo4j + backend
+          # health wait (~3m) exceeds it. Cf. run 25790084160 which hit
+          # the cap and left the frontend container in `Created` state.
+          command_timeout: 30m
           script: |
             cd /root/bounswe2026group7
             git fetch origin


### PR DESCRIPTION
Cold Maven rebuilds (~7m) plus the Neo4j + backend health wait push the deploy past appleboy/ssh-action's 10m default, killing docker compose mid-orchestration and leaving the frontend container in Created state (triggering a 502 on the public site). 30m leaves comfortable headroom.